### PR TITLE
ARCH-012: Implement async hook utilities and refactor read-only hooks

### DIFF
--- a/_ai_work/REPORTS/ARCH-012_async_hook_utilities_readonly_refactor_report.md
+++ b/_ai_work/REPORTS/ARCH-012_async_hook_utilities_readonly_refactor_report.md
@@ -1,0 +1,55 @@
+# ARCH-012: Async Hook Utilities and Read-Only Refactor Report
+
+## 1. Files Inspected
+- `_ai_work/REPORTS/ARCH-011_shared_async_hook_utility_design.md`
+- `src/data/hooks/useClinicDoctors.ts`
+- `src/data/hooks/usePatientAppointments.ts`
+- `src/data/hooks/useChiefComplaint.ts`
+- `src/data/repositories/DoctorRepository.ts`
+- `src/data/repositories/AppointmentRepository.ts`
+
+## 2. Files Changed
+- **New:** `src/data/hooks/useAsyncQuery.ts`
+- **New:** `src/data/hooks/useAsyncMutation.ts`
+- **Modified:** `src/data/hooks/useClinicDoctors.ts`
+- **Modified:** `src/data/hooks/usePatientAppointments.ts`
+
+## 3. useAsyncQuery Implementation Summary
+Created a generic, strongly typed internal utility hook `useAsyncQuery<T>` using only native React primitives. It handles initialization, loading states, error catching, and the `mounted` safety checks. It accepts a `queryFn`, `initialData`, and an `enabled` flag. A targeted `eslint-disable-next-line` was added to safely toggle off `isLoading` when `enabled` dynamically becomes false.
+
+## 4. useAsyncMutation Implementation Summary
+Created a generic `useAsyncMutation<TInput, TResult>` utility. It encapsulates `isMutating`, `isError`, and `error` states, and provides a safe wrapper around asynchronous `mutationFn` executions with `onSuccess` and `onError` callbacks. It safely catches thrown errors and casts them to standard `Error` objects.
+
+## 5. useClinicDoctors Refactor Summary
+Refactored to rely purely on `useAsyncQuery`. The boilerplate `useState` and `useEffect` blocks were deleted. It still calls `LocalStorageDoctorRepository.listDoctors()` inside a `useCallback`, ensuring that historical doctor names (even inactive ones) continue to be resolvable. The public return shape remains identical.
+
+## 6. usePatientAppointments Refactor Summary
+Refactored to rely on `useAsyncQuery`. Boilerplate was removed. The query explicitly passes `enabled: Boolean(patientId)` to prevent fetching if a patient ID is absent. The public API (`appointments`, `isLoading`, `isError`, `error`, `refetch`) remains fully backwards compatible.
+
+## 7. What Behavior Was Preserved
+- The public APIs of the migrated hooks are exactly the same.
+- UI components (e.g., `PatientHistoryTab`) were completely unaffected.
+- The `patientId` guard correctly prevents null fetching.
+- Repository behavior and storage access rules are unchanged.
+
+## 8. What Was Intentionally Not Changed
+- `useChiefComplaint` was **NOT** changed, as it contains mixed query/mutation logic and is reserved for the next stabilization phase.
+- UI components (`PatientHistoryTab`, `PatientCardPage`, `PatientOverviewTab`) were **NOT** changed.
+- `storage.ts` and `types/index.ts` were **NOT** changed.
+- Repositories were **NOT** changed.
+- Dependencies (`package.json`) were **NOT** changed.
+- Global state management (React Query/Redux) or real backends were **NOT** introduced.
+- No `any` casting was used.
+
+## 9. Checks Performed
+- ✅ `npm run lint` passed (0 errors, 0 warnings).
+- ✅ `npm run build` passed successfully.
+- ✅ Verified `useChiefComplaint` was not touched.
+- ✅ Verified UI components were unmodified.
+- ✅ Verified hook public return types correctly matched previous implementations.
+
+## 10. Remaining Risks
+The `useAsyncMutation` hook has been created but is not yet utilized. The `useChiefComplaint` hook remains the sole holdout of duplicated boilerplate. Migrating it will be slightly more complex since it must integrate both `useAsyncQuery` and `useAsyncMutation` into a single public interface.
+
+## 11. Recommended Next Task
+**ARCH-013 — Review async hook utility implementation and decide whether to refactor useChiefComplaint mutation flow next.**

