### PR TITLE
PATIENT-REAL-001A: Implement SupabasePatientRepository

### DIFF
--- a/_ai_work/REPORTS/PATIENT-REAL-001A_supabase_patient_repository_report.md
+++ b/_ai_work/REPORTS/PATIENT-REAL-001A_supabase_patient_repository_report.md
@@ -1,0 +1,61 @@
+# PATIENT-REAL-001A: Implement SupabasePatientRepository
+
+## Summary
+Successfully implemented the `SupabasePatientRepository` behind the `createPatientRepository` factory. Both `usePatientsCollection` and `usePatientProfile` have been updated to dynamically route to the appropriate backend based on `authMode` and tenant state, preserving the safe fallback for the `dev` mode. `PatientModal` now generates UUIDs via `crypto.randomUUID()`.
+
+## Changed Files
+- `src/components/patients/PatientModal.tsx`
+- `src/data/repositories/PatientRepository.ts`
+- `src/data/repositories/PatientRepository.test.ts`
+- `src/data/hooks/usePatientsCollection.ts`
+- `src/data/hooks/usePatientsCollection.test.tsx`
+- `src/data/hooks/usePatientProfile.ts`
+- `src/data/hooks/usePatientProfile.test.tsx`
+
+## Factory Routing Behavior
+`createPatientRepository(options)`:
+- Returns `SupabasePatientRepository` when `backend === 'supabase'` AND `options.tenantId` is present AND Supabase is configured.
+- Falls back to `LocalStoragePatientRepository` in all other cases.
+
+## Hook Routing Behavior
+Both `usePatientsCollection` and `usePatientProfile` determine the backend dynamically:
+```typescript
+  const backend = authMode === 'supabase-active' && activeTenant?.tenantId && isSupabaseConfigured
+    ? 'supabase'
+    : 'local';
+```
+This guarantees that `authMode: 'dev'` makes zero Supabase calls and acts exactly as before.
+
+## Supabase Query Design
+- **listPatients**: `supabase.from('patients').select('*').eq('tenant_id', tenantId).order('created_at', { ascending: false })`
+- **getPatientById**: `supabase.from('patients').select('*').eq('tenant_id', tenantId).eq('id', patientId).maybeSingle()`
+- **createPatient**: `supabase.from('patients').insert({ ...mappedPatient, tenant_id: tenantId })`
+- **updatePatient**: `supabase.from('patients').update({ ...mappedPatient }).eq('tenant_id', tenantId).eq('id', patient.id)`
+All queries strictly filter or insert `tenant_id`.
+
+## Mapping Details
+- DB rows (`snake_case`) map strictly to `Patient` (`camelCase`) inside the repository methods.
+- `row.created_at` successfully maps to `createdAt`.
+- Null values fallback to `undefined` for string optionals, and `0` for numerics.
+
+## ID Strategy Change
+`PatientModal.tsx` now generates `id: crypto.randomUUID()` instead of `p${Date.now()}`. This solves the strict UUID column constraint in Supabase `patients.id` while seamlessly supporting `localStorage`.
+
+## Tests Added/Updated
+- **PatientRepository.test.ts**: Tests the factory and verifies all mapped Supabase queries.
+- **usePatientsCollection.test.tsx**: Verifies the hook correctly resolves `local` or `supabase` backends based on `useAuth()` and `useTenant()`.
+- **usePatientProfile.test.tsx**: Verifies the profile hook correctly switches repositories.
+
+## Validation Results
+- `npm run lint` - 0 errors
+- `npm run test` - 78 tests passing
+- `npm run build` - successful
+
+## Mixed Backend Limitations
+Appointments, Treatment Plans, and Dental Charts are currently completely unaware of Supabase and continue saving `UUIDs` to `localStorage`. A user migrating machines will see patients but miss appointments until those repositories are migrated. This is known, allowed, and expected.
+
+## Remaining Risks
+- **Supabase Constraints**: `patient_id` in other tables (like `chief_complaints`) must exist in `patients`. Creating a patient via the UI should now succeed since the patient is properly written to Supabase!
+
+## Recommended Next Task
+**PATIENT-REAL-001B: Local browser QA for Supabase PatientRepository and ChiefComplaint FK flow**

