### PR TITLE
CLEAN-004: add visible prototype mode warning for localStorage-only data

### DIFF
--- a/_ai_work/REPORTS/CLEAN-004_prototype_mode_warning_report.md
+++ b/_ai_work/REPORTS/CLEAN-004_prototype_mode_warning_report.md
@@ -1,0 +1,31 @@
+# CLEAN-004 Prototype Mode Warning Report
+
+## Task ID
+CLEAN-004
+
+## Goal
+Add a visible, non-intrusive Prototype Mode warning in the app UI explaining that data is stored only in the current browser.
+
+## Where the warning was added
+The warning was added to `src/components/layout/Layout.tsx`, positioned horizontally right below the `<Header />` and just above the main scrollable `<main>` area.
+
+## Chosen Fix Option
+**Option B**: "If there is no shared component, add a small inline warning banner in the main app layout using existing Tailwind styles."
+
+## Why this placement was safest
+There was no existing `<Alert />` or `<Banner />` component in the codebase. Adding it directly to `Layout.tsx` ensures the warning is visible on every single page of the application (as they all use the global Layout wrapper) without needing to refactor individual page components. It occupies a small horizontal strip (using `shrink-0` and padding) and does not interfere with the absolute positioning or scrolling of the main content area below it.
+
+## Exact warning text used
+"Режим прототипа: данные сохраняются только в этом браузере. Очистка localStorage, другой браузер или другое устройство могут скрыть или удалить эти данные. Production backend/database ещё не подключены."
+
+## Files changed
+- `src/components/layout/Layout.tsx`
+
+## Checks performed
+- ✅ Verified `npm run lint` — passed (0 errors, 1 pre-existing warning in `DentalChartTab.tsx`).
+- ✅ Verified `npm run build` — passed successfully.
+- ✅ Verified no backend or storage architecture changes were made.
+- ✅ Verified no MCP tools or browser automation were used.
+
+## Remaining known limitations
+Since this is purely a visual UI banner, it doesn't provide an interactive way to "factory reset" or clear localStorage; testers who want to start fresh still need to clear their browser storage manually or use DevTools.

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { ScheduleProvider } from '../../context/ScheduleProvider';
+import { AlertTriangle } from 'lucide-react';
 
 export function Layout() {
   return (
@@ -10,6 +11,14 @@ export function Layout() {
         <Sidebar />
         <div className="flex flex-col flex-1 min-w-0">
           <Header />
+          <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 flex items-start gap-3 shrink-0">
+            <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+            <div className="text-sm text-amber-800">
+              <span className="font-semibold">Режим прототипа:</span> данные сохраняются только в этом браузере. 
+              Очистка localStorage, другой браузер или другое устройство могут скрыть или удалить эти данные. 
+              Production backend/database ещё не подключены.
+            </div>
+          </div>
           <main className="flex-1 overflow-auto relative">
             <Outlet />
           </main>


### PR DESCRIPTION
## CLEAN-004: Prototype Mode Warning

### Summary
Added a global Prototype Mode warning banner to the layout to clearly inform testers that data is stored only in the current browser.

### Details
- **Chosen Fix Option:** Option B.
- A new inline warning banner was added to \src/components/layout/Layout.tsx\ right below the \Header\ component.
- It uses existing Tailwind styles (amber background/border and \AlertTriangle\ icon) to make it visible but non-intrusive.
- The Russian text clearly communicates the limitations of the current prototype mode (localStorage only, no production backend yet).

### Changed files
- \src/components/layout/Layout.tsx\`n- \_ai_work/REPORTS/CLEAN-004_prototype_mode_warning_report.md\ (NEW)

### Checks
- [x] \
pm run lint\ (frontend) — passed (0 errors, 1 pre-existing warning).
- [x] \
pm run build\ (frontend) — success.
- [x] No storage or backend architecture changed.
- [x] No MCP tools or browser automation used.