### PR TITLE
ARCH-007: Migrate PatientHistoryTab to async repository + hook

### DIFF
--- a/_ai_work/REPORTS/ARCH-007_patient_history_appointments_hook_report.md
+++ b/_ai_work/REPORTS/ARCH-007_patient_history_appointments_hook_report.md
@@ -1,0 +1,54 @@
+# ARCH-007: PatientHistoryTab Appointments Hook Migration Report
+
+## 1. Files Inspected
+- `_ai_work/REPORTS/ARCH-006_review_chief_complaint_slice_and_next_migration_plan.md`
+- `src/components/patients/patient-card/PatientHistoryTab.tsx`
+- `src/pages/PatientCardPage.tsx`
+- `src/utils/storage.ts`
+- `src/types/index.ts`
+
+## 2. Files Changed
+- **New:** `src/data/repositories/AppointmentRepository.ts`
+- **New:** `src/data/hooks/usePatientAppointments.ts`
+- **Modified:** `src/components/patients/patient-card/PatientHistoryTab.tsx`
+- **Modified:** `src/pages/PatientCardPage.tsx`
+
+## 3. Repository Implementation Summary
+Created `IAppointmentRepository` and its `LocalStorageAppointmentRepository` adapter. It provides `listAppointmentsByPatient(patientId)` which filters and sorts appointments safely inside the repository using the existing `storage.getAppointments()`. It operates exclusively using the `Appointment` type.
+
+## 4. Hook Implementation Summary
+Created the `usePatientAppointments(patientId)` hook. It internally calls the repository and safely manages the async React lifecycle (`isLoading`, `isError`, `error`). Since appointments are read-only in this context, the hook focuses entirely on fetching and caching state natively without exposing mutation methods.
+
+## 5. PatientHistoryTab Migration Summary
+Replaced the `appointments` prop with `patientId`. The component now directly invokes `usePatientAppointments` to fetch data. Added a smooth `"Загрузка истории приёмов..."` placeholder and an error block, while keeping the main table design, empty state, and status helpers perfectly intact. Unused imports were cleaned up.
+
+## 6. PatientCardPage Change Summary
+Updated the `PatientHistoryTab` rendering to pass `patientId` instead of passing the synchronously computed `appointments` array. The global `appointments` list loaded by `PatientCardPage` remains untouched since it is still required to calculate global `lastVisit` and `nextVisit` in the header overview.
+
+## 7. What Behavior Was Preserved
+- The history tab lists appointments flawlessly with identical sorting and filtering.
+- Visual elements (table, colors, labels, empty state) remain the same.
+- Header summaries and global states on the page still load correctly.
+- Types and storage layer logic are fully preserved.
+
+## 8. What Was Intentionally Not Changed
+- `storage.ts` was **NOT** changed.
+- `src/types/index.ts` was **NOT** changed.
+- Global appointment fetching for the `PatientCardPage` summary was **NOT** changed (as requested).
+- Schedule Page was **NOT** changed.
+- Patient Overview Tab was **NOT** changed.
+- Appointment mutations (create/edit) were **NOT** added.
+- React Query, global state managers, or real backends were **NOT** introduced.
+- No `any` casting was used anywhere.
+
+## 9. Checks Performed
+- ✅ `npm run lint` passed (0 errors, 0 warnings).
+- ✅ `npm run build` passed successfully.
+- ✅ Verified `storage.ts` and types remained untouched.
+- ✅ Verified `SchedulePage` and other tabs were undisturbed.
+
+## 10. Remaining Risks
+The hook safely encapsulates read-only fetching. The biggest remaining challenge is that `PatientCardPage` still synchronously queries the entire appointments list to calculate `lastVisit` and `nextVisit`. This confirms that migrating aggregate/summary components (like `PatientOverviewTab` and headers) will require careful coordination of multiple async hooks or specialized backend aggregation endpoints in the future.
+
+## 11. Recommended Next Task
+**ARCH-008 — Review ARCH-007 appointments slice and plan next read-only migration.**

--- a/src/components/patients/patient-card/PatientHistoryTab.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.tsx
@@ -1,8 +1,10 @@
 import { Stethoscope, ClipboardList } from 'lucide-react';
-import type { Appointment, Doctor } from '../../../types';
+import type { Doctor } from '../../../types';
+
+import { usePatientAppointments } from '../../../data/hooks/usePatientAppointments';
 
 interface PatientHistoryTabProps {
-  appointments: Appointment[];
+  patientId: string;
   doctors: Doctor[];
 }
 
@@ -32,7 +34,17 @@ const getStatusColor = (status: string) => {
   }
 };
 