--- a/src/components/patients/PatientModal.tsx
+++ b/src/components/patients/PatientModal.tsx
@@ -87,7 +87,7 @@ export function PatientModal({ isOpen, onClose, onSave, initialData }: PatientMo
     }
 
     const patientToSave: Patient = {
-      id: formData.id || `p${Date.now()}`,
+      id: formData.id || crypto.randomUUID(),
       fullName,
       phone,
       birthDate: formData.birthDate,

--- a/src/data/hooks/usePatientProfile.test.tsx
+++ b/src/data/hooks/usePatientProfile.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { usePatientProfile } from './usePatientProfile';
+import * as PatientRepositoryModule from '../repositories/PatientRepository';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {},
+  isSupabaseConfigured: true,
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../contexts/TenantContext', () => ({
+  useTenant: vi.fn(),
+}));
+
+describe('usePatientProfile', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  const renderHookTest = async (hookFn: () => unknown) => {
+    let result: unknown;
+    const TestComponent = () => {
+      result = hookFn();
+      return null;
+    };
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+    return { result: result as ReturnType<typeof usePatientProfile> };
+  };
+
+  it('renders and exposes correct public API with dev fallback', async () => {
+    const factorySpy = vi.spyOn(PatientRepositoryModule, 'createPatientRepository');
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1' } } as unknown as ReturnType<typeof useTenant>);
+
+    const { result } = await renderHookTest(() => usePatientProfile('p1'));
+
+    expect(result).toHaveProperty('patient');
+    expect(result).toHaveProperty('savePatient');
+    expect(factorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 't1' }));
+  });
+
+  it('routes to supabase when active', async () => {
+    const factorySpy = vi.spyOn(PatientRepositoryModule, 'createPatientRepository');
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't2' } } as unknown as ReturnType<typeof useTenant>);
+
+    await renderHookTest(() => usePatientProfile('p1'));
+
+    expect(factorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'supabase', tenantId: 't2' }));
+  });
+
+  it('routes to local if no activeTenant', async () => {
+    const factorySpy = vi.spyOn(PatientRepositoryModule, 'createPatientRepository');
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as unknown as ReturnType<typeof useTenant>);
+
+    await renderHookTest(() => usePatientProfile('p1'));
+
+    expect(factorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local' }));
+  });
+});

--- a/src/data/hooks/usePatientProfile.ts
+++ b/src/data/hooks/usePatientProfile.ts
@@ -1,12 +1,29 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
+import { createPatientRepository } from '../repositories/PatientRepository';
 import type { Patient } from '../../types';
-import { LocalStoragePatientRepository } from '../repositories/PatientRepository';
+import { useTenant } from '../../contexts/TenantContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
 export function usePatientProfile(patientId: string) {
+  const { activeTenant } = useTenant();
+  const { authMode } = useAuth();
+
+  const backend = authMode === 'supabase-active' && activeTenant?.tenantId && isSupabaseConfigured
+    ? 'supabase'
+    : 'local';
+
+  const repo = useMemo(() => {
+    return createPatientRepository({
+      tenantId: activeTenant?.tenantId,
+      backend
+    });
+  }, [activeTenant?.tenantId, backend]);
+
   const queryFn = useCallback(
-    () => LocalStoragePatientRepository.getPatientById(patientId),
-    [patientId]
+    () => repo.getPatientById(patientId),
+    [patientId, repo]
   );
 
   const {
@@ -18,20 +35,20 @@ export function usePatientProfile(patientId: string) {
   } = useAsyncQuery<Patient | null>({
     queryFn,
     initialData: null,
-    enabled: Boolean(patientId),
+    enabled: !!patientId,
   });
 
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<Error | null>(null);
 
   const savePatient = async (updatedPatient: Patient) => {
+    setIsSaving(true);
+    setSaveError(null);
     try {
-      setIsSaving(true);
-      setSaveError(null);
-      await LocalStoragePatientRepository.updatePatient(updatedPatient);
+      await repo.updatePatient(updatedPatient);
       await refetch();
     } catch (e) {
-      const err = e instanceof Error ? e : new Error('Failed to save patient');
+      const err = e instanceof Error ? e : new Error('Failed to update patient');
       setSaveError(err);
       throw err;
     } finally {

--- a/src/data/hooks/usePatientsCollection.test.tsx
+++ b/src/data/hooks/usePatientsCollection.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { usePatientsCollection } from './usePatientsCollection';
+import * as PatientRepositoryModule from '../repositories/PatientRepository';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {},
+  isSupabaseConfigured: true,
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../contexts/TenantContext', () => ({
+  useTenant: vi.fn(),
+}));
+
+describe('usePatientsCollection', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  const renderHookTest = async (hookFn: () => unknown) => {
+    let result: unknown;
+    const TestComponent = () => {
+      result = hookFn();
+      return null;
+    };
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+    return { result: result as ReturnType<typeof usePatientsCollection> };
+  };
+
+  it('renders and exposes correct public API with dev fallback', async () => {
+    const factorySpy = vi.spyOn(PatientRepositoryModule, 'createPatientRepository');
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1' } } as unknown as ReturnType<typeof useTenant>);
+
+    const { result } = await renderHookTest(() => usePatientsCollection());
+
+    expect(result).toHaveProperty('patients');
+    expect(result).toHaveProperty('createPatient');
+    expect(result).toHaveProperty('updatePatient');
+    expect(factorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 't1' }));
+  });
+
+  it('routes to supabase when active', async () => {
+    const factorySpy = vi.spyOn(PatientRepositoryModule, 'createPatientRepository');
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't2' } } as unknown as ReturnType<typeof useTenant>);
+
+    await renderHookTest(() => usePatientsCollection());
+
+    expect(factorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'supabase', tenantId: 't2' }));
+  });
+
+  it('routes to local if no activeTenant', async () => {
+    const factorySpy = vi.spyOn(PatientRepositoryModule, 'createPatientRepository');
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as unknown as ReturnType<typeof useTenant>);
+
+    await renderHookTest(() => usePatientsCollection());
+
+    expect(factorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local' }));
+  });
+});

