### PR TITLE
AUTH-001: Wire Auth/Tenant providers with dev fallback

### DIFF
--- a/_ai_work/REPORTS/AUTH-001_auth_tenant_provider_wiring_report.md
+++ b/_ai_work/REPORTS/AUTH-001_auth_tenant_provider_wiring_report.md
@@ -1,0 +1,43 @@
+# AUTH-001: Auth/Tenant Provider Wiring Report
+
+## Summary
+The `AuthProvider` and `TenantProvider` have been successfully wired into the application root (`src/main.tsx`). A "dev-mode" fallback was implemented to guarantee that the application continues to run flawlessly on local `localStorage` singletons when Supabase is not configured, entirely preserving the current mock data flow.
+
+## Changed Files
+- `src/main.tsx`
+- `src/contexts/AuthContext.tsx`
+- `src/contexts/TenantContext.tsx`
+- `_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md`
+- `_ai_work/REPORTS/AUTH-001_auth_tenant_provider_wiring_report.md` (Created)
+
+## Provider Wiring Details
+- **Location**: `src/main.tsx`
+- **Order**: `<AuthProvider>` wraps `<TenantProvider>`, which wraps `<BrowserRouter>`.
+
+## Fallback Behavior
+- **AuthContext**: Reads `isSupabaseConfigured` from the client. If missing, `authMode` becomes `'dev'`. A deterministic mock user (`id: 'dev-user-000000000000'`) is yielded. `isLoading` is set to `false`.
+- **TenantContext**: Depends on `authMode`. If `'dev'`, it immediately yields a mock tenant (`11111111-1111-1111-1111-111111111111`, "Demo Clinic"). `isLoading` is set to `false`.
+
+## Confirmations
+- ✅ `storage.ts` remains completely untouched. Its synchronous initialization logic works precisely as before.
+- ✅ Repositories are unchanged and remain singletons.
+- ✅ UI components, pages, and specific routes remain untouched.
+- ✅ No login screen or authentication blocker was added.
+- ✅ Supabase cloud was not touched.
+
+## Validation Results
+- `npm ci`: Passed
+- `npm run lint`: Passed
+- `npm run test`: Passed (33 tests in 6 files)
+- `npm run build`: Passed
+- The application compiles and renders exactly as it did before, but now with context providers successfully mounted at the root.
+
+## CI Status Expectation
+The `.github/workflows/ci.yml` is expected to pass all checks.
+
+## Remaining Risks
+- Repositories are still statically exported singletons. They cannot access the newly available `useTenant()` context without refactoring.
+
+## Recommended Next Task
+**ARCH-075 — Implement Repository Adapter Boundary**
+*(Refactor the static `LocalStorage` repositories into a Dependency Injection / Factory pattern so they can safely receive `tenant_id` from the React tree, preparing them for the actual Supabase client migration without breaking the current flow).*

--- a/_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md
+++ b/_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md
@@ -9,39 +9,43 @@ The Supabase JS client must be initialized in a single dedicated module.
 - **SECURITY WARNING**: `service_role` keys are strictly forbidden in the frontend (`.env` or anywhere else). Only the `anon` key is permitted.
 
 ## 2. AuthContext (`src/contexts/AuthContext.tsx`)
-Currently a skeleton, this context will later:
-- Hook into `supabase.auth.onAuthStateChange`.
-- Expose the current authenticated user (`AppUser` shape).
-- Provide `login`/`logout` functions.
-- Serve as the gatekeeper for user sessions before any tenant logic runs.
+This context exposes an `authMode` flag (`dev` or `supabase-unwired`).
+- **Dev Fallback Mode**: When Supabase env vars are missing, it defaults to a deterministic mock user. This prevents the application from breaking for developers who haven't set up Supabase yet.
+- **Supabase-Unwired Mode**: When env vars are present, it stays in a safe loading/placeholder state since real auth is not yet implemented.
+- Future work: Hook into `supabase.auth.onAuthStateChange` and provide real login/logout.
 
 ## 3. TenantContext (`src/contexts/TenantContext.tsx`)
 Because the database strictly enforces `tenant_id` for almost all rows via RLS, the frontend must safely store and provide the active tenant context.
-- Once authenticated, the user will select or default to an `ActiveTenant`.
-- **Future Supabase Repositories MUST obtain `tenant_id` from this context** (or via an adapter layer that injects it automatically into repository queries).
+- **Dev Fallback Mode**: If `authMode` is `dev`, it automatically yields a mock tenant (e.g., `11111111-1111-1111-1111-111111111111`). This is for development fallback only.
+- **Production Tenant Selection**: Once real auth is implemented, production tenant selection must come from authenticated user tenant membership.
+- **Future Supabase Repositories MUST obtain `tenant_id` from this context** (or via an adapter layer).
 - This ensures developers cannot accidentally hardcode production tenant IDs.
 
