### PR TITLE
AUTH-REAL-001C: Extract App routing before auth

### DIFF
--- a/_ai_work/REPORTS/AUTH-REAL-001C_extract_app_routing_report.md
+++ b/_ai_work/REPORTS/AUTH-REAL-001C_extract_app_routing_report.md
@@ -1,0 +1,31 @@
+# AUTH-REAL-001C: Extract App Routing Report
+
+## Summary
+The application routing logic has been successfully extracted from `src/main.tsx` into a new `src/App.tsx` component. This was a purely structural refactor designed to unblock the safe injection of authentication route guards in the next task. 
+
+## Changed Files
+- `src/App.tsx` (Added)
+- `src/main.tsx` (Modified)
+- `_ai_work/REPORTS/AUTH-REAL-001C_extract_app_routing_report.md` (Added)
+
+## Confirmations
+- ✅ **Routing Moved**: All `BrowserRouter`, `Routes`, and `Route` elements were seamlessly moved from `main.tsx` to `App.tsx`.
+- ✅ **Provider Order Unchanged**: `main.tsx` perfectly preserves the required context tree hierarchy: `StrictMode` -> `AuthProvider` -> `TenantProvider` -> `App`.
+- ✅ **Routes Unchanged**: All 16 routes (`/`, `crm`, `patients`, etc.) remain identical to the previous implementation.
+- ✅ **No Auth Logic Added**: No new authentication behavior, guards, or login UI components were added.
+- ✅ **No UI Changes**: The application continues to render exactly as it did before.
+- ✅ **No Dependencies**: No new NPM dependencies were added.
+- ✅ **No Backend/Storage Changes**: `storage.ts`, Supabase logic, and repositories remain completely untouched.
+
+## Validation Results
+- `npm ci`: Passed
+- `npm run lint`: Passed
+- `npm run test`: Passed
+- `npm run build`: Passed
+
+## Remaining Risks
+- There are no structural risks remaining for routing. The application is now perfectly aligned to receive an authentication wrapper (e.g. `RequireAuth`) inside `App.tsx` where the `useAuth` hook can be safely called as a child of `AuthProvider`.
+
+## Recommended Next Task
+**AUTH-REAL-001A: Add Supabase session handling to AuthContext and minimal LoginPage**
+*(With the routing properly extracted, we can now safely add the `LoginPage`, listen to `supabase.auth.onAuthStateChange`, and conditionally render the main `Layout` vs `LoginPage` inside `App.tsx`).*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,45 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Layout } from './components/layout/Layout';
+import { SchedulePage } from './pages/SchedulePage';
+import { CrmPage } from './pages/CrmPage';
+import { AppointmentsPage } from './pages/AppointmentsPage';
+import { DocumentsPage } from './pages/DocumentsPage';
+import { PatientsPage } from './pages/PatientsPage';
+import { DoctorsPage } from './pages/DoctorsPage';
+import { MedicalPage } from './pages/MedicalPage';
+import { FinancePage } from './pages/FinancePage';
+import { WarehousePage } from './pages/WarehousePage';
+import { StatisticsPage } from './pages/StatisticsPage';
+import { ReportsPage } from './pages/ReportsPage';
+import { BonusPage } from './pages/BonusPage';
+import { MailingPage } from './pages/MailingPage';
+import { SmsPage } from './pages/SmsPage';
+import { SettingsPage } from './pages/SettingsPage';
+import { PatientCardPage } from './pages/PatientCardPage';
+
+export function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<SchedulePage />} />
+          <Route path="crm" element={<CrmPage />} />
+          <Route path="appointments" element={<AppointmentsPage />} />
+          <Route path="documents" element={<DocumentsPage />} />
+          <Route path="patients" element={<PatientsPage />} />
+          <Route path="patients/:patientId" element={<PatientCardPage />} />
+          <Route path="doctors" element={<DoctorsPage />} />
+          <Route path="medical" element={<MedicalPage />} />
+          <Route path="finance" element={<FinancePage />} />
+          <Route path="warehouse" element={<WarehousePage />} />
+          <Route path="statistics" element={<StatisticsPage />} />
+          <Route path="reports" element={<ReportsPage />} />
+          <Route path="bonus" element={<BonusPage />} />
+          <Route path="mailing" element={<MailingPage />} />
+          <Route path="sms" element={<SmsPage />} />
+          <Route path="settings" element={<SettingsPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,29 +1,12 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 
-import { Layout } from './components/layout/Layout';
-import { SchedulePage } from './pages/SchedulePage';
-import { CrmPage } from './pages/CrmPage';
-import { AppointmentsPage } from './pages/AppointmentsPage';
-import { DocumentsPage } from './pages/DocumentsPage';
-import { PatientsPage } from './pages/PatientsPage';
-import { DoctorsPage } from './pages/DoctorsPage';
-import { MedicalPage } from './pages/MedicalPage';
-import { FinancePage } from './pages/FinancePage';
-import { WarehousePage } from './pages/WarehousePage';
-import { StatisticsPage } from './pages/StatisticsPage';
-import { ReportsPage } from './pages/ReportsPage';
-import { BonusPage } from './pages/BonusPage';
-import { MailingPage } from './pages/MailingPage';
-import { SmsPage } from './pages/SmsPage';
-import { SettingsPage } from './pages/SettingsPage';
-import { PatientCardPage } from './pages/PatientCardPage';
 import { storage } from './utils/storage';
 
 import { AuthProvider } from './contexts/AuthContext';
 import { TenantProvider } from './contexts/TenantContext';
+import { App } from './App';
 
 // Initialize localStorage seed data if not present
 storage.init();
@@ -32,28 +15,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
       <TenantProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Layout />}>
-              <Route index element={<SchedulePage />} />
-              <Route path="crm" element={<CrmPage />} />
-              <Route path="appointments" element={<AppointmentsPage />} />
-              <Route path="documents" element={<DocumentsPage />} />
-              <Route path="patients" element={<PatientsPage />} />
-              <Route path="patients/:patientId" element={<PatientCardPage />} />
-              <Route path="doctors" element={<DoctorsPage />} />
-              <Route path="medical" element={<MedicalPage />} />
-              <Route path="finance" element={<FinancePage />} />
-              <Route path="warehouse" element={<WarehousePage />} />
-              <Route path="statistics" element={<StatisticsPage />} />
-              <Route path="reports" element={<ReportsPage />} />
-              <Route path="bonus" element={<BonusPage />} />
-              <Route path="mailing" element={<MailingPage />} />
-              <Route path="sms" element={<SmsPage />} />
-              <Route path="settings" element={<SettingsPage />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
+        <App />
       </TenantProvider>
     </AuthProvider>
   </StrictMode>


### PR DESCRIPTION
## Summary
This PR extracts the application's routing logic out of `src/main.tsx` into a new `src/App.tsx` component. This is a pure structural refactor to unblock the safe injection of authentication route guards in the next step.

## Changes
- Created `src/App.tsx` holding `<BrowserRouter>` and all application `<Routes>`.
- Refactored `src/main.tsx` to mount `<App />` strictly inside the required provider hierarchy (`StrictMode` -> `AuthProvider` -> `TenantProvider` -> `App`).
- Validated that no functional, behavioral, or UI changes occurred. Dev fallback mock state remains perfectly intact.