--- a/src/data/hooks/usePatientsCollection.ts
+++ b/src/data/hooks/usePatientsCollection.ts
@@ -1,12 +1,29 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
-import { LocalStoragePatientRepository } from '../repositories/PatientRepository';
+import { createPatientRepository } from '../repositories/PatientRepository';
 import type { Patient } from '../../types';
+import { useTenant } from '../../contexts/TenantContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
 export function usePatientsCollection() {
+  const { activeTenant } = useTenant();
+  const { authMode } = useAuth();
+
+  const backend = authMode === 'supabase-active' && activeTenant?.tenantId && isSupabaseConfigured
+    ? 'supabase'
+    : 'local';
+
+  const repo = useMemo(() => {
+    return createPatientRepository({
+      tenantId: activeTenant?.tenantId,
+      backend
+    });
+  }, [activeTenant?.tenantId, backend]);
+
   const queryFn = useCallback(
-    () => LocalStoragePatientRepository.listPatients(),
-    []
+    () => repo.listPatients(),
+    [repo]
   );
 
   const {
@@ -28,7 +45,7 @@ export function usePatientsCollection() {
     setIsSaving(true);
     setSaveError(null);
     try {
-      await LocalStoragePatientRepository.createPatient(patient);
+      await repo.createPatient(patient);
       await refetch();
     } catch (e) {
       const err = e instanceof Error ? e : new Error('Failed to create patient');
@@ -43,7 +60,7 @@ export function usePatientsCollection() {
     setIsSaving(true);
     setSaveError(null);
     try {
-      await LocalStoragePatientRepository.updatePatient(patient);
+      await repo.updatePatient(patient);
       await refetch();
     } catch (e) {
       const err = e instanceof Error ? e : new Error('Failed to update patient');

--- a/src/data/repositories/PatientRepository.test.ts
+++ b/src/data/repositories/PatientRepository.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createPatientRepository, LocalStoragePatientRepository, SupabasePatientRepository } from './PatientRepository';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Patient } from '../../types';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+describe('PatientRepository Factory', () => {
+  it('returns LocalStoragePatientRepository for backend local', () => {
+    const repo = createPatientRepository({ backend: 'local' });
+    expect(repo).toBe(LocalStoragePatientRepository);
+  });
+
+  it('returns SupabasePatientRepository for backend supabase with tenantId', () => {
+    const repo = createPatientRepository({ backend: 'supabase', tenantId: '123' });
+    expect(repo).toBeInstanceOf(SupabasePatientRepository);
+  });
+
+  it('returns LocalStoragePatientRepository for backend supabase without tenantId', () => {
+    const repo = createPatientRepository({ backend: 'supabase' });
+    expect(repo).toBe(LocalStoragePatientRepository);
+  });
+});
+
+describe('SupabasePatientRepository', () => {
+  it('listPatients fetches and maps correctly', async () => {
+    const mockOrder = vi.fn().mockResolvedValue({
+      data: [{
+        id: 'p1',
+        full_name: 'John',
+        phone: '123',
+        status: 'active',
+        source: 'phone',
+        created_at: '2023'
+      }],
+      error: null
+    });
+    const mockEqTenant = vi.fn().mockReturnValue({ order: mockOrder });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEqTenant });
+    const mockClient = { from: vi.fn().mockReturnValue({ select: mockSelect }) } as unknown as SupabaseClient;
+
+    const repo = new SupabasePatientRepository('t_1', mockClient);
+    const result = await repo.listPatients();
+    
+    expect(mockClient.from).toHaveBeenCalledWith('patients');
+    expect(mockEqTenant).toHaveBeenCalledWith('tenant_id', 't_1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('p1');
+    expect(result[0].fullName).toBe('John');
+  });
+
+  it('getPatientById fetches maybeSingle and maps', async () => {
+    const mockMaybeSingle = vi.fn().mockResolvedValue({
+      data: { id: 'p1', full_name: 'John', phone: '123', source: 'walk_in', status: 'active', created_at: '2023' },
+      error: null
+    });
+    const mockEqId = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEqTenant = vi.fn().mockReturnValue({ eq: mockEqId });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEqTenant });
+    const mockClient = { from: vi.fn().mockReturnValue({ select: mockSelect }) } as unknown as SupabaseClient;
+
+    const repo = new SupabasePatientRepository('t_1', mockClient);
+    const result = await repo.getPatientById('p1');
+    
+    expect(mockEqId).toHaveBeenCalledWith('id', 'p1');
+    expect(result?.id).toBe('p1');
+    expect(result?.fullName).toBe('John');
+  });
+
+  it('getPatientById returns null if missing', async () => {
+    const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+    const mockEqId = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEqTenant = vi.fn().mockReturnValue({ eq: mockEqId });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEqTenant });
+    const mockClient = { from: vi.fn().mockReturnValue({ select: mockSelect }) } as unknown as SupabaseClient;
+
+    const repo = new SupabasePatientRepository('t_1', mockClient);
+    const result = await repo.getPatientById('p1');
+    expect(result).toBeNull();
+  });
+
+  it('createPatient inserts mapped row with tenant_id', async () => {
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+    const mockClient = { from: vi.fn().mockReturnValue({ insert: mockInsert }) } as unknown as SupabaseClient;
+    const repo = new SupabasePatientRepository('t_1', mockClient);
+
+    await repo.createPatient({
+      id: 'p1', fullName: 'John', phone: '123', source: 'walk_in', status: 'active', createdAt: '2023'
+    });
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'p1',
+      tenant_id: 't_1',
+      full_name: 'John',
+      phone: '123'
+    }));
+  });
+
+  it('updatePatient updates mapped row with tenant_id filter', async () => {
+    const mockEqId = vi.fn().mockResolvedValue({ error: null });
+    const mockEqTenant = vi.fn().mockReturnValue({ eq: mockEqId });
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockEqTenant });
+    const mockClient = { from: vi.fn().mockReturnValue({ update: mockUpdate }) } as unknown as SupabaseClient;
+    const repo = new SupabasePatientRepository('t_1', mockClient);
+
+    await repo.updatePatient({
+      id: 'p1', fullName: 'John', phone: '123', source: 'walk_in', status: 'active', createdAt: '2023'
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      full_name: 'John'
+    }));
+    expect(mockEqTenant).toHaveBeenCalledWith('tenant_id', 't_1');
+    expect(mockEqId).toHaveBeenCalledWith('id', 'p1');
+  });
+
+  it('throws on error', async () => {
+    const mockEqId = vi.fn().mockResolvedValue({ error: new Error('DB Update Error') });
+    const mockEqTenant = vi.fn().mockReturnValue({ eq: mockEqId });
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockEqTenant });
+    const mockClient = { from: vi.fn().mockReturnValue({ update: mockUpdate }) } as unknown as SupabaseClient;
+    const repo = new SupabasePatientRepository('t_1', mockClient);
+
+    await expect(repo.updatePatient({ id: 'p1' } as Patient)).rejects.toThrow('DB Update Error');
+  });
+});

