### PR TITLE
CLEAN-003: replace native complaint save alert with proper in-app feedback

### DIFF
--- a/_ai_work/REPORTS/CLEAN-003_replace_complaint_save_alert_report.md
+++ b/_ai_work/REPORTS/CLEAN-003_replace_complaint_save_alert_report.md
@@ -1,0 +1,34 @@
+# CLEAN-003 Replace Complaint Save Alert Report
+
+## Task ID
+CLEAN-003
+
+## Goal
+Remove the native browser alert shown when saving a patient complaint and replace it with proper in-app feedback.
+
+## What alert usage was found
+A codebase search via `Select-String` confirmed that `FindingsRisksTab.tsx` was the only component using a native `alert()` for user feedback:
+- `FindingsRisksTab.tsx` (line 105): `alert('Жалоба сохранена');`
+
+## Chosen Fix Option
+**Option B**: "If no shared feedback system exists, replace the alert with a small inline success message near the complaint form/button... The message should disappear after a short time."
+
+## Why this option was safest
+A search of `src/components/common` and `src/context` revealed no existing toast or notification system in the prototype. Building a global toast provider (Option A) would require broad refactoring and violate the rule against adding large notification systems. Showing an inline state (Option B) allows us to safely replace the alert with only a few lines of isolated local state (`isSaved`) without affecting any other modules.
+
+## Files changed
+- `src/components/dental/FindingsRisksTab.tsx`: 
+  - Added `const [isSaved, setIsSaved] = useState(false);`
+  - Replaced `alert('Жалоба сохранена');` with `setIsSaved(true); setTimeout(() => setIsSaved(false), 3000);`
+  - Added inline UI next to the save button: `<CheckCircle /> Сохранено` which conditionally renders when `isSaved` is true.
+
+## Checks performed
+- ✅ Searched the entire `src/` directory for other instances of `alert(`. None were found.
+- ✅ Verified `FindingsRisksTab.tsx` saves correctly.
+- ✅ `npm run lint` — passed (0 errors, 1 pre-existing warning in `DentalChartTab.tsx`).
+- ✅ `npm run build` — passed successfully.
+- ✅ Verified no other files or dependencies were modified.
+- ✅ Verified no MCP tools or browser automation were used.
+
+## Remaining known limitations
+The app still lacks a global notification (toast) system. Any future actions that need success feedback will either require similar local inline state or the implementation of a proper global toast context.

--- a/src/components/dental/FindingsRisksTab.tsx
+++ b/src/components/dental/FindingsRisksTab.tsx
@@ -63,6 +63,8 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedFinding, setSelectedFinding] = useState<DentalFinding | null>(null);
 
+  const [isSaved, setIsSaved] = useState(false);
+
   const loadData = () => {
     setFindings(storage.getFindings(patientId));
     const chiefComplaint = storage.getChiefComplaint(patientId);
@@ -102,7 +104,8 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
       text: complaintText,
       relatedTeeth: validTeethIds,
     });
-    alert('Жалоба сохранена');
+    setIsSaved(true);
+    setTimeout(() => setIsSaved(false), 3000);
   };
 
   const handleDelete = (findingId: string) => {
@@ -254,7 +257,12 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
           </div>
         </div>
 
-        <div className="flex justify-end">
+        <div className="flex justify-end items-center gap-3">
+          {isSaved && (
+            <span className="text-sm font-medium text-emerald-600 flex items-center gap-1">
+              <CheckCircle className="w-4 h-4" /> Сохранено
+            </span>
+          )}
           <button
             onClick={handleSaveComplaint}
             className="px-4 py-2 text-sm font-medium text-white bg-slate-800 hover:bg-slate-900 rounded-lg transition-colors"


### PR DESCRIPTION
## CLEAN-003: Replace Complaint Save Alert

### Summary
Removed the native browser \lert()\ that appeared when saving a patient complaint and replaced it with an inline success message.

### Details
- **Chosen Fix Option:** Option B.
- A codebase search confirmed that \FindingsRisksTab.tsx\ was the only component using a native \lert()\ for user feedback.
- A search of \src/components/common\ and \src/context\ revealed no existing toast or notification system in the prototype.
- To avoid inventing a large new notification system, the alert was safely replaced with a local \isSaved\ state that shows an inline success message (with a \CheckCircle\ icon) next to the save button, which disappears after 3 seconds.

### Changed files
- \src/components/dental/FindingsRisksTab.tsx\`n- \_ai_work/REPORTS/CLEAN-003_replace_complaint_save_alert_report.md\ (NEW)

### Checks
- [x] Searched codebase for other \lert(\ usages (none found).
- [x] \
pm run lint\ (frontend) — 0 errors, 1 pre-existing warning.
- [x] \
pm run build\ (frontend) — success.
- [x] No unrelated files or architecture changed.
- [x] No MCP tools or browser automation used.