### PR TITLE
TREATMENT-GENERATION-REAL-001A: Implement safe Supabase-backed treatment plan generation

### DIFF
--- a/_ai_work/REPORTS/TREATMENT-GENERATION-REAL-001A_safe_supabase_treatment_plan_generation.md
+++ b/_ai_work/REPORTS/TREATMENT-GENERATION-REAL-001A_safe_supabase_treatment_plan_generation.md
@@ -48,8 +48,8 @@ If no active tenant exists, the orchestrator forcibly downgrades to `local` back
 * **Supabase mode:** Generates strict `crypto.randomUUID()` values for both `planId` and all `stage.id` entries.
 * **Local mode:** Retains the legacy `plan_${timestamp}` behavior for maximum compatibility.
 
-## 13. finding_ids UUID safety
-The orchestrator now explicitly evaluates `validateUuid` against the passed `patientId` and all source `finding.id` references before initiating a Supabase operation. Invalid arrays are strictly rejected before any writes occur.
+## 13. finding_ids and Patient ownership safety
+The orchestrator now explicitly evaluates `validateUuid` against the passed `patientId` and all source `finding.id` and `finding.patientId` references before initiating a Supabase operation. It explicitly validates that `finding.patientId === patientId` for every selected finding. Invalid arrays or cross-patient finding selections are strictly rejected before any writes occur.
 
 ## 14. Save order and failure behavior
 * The execution flow was hardened. The treatment plan is strictly saved **first**.
@@ -80,7 +80,7 @@ The generation algorithm did NOT issue automated diagnoses, did NOT automaticall
 
 ## 20. Command results
 * **`npm run lint`:** PASS
-* **`npm test`:** PASS (149 tests passed across 25 files).
+* **`npm test`:** PASS (151 tests passed across 25 files).
 * **`npm run build`:** PASS
 
 ## 21. What was NOT changed

