### PR TITLE
ARCH-076: Implement ChiefComplaint repository factory boundary

### DIFF
--- a/_ai_work/REPORTS/ARCH-076_chief_complaint_repository_factory_report.md
+++ b/_ai_work/REPORTS/ARCH-076_chief_complaint_repository_factory_report.md
@@ -1,0 +1,46 @@
+# ARCH-076: ChiefComplaint Repository Factory Report
+
+## Summary
+The `ChiefComplaintRepository` has been successfully refactored to use the factory pattern adapter boundary designed in ARCH-075. The `useChiefComplaint` hook now seamlessly injects the active `tenantId` into the factory. As requested, the factory currently yields only the `localStorage` implementation to guarantee that the application remains fully functional without breaking any current data flows. 
+
+## Changed Files
+- `src/data/repositories/ChiefComplaintRepository.ts`
+- `src/data/hooks/useChiefComplaint.ts`
+- `_ai_work/REPORTS/ARCH-076_chief_complaint_repository_factory_report.md` (Created)
+
+## Exact Factory Design
+The `ChiefComplaintRepository` now exports:
+```typescript
+export function createChiefComplaintRepository(tenantId?: string): IChiefComplaintRepository {
+  // localStorage remains the only active backend for this repository.
+  return LocalStorageChiefComplaintRepository;
+}
+```
+The parameter `tenantId` is accepted as a future boundary parameter for Supabase RLS but is unused in this step.
+
+## Hook Changes
+`useChiefComplaint.ts` was updated to:
+- Import `useTenant` and `createChiefComplaintRepository`.
+- Extract `activeTenant` from the tenant context.
+- Instantiate the repository via `useMemo`.
+- Replace static calls to `LocalStorageChiefComplaintRepository` with instance method calls on the newly created `repo`.
+
+## Confirmations
+- ✅ ONLY `ChiefComplaintRepository` was touched. All other repositories remain static singletons.
+- ✅ No Supabase implementation was added.
+- ✅ `storage.ts` remains completely untouched.
+- ✅ No UI components, pages, or routes were modified.
+- ✅ The public API of the hook (`complaint`, `isLoading`, `saveComplaint`, etc.) remains exactly the same.
+
+## Validation Results
+- `npm ci`: Passed
+- `npm run lint`: Passed
+- `npm run test`: Passed
+- `npm run build`: Passed
+
+## Remaining Risks
+- The factory pattern is successfully proven on a low-risk repository, but the higher-risk repositories (`PatientRepository`, `AppointmentRepository`) are still tightly coupled to `localStorage`.
+
+## Recommended Next Task
+**ARCH-077: Supabase Migration for ChiefComplaintRepository**
+*(Now that the adapter boundary is active, the first actual Supabase implementation can be safely built inside `createChiefComplaintRepository`, allowing us to prove end-to-end data flow with real RLS).*

--- a/src/data/hooks/useChiefComplaint.ts
+++ b/src/data/hooks/useChiefComplaint.ts
@@ -1,13 +1,20 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { ChiefComplaint } from '../../types';
-import { LocalStorageChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
+import { createChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
 import { useAsyncQuery } from './useAsyncQuery';
+import { useTenant } from '../../contexts/TenantContext';
 
 export function useChiefComplaint(patientId: string) {
+  const { activeTenant } = useTenant();
+  
+  const repo = useMemo(() => {
+    return createChiefComplaintRepository(activeTenant?.tenantId);
+  }, [activeTenant?.tenantId]);
+
   // Query: load complaint via useAsyncQuery
   const queryFn = useCallback(
-    () => LocalStorageChiefComplaintRepository.getChiefComplaint(patientId),
-    [patientId]
+    () => repo.getChiefComplaint(patientId),
+    [repo, patientId]
   );
   
   const {
@@ -44,7 +51,7 @@ export function useChiefComplaint(patientId: string) {
     setIsSaveError(false);
     setSaveError(null);
     try {
-      await LocalStorageChiefComplaintRepository.saveChiefComplaint(patientId, input);
+      await repo.saveChiefComplaint(patientId, input);
       await refetchComplaint();
     } catch (err) {
       const parsedError = err instanceof Error ? err : new Error(String(err));
@@ -54,7 +61,7 @@ export function useChiefComplaint(patientId: string) {
     } finally {
       setIsSaving(false);
     }
-  }, [patientId, refetchComplaint]);
+  }, [patientId, refetchComplaint, repo]);
 
   // Merge error state for public API compatibility
   const isError = isQueryError || isSaveError;

--- a/src/data/repositories/ChiefComplaintRepository.ts
+++ b/src/data/repositories/ChiefComplaintRepository.ts
@@ -22,3 +22,18 @@ export const LocalStorageChiefComplaintRepository: IChiefComplaintRepository = {
     return Promise.resolve();
   }
 };
+
+/**
+ * Factory function to instantiate the ChiefComplaintRepository.
+ * 
+ * @param tenantId Accepted as a future boundary parameter for Supabase RLS.
+ *                 Currently unused because the Supabase implementation is intentionally 
+ *                 not included in this task.
+ * @returns IChiefComplaintRepository
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function createChiefComplaintRepository(_tenantId?: string): IChiefComplaintRepository {
+  // localStorage remains the only active backend for this repository.
+  return LocalStorageChiefComplaintRepository;
+}
+


### PR DESCRIPTION
## Summary
Implemented the adapter boundary designed in ARCH-075 for exactly ONE pilot repository: `ChiefComplaintRepository`.
The repository now exposes a factory function that accepts an optional `tenantId` parameter, which is injected cleanly via `useTenant()` in the `useChiefComplaint` hook.

## Confirmations
- ✅ The factory strictly yields the existing `LocalStorageChiefComplaintRepository`.
- ✅ No Supabase SDK/client is implemented.
- ✅ No other repositories were touched.
- ✅ `storage.ts` remains untouched.
- ✅ UI behavior remains exactly the same.
- ✅ The public API of the `useChiefComplaint` hook remains exactly the same.

## Validation Results
- `npm ci`: Passed
- `npm run lint`: Passed (Fixed unused `tenantId` by prefixing with underscore `_tenantId`).
- `npm run test`: Passed (33 tests)
- `npm run build`: Passed

## Recommended Next Task
**ARCH-077: Supabase Migration for ChiefComplaintRepository**
*(Now that the adapter boundary is active, the first actual Supabase implementation can be safely built inside `createChiefComplaintRepository`, allowing us to prove end-to-end data flow with real RLS).*