-## 4. Why Repository Migration is Still Forbidden
-At this stage, the `AuthContext` and `TenantContext` are strictly un-wired skeletons.
+## 4. Provider Order and App Root (`src/main.tsx`)
+The providers are wired around the main `<BrowserRouter>` in the following strict order:
+```tsx
+<StrictMode>
+  <AuthProvider>
+    <TenantProvider>
+      <BrowserRouter>
+        ...
+      </BrowserRouter>
+    </TenantProvider>
+  </AuthProvider>
+</StrictMode>
+```
+This ensures `TenantProvider` can depend on the `useAuth` hook safely.
+
+## 5. Why Repository Migration is Still Forbidden
+At this stage, the `AuthContext` and `TenantContext` are safely wired with dev fallbacks, but repositories are still synchronous `localStorage` singletons.
 If we were to migrate a repository now:
 1. We would have to hardcode a `tenant_id` which breaks multi-tenancy rules.
-2. Or we would wire it to the `TenantContext`, which currently has a `null` active tenant.
-3. The real Supabase RLS policies require a valid JWT with `auth.uid()`, meaning the real authentication flow must be functional before repositories can successfully insert/select data.
+2. The real Supabase RLS policies require a valid JWT with `auth.uid()`, meaning the real authentication flow must be functional before repositories can successfully insert/select data.
 
-## 5. What Remains Before First Repository Migration
-**COORDINATOR NOTE:** Before implementing real auth/provider wiring, run **RECON-074** to inspect:
-- current app root and routing
-- whether providers can be wired without changing visible behavior
-- provider ordering: AuthProvider before TenantProvider
-- how tenant selection should work
-- fallback behavior when Supabase env is missing
-- whether login UI exists or must be designed separately
-- risks to current localStorage flow
-- whether the next step should be auth wiring, tenant wiring, repository adapter boundary, pilot repository, or product-visible work
-
-Subsequent implementation steps will likely involve:
-- Wire `AuthProvider` into the application root (likely inside `src/main.tsx` or `App.tsx`).
+## 6. What Remains Before Real Auth
+- Replace the mock login UI with actual authentication flow (LoginPage, routing).
 - Connect `AuthProvider` to the real Supabase Auth endpoints.
 - Wire `TenantProvider` to fetch the user's allowed tenants from `tenant_users` and set an active tenant.
