### PR TITLE
NO-TENANT-UI-001: Add no-tenant blocked screen

### DIFF
--- a/_ai_work/REPORTS/NO-TENANT-UI-001_blocked_screen_report.md
+++ b/_ai_work/REPORTS/NO-TENANT-UI-001_blocked_screen_report.md
@@ -1,0 +1,43 @@
+# NO-TENANT-UI-001: Add no-tenant blocked screen
+
+## Summary
+Added blocked UI states in `App.tsx` for authenticated users connecting via Supabase who do not yet have an assigned clinic (`tenant`), as well as dedicated loading and error states for the tenant data fetching layer.
+
+## Changed Files
+- `src/App.tsx`
+- `src/App.test.tsx`
+- `_ai_work/REPORTS/NO-TENANT-UI-001_blocked_screen_report.md` (Added)
+
+## Behavior Added
+- **Tenant Loading Screen**: An explicit "Загрузка клиники..." spinner appears when an authenticated user is awaiting `TenantContext` initialization.
+- **Tenant Error Screen**: If the `tenant_users` query fails, the user sees a "Не удалось загрузить клинику" view displaying the error message and a "Выйти" (Logout) button.
+- **No-Tenant Blocked Screen**: If `activeTenant === null` and `availableTenants` is empty after fetching is complete, the user is presented with a "Клиника не назначена" screen. This securely blocks all private `react-router` routes and prompts them to log out or contact an administrator.
+
+## Tests Added
+Tests in `App.test.tsx` have been completely revamped to explicitly assert all 7 required states:
+1. Dev mode remains perfectly bypassed into regular app routing.
+2. Auth loading renders the auth spinner.
+3. No user renders `LoginPage`.
+4. User + Tenant loading renders "Загрузка клиники...".
+5. User + Tenant error renders "Не удалось загрузить клинику" and logout button works.
+6. User + Zero tenants renders "Клиника не назначена" and logout button works.
+7. User + Active tenant renders regular app routes securely.
+
+## Confirmations
+- ✅ Dev mode unchanged.
+- ✅ No `TenantContext.tsx` or `AuthContext.tsx` logic changes.
+- ✅ No repositories, storage, migrations, seed, or package dependencies were altered.
+
+## Validation Results
+- `npm ci`: Passed
+- `npm run lint`: Passed
+- `npm run test`: Passed
+- `npm run build`: Passed
+
+## Remaining Risks
+- Now that both frontend and backend architectures are in place for fetching tenants, local testing remains impossible out-of-the-box because `seed.sql` deliberately omits `auth.users` row seeding. A developer must know the manual steps required to set up local Supabase Auth for a clinic.
+
+## Recommended Next Task
+**DOCS-TENANT-LOCAL-001: Document local Supabase auth user/profile/tenant_users setup**
+
+This continues to be the primary blocker before anyone can QA the new login-to-tenant workflow. We need a clear, repeatable, documented process for creating test users via the local Supabase Studio and linking them to mock clinics.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import { App } from './App';
 import * as AuthContextModule from './contexts/AuthContext';