--- a/_ai_work/REPORTS/TREATMENT-GENERATION-REAL-001A_safe_supabase_treatment_plan_generation.md
+++ b/_ai_work/REPORTS/TREATMENT-GENERATION-REAL-001A_safe_supabase_treatment_plan_generation.md
@@ -1,0 +1,112 @@
+# Implementation Report: TREATMENT-GENERATION-REAL-001A
+**Title:** Implement safe Supabase-backed treatment plan generation
+**Date:** 10.06.2026
+
+## 1. Summary
+This task successfully implemented safe, Supabase-backed treatment plan generation from findings. The severe mixed-persistence bug in `ClinicalWorkflowOrchestrator`—where findings were updated in Supabase but generated treatment plans were forced into LocalStorage—has been resolved. The orchestrator now respects the global `authMode` routing and seamlessly utilizes the `SupabaseTreatmentPlansRepository` when configured, completely preserving tenant isolation, RLS rules, and UUID validation.
+
+## 2. Scope
+Implementation was strictly bounded to persistence routing logic and UUID generation for treatment plans derived from findings. No new UI, billing, documents, or appointment logic was added. All work remained within the orchestrator and hook layers.
+
+## 3. Files changed
+* `src/data/hooks/useClinicalWorkflow.ts`
+* `src/data/hooks/useClinicalWorkflow.test.tsx`
+* `src/data/orchestrators/ClinicalWorkflowOrchestrator.ts`
+* `src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts`
+
+## 4. Files inspected
+* `src/types/index.ts`
+* `src/data/repositories/TreatmentPlansRepository.ts`
+
+## 5. Reports inspected
+* `TREATMENT-GENERATION-RECON-001_automatic_treatment_plan_generation_recon.md`
+* `TREATMENT-REAL-001A_supabase_treatment_plans_repository_implementation.md`
+* `TREATMENT-REAL-001B_real_browser_qa_supabase_treatment_plans.md`
+* `FINDINGS-REAL-001A_supabase_findings_repository_implementation.md`
+
+## 6. Implementation details
+* Replaced hardcoded `LocalStorageTreatmentPlansRepository` inside `useClinicalWorkflow` with dynamic `createTreatmentPlansRepository` routing.
+* Modified `ClinicalWorkflowOrchestratorDependencies` to accept a `backend?: 'local' | 'supabase'` configuration.
+* Replaced non-compliant template string IDs (`plan_12345`) with valid `crypto.randomUUID()` values when operating in `supabase` mode.
+
+## 7. Previous mixed-persistence problem
+Previously, running "Создать план из проблем" with `supabase-active` updated findings globally in the Supabase database but saved the new treatment plan only in the local browser cache. This caused severe data desynchronization.
+
+## 8. New repository routing behavior
+`useClinicalWorkflow` now acts identically to all other repository hooks. It monitors `authMode`, `activeTenant?.tenantId`, and `isSupabaseConfigured` to select a unified backend across all integrated repositories.
+
+## 9. Supabase-active behavior
+When `supabase-active` mode is engaged, a valid tenant is active, and Supabase is configured, both the finding status update and the plan creation occur securely through the Supabase remote API.
+
+## 10. Local/dev fallback behavior
+If Supabase is not active, the system safely falls back to local JSON/storage, utilizing timestamp-based IDs (`plan_timestamp`) as before to maintain backward compatibility.
+
+## 11. No-tenant behavior
+If no active tenant exists, the orchestrator forcibly downgrades to `local` backend mode to prevent invalid RLS writes to the database.
+
+## 12. ID strategy
+* **Supabase mode:** Generates strict `crypto.randomUUID()` values for both `planId` and all `stage.id` entries.
+* **Local mode:** Retains the legacy `plan_${timestamp}` behavior for maximum compatibility.
+
+## 13. finding_ids UUID safety
+The orchestrator now explicitly evaluates `validateUuid` against the passed `patientId` and all source `finding.id` references before initiating a Supabase operation. Invalid arrays are strictly rejected before any writes occur.
+
+## 14. Save order and failure behavior
+* The execution flow was hardened. The treatment plan is strictly saved **first**.
+* If the plan creation fails, execution halts immediately. No findings are mutated.
+* Findings are updated one-by-one **only** after plan validation.
+* If a finding fails to update post-plan creation, the system throws an explicit, trackable error exposing the desync without quietly silencing it.
+
+## 15. Tenant/patient/RLS safety
+Because the backend injection now uses the standard repository configurations, `tenant_id` is automatically and safely attached to all created stages and plans deep inside `SupabaseTreatmentPlansRepository`. RLS remains entirely intact and no manual bypasses were utilized.
+
+## 16. Stage generation behavior
+Existing mapping logic for stages (extracting `title`, `toothNumber`, generating `description` strings, and preserving zero price with `status: 'planned'`) was left exactly as originally designed.
+
+## 17. Clinical domain boundaries
+No boundaries were crossed.
+The generation algorithm did NOT issue automated diagnoses, did NOT automatically create billing invoices, did NOT close appointments, and did NOT create missing documents.
+
+## 18. Tests added/updated
+* Updated `useClinicalWorkflow.test.tsx` to assert that `createTreatmentPlansRepository` is invoked correctly based on the environment context.
+* Expanded `ClinicalWorkflowOrchestrator.test.ts` to simulate local generation behavior.
+* Added `it('creates draft treatment plan with valid UUIDs in supabase backend')` in the orchestrator test file.
+* Added boundary tests confirming UUID validation rejects faulty arrays before save attempts.
+
+## 19. Commands run
+* `npm run lint`
+* `npm test`
+* `npm run build`
+
+## 20. Command results
+* **`npm run lint`:** PASS
+* **`npm test`:** PASS (149 tests passed across 25 files).
+* **`npm run build`:** PASS
+
+## 21. What was NOT changed
+* No documents were implemented.
+* No billing/payment logic was implemented.
+* No appointments were implemented.
+* No completed services were implemented.
+* No dental chart mutation was added.
+* `FindingsRepository` was NOT changed.
+* `DentalChartRepository` was NOT changed.
+* `PatientRepository` was NOT changed.
+* `AppointmentRepository` was NOT changed.
+* `DoctorRepository` was NOT changed.
+* `supabase/migrations` were NOT changed.
+* `supabase/seed.sql` was NOT changed.
+* `package.json`/`package-lock.json` were NOT changed.
+* No `.env` files were committed.
+* No screenshots were committed.
+* No credentials/tokens/API keys were committed.
+* No browser QA was performed in this task.
+
+## 22. Known limitations
+If Supabase successfully stores the generated plan but encounters a network disconnect halfway through iterating and updating findings, the database will be partially desynchronized (Plan exists, but a source finding remains 'discovered'). An explicit error trace is now thrown, but the operation lacks a true transactional rollback since it bridges two separate repository domains.
+
+## 23. Final verdict
+READY FOR REVIEW
+
+## 24. Recommended next task
+TREATMENT-GENERATION-REAL-001B — Real browser QA for Supabase-backed treatment plan generation