-- Replace the mock login UI with actual authentication.
-- Create an adapter or base class for Repositories so they don't manually pull `tenant_id` from React Context directly, but rather through a safe injection boundary.
+
+## 7. What Remains Before First Repository Migration
+- Implement an adapter or dependency injection boundary for Repositories so they don't manually pull `tenant_id` from React Context directly, but rather through a safe injection boundary (e.g., a Factory pattern).

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext } from 'react';
+import { isSupabaseConfigured } from '../lib/supabaseClient';
 
 // TODO: Replace with real Supabase User type once implemented
 export interface AppUser {
@@ -11,21 +12,21 @@ interface AuthContextType {
   user: AppUser | null;
   isLoading: boolean;
   error: Error | null;
+  authMode: 'dev' | 'supabase-unwired';
   // TODO: Add login/logout methods when implementing real auth
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  // Skeleton state. Currently does not connect to real Supabase.
-  const [user] = useState<AppUser | null>(null);
-  const [isLoading] = useState(false);
-  const [error] = useState<Error | null>(null);
+  const authMode: 'dev' | 'supabase-unwired' = isSupabaseConfigured ? 'supabase-unwired' : 'dev';
 
-  // TODO: Implement Supabase onAuthStateChange listener here
+  const user = authMode === 'dev' ? { id: 'dev-user-000000000000', email: 'dev@example.com' } : null;
+  const isLoading = authMode !== 'dev';
+  const error = null;
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, error }}>
+    <AuthContext.Provider value={{ user, isLoading, error, authMode }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/contexts/TenantContext.tsx
+++ b/src/contexts/TenantContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { useAuth } from './AuthContext';
 
 export interface ActiveTenant {
   tenantId: string;
@@ -17,22 +18,40 @@ interface TenantContextType {
 const TenantContext = createContext<TenantContextType | undefined>(undefined);
 
 export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  // Skeleton state. Does not connect to real Supabase yet.
-  const [activeTenant] = useState<ActiveTenant | null>(null);
-  const [availableTenants] = useState<ActiveTenant[]>([]);
-  const [isLoading] = useState(false);
-  const [error] = useState<Error | null>(null);
+  const { authMode } = useAuth();
+
+  const devTenant: ActiveTenant = {
+    tenantId: "11111111-1111-1111-1111-111111111111",
+    tenantName: "Demo Clinic",
+    role: "admin",
+  };
+
+  const availableTenants = authMode === 'dev' ? [devTenant] : [];
+  
+  const [activeTenantState, setActiveTenantState] = useState<ActiveTenant | null>(
+    authMode === 'dev' ? devTenant : null
+  );
+
+  const isLoading = authMode !== 'dev';
+  const error = null;
 
   const setActiveTenant = (tenantId: string) => {
     // TODO: implement real tenant switching
     console.warn('Tenant switching not yet implemented. Requested ID:', tenantId);
+    
+    if (authMode === 'dev') {
+       const tenant = availableTenants.find(t => t.tenantId === tenantId);
+       if (tenant) {
+         setActiveTenantState(tenant);
+       }
+    }
   };
 
   // FUTURE SUPABASE REPOSITORIES MUST OBTAIN tenant_id FROM THIS CONTEXT OR AN ADAPTER
   // Do NOT hardcode production tenant IDs.
 
   return (
-    <TenantContext.Provider value={{ activeTenant, availableTenants, setActiveTenant, isLoading, error }}>
+    <TenantContext.Provider value={{ activeTenant: activeTenantState, availableTenants, setActiveTenant, isLoading, error }}>
       {children}
     </TenantContext.Provider>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,32 +22,39 @@ import { SettingsPage } from './pages/SettingsPage';
 import { PatientCardPage } from './pages/PatientCardPage';
 import { storage } from './utils/storage';
 
+import { AuthProvider } from './contexts/AuthContext';
+import { TenantProvider } from './contexts/TenantContext';
+
 // Initialize localStorage seed data if not present
 storage.init();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<SchedulePage />} />
-          <Route path="crm" element={<CrmPage />} />
-          <Route path="appointments" element={<AppointmentsPage />} />
-          <Route path="documents" element={<DocumentsPage />} />
-          <Route path="patients" element={<PatientsPage />} />
-          <Route path="patients/:patientId" element={<PatientCardPage />} />
-          <Route path="doctors" element={<DoctorsPage />} />
-          <Route path="medical" element={<MedicalPage />} />
-          <Route path="finance" element={<FinancePage />} />
-          <Route path="warehouse" element={<WarehousePage />} />
-          <Route path="statistics" element={<StatisticsPage />} />
-          <Route path="reports" element={<ReportsPage />} />
-          <Route path="bonus" element={<BonusPage />} />
-          <Route path="mailing" element={<MailingPage />} />
-          <Route path="sms" element={<SmsPage />} />
-          <Route path="settings" element={<SettingsPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <TenantProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Layout />}>
+              <Route index element={<SchedulePage />} />
+              <Route path="crm" element={<CrmPage />} />
+              <Route path="appointments" element={<AppointmentsPage />} />
+              <Route path="documents" element={<DocumentsPage />} />
+              <Route path="patients" element={<PatientsPage />} />
+              <Route path="patients/:patientId" element={<PatientCardPage />} />
+              <Route path="doctors" element={<DoctorsPage />} />
+              <Route path="medical" element={<MedicalPage />} />
+              <Route path="finance" element={<FinancePage />} />
+              <Route path="warehouse" element={<WarehousePage />} />
+              <Route path="statistics" element={<StatisticsPage />} />
+              <Route path="reports" element={<ReportsPage />} />
+              <Route path="bonus" element={<BonusPage />} />
+              <Route path="mailing" element={<MailingPage />} />
+              <Route path="sms" element={<SmsPage />} />
+              <Route path="settings" element={<SettingsPage />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </TenantProvider>
+    </AuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
The `AuthProvider` and `TenantProvider` have been successfully wired into the application root (`src/main.tsx`). A "dev-mode" fallback was implemented to guarantee that the application continues to run flawlessly on local `localStorage` singletons when Supabase is not configured, entirely preserving the current mock data flow.

## Changed Files
- `src/main.tsx`
- `src/contexts/AuthContext.tsx`
- `src/contexts/TenantContext.tsx`
- `_ai_work/SUPABASE_AUTH_TENANT_CONTEXT.md`
- `_ai_work/REPORTS/AUTH-001_auth_tenant_provider_wiring_report.md` (Created)

## Confirmations
- ✅ `storage.ts` remains completely untouched. Its synchronous initialization logic works precisely as before.
- ✅ Repositories are unchanged and remain singletons.
- ✅ UI components, pages, and specific routes remain untouched.
- ✅ No login screen or authentication blocker was added.
- ✅ Supabase cloud was not touched.

## Validation Results
- `npm ci`: Passed
- `npm run lint`: Passed
- `npm run test`: Passed (33 tests in 6 files)
- `npm run build`: Passed

## Recommended Next Task
**ARCH-075 — Implement Repository Adapter Boundary**
*(Refactor the static `LocalStorage` repositories into a Dependency Injection / Factory pattern so they can safely receive `tenant_id` from the React tree, preparing them for the actual Supabase client migration without breaking the current flow).*