--- a/src/data/repositories/PatientRepository.ts
+++ b/src/data/repositories/PatientRepository.ts
@@ -1,11 +1,20 @@
 import { storage } from '../../utils/storage';
-import type { Patient } from '../../types';
+import type { Patient, Source, PatientIntegrationMeta } from '../../types';
+import { supabase } from '../../lib/supabaseClient';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 export interface PatientRepository {
   getPatientById(patientId: string): Promise<Patient | null>;
   updatePatient(patient: Patient): Promise<void>;
   listPatients(): Promise<Patient[]>;
   createPatient(patient: Patient): Promise<void>;
+}
+
+export type PatientRepositoryBackend = 'local' | 'supabase';
+
+export interface CreatePatientRepositoryOptions {
+  tenantId?: string | null;
+  backend: PatientRepositoryBackend;
 }
 
 export const LocalStoragePatientRepository: PatientRepository = {
@@ -27,3 +36,99 @@ export const LocalStoragePatientRepository: PatientRepository = {
     storage.addPatient(patient);
   },
 };
+
+export class SupabasePatientRepository implements PatientRepository {
+  private readonly tenantId: string;
+  private readonly client: SupabaseClient;
+
+  constructor(tenantId: string, client: SupabaseClient) {
+    this.tenantId = tenantId;
+    this.client = client;
+  }
+
+  async getPatientById(patientId: string): Promise<Patient | null> {
+    const { data, error } = await this.client
+      .from('patients')
+      .select('*')
+      .eq('tenant_id', this.tenantId)
+      .eq('id', patientId)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+
+    return this.mapToPatient(data);
+  }
+
+  async updatePatient(patient: Patient): Promise<void> {
+    const { error } = await this.client
+      .from('patients')
+      .update(this.mapToRow(patient))
+      .eq('tenant_id', this.tenantId)
+      .eq('id', patient.id);
+
+    if (error) throw error;
+  }
+
+  async listPatients(): Promise<Patient[]> {
+    const { data, error } = await this.client
+      .from('patients')
+      .select('*')
+      .eq('tenant_id', this.tenantId)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return (data || []).map(this.mapToPatient);
+  }
+
+  async createPatient(patient: Patient): Promise<void> {
+    const { error } = await this.client
+      .from('patients')
+      .insert({
+        ...this.mapToRow(patient),
+        tenant_id: this.tenantId
+      });
+
+    if (error) throw error;
+  }
+
+  private mapToPatient(row: Record<string, unknown>): Patient {
+    return {
+      id: row.id as string,
+      fullName: row.full_name as string,
+      phone: row.phone as string,
+      birthDate: (row.birth_date as string) || undefined,
+      source: row.source as Source,
+      status: row.status as string,
+      notes: (row.notes as string) || undefined,
+      allergies: (row.allergies as string) || undefined,
+      balance: (row.balance as number) || 0,
+      bonusBalance: (row.bonus_balance as number) || 0,
+      integration: (row.integration as PatientIntegrationMeta) || undefined,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  private mapToRow(patient: Patient): Record<string, unknown> {
+    return {
+      id: patient.id,
+      full_name: patient.fullName,
+      phone: patient.phone,
+      birth_date: patient.birthDate || null,
+      source: patient.source,
+      status: patient.status,
+      notes: patient.notes || null,
+      allergies: patient.allergies || null,
+      balance: patient.balance || 0,
+      bonus_balance: patient.bonusBalance || 0,
+      integration: patient.integration || null,
+    };
+  }
+}
+
+export function createPatientRepository(options?: CreatePatientRepositoryOptions): PatientRepository {
+  if (options?.backend === 'supabase' && typeof options.tenantId === 'string' && supabase) {
+    return new SupabasePatientRepository(options.tenantId, supabase);
+  }
+  return LocalStoragePatientRepository;
+}


### PR DESCRIPTION
## Summary
Successfully implemented the `SupabasePatientRepository` behind the `createPatientRepository` factory. Both `usePatientsCollection` and `usePatientProfile` have been updated to dynamically route to the appropriate backend based on `authMode` and tenant state, preserving the safe fallback for the `dev` mode. `PatientModal` now generates UUIDs via `crypto.randomUUID()`.

## Highlights
- **Safe Fallback**: `authMode === 'dev'` forces the hooks to use `LocalStoragePatientRepository`.
- **ID Strategy**: Switched to `crypto.randomUUID()` in `PatientModal` since Supabase demands valid UUIDs. This naturally works with `localStorage` as well.
- **Strict Tenant Scoping**: All Supabase queries strictly filter or inject `tenant_id`.
- **Verified**: CI is fully green (78 tests).
- **Mixed Backend**: `AppointmentRepository` and `TreatmentPlansRepository` continue to store `UUIDs` locally as expected in this incremental phase.

Ready for review!