### PR TITLE
test: verify Jules branch delivery

### DIFF
--- a/_ai_work/REPORTS/TEST-PR-001_jules_branch_delivery_check.md
+++ b/_ai_work/REPORTS/TEST-PR-001_jules_branch_delivery_check.md
@@ -1,0 +1,17 @@
+# TEST-PR-001 Jules branch delivery check
+
+Repository: NckNA/codex-test
+Target PR branch: main
+
+This file verifies that Jules can create a fresh PR targeted at main.
+
+No application code changed.
+
+## Delivery checklist
+
+- Repository confirmed
+- Fresh PR created
+- PR targets main
+- Only _ai_work/REPORTS file changed
+- Build checked
+- PR visible on GitHub


### PR DESCRIPTION
This PR verifies the fallback delivery path for Jules-created patches. It only adds _ai_work/REPORTS/TEST-PR-001_jules_branch_delivery_check.md and does not change application code.