### PR TITLE
ARCH-064: Migrate patient list visit summary to AppointmentRepository

### DIFF
--- a/_ai_work/REPORTS/ARCH-064_patient_list_summary_appointment_repository_report.md
+++ b/_ai_work/REPORTS/ARCH-064_patient_list_summary_appointment_repository_report.md
@@ -1,0 +1,41 @@
+# ARCH-064: Patient List Visit Summary Aggregator Migration Report
+
+## Files Inspected
+- `src/data/aggregators/PatientListVisitSummaryAggregator.ts`
+- `src/data/repositories/AppointmentRepository.ts`
+- `src/data/hooks/usePatientListVisitSummary.ts`
+
+## Files Changed
+- `src/data/aggregators/PatientListVisitSummaryAggregator.ts`
+- `_ai_work/REPORTS/ARCH-064_patient_list_summary_appointment_repository_report.md` (this file)
+
+## Before: Direct Storage Dependency
+The aggregator directly imported `storage` from `../../utils/storage` and populated its appointment array via a synchronous call to `storage.getAppointments()`.
+
+## After: Repository Dependency
+The aggregator now imports `LocalStorageAppointmentRepository` from `../repositories/AppointmentRepository` and awaits `LocalStorageAppointmentRepository.listAppointments()` to populate its appointments array.
+
+## Confirmation: Storage Import Removed
+Confirmed. `import { storage } from '../../utils/storage';` was completely removed from `PatientListVisitSummaryAggregator.ts`.
+
+## Confirmation: storage.getAppointments() Removed
+Confirmed. The direct call to `storage.getAppointments()` was successfully removed and replaced by an asynchronous call to the repository layer.
+
+## Confirmation: Hook Signature Preserved
+Confirmed. `PatientListVisitSummaryAggregator.getVisitSummaryByPatientId` still retains the exact same signature:
+`async getVisitSummaryByPatientId(now = new Date()): Promise<PatientVisitSummaryByPatientId>`.
+Consequently, the consuming hook `usePatientListVisitSummary` required zero changes.
+
+## Confirmation: UI Components/Pages Not Changed
+Confirmed. `PatientsPage.tsx` and all other UI components remain strictly untouched.
+
+## Confirmation: ClinicalSummaryAggregator Not Changed
+Confirmed. `ClinicalSummaryAggregator.ts` remains unchanged. Its complex 5-domain dependencies are preserved for a future task.
+
+## Known Limitations
+- `ClinicalSummaryAggregator` still maintains direct connections to `storage.ts`.
+- Filtering logic (`appt.status === 'blocked'`, `cancelled`) is currently executed post-fetch inside the aggregator rather than being queried at the repository layer. Since data sets are small (LocalStorage), this is an acceptable tradeoff for preserving exactly identical behavior.
+
+## Recommended Next Task
+**ARCH-065 — Migrate ClinicalSummaryAggregator to use Repositories**
+Migrate the final read-model dependency `ClinicalSummaryAggregator` to use `DentalChartRepository`, `TreatmentPlansRepository`, `FindingsRepository`, `ChiefComplaintRepository`, and `AppointmentRepository` in parallel, safely completing the full application-wide storage decoupling.

--- a/src/data/aggregators/PatientListVisitSummaryAggregator.ts
+++ b/src/data/aggregators/PatientListVisitSummaryAggregator.ts
@@ -1,4 +1,4 @@
-import { storage } from '../../utils/storage';
+import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
 
 export interface PatientVisitSummary {
   lastVisit?: Date;
@@ -10,7 +10,7 @@ export type PatientVisitSummaryByPatientId = Record<string, PatientVisitSummary>
 export const PatientListVisitSummaryAggregator = {
   async getVisitSummaryByPatientId(now = new Date()): Promise<PatientVisitSummaryByPatientId> {
     const visits: PatientVisitSummaryByPatientId = {};
-    const appointments = storage.getAppointments();
+    const appointments = await LocalStorageAppointmentRepository.listAppointments();
 
     const sortedAppts = [...appointments].sort(
       (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()


### PR DESCRIPTION
Implements ARCH-064.

### Summary
Migrates the PatientListVisitSummaryAggregator to depend strictly on LocalStorageAppointmentRepository rather than querying storage.ts directly. This fully decouples the aggregator layer from the underlying persistence storage logic without impacting the consuming UI or hook signatures.

### Changed files
- src/data/aggregators/PatientListVisitSummaryAggregator.ts
- _ai_work/REPORTS/ARCH-064_patient_list_summary_appointment_repository_report.md

### Checks results
- 
pm run test: Passed
- 
pm run lint: Passed
- 
pm run build: Passed

### Confirmation
- No UI components or pages were touched.
- No hooks or repository signatures were altered.
- ClinicalSummaryAggregator was completely untouched.
- storage.ts was not modified.