### PR TITLE
MVP-004: Review and improve patient-facing treatment plan preview

### DIFF
--- a/_ai_work/REPORTS/MVP-004_treatment_plan_preview_review_report.md
+++ b/_ai_work/REPORTS/MVP-004_treatment_plan_preview_review_report.md
@@ -1,0 +1,35 @@
+# MVP-004 Treatment Plan Preview Review Report
+
+## What was inspected
+- `src/components/treatment/TreatmentPlanPatientPreview.tsx`
+- The entire layout and presentation text of the patient-facing Treatment Plan preview.
+
+## What patient-facing risks were found
+- The word "Результат осмотра" (exam result) was somewhat ambiguous and lacked clarity regarding the risks being communicated to the patient.
+- The disclaimer at the bottom was dense and used clinical wording ("клинические обстоятельства").
+- The treatment stages block used rigid "key: value" formatting (e.g. `Зубы: не указаны`, `Описание: не указано`), which looked too technical and robotic for a patient summary.
+- The total amount stated "Итого по плану" which could incorrectly imply a final, guaranteed price.
+
+## What wording/layout improvements were made
+- Changed section 2 title to **"Выявленные проблемы и риски"** to be clear and patient-safe without asserting a final diagnosis.
+- Rewrote the main disclaimer to be simpler and safer: **"План лечения является предварительным и может быть уточнён врачом после осмотра, снимков или дополнительных данных."**
+- Refactored the treatment stages display to gracefully hide empty attributes (no more "не указаны"). Teeth, descriptions, and prices only show up if they actually exist, making the list look clean.
+- Updated total pricing language to **"Ориентировочная итоговая стоимость"** to clearly indicate the estimate is not legally binding.
+
+## What was intentionally not changed
+- The underlying `TreatmentPlan` and `DentalFinding` data models were entirely untouched.
+- No storage logic or CRM sync logic was modified.
+- No PDF generation or document signing mechanisms were added.
+
+## Checks performed
+- `npm run lint` — passed.
+- `npm run build` — passed successfully.
+- Verified no internal `amoCRM` sync details were ever visible on the preview modal.
+
+## Remaining risks
+- The patient preview still relies heavily on the `PatientCardPage` and `storage` utility running fully client-side.
+- A future print functionality (`window.print()`) or PDF export might be needed for actual clinical use if patients request a physical copy.
+
+## Recommended next task
+**MVP-005 — Medical MVP UX gaps cleanup.**
+This task should focus on rounding out the remaining minor UI/UX issues across the entire medical flow before we sign off the MVP phase.

--- a/src/components/treatment/TreatmentPlanPatientPreview.tsx
+++ b/src/components/treatment/TreatmentPlanPatientPreview.tsx
@@ -62,7 +62,7 @@ const STAGE_STATUS_LABELS: Record<TreatmentStageStatus, string> = {
   cancelled: 'Отменён',
 };
 
-const IMPORTANT_NOTE = 'План лечения составлен на основании осмотра на указанную дату. Окончательная стоимость и объём лечения могут измениться при выявлении дополнительных клинических обстоятельств, необходимости дополнительной диагностики или изменении выбранного метода лечения.';
+const IMPORTANT_NOTE = 'План лечения является предварительным и может быть уточнён врачом после осмотра, снимков или дополнительных данных.';
 
 function FindingPreview({ finding }: { finding: DentalFinding }) {
   return (
@@ -170,7 +170,7 @@ export function TreatmentPlanPatientPreview({ patientId, plan, isOpen, onClose }
             </section>
 
             <section>
-              <h3 className="text-base font-semibold text-slate-800 mb-3">2. Результат осмотра</h3>
+              <h3 className="text-base font-semibold text-slate-800 mb-3">2. Выявленные проблемы и риски</h3>
               {linkedFindings.length > 0 ? (
                 <div className="space-y-3">
                   {linkedFindings.map(finding => (
@@ -199,16 +199,22 @@ export function TreatmentPlanPatientPreview({ patientId, plan, isOpen, onClose }
                           {STAGE_STATUS_LABELS[stage.status]}
                         </span>
                       </div>
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm text-slate-600">
-                        <div>
-                          <span className="font-medium text-slate-700">Зубы:</span> {stage.teeth.length > 0 ? stage.teeth.join(', ') : 'не указаны'}
-                        </div>
-                        <div>
-                          <span className="font-medium text-slate-700">Стоимость:</span> {stage.price.toLocaleString()} ₸
-                        </div>
-                        <div className="md:col-span-3">
-                          <span className="font-medium text-slate-700">Описание:</span> {stage.description || 'не указано'}
-                        </div>
+                      <div className="flex flex-col gap-2 text-sm text-slate-600">
+                        {stage.teeth && stage.teeth.length > 0 && (
+                          <div>
+                            <span className="font-medium text-slate-700">Связанные зубы:</span> {stage.teeth.join(', ')}
+                          </div>
+                        )}
+                        {stage.description && (
+                          <div>
+                            <span className="font-medium text-slate-700">Описание:</span> {stage.description}
+                          </div>
+                        )}
+                        {stage.price > 0 && (
+                          <div>
+                            <span className="font-medium text-slate-700">Стоимость этапа:</span> {stage.price.toLocaleString()} ₸
+                          </div>
+                        )}
                       </div>
                     </div>
                   ))}
@@ -218,7 +224,7 @@ export function TreatmentPlanPatientPreview({ patientId, plan, isOpen, onClose }
               )}
               <div className="mt-4 rounded-lg border border-blue-100 bg-blue-50 p-4">
                 <div className="text-base font-semibold text-blue-900">
-                  Итого по плану: {plan.totalPrice.toLocaleString()} ₸
+                  Ориентировочная итоговая стоимость: {plan.totalPrice > 0 ? `${plan.totalPrice.toLocaleString()} ₸` : 'не указана'}
                 </div>
                 {plan.totalPrice === 0 && (
                   <div className="mt-1 text-sm text-blue-800">Стоимость будет уточнена после заполнения этапов лечения.</div>


### PR DESCRIPTION
## MVP-004: Patient-Facing Plan Preview Review

### Summary
Audited and improved the patient-facing treatment plan preview (\TreatmentPlanPatientPreview.tsx\) to ensure wording is safe, clear, and professional, without implying guaranteed treatment or exposing internal diagnostics.

### Details
- Changed section title from 'Результат осмотра' to 'Выявленные проблемы и риски' to use patient-safe language instead of asserting a final diagnosis.
- Rewrote the main disclaimer to be simpler and safer, stating the plan is preliminary and may be refined.
- Refactored the treatment stages display to gracefully hide empty attributes (teeth, descriptions, and prices only show if they exist), avoiding technical placeholders like 'не указаны'.
- Changed total pricing language to 'Ориентировочная итоговая стоимость' to clarify it's an estimate.

### Changed files
- \src/components/treatment/TreatmentPlanPatientPreview.tsx\ (MODIFIED)
- \_ai_work/REPORTS/MVP-004_treatment_plan_preview_review_report.md\ (NEW)

### Checks
- [x] No data models changed.
- [x] No internal amoCRM/storage details exposed.
- [x] \
pm run lint\ (frontend) — passed.
- [x] \
pm run build\ (frontend) — success.
- [x] No MCP tools or browser automation used.