### PR TITLE
ARCH-065: Migrate clinical summary aggregator to repositories

### DIFF
--- a/_ai_work/REPORTS/ARCH-065_clinical_summary_repositories_report.md
+++ b/_ai_work/REPORTS/ARCH-065_clinical_summary_repositories_report.md
@@ -1,0 +1,35 @@
+# ARCH-065: Clinical Summary Aggregator Migration Report
+
+## Files Inspected
+- `src/data/aggregators/ClinicalSummaryAggregator.ts`
+- `src/data/repositories/DentalChartRepository.ts`
+- `src/data/repositories/TreatmentPlansRepository.ts`
+- `src/data/repositories/ChiefComplaintRepository.ts`
+- `src/data/repositories/FindingsRepository.ts`
+- `src/data/repositories/AppointmentRepository.ts`
+
+## Files Changed
+- `src/data/aggregators/ClinicalSummaryAggregator.ts`
+- `_ai_work/REPORTS/ARCH-065_clinical_summary_repositories_report.md` (this file)
+
+## Before: Direct Storage Dependencies
+The aggregator directly imported `storage` from `../../utils/storage` and executed 5 synchronous calls to `storage.get...` for dental chart, treatment plans, chief complaint, findings, and appointments.
+
+## After: Repository Dependencies
+The aggregator now imports the five local storage repositories (`LocalStorageDentalChartRepository`, `LocalStorageTreatmentPlansRepository`, `LocalStorageChiefComplaintRepository`, `LocalStorageFindingsRepository`, `LocalStorageAppointmentRepository`) and fetches all data concurrently using a single `Promise.all` block. 
+
+## Confirmations
+- **Storage import removed:** Confirmed. The `import { storage } from '../../utils/storage';` line is gone.
+- **No storage.* calls remain:** Confirmed. All direct storage calls have been replaced with repository awaits.
+- **Function signature unchanged:** Confirmed. `getPatientMedicalSummary` continues to take a `patientId: string` and return `Promise<PatientMedicalSummaryData>`.
+- **Hook/UI untouched:** Confirmed. No changes were made to `usePatientMedicalSummary` or `PatientCardPage.tsx`.
+- **Repositories untouched:** Confirmed. Existing repository interfaces and implementations were used as-is.
+- **PatientListVisitSummaryAggregator untouched:** Confirmed.
+
+## Known Limitations
+- The aggregator still performs in-memory filtering and sorting for appointments after fetching `listAppointments()`. While acceptable for local storage, in a real database environment, we would want the repository to expose a `listAppointmentsByPatientId` method that handles filtering natively.
+- As the application grows, fetching 5 full data domains just to calculate summary statistics might become a performance bottleneck. In the future, a dedicated backend endpoint for the summary data would be preferred over client-side aggregation.
+
+## Recommended Next Task
+**ARCH-066 — Full Storage Dependency Audit**
+Now that the read-model aggregators have been successfully decoupled from `storage.ts`, conduct a final codebase-wide scan to ensure 100% of all components, hooks, and aggregators are completely free of direct `storage.ts` imports, confirming the success of the architecture decoupling phase.

--- a/src/data/aggregators/ClinicalSummaryAggregator.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.ts
@@ -1,4 +1,8 @@
-import { storage } from '../../utils/storage';
+import { LocalStorageDentalChartRepository } from '../repositories/DentalChartRepository';
+import { LocalStorageTreatmentPlansRepository } from '../repositories/TreatmentPlansRepository';
+import { LocalStorageChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
+import { LocalStorageFindingsRepository } from '../repositories/FindingsRepository';
+import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
 
 export interface PatientDentalSummary {
   needsTreatment: number;
@@ -37,12 +41,14 @@ export async function getPatientMedicalSummary(patientId: string): Promise<Patie
     return EMPTY_PATIENT_MEDICAL_SUMMARY;
   }
 
-  const chart = storage.getDentalChart(patientId);
-  const plans = storage.getTreatmentPlans(patientId);
-  const complaint = storage.getChiefComplaint(patientId);
-  const findings = storage.getFindings(patientId);
-  
-  const allAppointments = storage.getAppointments();
+  const [chart, plans, complaint, findings, allAppointments] = await Promise.all([
+    LocalStorageDentalChartRepository.getDentalChart(patientId),
+    LocalStorageTreatmentPlansRepository.listTreatmentPlansByPatient(patientId),
+    LocalStorageChiefComplaintRepository.getChiefComplaint(patientId),
+    LocalStorageFindingsRepository.listFindingsByPatient(patientId),
+    LocalStorageAppointmentRepository.listAppointments(),
+  ]);
+
   const patientAppointments = allAppointments
     .filter(a => a.patientId === patientId)
     .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());


### PR DESCRIPTION
Implements ARCH-065.

### Summary
Migrates the complex 5-domain ClinicalSummaryAggregator to depend strictly on repository abstractions instead of directly querying storage.ts. Replaces synchronous storage calls with an optimized Promise.all fetching strategy across LocalStorageDentalChartRepository, LocalStorageTreatmentPlansRepository, LocalStorageChiefComplaintRepository, LocalStorageFindingsRepository, and LocalStorageAppointmentRepository.

### Changed files
- src/data/aggregators/ClinicalSummaryAggregator.ts
- _ai_work/REPORTS/ARCH-065_clinical_summary_repositories_report.md

### Checks results
- 
pm run test: Passed
- 
pm run lint: Passed
- 
pm run build: Passed

### Confirmation
- No UI components or pages were touched.
- No hooks or repository interfaces/implementations were altered.
- PatientListVisitSummaryAggregator was completely untouched.
- Direct storage import was removed from ClinicalSummaryAggregator.
- Browser smoke test skipped (no UI changes).