### PR TITLE
ARCH-073: Add Supabase auth and tenant context skeleton

### DIFF
--- a/_ai_work/REPORTS/ARCH-073_supabase_auth_tenant_skeleton_report.md
+++ b/_ai_work/REPORTS/ARCH-073_supabase_auth_tenant_skeleton_report.md
@@ -30,5 +30,5 @@ Added the fundamental skeletons for the Supabase JS client, `AuthContext`, and `
 - The providers are not yet wired into the React tree. When they are, careful attention will be needed to ensure they don't break existing mock context providers if any.
 
 ## Recommended Next Task
-**ARCH-074 — Implement Real Auth Flow and Provider Wiring**
-(Connect `AuthProvider` to Supabase, implement login, and wrap the app root).
+**RECON-074 — Auth/Tenant wiring readiness and next-step selection**
+(Real AuthProvider wiring is NOT automatically approved yet. The next step must be a reconnaissance to inspect root wiring, routing, fallback behaviors, UI readiness, and risks to the current flow before any implementation begins.)

--- a/_ai_work/REPORTS/ARCH-073_supabase_auth_tenant_skeleton_report.md
+++ b/_ai_work/REPORTS/ARCH-073_supabase_auth_tenant_skeleton_report.md
@@ -1,0 +1,34 @@
+# ARCH-073 Supabase Auth & Tenant Context Skeleton Report
+
+## Summary
+Added the fundamental skeletons for the Supabase JS client, `AuthContext`, and `TenantContext`. The goal was to establish the structural boundaries for authentication and multi-tenancy before any repositories are migrated, while strictly preserving the existing `localStorage` logic.
+
+## Changed Files
+- `package.json` / `package-lock.json` (Installed `@supabase/supabase-js`)
+- `src/lib/supabaseClient.ts` (Created)
+- `src/contexts/AuthContext.tsx` (Created)
+- `src/contexts/TenantContext.tsx` (Created)
+- `_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md` (Created)
+- `_ai_work/REPORTS/ARCH-073_supabase_auth_tenant_skeleton_report.md` (Created)
+
+## Dependency Changes
+- Installed `@supabase/supabase-js` as the only dependency.
+
+## Confirmations
+- ✅ **No repositories migrated**: `src/data/repositories/*` were untouched.
+- ✅ **No storage changes**: `src/utils/storage.ts` remains intact.
+- ✅ **No migration/seed changes**: The SQL schema and seed data remain intact.
+- ✅ **No secrets or cloud used**: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are read dynamically. `service_role` keys are explicitly banned.
+- ✅ **No live wiring**: Providers were created as contracts, but were not wrapped around `src/main.tsx` yet.
+
+## Validation Results
+- `npm run build`: Success
+- `npm run lint`: Success
+- `npm run test`: Success (33 tests passed in 6 files)
+
+## Remaining Risks
+- The providers are not yet wired into the React tree. When they are, careful attention will be needed to ensure they don't break existing mock context providers if any.
+
+## Recommended Next Task
+**ARCH-074 — Implement Real Auth Flow and Provider Wiring**
+(Connect `AuthProvider` to Supabase, implement login, and wrap the app root).

--- a/_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md
+++ b/_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md
@@ -29,6 +29,17 @@ If we were to migrate a repository now:
 3. The real Supabase RLS policies require a valid JWT with `auth.uid()`, meaning the real authentication flow must be functional before repositories can successfully insert/select data.
 
 ## 5. What Remains Before First Repository Migration
+**COORDINATOR NOTE:** Before implementing real auth/provider wiring, run **RECON-074** to inspect:
+- current app root and routing
+- whether providers can be wired without changing visible behavior
+- provider ordering: AuthProvider before TenantProvider
+- how tenant selection should work
+- fallback behavior when Supabase env is missing
+- whether login UI exists or must be designed separately
+- risks to current localStorage flow
+- whether the next step should be auth wiring, tenant wiring, repository adapter boundary, pilot repository, or product-visible work
+
+Subsequent implementation steps will likely involve:
 - Wire `AuthProvider` into the application root (likely inside `src/main.tsx` or `App.tsx`).
 - Connect `AuthProvider` to the real Supabase Auth endpoints.
 - Wire `TenantProvider` to fetch the user's allowed tenants from `tenant_users` and set an active tenant.

--- a/_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md
+++ b/_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md
@@ -1,0 +1,36 @@
+# Supabase Auth and Tenant Context
+
+This document outlines the skeleton design for introducing the Supabase client and the required frontend contexts for multi-tenancy.
+
+## 1. Supabase Client Isolation (`src/lib/supabaseClient.ts`)
+The Supabase JS client must be initialized in a single dedicated module.
+- It safely reads `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
+- If these are missing, it initializes as `null` to avoid crashing the current non-Supabase `localStorage` repository logic.
+- **SECURITY WARNING**: `service_role` keys are strictly forbidden in the frontend (`.env` or anywhere else). Only the `anon` key is permitted.
+
+## 2. AuthContext (`src/contexts/AuthContext.tsx`)
+Currently a skeleton, this context will later:
+- Hook into `supabase.auth.onAuthStateChange`.
+- Expose the current authenticated user (`AppUser` shape).
+- Provide `login`/`logout` functions.
+- Serve as the gatekeeper for user sessions before any tenant logic runs.
+
+## 3. TenantContext (`src/contexts/TenantContext.tsx`)
+Because the database strictly enforces `tenant_id` for almost all rows via RLS, the frontend must safely store and provide the active tenant context.
+- Once authenticated, the user will select or default to an `ActiveTenant`.
+- **Future Supabase Repositories MUST obtain `tenant_id` from this context** (or via an adapter layer that injects it automatically into repository queries).
+- This ensures developers cannot accidentally hardcode production tenant IDs.
+
+## 4. Why Repository Migration is Still Forbidden
+At this stage, the `AuthContext` and `TenantContext` are strictly un-wired skeletons.
+If we were to migrate a repository now:
+1. We would have to hardcode a `tenant_id` which breaks multi-tenancy rules.
+2. Or we would wire it to the `TenantContext`, which currently has a `null` active tenant.
+3. The real Supabase RLS policies require a valid JWT with `auth.uid()`, meaning the real authentication flow must be functional before repositories can successfully insert/select data.
+
+## 5. What Remains Before First Repository Migration
+- Wire `AuthProvider` into the application root (likely inside `src/main.tsx` or `App.tsx`).
+- Connect `AuthProvider` to the real Supabase Auth endpoints.
+- Wire `TenantProvider` to fetch the user's allowed tenants from `tenant_users` and set an active tenant.
+- Replace the mock login UI with actual authentication.
+- Create an adapter or base class for Repositories so they don't manually pull `tenant_id` from React Context directly, but rather through a safe injection boundary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.108.0",
         "clsx": "^2.1.1",
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",
@@ -1145,6 +1146,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.0.tgz",
+      "integrity": "sha512-0CzVGVqHfNOhRQVEcAmu58Mex2Ce0zL3aGfyV+iFQjTK6OntLK/hLCLr/VDRX0E8/2CdsiY99L7fZ/8ys/op4w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@supabase/cli-darwin-arm64": {
       "version": "2.105.0",
       "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.105.0.tgz",
@@ -1268,6 +1281,78 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.0.tgz",
+      "integrity": "sha512-lqEGDzT7QBUuKYzi5lHpV/XecXT9wikzcbXMbFo6krNpSDynD1sHM8wcsfB/BAqa4NkFuy3vF4JCV8MeakV8IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.0.tgz",
+      "integrity": "sha512-8AwTkPqowDYv/qh016CyXeZ3Ukpw6NHyfqc7DWV4afLR2hAiapf3zRKV2ZLG+//T1LK84HrR6X8VBwfgHWmNyw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.0.tgz",
+      "integrity": "sha512-N3xR0u7TNr+c5wuLSU60rcfu/H/8N0WBs7iHWwjI/NxKwY3XWSyLUbpbpU8bzmL0dA/Gk9Mupri8mxKUXBW+iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.0.tgz",
+      "integrity": "sha512-zMYQmh87CId7d8i/1FIfv4fMDcXPutmIJSpoY58GLXi7M266MNzxWGNabDk4i555Oj1Nqtsu2i3Qo3rpWUXO6A==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.0.tgz",
+      "integrity": "sha512-AjPoimM9MZLZbddnlDBGmpZ/Tas1dNcJvuZy/VD1AfmrjBC8J2RSw6UOqR4ISLLlEioOLca/5t1crFnAxa0wRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.0",
+        "@supabase/functions-js": "2.108.0",
+        "@supabase/postgrest-js": "2.108.0",
+        "@supabase/realtime-js": "2.108.0",
+        "@supabase/storage-js": "2.108.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -2723,6 +2808,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4344,9 +4438,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.108.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState } from 'react';
+
+// TODO: Replace with real Supabase User type once implemented
+export interface AppUser {
+  id: string;
+  email?: string;
+  // Add other profile fields when ready
+}
+
+interface AuthContextType {
+  user: AppUser | null;
+  isLoading: boolean;
+  error: Error | null;
+  // TODO: Add login/logout methods when implementing real auth
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  // Skeleton state. Currently does not connect to real Supabase.
+  const [user] = useState<AppUser | null>(null);
+  const [isLoading] = useState(false);
+  const [error] = useState<Error | null>(null);
+
+  // TODO: Implement Supabase onAuthStateChange listener here
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, error }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/contexts/TenantContext.tsx
+++ b/src/contexts/TenantContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface ActiveTenant {
+  tenantId: string;
+  tenantName: string;
+  role?: string;
+}
+
+interface TenantContextType {
+  activeTenant: ActiveTenant | null;
+  availableTenants: ActiveTenant[];
+  setActiveTenant: (tenantId: string) => void;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const TenantContext = createContext<TenantContextType | undefined>(undefined);
+
+export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  // Skeleton state. Does not connect to real Supabase yet.
+  const [activeTenant] = useState<ActiveTenant | null>(null);
+  const [availableTenants] = useState<ActiveTenant[]>([]);
+  const [isLoading] = useState(false);
+  const [error] = useState<Error | null>(null);
+
+  const setActiveTenant = (tenantId: string) => {
+    // TODO: implement real tenant switching
+    console.warn('Tenant switching not yet implemented. Requested ID:', tenantId);
+  };
+
+  // FUTURE SUPABASE REPOSITORIES MUST OBTAIN tenant_id FROM THIS CONTEXT OR AN ADAPTER
+  // Do NOT hardcode production tenant IDs.
+
+  return (
+    <TenantContext.Provider value={{ activeTenant, availableTenants, setActiveTenant, isLoading, error }}>
+      {children}
+    </TenantContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useTenant = () => {
+  const context = useContext(TenantContext);
+  if (context === undefined) {
+    throw new Error('useTenant must be used within a TenantProvider');
+  }
+  return context;
+};

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,14 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+
+// Create the Supabase client if env vars are present.
+// If missing, this will be null so the app doesn't crash during the transition.
+export const supabase: SupabaseClient | null = isSupabaseConfigured
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : null;
+
+// DO NOT USE SERVICE ROLE KEYS IN THE FRONTEND


### PR DESCRIPTION
## Summary
Added the fundamental skeletons for the Supabase JS client, `AuthContext`, and `TenantContext`. The goal was to establish the structural boundaries for authentication and multi-tenancy before any repositories are migrated, while strictly preserving the existing `localStorage` logic.

## Changed Files
- `package.json` / `package-lock.json` (Installed `@supabase/supabase-js`)
- `src/lib/supabaseClient.ts` (Created)
- `src/contexts/AuthContext.tsx` (Created)
- `src/contexts/TenantContext.tsx` (Created)
- `_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md` (Created)
- `_ai_work/REPORTS/ARCH-073_supabase_auth_tenant_skeleton_report.md` (Created)

## Confirmations
- ✅ **No repositories migrated**: `src/data/repositories/*` were untouched.
- ✅ **No storage changes**: `src/utils/storage.ts` remains intact.
- ✅ **No migration/seed changes**: The SQL schema and seed data remain intact.
- ✅ **No secrets or cloud used**: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are read dynamically. `service_role` keys are explicitly banned.
- ✅ **No live wiring**: Providers were created as contracts, but were not wrapped around `src/main.tsx` yet.

## Validation Results
- `npm run build`: Success
- `npm run lint`: Success
- `npm run test`: Success (33 tests passed in 6 files)

## Recommended Next Task
**RECON-074 — Auth/Tenant wiring readiness and next-step selection**