### PR TITLE
AUTH-REAL-001B: Add minimal LoginPage and auth gate

### DIFF
--- a/_ai_work/REPORTS/AUTH-REAL-001B_login_page_auth_gate_report.md
+++ b/_ai_work/REPORTS/AUTH-REAL-001B_login_page_auth_gate_report.md
@@ -1,0 +1,52 @@
+# AUTH-REAL-001B: Login Page and Auth Gate Report
+
+## Summary
+A minimal login screen (`LoginPage`) and a structural authentication gate have been added to the application, leveraging the Supabase session state previously established in `AUTH-REAL-001A`. 
+
+## Changed Files
+- `src/contexts/AuthContext.tsx`
+- `src/pages/LoginPage.tsx` (Added)
+- `src/App.tsx`
+- `_ai_work/REPORTS/AUTH-REAL-001B_login_page_auth_gate_report.md` (Added)
+
+## AuthContext Changes
+- Exposed `signIn: (email, password) => Promise<void>`.
+- In `supabase-active` mode, `signIn` calls `supabase.auth.signInWithPassword`.
+- In `dev` mode, `signIn` resolves instantly as a safe no-op.
+- Any errors during login are captured, propagated, and cleared before subsequent attempts.
+
+## LoginPage Behavior
+- A clean, accessible `LoginPage` was created utilizing existing project styles (`lucide-react` icons, tailwind forms).
+- Contains strictly an Email field, a Password field, and a submit button.
+- Properly reflects submission loading state and presents errors natively or from context.
+- **Excluded**: Signup, Password Reset, OAuth, and Clinic Selection.
+
+## App.tsx Auth Gate Behavior
+- Evaluates `useAuth()` state directly at the application root:
+  - **Dev Mode**: Completely bypasses the gate, rendering `<BrowserRouter>` and inner routes instantly as before.
+  - **Supabase Active + Loading**: Renders a centered minimal loading spinner.
+  - **Supabase Active + Unauthenticated**: Renders `<LoginPage />`. All nested application structure (`Layout`, routing) is fully shielded.
+  - **Supabase Active + Authenticated**: Renders the complete application routing structure.
+
+## Confirmations
+- ✅ Dev fallback behavior fully preserved.
+- ✅ Supabase authentication cleanly enforced when active.
+- ✅ No `TenantContext` changes.
+- ✅ No Repository or Storage changes.
+- ✅ No Supabase migration/seed changes.
+- ✅ No Signup / Password Reset / OAuth implementations added.
+- ✅ Logout button (`Header.tsx`) purposely excluded from this task.
+
+## Validation Results
+- `npm ci`: Passed
+- `npm run lint`: Passed
+- `npm run test`: Passed
+- `npm run build`: Passed
+
+## Remaining Risks
+- Users can log in, but `TenantContext` still has no real Supabase tenant loading. In `supabase-active` mode, `activeTenant` remains null, `availableTenants` remains empty, and tenant `isLoading` remains true until `TENANT-REAL-001` implements `tenant_users`/`tenants` loading. Repository migration remains blocked until tenant loading is implemented.
+- The logout button does not exist, so a user who logs in must manually clear their local storage/cookies to sign out.
+
+## Recommended Next Task
+**AUTH-REAL-001D: Add logout UI and auth state smoke tests**
+*(It is safe to quickly add the logout UI to the header and add minimal unit tests for `LoginPage`/gate interactions before tackling the much more complex `TENANT-REAL-001` data loading).*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useAuth } from './contexts/AuthContext';
+import { LoginPage } from './pages/LoginPage';
 import { Layout } from './components/layout/Layout';
 import { SchedulePage } from './pages/SchedulePage';
 import { CrmPage } from './pages/CrmPage';
@@ -18,6 +20,23 @@ import { SettingsPage } from './pages/SettingsPage';
 import { PatientCardPage } from './pages/PatientCardPage';
 
 export function App() {
+  const { authMode, isLoading, user } = useAuth();
+
+  // B) Supabase active + loading
+  if (authMode === 'supabase-active' && isLoading) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  // C) Supabase active + no user
+  if (authMode === 'supabase-active' && !user) {
+    return <LoginPage />;
+  }
+
+  // A & D) Dev mode OR Supabase active + user exists
   return (
     <BrowserRouter>
       <Routes>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthContextType {
   isLoading: boolean;
   error: Error | null;
   authMode: 'dev' | 'supabase-active';
+  signIn: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
 }
 
@@ -82,6 +83,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     };
   }, [authMode]);
 
+  const signIn = async (email: string, password: string) => {
+    if (authMode === 'dev' || !supabase) {
+      return Promise.resolve();
+    }
+
+    setError(null);
+    try {
+      const { data, error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+      if (signInError) throw signInError;
+      
+      if (data.session?.user) {
+        setUser({
+          id: data.session.user.id,
+          email: data.session.user.email ?? undefined
+        });
+      }
+    } catch (err) {
+      console.error('Sign in error:', err);
+      setError(err instanceof Error ? err : new Error('Failed to sign in'));
+      throw err;
+    }
+  };
+
   const signOut = async () => {
     if (authMode === 'dev' || !supabase) {
       return Promise.resolve();
@@ -98,7 +122,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, error, authMode, signOut }}>
+    <AuthContext.Provider value={{ user, isLoading, error, authMode, signIn, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { AlertTriangle, Lock, Mail } from 'lucide-react';
+
+export function LoginPage() {
+  const { signIn, error: authError } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [localError, setLocalError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setLocalError('');
+    
+    try {
+      await signIn(email, password);
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Ошибка при авторизации');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8 font-sans">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-extrabold text-slate-900">
+          Вход в систему
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-slate-200">
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            {(authError || localError) && (
+              <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm flex items-start gap-2">
+                <AlertTriangle className="w-5 h-5 shrink-0" />
+                <span>{localError || authError?.message}</span>
+              </div>
+            )}
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-slate-700">
+                Email
+              </label>
+              <div className="mt-1 relative rounded-md shadow-sm">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <Mail className="h-5 w-5 text-slate-400" />
+                </div>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="focus:ring-blue-500 focus:border-blue-500 block w-full pl-10 sm:text-sm border-slate-300 rounded-md py-2 border outline-none"
+                  placeholder="admin@example.com"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-slate-700">
+                Пароль
+              </label>
+              <div className="mt-1 relative rounded-md shadow-sm">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <Lock className="h-5 w-5 text-slate-400" />
+                </div>
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="focus:ring-blue-500 focus:border-blue-500 block w-full pl-10 sm:text-sm border-slate-300 rounded-md py-2 border outline-none"
+                  placeholder="••••••••"
+                />
+              </div>
+            </div>
+
+            <div>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {isSubmitting ? 'Вход...' : 'Войти'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds a minimal `LoginPage` and a structural authentication gate inside `App.tsx` that leverages the Supabase session state implemented in `AUTH-REAL-001A`.

## Scope of Work
- Added `signIn` to `AuthContext` to trigger `supabase.auth.signInWithPassword`.
- Created a straightforward `LoginPage` utilizing existing Tailwind and Lucide styles.
- Updated `App.tsx` to conditionally block access to private routes when Supabase is configured but the user is unauthenticated.
- Preserved the transparent `dev` fallback behavior for unconfigured local environments.

## Validation
- Verified all constraints: no Supabase API changes, no `TenantContext` changes, no repository modifications.
- Local `tsc`, `lint`, and Vitest checks pass completely.

The project is now fully capable of enforcing authentication via Supabase while retaining developer ergonomics.