+import * as TenantContextModule from './contexts/TenantContext';
 
 // Mock matchMedia for nested components if necessary
 Object.defineProperty(window, 'matchMedia', {
@@ -21,16 +22,54 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-describe('App Auth Gate', () => {
-  it('renders loading state when supabase is active and loading', async () => {
-    vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
-      user: null,
-      isLoading: true,
-      error: null,
-      authMode: 'supabase-active',
-      signIn: vi.fn(),
-      signOut: vi.fn()
+const mockUseAuth = (overrides: Partial<ReturnType<typeof AuthContextModule.useAuth>> = {}) => {
+  vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    user: null,
+    isLoading: false,
+    error: null,
+    authMode: 'dev',
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  });
+};
+
+const mockUseTenant = (overrides: Partial<ReturnType<typeof TenantContextModule.useTenant>> = {}) => {
+  vi.spyOn(TenantContextModule, 'useTenant').mockReturnValue({
+    activeTenant: null,
+    availableTenants: [],
+    setActiveTenant: vi.fn(),
+    isLoading: false,
+    error: null,
+    ...overrides,
+  });
+};
+
+describe('App Auth & Tenant Gate', () => {
+  it('1. dev mode renders app routes, not LoginPage, not no-tenant screen', async () => {
+    mockUseAuth({ authMode: 'dev', isLoading: false });
+    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Dev' }, availableTenants: [{ tenantId: '123', tenantName: 'Dev' }], isLoading: false });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<App />);
     });
+
+    expect(container.textContent).not.toContain('Вход в систему');
+    expect(container.textContent).not.toContain('Клиника не назначена');
+    // It should render Layout containing Header, which contains user name or date
+    expect(container.textContent).toBeDefined();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('2. supabase-active + auth loading renders auth loading screen', async () => {
+    mockUseAuth({ authMode: 'supabase-active', isLoading: true });
+    mockUseTenant();
 
     const container = document.createElement('div');
     const root = createRoot(container);
@@ -46,15 +85,9 @@ describe('App Auth Gate', () => {
     });
   });
 
-  it('renders LoginPage when supabase is active and no user', async () => {
-    vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
-      user: null,
-      isLoading: false,
-      error: null,
-      authMode: 'supabase-active',
-      signIn: vi.fn(),
-      signOut: vi.fn()
-    });
+  it('3. supabase-active + no user renders LoginPage', async () => {
+    mockUseAuth({ authMode: 'supabase-active', user: null, isLoading: false });
+    mockUseTenant();
 
     const container = document.createElement('div');
     const root = createRoot(container);
@@ -64,6 +97,101 @@ describe('App Auth Gate', () => {
     });
 
     expect(container.textContent).toContain('Вход в систему');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('4. supabase-active + user + tenant loading renders "Загрузка клиники..."', async () => {
+    mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
+    mockUseTenant({ isLoading: true });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(container.textContent).toContain('Загрузка клиники...');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('5. supabase-active + user + tenant error renders "Не удалось загрузить клинику" and logout button calls signOut', async () => {
+    const signOutMock = vi.fn();
+    mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false, signOut: signOutMock });
+    mockUseTenant({ error: new Error('Network fail'), isLoading: false });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(container.textContent).toContain('Не удалось загрузить клинику');
+    expect(container.textContent).toContain('Network fail');
+
+    const button = container.querySelector('button');
+    expect(button?.textContent).toContain('Выйти');
+    
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(signOutMock).toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('6. supabase-active + user + no tenants renders "Клиника не назначена" and logout button calls signOut', async () => {
+    const signOutMock = vi.fn();
+    mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false, signOut: signOutMock });
+    mockUseTenant({ activeTenant: null, availableTenants: [], isLoading: false });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(container.textContent).toContain('Клиника не назначена');
+
+    const button = container.querySelector('button');
+    expect(button?.textContent).toContain('Выйти');
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(signOutMock).toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('7. supabase-active + user + activeTenant renders normal app routes', async () => {
+    mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
+    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Real' }, availableTenants: [{ tenantId: '123', tenantName: 'Real' }], isLoading: false });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    expect(container.textContent).not.toContain('Загрузка клиники...');
+    expect(container.textContent).not.toContain('Клиника не назначена');
+    expect(container.textContent).not.toContain('Вход в систему');
 
     await act(async () => {
       root.unmount();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
+import { useTenant } from './contexts/TenantContext';
 import { LoginPage } from './pages/LoginPage';
 import { Layout } from './components/layout/Layout';
 import { SchedulePage } from './pages/SchedulePage';
@@ -20,10 +21,11 @@ import { SettingsPage } from './pages/SettingsPage';
 import { PatientCardPage } from './pages/PatientCardPage';
 
 export function App() {
-  const { authMode, isLoading, user } = useAuth();
+  const { authMode, isLoading: authLoading, user, signOut } = useAuth();
+  const { activeTenant, availableTenants, isLoading: tenantLoading, error: tenantError } = useTenant();
 
   // B) Supabase active + loading
-  if (authMode === 'supabase-active' && isLoading) {
+  if (authMode === 'supabase-active' && authLoading) {
     return (
       <div className="min-h-screen bg-slate-50 flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
@@ -36,7 +38,58 @@ export function App() {
     return <LoginPage />;
   }
 
-  // A & D) Dev mode OR Supabase active + user exists
+  // Tenant loading/error/blocked states for supabase-active authenticated users
+  if (authMode === 'supabase-active' && user) {
+    if (tenantLoading) {
+      return (
+        <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mb-4"></div>
+          <p className="text-slate-600 font-medium">Загрузка клиники...</p>
+        </div>
+      );
+    }
+
+    if (tenantError) {
+      return (
+        <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-4 text-center">
+          <div className="bg-white p-8 rounded-xl shadow-sm max-w-md w-full border border-red-100">
+            <h1 className="text-xl font-bold text-red-600 mb-2">Не удалось загрузить клинику</h1>
+            <p className="text-slate-600 mb-4">
+              Попробуйте выйти и войти снова. Если ошибка повторится, обратитесь к администратору.
+            </p>
+            <p className="text-xs text-slate-400 mb-6">{tenantError.message}</p>
+            <button
+              onClick={() => void signOut()}
+              className="px-4 py-2 bg-slate-100 text-slate-700 rounded-lg hover:bg-slate-200 transition-colors w-full font-medium"
+            >
+              Выйти
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    if (!activeTenant && availableTenants.length === 0) {
+      return (
+        <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-4 text-center">
+          <div className="bg-white p-8 rounded-xl shadow-sm max-w-md w-full border border-slate-100">
+            <h1 className="text-xl font-bold text-slate-800 mb-2">Клиника не назначена</h1>
+            <p className="text-slate-600 mb-6">
+              Ваш пользователь авторизован, но не привязан ни к одной клинике. Обратитесь к администратору.
+            </p>
+            <button
+              onClick={() => void signOut()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors w-full font-medium"
+            >
+              Выйти
+            </button>
+          </div>
+        </div>
+      );
+    }
+  }
+
+  // A & D) Dev mode OR Supabase active + user exists + activeTenant exists
   return (
     <BrowserRouter>
       <Routes>


### PR DESCRIPTION
## Summary
Added a blocked UI state in `App.tsx` for authenticated Supabase users who do not have an assigned tenant. Also added explicit loading and error screens for the tenant fetching phase.

## What is tested
- **Dev Mode**: Confirmed dev fallback remains untouched.
- **Tenant Loading**: Renders a "Загрузка клиники..." spinner.
- **Tenant Error**: Renders a "Не удалось загрузить клинику" screen.
- **No Tenants**: Renders a securely blocked "Клиника не назначена" screen preventing access to private routes.

## Important Notes
- No changes were made to `TenantContext` or repositories.
- `signOut` functionality is correctly wired into the error and blocked screens to allow the user to gracefully escape.