-export function PatientHistoryTab({ appointments, doctors }: PatientHistoryTabProps) {
+export function PatientHistoryTab({ patientId, doctors }: PatientHistoryTabProps) {
+  const { appointments, isLoading, isError } = usePatientAppointments(patientId);
+
+  if (isError) {
+    return (
+      <div className="bg-white rounded-xl border border-red-200 shadow-sm p-8 text-center text-red-500">
+        <p>Ошибка при загрузке истории приёмов.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
       <div className="p-4 border-b border-slate-200 bg-slate-50/50 flex items-center justify-between">
@@ -44,7 +56,11 @@ export function PatientHistoryTab({ appointments, doctors }: PatientHistoryTabPr
         </span>
       </div>
 
-      {appointments.length === 0 ? (
+      {isLoading ? (
+        <div className="p-8 text-center text-slate-500">
+          <p>Загрузка истории приёмов...</p>
+        </div>
+      ) : appointments.length === 0 ? (
         <div className="p-8 text-center text-slate-500">
           <ClipboardList className="w-12 h-12 mx-auto mb-3 text-slate-300" />
           <p>У пациента еще не было приёмов.</p>

--- a/src/data/hooks/usePatientAppointments.ts
+++ b/src/data/hooks/usePatientAppointments.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Appointment } from '../../types';
+import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
+
+export function usePatientAppointments(patientId: string) {
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(!!patientId);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchAppointments = useCallback(async () => {
+    if (!patientId) return;
+    setIsLoading(true);
+    setIsError(false);
+    setError(null);
+    try {
+      const data = await LocalStorageAppointmentRepository.listAppointmentsByPatient(patientId);
+      setAppointments(data);
+    } catch (err) {
+      setIsError(true);
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [patientId]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    if (!patientId) {
+      return;
+    }
+
+    const initFetch = async () => {
+      setIsLoading(true);
+      setIsError(false);
+      setError(null);
+      try {
+        const data = await LocalStorageAppointmentRepository.listAppointmentsByPatient(patientId);
+        if (mounted) {
+          setAppointments(data);
+          setIsLoading(false);
+        }
+      } catch (err) {
+        if (mounted) {
+          setIsError(true);
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsLoading(false);
+        }
+      }
+    };
+
+    initFetch();
+
+    return () => {
+      mounted = false;
+    };
+  }, [patientId]);
+
+  return {
+    appointments,
+    isLoading,
+    isError,
+    error,
+    refetch: fetchAppointments,
+  };
+}

--- a/src/data/repositories/AppointmentRepository.ts
+++ b/src/data/repositories/AppointmentRepository.ts
@@ -1,0 +1,16 @@
+import type { Appointment } from '../../types';
+import { storage } from '../../utils/storage';
+
+export interface IAppointmentRepository {
+  listAppointmentsByPatient(patientId: string): Promise<Appointment[]>;
+}
+
+export const LocalStorageAppointmentRepository: IAppointmentRepository = {
+  listAppointmentsByPatient: async (patientId: string): Promise<Appointment[]> => {
+    // Mimics the sorting behavior from the UI component directly in the repository
+    const appointments = storage.getAppointments()
+      .filter(a => a.patientId === patientId)
+      .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
+    return Promise.resolve(appointments);
+  }
+};

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -181,7 +181,7 @@ export function PatientCardPage() {
 
         {activeTab === 'history' && (
           <PatientHistoryTab
-            appointments={appointments}
+            patientId={patient.id}
             doctors={doctors}
           />
         )}


### PR DESCRIPTION
## ARCH-007: Appointments Hook Migration

### Summary
Implemented the second Data Access Layer (DAL) migration slice, replacing synchronous appointment array passing with the \usePatientAppointments\ hook inside \PatientHistoryTab\.

### Details
- Created \AppointmentRepository\ with a read-only \LocalStorage\ adapter (\listAppointmentsByPatient\).
- Created \usePatientAppointments\ hook to manage the array fetch and loading state.
- Refactored \PatientHistoryTab\ to rely exclusively on this hook for its appointment array, isolating its data loading from the parent \PatientCardPage\.
- Added a smooth loading placeholder while preserving the table, empty state, and status helpers.
- Cleaned up unused types (\Appointment\ import in Tab).
- Verified that \SchedulePage\, overview calculations, and global states remained fully untouched and functional.

### Changed files
- \src/data/repositories/AppointmentRepository.ts\ (NEW)
- \src/data/hooks/usePatientAppointments.ts\ (NEW)
- \src/components/patients/patient-card/PatientHistoryTab.tsx\ (MODIFIED)
- \src/pages/PatientCardPage.tsx\ (MODIFIED)
- \_ai_work/REPORTS/ARCH-007_patient_history_appointments_hook_report.md\ (NEW)

### Checks
- [x] No \ny\ casting used.
- [x] \storage.ts\ logic was strictly preserved.
- [x] \
pm run lint\ (frontend) — passed (0 errors, 0 warnings).
- [x] \
pm run build\ (frontend) — success.
- [x] No MCP tools or browser automation used.