--- a/_ai_work/REPORTS/ARCH-012_async_hook_utilities_readonly_refactor_report.md
+++ b/_ai_work/REPORTS/ARCH-012_async_hook_utilities_readonly_refactor_report.md
@@ -15,10 +15,10 @@
 - **Modified:** `src/data/hooks/usePatientAppointments.ts`
 
 ## 3. useAsyncQuery Implementation Summary
-Created a generic, strongly typed internal utility hook `useAsyncQuery<T>` using only native React primitives. It handles initialization, loading states, error catching, and the `mounted` safety checks. It accepts a `queryFn`, `initialData`, and an `enabled` flag. A targeted `eslint-disable-next-line` was added to safely toggle off `isLoading` when `enabled` dynamically becomes false.
+Created a generic, strongly typed internal utility hook `useAsyncQuery<T>` using only native React primitives. It handles initialization, loading states, error catching, and safely blocks state updates if the component is unmounted (using a shared `isMountedRef`). This unmount safety explicitly protects *both* the initial load and any subsequent manual `refetch` calls. It accepts a `queryFn`, `initialData`, and an `enabled` flag. A targeted `eslint-disable-next-line` was added to safely toggle off `isLoading` when `enabled` dynamically becomes false.
 
 ## 4. useAsyncMutation Implementation Summary
-Created a generic `useAsyncMutation<TInput, TResult>` utility. It encapsulates `isMutating`, `isError`, and `error` states, and provides a safe wrapper around asynchronous `mutationFn` executions with `onSuccess` and `onError` callbacks. It safely catches thrown errors and casts them to standard `Error` objects.
+Created a generic `useAsyncMutation<TInput, TResult>` utility. It encapsulates `isMutating`, `isError`, and `error` states, and provides a safe wrapper around asynchronous `mutationFn` executions. Like `useAsyncQuery`, it uses a shared `isMountedRef` to strictly prevent `setState` calls or `onSuccess`/`onError` callback executions if the component has unmounted before the Promise resolves. It safely catches thrown errors and casts them to standard `Error` objects.
 
 ## 5. useClinicDoctors Refactor Summary
 Refactored to rely purely on `useAsyncQuery`. The boilerplate `useState` and `useEffect` blocks were deleted. It still calls `LocalStorageDoctorRepository.listDoctors()` inside a `useCallback`, ensuring that historical doctor names (even inactive ones) continue to be resolvable. The public return shape remains identical.

--- a/src/data/hooks/useAsyncMutation.ts
+++ b/src/data/hooks/useAsyncMutation.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from 'react';
+
+interface UseAsyncMutationOptions<TInput, TResult> {
+  mutationFn: (input: TInput) => Promise<TResult>;
+  onSuccess?: (result: TResult, input: TInput) => void;
+  onError?: (error: Error, input: TInput) => void;
+}
+
+export function useAsyncMutation<TInput, TResult>({
+  mutationFn,
+  onSuccess,
+  onError,
+}: UseAsyncMutationOptions<TInput, TResult>) {
+  const [isMutating, setIsMutating] = useState<boolean>(false);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mutate = useCallback(async (input: TInput): Promise<TResult | undefined> => {
+    setIsMutating(true);
+    setIsError(false);
+    setError(null);
+    try {
+      const result = await mutationFn(input);
+      setIsMutating(false);
+      onSuccess?.(result, input);
+      return result;
+    } catch (err) {
+      const parsedError = err instanceof Error ? err : new Error(String(err));
+      setIsError(true);
+      setError(parsedError);
+      setIsMutating(false);
+      onError?.(parsedError, input);
+      return undefined;
+    }
+  }, [mutationFn, onSuccess, onError]);
+
+  const reset = useCallback(() => {
+    setIsMutating(false);
+    setIsError(false);
+    setError(null);
+  }, []);
+
+  return {
+    isMutating,
+    isError,
+    error,
+    mutate,
+    reset,
+  };
+}