--- a/src/data/hooks/useClinicalWorkflow.test.tsx
+++ b/src/data/hooks/useClinicalWorkflow.test.tsx
@@ -6,6 +6,7 @@ import { act } from 'react';
 import { useClinicalWorkflow } from './useClinicalWorkflow';
 import * as DentalChartRepositoryModule from '../repositories/DentalChartRepository';
 import * as FindingsRepositoryModule from '../repositories/FindingsRepository';
+import * as TreatmentPlansRepositoryModule from '../repositories/TreatmentPlansRepository';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 
@@ -30,6 +31,7 @@ describe('useClinicalWorkflow', () => {
   it('routes to supabase repositories when authMode is supabase-active, activeTenant exists, and supabase is configured', async () => {
     const dentalChartFactorySpy = vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository');
     const findingsFactorySpy = vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository');
+    const treatmentPlansFactorySpy = vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
     vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
@@ -48,6 +50,7 @@ describe('useClinicalWorkflow', () => {
 
     expect(dentalChartFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'supabase', tenantId: 'real-tenant-id' }));
     expect(findingsFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'supabase', tenantId: 'real-tenant-id' }));
+    expect(treatmentPlansFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'supabase', tenantId: 'real-tenant-id' }));
 
     await act(async () => {
       root.unmount();
@@ -57,6 +60,7 @@ describe('useClinicalWorkflow', () => {
   it('routes to local backend when authMode is dev', async () => {
     const dentalChartFactorySpy = vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository');
     const findingsFactorySpy = vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository');
+    const treatmentPlansFactorySpy = vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
     vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
@@ -75,6 +79,7 @@ describe('useClinicalWorkflow', () => {
 
     expect(dentalChartFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
     expect(findingsFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
+    expect(treatmentPlansFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
 
     await act(async () => {
       root.unmount();
@@ -84,6 +89,7 @@ describe('useClinicalWorkflow', () => {
   it('routes to local backend when no active tenant', async () => {
     const dentalChartFactorySpy = vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository');
     const findingsFactorySpy = vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository');
+    const treatmentPlansFactorySpy = vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
     vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as unknown as ReturnType<typeof useTenant>);
@@ -102,6 +108,7 @@ describe('useClinicalWorkflow', () => {
 
     expect(dentalChartFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: undefined }));
     expect(findingsFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: undefined }));
+    expect(treatmentPlansFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: undefined }));
 
     await act(async () => {
       root.unmount();

--- a/src/data/hooks/useClinicalWorkflow.test.tsx
+++ b/src/data/hooks/useClinicalWorkflow.test.tsx
@@ -12,7 +12,9 @@ import { useTenant } from '../../contexts/TenantContext';
 
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: {},
-  isSupabaseConfigured: true,
+  get isSupabaseConfigured() {
+    return (globalThis as typeof globalThis & { __IS_SUPABASE_CONFIGURED__?: boolean }).__IS_SUPABASE_CONFIGURED__ ?? true;
+  }
 }));
 
 vi.mock('../../contexts/AuthContext', () => ({
@@ -113,5 +115,38 @@ describe('useClinicalWorkflow', () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it('routes to local backend when authMode is supabase-active but isSupabaseConfigured is false', async () => {
+    const dentalChartFactorySpy = vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository');
+    const findingsFactorySpy = vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository');
+    const treatmentPlansFactorySpy = vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository');
+
+    (globalThis as typeof globalThis & { __IS_SUPABASE_CONFIGURED__?: boolean }).__IS_SUPABASE_CONFIGURED__ = false;
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+
+    const TestComponent = () => {
+      useClinicalWorkflow();
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+
+    expect(dentalChartFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
+    expect(findingsFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
+    expect(treatmentPlansFactorySpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    (globalThis as typeof globalThis & { __IS_SUPABASE_CONFIGURED__?: boolean }).__IS_SUPABASE_CONFIGURED__ = true;
   });
 });

--- a/src/data/hooks/useClinicalWorkflow.ts
+++ b/src/data/hooks/useClinicalWorkflow.ts
@@ -2,7 +2,7 @@ import { useCallback, useState, useMemo } from 'react';
 import { createClinicalWorkflowOrchestrator } from '../orchestrators/ClinicalWorkflowOrchestrator';
 import { createDentalChartRepository } from '../repositories/DentalChartRepository';
 import { createFindingsRepository } from '../repositories/FindingsRepository';
-import { LocalStorageTreatmentPlansRepository } from '../repositories/TreatmentPlansRepository';
+import { createTreatmentPlansRepository } from '../repositories/TreatmentPlansRepository';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 import { isSupabaseConfigured } from '../../lib/supabaseClient';
@@ -32,13 +32,16 @@ export function useClinicalWorkflow() {
       backend,
     });
 
-    // Explicitly keep TreatmentPlansRepository local since it is not yet migrated to Supabase.
-    const treatmentPlansRepository = LocalStorageTreatmentPlansRepository;
+    const treatmentPlansRepository = createTreatmentPlansRepository({
+      tenantId: activeTenant?.tenantId,
+      backend,
+    });
 
     return createClinicalWorkflowOrchestrator({
       dentalChartRepository,
       findingsRepository,
       treatmentPlansRepository,
+      backend,
     });
   }, [authMode, activeTenant?.tenantId]);
 

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
@@ -254,7 +254,7 @@ describe('ClinicalWorkflowOrchestrator', () => {
       expect(fakeDentalChartRepository.saveDentalChart).not.toHaveBeenCalled();
     });
 
-    it('creates draft treatment plan and updates findings', async () => {
+    it('creates draft treatment plan and updates findings (local backend)', async () => {
       const orchestrator = createClinicalWorkflowOrchestrator({
         dentalChartRepository: fakeDentalChartRepository,
         findingsRepository: fakeFindingsRepository,
@@ -284,6 +284,7 @@ describe('ClinicalWorkflowOrchestrator', () => {
       expect(result?.updatedAt).toBe(now.toISOString());
       
       expect(result?.stages).toHaveLength(2);
+      expect(result?.stages[0].id).toBe(`stage_${now.getTime()}_0_f1`);
       expect(result?.stages[0].title).toBe('Find 1');
       expect(result?.stages[0].teeth).toEqual([11]);
       expect(result?.stages[0].description).toContain('desc 1');
@@ -312,6 +313,81 @@ describe('ClinicalWorkflowOrchestrator', () => {
       expect(operationsLog[0]).toBe('create-plan');
       expect(operationsLog[1]).toBe('update-finding:f1');
       expect(operationsLog[2]).toBe('update-finding:f2');
+    });
+
+    it('creates draft treatment plan with valid UUIDs in supabase backend', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase',
+      });
+
+      const now = new Date('2026-01-10T12:00:00.000Z');
+      const validPatientId = crypto.randomUUID();
+      const validFindingId1 = crypto.randomUUID();
+      const validFindingId2 = crypto.randomUUID();
+
+      const selectedFindings: DentalFinding[] = [
+        { id: validFindingId1, patientId: validPatientId, toothNumber: 11, category: 'caries', title: 'Find 1', severity: 'medium', description: 'desc 1', recommendation: 'rec 1', status: 'discovered', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' },
+        { id: validFindingId2, patientId: validPatientId, category: 'hygiene', title: 'Find 2', severity: 'low', description: 'desc 2', status: 'discovered', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' }
+      ];
+
+      const result = await orchestrator.createTreatmentPlanFromFindings({
+        patientId: validPatientId,
+        selectedFindings,
+        now
+      });
+
+      expect(fakeTreatmentPlansRepository.createTreatmentPlan).toHaveBeenCalledOnce();
+      expect(result).not.toBeNull();
+      // Should be valid UUID
+      expect(result?.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(result?.patientId).toBe(validPatientId);
+      
+      expect(result?.stages).toHaveLength(2);
+      expect(result?.stages[0].id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(result?.stages[0].findingIds).toEqual([validFindingId1]);
+
+      expect(result?.stages[1].id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+
+      // Verify Findings Updated
+      expect(fakeFindingsRepository.updateFinding).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects supabase generation if patientId is invalid UUID', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase',
+      });
+
+      const selectedFindings: DentalFinding[] = [
+        { id: crypto.randomUUID(), patientId: 'p1', toothNumber: 11, category: 'caries', title: 'Find 1', severity: 'medium', description: '', status: 'discovered', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' }
+      ];
+
+      await expect(orchestrator.createTreatmentPlanFromFindings({ patientId: 'invalid-id', selectedFindings }))
+        .rejects.toThrow('Invalid patient UUID for Supabase generation');
+      expect(fakeTreatmentPlansRepository.createTreatmentPlan).not.toHaveBeenCalled();
+    });
+
+    it('rejects supabase generation if any finding ID is invalid UUID', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase',
+      });
+
+      const validPatientId = crypto.randomUUID();
+      const selectedFindings: DentalFinding[] = [
+        { id: 'f1', patientId: validPatientId, toothNumber: 11, category: 'caries', title: 'Find 1', severity: 'medium', description: '', status: 'discovered', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' }
+      ];
+
+      await expect(orchestrator.createTreatmentPlanFromFindings({ patientId: validPatientId, selectedFindings }))
+        .rejects.toThrow('Invalid finding UUID for Supabase generation: f1');
+      expect(fakeTreatmentPlansRepository.createTreatmentPlan).not.toHaveBeenCalled();
     });
 
     it('propagates repository errors and does not update findings if plan creation fails', async () => {

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
@@ -390,6 +390,29 @@ describe('ClinicalWorkflowOrchestrator', () => {
       expect(fakeTreatmentPlansRepository.createTreatmentPlan).not.toHaveBeenCalled();
     });
 
+    it('rejects supabase generation if any finding belongs to a different patient', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase',
+      });
+
+      const validPatientIdA = crypto.randomUUID();
+      const validPatientIdB = crypto.randomUUID();
+      const validFindingId = crypto.randomUUID();
+
+      const selectedFindings: DentalFinding[] = [
+        { id: validFindingId, patientId: validPatientIdB, toothNumber: 11, category: 'caries', title: 'Find 1', severity: 'medium', description: '', status: 'discovered', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' }
+      ];
+
+      await expect(orchestrator.createTreatmentPlanFromFindings({ patientId: validPatientIdA, selectedFindings }))
+        .rejects.toThrow(`Selected finding does not belong to patient: ${validFindingId}`);
+      
+      expect(fakeTreatmentPlansRepository.createTreatmentPlan).not.toHaveBeenCalled();
+      expect(fakeFindingsRepository.updateFinding).not.toHaveBeenCalled();
+    });
+
     it('propagates repository errors and does not update findings if plan creation fails', async () => {
       const orchestrator = createClinicalWorkflowOrchestrator({
         dentalChartRepository: fakeDentalChartRepository,

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -40,7 +40,9 @@ export interface ClinicalWorkflowOrchestratorDependencies {
   dentalChartRepository: DentalChartRepository;
   findingsRepository: FindingsRepository;
   treatmentPlansRepository: TreatmentPlansRepository;
+  backend?: 'local' | 'supabase';
 }
+
 
 function buildStageDescription(finding: DentalFinding): string {
   return [
@@ -52,7 +54,12 @@ function buildStageDescription(finding: DentalFinding): string {
 export function createClinicalWorkflowOrchestrator(
   dependencies: ClinicalWorkflowOrchestratorDependencies
 ): ClinicalWorkflowOrchestrator {
-  const { dentalChartRepository, findingsRepository, treatmentPlansRepository } = dependencies;
+  const { dentalChartRepository, findingsRepository, treatmentPlansRepository, backend = 'local' } = dependencies;
+
+  const validateUuid = (id: string): boolean => {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    return uuidRegex.test(id);
+  };
 
   return {
     async applyToothStatusChange(input: ApplyToothStatusChangeInput): Promise<DentalChart> {
@@ -119,12 +126,25 @@ export function createClinicalWorkflowOrchestrator(
         return null;
       }
 
+      if (backend === 'supabase') {
+        if (!validateUuid(patientId)) {
+          throw new Error('Invalid patient UUID for Supabase generation');
+        }
+        for (const finding of selectedFindings) {
+          if (!validateUuid(finding.id)) {
+            throw new Error(`Invalid finding UUID for Supabase generation: ${finding.id}`);
+          }
+        }
+      }
+
       const date = input.now ?? new Date();
       const nowIso = date.toISOString();
       const planTimestamp = date.getTime();
 
+      const planId = backend === 'supabase' ? crypto.randomUUID() : `plan_${planTimestamp}`;
+
       const stages = selectedFindings.map((finding, index): TreatmentStage => ({
-        id: `stage_${planTimestamp}_${index}_${finding.id}`,
+        id: backend === 'supabase' ? crypto.randomUUID() : `stage_${planTimestamp}_${index}_${finding.id}`,
         title: finding.title,
         teeth: finding.toothNumber ? [finding.toothNumber] : [],
         description: buildStageDescription(finding),
@@ -135,7 +155,7 @@ export function createClinicalWorkflowOrchestrator(
       }));
 
       const plan: TreatmentPlan = {
-        id: `plan_${planTimestamp}`,
+        id: planId,
         patientId,
         title: `План лечения от ${date.toLocaleDateString('ru-RU')}`,
         status: 'draft',
@@ -145,15 +165,22 @@ export function createClinicalWorkflowOrchestrator(
         updatedAt: nowIso,
       };
 
+      // 1. Save the plan first. If this fails, we do NOT touch findings.
       await treatmentPlansRepository.createTreatmentPlan(patientId, plan);
 
+      // 2. Only after successful plan save, update finding statuses.
       for (const finding of selectedFindings) {
-        await findingsRepository.updateFinding(patientId, {
-          ...finding,
-          status: 'included_in_plan',
-          includeInTreatmentPlan: true,
-          updatedAt: nowIso,
-        });
+        try {
+          await findingsRepository.updateFinding(patientId, {
+            ...finding,
+            status: 'included_in_plan',
+            includeInTreatmentPlan: true,
+            updatedAt: nowIso,
+          });
+        } catch (e) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          throw new Error(`Plan saved, but failed to update finding ${finding.id} status: ${errMsg}`, { cause: e });
+        }
       }
 
       return plan;

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -134,6 +134,9 @@ export function createClinicalWorkflowOrchestrator(
           if (!validateUuid(finding.id)) {
             throw new Error(`Invalid finding UUID for Supabase generation: ${finding.id}`);
           }
+          if (!finding.patientId || !validateUuid(finding.patientId) || finding.patientId !== patientId) {
+            throw new Error(`Selected finding does not belong to patient: ${finding.id}`);
+          }
         }
       }
 


### PR DESCRIPTION
## TREATMENT-GENERATION-REAL-001A

This PR implements safe Supabase-backed treatment plan generation. It fixes the dangerous mixed-persistence issue where generated plans were always saved to local storage while findings were updated in Supabase.

**Changed Files:**
* `src/data/hooks/useClinicalWorkflow.ts`
* `src/data/hooks/useClinicalWorkflow.test.tsx`
* `src/data/orchestrators/ClinicalWorkflowOrchestrator.ts`
* `src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts`
* `_ai_work/REPORTS/TREATMENT-GENERATION-REAL-001A_safe_supabase_treatment_plan_generation.md`

**Bug Fixed:**
* Previously, `useClinicalWorkflow` hardcoded `LocalStorageTreatmentPlansRepository` regardless of the authentication or active tenant state.
* The orchestrator used template string IDs (`plan_${timestamp}`) incompatible with `SupabaseTreatmentPlansRepository` UUID validation.

**Implementation Scope & Repository Routing:**
* Replaced the hardcoded local repository logic with dynamic `createTreatmentPlansRepository` routing, mirroring the behavior in `useTreatmentPlans`.
* Added `backend` flag propagation deep into the `ClinicalWorkflowOrchestrator`.

**ID Strategy & `finding_ids` Safety:**
* Employs `crypto.randomUUID()` to safely generate strictly compliant UUIDs for `planId` and `stage.id` when the backend is configured as `supabase`.
* Uses `validateUuid` iteratively over all provided input findings before executing any Supabase write operations.

**Save Order:**
* Hardened execution flow: the Treatment Plan is safely inserted into the database **before** any source finding status updates are invoked. If plan creation fails, source findings remain untouched.

**Tests Added/Updated:**
* All unit tests extended to trace proper invocation of `createTreatmentPlansRepository` during component renders.
* Augmented `ClinicalWorkflowOrchestrator.test.ts` to strictly validate payload UUID safety during simulated Supabase operations.

**Commands Run:**
* `npm run lint`: PASS
* `npm test`: PASS (149 tests passed in 25 files)
* `npm run build`: PASS

**Known Limitations:**
* The update mapping process between the Plan generation and subsequent Finding status updates lacks a full network transaction block. If an update drops halfway through, explicit error tracing captures the failure but cannot natively rollback the prior successful plan creation.

**Final Verdict:**
READY FOR REVIEW

**Recommended Next Task:**
TREATMENT-GENERATION-REAL-001B — Real browser QA for Supabase-backed treatment plan generation

**Explicit Statements:**
* NO documents, billing, payment logic, or appointment automation features were implemented or modified.
* NO completed services automation was implemented.
* NO SQL migrations, database seed data, package dependencies, or `.env` configuration files were altered.