### PR TITLE
AUTH-REAL-001A: Add Supabase session handling to AuthContext

### DIFF
--- a/_ai_work/REPORTS/AUTH-REAL-001A_supabase_session_context_report.md
+++ b/_ai_work/REPORTS/AUTH-REAL-001A_supabase_session_context_report.md
@@ -1,0 +1,56 @@
+# AUTH-REAL-001A: Supabase Session Context Report
+
+## Summary
+Real Supabase authentication session handling has been integrated into `AuthContext`. The context now actively checks `supabase.auth.getSession()` on mount and listens for changes via `supabase.auth.onAuthStateChange()`. The legacy `dev` fallback functionality remains entirely intact and protects local development.
+
+## Changed Files
+- `src/contexts/AuthContext.tsx`
+- `_ai_work/REPORTS/AUTH-REAL-001A_supabase_session_context_report.md` (Added)
+
+## Behaviors Implemented
+
+**Dev Fallback Behavior (Missing Supabase env vars):**
+- `authMode` correctly defaults to `'dev'`.
+- The application automatically simulates a logged-in session with `dev-user-000000000000`.
+- `isLoading` stays `false`.
+- The `useEffect` gracefully returns early without attempting Supabase API calls.
+- `signOut()` resolves successfully as a harmless no-op.
+
+**Supabase Configured Behavior (Env vars present):**
+- `authMode` correctly switches to `'supabase-active'`.
+- `isLoading` defaults to `true` while the session is fetched.
+- The `useEffect` invokes `supabase.auth.getSession()` and maps the session user to `AppUser` (`{ id, email }`).
+- A subscription is attached to `onAuthStateChange` to keep the context tightly synchronized with the Supabase client state.
+- `signOut()` invokes `supabase.auth.signOut()` and handles errors safely.
+- All Supabase calls are strictly guarded against `supabase === null`.
+
+## AuthContext API After Change
+```typescript
+interface AuthContextType {
+  user: AppUser | null;
+  isLoading: boolean;
+  error: Error | null;
+  authMode: 'dev' | 'supabase-active';
+  signOut: () => Promise<void>;
+}
+```
+
+## Confirmations
+- ✅ **No LoginPage Added**: Registration, login UI, and route guards were explicitly skipped.
+- ✅ **No Route Guards Added**: Application routing is visually and behaviorally identical.
+- ✅ **App.tsx / main.tsx Unchanged**: The provider order and component tree were not touched.
+- ✅ **TenantContext Unchanged**: Tenant loading is untouched.
+- ✅ **No Backend/Storage/Migration Changes**: Database logic is untouched.
+
+## Validation Results
+- `npm ci`: Passed
+- `npm run lint`: Passed
+- `npm run test`: Passed
+- `npm run build`: Passed
+
+## Remaining Risks
+- The application will now effectively sit in a "logged out" state for users with Supabase env vars, as `getSession` will yield null (until they log in). However, because there are no route guards yet, the application currently acts exactly as it did before (data repositories might fail if they require auth, but they haven't been migrated yet).
+
+## Recommended Next Task
+**AUTH-REAL-001B: Add minimal LoginPage and auth gate in App.tsx**
+*(The AuthContext is now fully capable of managing sessions. The next logical step is to build a minimal Login UI and wrap the main `<Layout />` in `App.tsx` with a `<RequireAuth>` guard, forcing unauthenticated Supabase users to sign in).*

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useContext } from 'react';
-import { isSupabaseConfigured } from '../lib/supabaseClient';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { isSupabaseConfigured, supabase } from '../lib/supabaseClient';
 
 // TODO: Replace with real Supabase User type once implemented
 export interface AppUser {
@@ -12,21 +12,93 @@ interface AuthContextType {
   user: AppUser | null;
   isLoading: boolean;
   error: Error | null;
-  authMode: 'dev' | 'supabase-unwired';
-  // TODO: Add login/logout methods when implementing real auth
+  authMode: 'dev' | 'supabase-active';
+  signOut: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const authMode: 'dev' | 'supabase-unwired' = isSupabaseConfigured ? 'supabase-unwired' : 'dev';
+  const authMode: 'dev' | 'supabase-active' = isSupabaseConfigured ? 'supabase-active' : 'dev';
 
-  const user = authMode === 'dev' ? { id: 'dev-user-000000000000', email: 'dev@example.com' } : null;
-  const isLoading = authMode !== 'dev';
-  const error = null;
+  const [user, setUser] = useState<AppUser | null>(
+    authMode === 'dev' ? { id: 'dev-user-000000000000', email: 'dev@example.com' } : null
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(authMode !== 'dev');
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (authMode === 'dev' || !supabase) {
+      return;
+    }
+
+    let mounted = true;
+
+    async function initializeSession() {
+      try {
+        const { data, error: sessionError } = await supabase!.auth.getSession();
+        if (sessionError) {
+          throw sessionError;
+        }
+        
+        if (mounted) {
+          if (data.session?.user) {
+            setUser({
+              id: data.session.user.id,
+              email: data.session.user.email ?? undefined
+            });
+          } else {
+            setUser(null);
+          }
+          setIsLoading(false);
+        }
+      } catch (err) {
+        if (mounted) {
+          console.error('Error fetching Supabase session:', err);
+          setError(err instanceof Error ? err : new Error('Failed to fetch session'));
+          setIsLoading(false);
+        }
+      }
+    }
+
+    initializeSession();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) {
+        if (session?.user) {
+          setUser({
+            id: session.user.id,
+            email: session.user.email ?? undefined
+          });
+        } else {
+          setUser(null);
+        }
+      }
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, [authMode]);
+
+  const signOut = async () => {
+    if (authMode === 'dev' || !supabase) {
+      return Promise.resolve();
+    }
+    
+    try {
+      const { error: signOutError } = await supabase.auth.signOut();
+      if (signOutError) throw signOutError;
+      setUser(null);
+    } catch (err) {
+      console.error('Sign out error:', err);
+      setError(err instanceof Error ? err : new Error('Failed to sign out'));
+    }
+  };
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, error, authMode }}>
+    <AuthContext.Provider value={{ user, isLoading, error, authMode, signOut }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
This PR adds real Supabase session fetching and state management to the `AuthContext`, strictly without altering the application routing or UI.

## Scope of Work
- Modified `AuthContext.tsx` to handle the `supabase-active` state.
- Implemented `supabase.auth.getSession()` on mount.
- Implemented `supabase.auth.onAuthStateChange()` subscription for real-time auth synchronization.
- Added a basic `signOut` function.
- Successfully preserved the `dev` fallback mode when Supabase is unconfigured, ensuring backward compatibility for the local environment.

## Validation
- No UI components or route guards were implemented.
- `App.tsx` and `main.tsx` are untouched.
- Unit tests pass.

The system is now primed for adding a login UI and route guards in `App.tsx` in the subsequent step (`AUTH-REAL-001B`).