--- a/src/data/hooks/useAsyncMutation.ts
+++ b/src/data/hooks/useAsyncMutation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 interface UseAsyncMutationOptions<TInput, TResult> {
   mutationFn: (input: TInput) => Promise<TResult>;
@@ -15,29 +15,44 @@ export function useAsyncMutation<TInput, TResult>({
   const [isError, setIsError] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
 
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const mutate = useCallback(async (input: TInput): Promise<TResult | undefined> => {
     setIsMutating(true);
     setIsError(false);
     setError(null);
     try {
       const result = await mutationFn(input);
-      setIsMutating(false);
-      onSuccess?.(result, input);
+      if (isMountedRef.current) {
+        setIsMutating(false);
+        onSuccess?.(result, input);
+      }
       return result;
     } catch (err) {
-      const parsedError = err instanceof Error ? err : new Error(String(err));
-      setIsError(true);
-      setError(parsedError);
-      setIsMutating(false);
-      onError?.(parsedError, input);
+      if (isMountedRef.current) {
+        const parsedError = err instanceof Error ? err : new Error(String(err));
+        setIsError(true);
+        setError(parsedError);
+        setIsMutating(false);
+        onError?.(parsedError, input);
+      }
       return undefined;
     }
   }, [mutationFn, onSuccess, onError]);
 
   const reset = useCallback(() => {
-    setIsMutating(false);
-    setIsError(false);
-    setError(null);
+    if (isMountedRef.current) {
+      setIsMutating(false);
+      setIsError(false);
+      setError(null);
+    }
   }, []);
 
   return {

--- a/src/data/hooks/useAsyncQuery.ts
+++ b/src/data/hooks/useAsyncQuery.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 interface UseAsyncQueryOptions<T> {
   queryFn: () => Promise<T>;
@@ -20,19 +20,28 @@ export function useAsyncQuery<T>({
   const [isError, setIsError] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const executeFetch = useCallback(async (isMounted: () => boolean) => {
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const executeFetch = useCallback(async () => {
     setIsLoading(true);
     setIsError(false);
     setError(null);
     try {
       const result = await queryFn();
-      if (isMounted()) {
+      if (isMountedRef.current) {
         setData(result);
         setIsLoading(false);
         onSuccess?.(result);
       }
     } catch (err) {
-      if (isMounted()) {
+      if (isMountedRef.current) {
         const parsedError = err instanceof Error ? err : new Error(String(err));
         setIsError(true);
         setError(parsedError);
@@ -43,32 +52,20 @@ export function useAsyncQuery<T>({
   }, [queryFn, onSuccess, onError]);
 
   useEffect(() => {
-    let mounted = true;
-    const isMounted = () => mounted;
-
     if (!enabled) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsLoading(false);
-      return () => {
-        mounted = false;
-      };
+      return;
     }
 
-    executeFetch(isMounted);
-
-    return () => {
-      mounted = false;
-    };
+    executeFetch();
   }, [enabled, executeFetch]);
 
   const refetch = useCallback(async () => {
-    // If we trigger a manual refetch, we usually want to fetch regardless of the `enabled` prop on initial mount,
-    // but to be perfectly safe, if `enabled` is false, it means dependencies might not be ready (e.g., missing patientId).
-    // The design asks to be safe: "respect enabled".
     if (!enabled) {
       return;
     }
-    await executeFetch(() => true);
+    await executeFetch();
   }, [enabled, executeFetch]);
 
   return {

--- a/src/data/hooks/useAsyncQuery.ts
+++ b/src/data/hooks/useAsyncQuery.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface UseAsyncQueryOptions<T> {
+  queryFn: () => Promise<T>;
+  initialData: T;
+  enabled?: boolean;
+  onSuccess?: (data: T) => void;
+  onError?: (error: Error) => void;
+}
+
+export function useAsyncQuery<T>({
+  queryFn,
+  initialData,
+  enabled = true,
+  onSuccess,
+  onError,
+}: UseAsyncQueryOptions<T>) {
+  const [data, setData] = useState<T>(initialData);
+  const [isLoading, setIsLoading] = useState<boolean>(enabled);
+  const [isError, setIsError] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const executeFetch = useCallback(async (isMounted: () => boolean) => {
+    setIsLoading(true);
+    setIsError(false);
+    setError(null);
+    try {
+      const result = await queryFn();
+      if (isMounted()) {
+        setData(result);
+        setIsLoading(false);
+        onSuccess?.(result);
+      }
+    } catch (err) {
+      if (isMounted()) {
+        const parsedError = err instanceof Error ? err : new Error(String(err));
+        setIsError(true);
+        setError(parsedError);
+        setIsLoading(false);
+        onError?.(parsedError);
+      }
+    }
+  }, [queryFn, onSuccess, onError]);
+
+  useEffect(() => {
+    let mounted = true;
+    const isMounted = () => mounted;
+
+    if (!enabled) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsLoading(false);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    executeFetch(isMounted);
+
+    return () => {
+      mounted = false;
+    };
+  }, [enabled, executeFetch]);
+
+  const refetch = useCallback(async () => {
+    // If we trigger a manual refetch, we usually want to fetch regardless of the `enabled` prop on initial mount,
+    // but to be perfectly safe, if `enabled` is false, it means dependencies might not be ready (e.g., missing patientId).
+    // The design asks to be safe: "respect enabled".
+    if (!enabled) {
+      return;
+    }
+    await executeFetch(() => true);
+  }, [enabled, executeFetch]);
+
+  return {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  };
+}

--- a/src/data/hooks/useClinicDoctors.ts
+++ b/src/data/hooks/useClinicDoctors.ts
@@ -1,64 +1,28 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import type { Doctor } from '../../types';
 import { LocalStorageDoctorRepository } from '../repositories/DoctorRepository';
+import { useAsyncQuery } from './useAsyncQuery';
 
 export function useClinicDoctors() {
-  const [doctors, setDoctors] = useState<Doctor[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [isError, setIsError] = useState<boolean>(false);
-  const [error, setError] = useState<Error | null>(null);
+  const queryFn = useCallback(() => LocalStorageDoctorRepository.listDoctors(), []);
 
-  const fetchDoctors = useCallback(async () => {
-    setIsLoading(true);
-    setIsError(false);
-    setError(null);
-    try {
-      // Using listDoctors() instead of listActiveDoctors() to ensure
-      // history tabs can still resolve names of inactive doctors for past appointments.
-      const data = await LocalStorageDoctorRepository.listDoctors();
-      setDoctors(data);
-    } catch (err) {
-      setIsError(true);
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    let mounted = true;
-
-    const initFetch = async () => {
-      setIsLoading(true);
-      setIsError(false);
-      setError(null);
-      try {
-        const data = await LocalStorageDoctorRepository.listDoctors();
-        if (mounted) {
-          setDoctors(data);
-          setIsLoading(false);
-        }
-      } catch (err) {
-        if (mounted) {
-          setIsError(true);
-          setError(err instanceof Error ? err : new Error(String(err)));
-          setIsLoading(false);
-        }
-      }
-    };
-
-    initFetch();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
+  const {
+    data: doctors,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useAsyncQuery<Doctor[]>({
+    queryFn,
+    initialData: [],
+    enabled: true,
+  });
 
   return {
     doctors,
     isLoading,
     isError,
     error,
-    refetch: fetchDoctors,
+    refetch,
   };
 }

--- a/src/data/hooks/usePatientAppointments.ts
+++ b/src/data/hooks/usePatientAppointments.ts
@@ -1,67 +1,30 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import type { Appointment } from '../../types';
 import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
+import { useAsyncQuery } from './useAsyncQuery';
 
 export function usePatientAppointments(patientId: string) {
-  const [appointments, setAppointments] = useState<Appointment[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(!!patientId);
-  const [isError, setIsError] = useState<boolean>(false);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchAppointments = useCallback(async () => {
-    if (!patientId) return;
-    setIsLoading(true);
-    setIsError(false);
-    setError(null);
-    try {
-      const data = await LocalStorageAppointmentRepository.listAppointmentsByPatient(patientId);
-      setAppointments(data);
-    } catch (err) {
-      setIsError(true);
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      setIsLoading(false);
-    }
+  const queryFn = useCallback(() => {
+    return LocalStorageAppointmentRepository.listAppointmentsByPatient(patientId);
   }, [patientId]);
 
-  useEffect(() => {
-    let mounted = true;
-
-    if (!patientId) {
-      return;
-    }
-
-    const initFetch = async () => {
-      setIsLoading(true);
-      setIsError(false);
-      setError(null);
-      try {
-        const data = await LocalStorageAppointmentRepository.listAppointmentsByPatient(patientId);
-        if (mounted) {
-          setAppointments(data);
-          setIsLoading(false);
-        }
-      } catch (err) {
-        if (mounted) {
-          setIsError(true);
-          setError(err instanceof Error ? err : new Error(String(err)));
-          setIsLoading(false);
-        }
-      }
-    };
-
-    initFetch();
-
-    return () => {
-      mounted = false;
-    };
-  }, [patientId]);
+  const {
+    data: appointments,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useAsyncQuery<Appointment[]>({
+    queryFn,
+    initialData: [],
+    enabled: Boolean(patientId),
+  });
 
   return {
     appointments,
     isLoading,
     isError,
     error,
-    refetch: fetchAppointments,
+    refetch,
   };
 }


### PR DESCRIPTION
## ARCH-012: Async Hook Utilities Implementation

### Summary
Implemented the shared async hook utilities (\useAsyncQuery\ and \useAsyncMutation\) as designed in \ARCH-011\ and successfully refactored the read-only DAL hooks to use them.

### Details
- Created \useAsyncQuery<T>\ handling data fetching, loading/error states, and unmounted safety using pure React hooks.
- Created \useAsyncMutation<TInput, TResult>\ handling mutation state, error catching, and callbacks.
- Refactored \useClinicDoctors\ and \usePatientAppointments\ to completely eliminate their internal boilerplate by adopting \useAsyncQuery\.
- Maintained perfect backward compatibility: the public APIs of both hooks remained identical.
- Verified that \useChiefComplaint\ and all UI components were untouched, preserving current application behavior perfectly.

### Changed files
- \src/data/hooks/useAsyncQuery.ts\ (NEW)
- \src/data/hooks/useAsyncMutation.ts\ (NEW)
- \src/data/hooks/useClinicDoctors.ts\ (MODIFIED)
- \src/data/hooks/usePatientAppointments.ts\ (MODIFIED)
- \_ai_work/REPORTS/ARCH-012_async_hook_utilities_readonly_refactor_report.md\ (NEW)

### Checks
- [x] No \ny\ casting used.
- [x] \storage.ts\ logic and UI components were strictly preserved.
- [x] \
pm run lint\ (frontend) — passed (0 errors, 0 warnings).
- [x] \
pm run build\ (frontend) — success.
- [x] No MCP tools or browser automation used.