### PR TITLE
TREATMENT-DELETE-REAL-001A: Implement Supabase-safe treatment plan deletion cleanup

### DIFF
--- a/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
+++ b/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
@@ -1,0 +1,113 @@
+# Implementation Report: TREATMENT-DELETE-REAL-001A
+## Supabase-safe treatment plan deletion and cleanup
+
+## 1. Summary
+Implemented a safe, orchestrated treatment plan deletion workflow. A new method `deleteTreatmentPlanWithCleanup` was added to `ClinicalWorkflowOrchestrator` to coordinate the physical deletion of the plan and the restoration of finding statuses. `TreatmentPlansTab.tsx` was updated to use this orchestrated flow instead of direct repository hooks, and displays robust error alerts to handle RLS failures for non-admin roles gracefully.
+
+## 2. Scope
+- Implemented orchestrated deletion in `ClinicalWorkflowOrchestrator.ts`.
+- Wired `useClinicalWorkflow.ts` and `TreatmentPlansTab.tsx` to utilize the new workflow.
+- Cleaned up obsolete direct repository methods in `useTreatmentPlans.ts`.
+- Added test coverage in `ClinicalWorkflowOrchestrator.test.ts`.
+- Verified lint, test, and build passing cleanly.
+
+## 3. Files changed
+- `src/data/orchestrators/ClinicalWorkflowOrchestrator.ts`
+- `src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts`
+- `src/data/hooks/useClinicalWorkflow.ts`
+- `src/components/treatment/TreatmentPlansTab.tsx`
+- `src/data/hooks/useTreatmentPlans.ts`
+
+## 4. Files inspected
+- `src/data/hooks/useClinicalWorkflow.test.tsx`
+- `src/data/hooks/useTreatmentPlans.test.tsx`
+
+## 5. Reports inspected
+- `TREATMENT-DELETE-RECON-001_supabase_safe_treatment_plan_deletion_recon.md`
+- `TREATMENT-GENERATION-REAL-001B_real_browser_qa_supabase_generation.md`
+- `TREATMENT-GENERATION-REAL-001A_safe_supabase_treatment_plan_generation.md`
+
+## 6. Previous deletion problem
+Previously, deleting a treatment plan only issued a `DELETE` against the repository. While Supabase's `ON DELETE CASCADE` constraint safely removed stages, the `findings` linked via `finding_ids` in the stages were completely abandoned in an `included_in_plan` status. As a result, those findings became invisible for future plan generation, corrupting clinical state.
+
+## 7. Implementation details
+Added `deleteTreatmentPlanWithCleanup(input: DeleteTreatmentPlanWithCleanupInput): Promise<void>`.
+The method explicitly separates operations: extracting finding references, issuing plan deletion, and then individually resetting the finding states.
+
+## 8. New orchestrated delete workflow
+1. **Validate:** Ensures `patientId` and `plan.id` are valid UUIDs in Supabase mode.
+2. **Collect:** Iterates over the plan stages to collect and deduplicate all `findingIds`. Safe skips occur if the finding ID format is invalid.
+3. **Delete Plan:** Deletes the treatment plan via `TreatmentPlansRepository`.
+4. **Restore Findings:** Updates each finding collected to `status: 'discovered'` and `includeInTreatmentPlan: false` using `FindingsRepository.updateFinding()`.
+5. **Throw on Failure:** Throws a detailed error message aggregating all finding restoration failures, avoiding silent partial failures.
+
+## 9. Treatment plan deletion behavior
+The treatment plan deletion executes first. The UI provides a prompt confirmation and dispatches the task. If this delete fails (e.g. Supabase RLS rejection), the method immediately propagates the error, preventing finding state resets on a plan that was not actually deleted.
+
+## 10. Stage cleanup behavior
+Stage cleanup is entirely deferred to Supabase `ON DELETE CASCADE` triggers for the `supabase` backend, and repository logic for the `local` backend. No manual staging deletion is orchestrated, adhering to project specs.
+
+## 11. Findings restore/unlink behavior
+Findings are fetched before plan deletion to guarantee only real, active records are affected. They are then explicitly patched back to `status = 'discovered'` preventing infinite loop states.
+
+## 12. Supabase-active behavior
+Supabase backend strictly checks for UUID compliance and relies on tenant/patient isolation in the repositories.
+
+## 13. Local/dev fallback behavior
+The local backend processes exactly the same orchestration flow, utilizing local repositories and omitting UUID regex constraints.
+
+## 14. Role/permission UX behavior
+If a non-admin/owner attempts deletion, Supabase enforces RLS and rejects the query. The orchestrator throws, and `TreatmentPlansTab.tsx` intercepts the rejection and shows a robust native `window.alert()` notifying the user of the lack of privileges or server rejection, resolving the previous silent console error problem.
+
+## 15. Tenant/patient/RLS safety
+All deletes and updates are heavily scoped by both `tenantId` and `patientId` down inside the repository layers. The orchestrator purely manages flow.
+
+## 16. UUID/local ID safety
+A stringent `validateUuid` block runs in Supabase backend mode across the `patientId`, `plan.id`, and every `findingId` during stage collection to ensure no invalid IDs are transmitted.
+
+## 17. Error handling behavior
+Any error from Supabase (e.g. network timeout or RLS constraint) causes the Promise to reject entirely. In UI, an alert provides human-readable context. For finding updates, all errors are caught and aggregated into a single throw.
+
+## 18. Tests added/updated
+Added 4 new test suites in `ClinicalWorkflowOrchestrator.test.ts`:
+- Deletes treatment plan and restores linked findings successfully.
+- Rejects if delete fails and does not update findings.
+- Throws combined error if finding restore fails after plan deletion.
+- Validates UUIDs in supabase backend.
+
+## 19. Commands run
+- `npm run lint`
+- `npm run build`
+- `npm test -- --run`
+
+## 20. Command results
+- **npm run lint:** PASS
+- **npm run build:** PASS
+- **npm test:** PASS (155 tests passed)
+
+## 21. What was NOT changed
+- No migrations were changed.
+- No RLS policies were changed.
+- No seed data was changed.
+- No package files were changed.
+- No .env files were committed.
+- No screenshots were committed.
+- No credentials/tokens/API keys were committed.
+- No documents were implemented.
+- No billing/payment logic was implemented.
+- No appointments were implemented.
+- No completed services were implemented.
+- DentalChartRepository was not changed.
+- PatientRepository was not changed.
+- AppointmentRepository was not changed.
+- DoctorRepository was not changed.
+- No browser QA was performed.
+
+## 22. Known limitations
+There is no cross-RPC atomicity for the deletion flow. If the finding status update fails *after* successful plan deletion, the user receives an alert warning them of a dirty state, but the plan is functionally unrecoverable from the database.
+
+## 23. Final verdict
+**READY FOR REVIEW**
+
+## 24. Recommended next task
+**TREATMENT-DELETE-REAL-001B — Real browser QA for Supabase-safe treatment plan deletion cleanup**

--- a/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
+++ b/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
@@ -35,8 +35,8 @@ Added `deleteTreatmentPlanWithCleanup(input: DeleteTreatmentPlanWithCleanupInput
 The method explicitly separates operations: extracting finding references, issuing plan deletion, and then individually resetting the finding states.
 
 ## 8. New orchestrated delete workflow
-1. **Validate:** Ensures `patientId` and `plan.id` are valid UUIDs in Supabase mode.
-2. **Collect:** Iterates over the plan stages to collect and deduplicate all `findingIds`. Safe skips occur if the finding ID format is invalid.
+1. **Validate:** Ensures `patientId` matches `plan.patientId`. Validates `patientId`, `plan.patientId`, and `plan.id` are valid UUIDs in Supabase mode.
+2. **Collect:** Iterates over the plan stages to collect and deduplicate all `findingIds`. In Supabase mode, actively rejects if any collected `findingId` is not a valid UUID (fail-fast).
 3. **Delete Plan:** Deletes the treatment plan via `TreatmentPlansRepository`.
 4. **Restore Findings:** Updates each finding collected to `status: 'discovered'` and `includeInTreatmentPlan: false` using `FindingsRepository.updateFinding()`.
 5. **Throw on Failure:** Throws a detailed error message aggregating all finding restoration failures, avoiding silent partial failures.
@@ -63,17 +63,20 @@ If a non-admin/owner attempts deletion, Supabase enforces RLS and rejects the qu
 All deletes and updates are heavily scoped by both `tenantId` and `patientId` down inside the repository layers. The orchestrator purely manages flow.
 
 ## 16. UUID/local ID safety
-A stringent `validateUuid` block runs in Supabase backend mode across the `patientId`, `plan.id`, and every `findingId` during stage collection to ensure no invalid IDs are transmitted.
+A stringent `validateUuid` block runs in Supabase backend mode across the `patientId`, `plan.patientId`, `plan.id`, and every `findingId` during stage collection to ensure no invalid IDs are transmitted. If any ID is malformed, it throws immediately before issuing any DB commands.
 
 ## 17. Error handling behavior
 Any error from Supabase (e.g. network timeout or RLS constraint) causes the Promise to reject entirely. In UI, an alert provides human-readable context. For finding updates, all errors are caught and aggregated into a single throw.
 
 ## 18. Tests added/updated
-Added 4 new test suites in `ClinicalWorkflowOrchestrator.test.ts`:
+Added 7 new test suites in `ClinicalWorkflowOrchestrator.test.ts`:
 - Deletes treatment plan and restores linked findings successfully.
 - Rejects if delete fails and does not update findings.
 - Throws combined error if finding restore fails after plan deletion.
 - Validates UUIDs in supabase backend.
+- Rejects in Supabase mode if findingId is invalid UUID.
+- Rejects in Supabase mode if plan.patientId mismatches input patientId.
+- Rejects in Supabase mode if plan.patientId is invalid UUID.
 
 ## 19. Commands run
 - `npm run lint`

--- a/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
+++ b/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
@@ -38,7 +38,7 @@ The method explicitly separates operations: extracting finding references, issui
 1. **Validate:** Ensures `patientId` matches `plan.patientId`. Validates `patientId`, `plan.patientId`, and `plan.id` are valid UUIDs in Supabase mode.
 2. **Collect:** Iterates over the plan stages to collect and deduplicate all `findingIds`. In Supabase mode, actively rejects if any collected `findingId` is not a valid UUID (fail-fast).
 3. **Delete Plan:** Deletes the treatment plan via `TreatmentPlansRepository`.
-4. **Restore Findings:** Updates each finding collected to `status: 'discovered'` and `includeInTreatmentPlan: false` using `FindingsRepository.updateFinding()`.
+4. **Restore Findings:** Updates each finding collected to `status: 'discovered'` and `includeInTreatmentPlan: true` using `FindingsRepository.updateFinding()`. This ensures the finding is returned to the active candidate pool and remains eligible for future treatment plan generation.
 5. **Throw on Failure:** Throws a detailed error message aggregating all finding restoration failures, avoiding silent partial failures.
 
 ## 9. Treatment plan deletion behavior

--- a/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
+++ b/_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md
@@ -86,7 +86,7 @@ Added 7 new test suites in `ClinicalWorkflowOrchestrator.test.ts`:
 ## 20. Command results
 - **npm run lint:** PASS
 - **npm run build:** PASS
-- **npm test:** PASS (155 tests passed)
+- **npm test:** PASS (158 tests passed)
 
 ## 21. What was NOT changed
 - No migrations were changed.

--- a/src/components/treatment/TreatmentPlansTab.tsx
+++ b/src/components/treatment/TreatmentPlansTab.tsx
@@ -46,7 +46,6 @@ export function TreatmentPlansTab({ patientId }: TreatmentPlansTabProps) {
     treatmentPlans,
     createTreatmentPlan,
     updateTreatmentPlan,
-    deleteTreatmentPlan,
     refetch: refetchTreatmentPlans,
   } = useTreatmentPlans(patientId);
 
@@ -58,6 +57,7 @@ export function TreatmentPlansTab({ patientId }: TreatmentPlansTabProps) {
   const {
     isSaving: isWorkflowSaving,
     createTreatmentPlanFromFindings,
+    deleteTreatmentPlanWithCleanup,
   } = useClinicalWorkflow();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -105,13 +105,17 @@ export function TreatmentPlansTab({ patientId }: TreatmentPlansTabProps) {
     }
   };
 
-  const handleDeletePlan = async (planId: string) => {
+  const handleDeletePlan = async (plan: TreatmentPlan) => {
     if (!window.confirm('Вы уверены, что хотите удалить этот план лечения?')) return;
 
     try {
-      await deleteTreatmentPlan(planId);
+      await deleteTreatmentPlanWithCleanup({ patientId, plan });
+      await refetchTreatmentPlans();
+      await refetchFindings();
     } catch (e) {
       console.error('Failed to delete treatment plan', e);
+      const msg = e instanceof Error ? e.message : String(e);
+      window.alert(`Не удалось удалить план лечения:\n${msg}`);
     }
   };
 
@@ -202,9 +206,10 @@ export function TreatmentPlansTab({ patientId }: TreatmentPlansTabProps) {
                         <Edit2 className="w-4 h-4" />
                       </button>
                       <button
-                        onClick={() => handleDeletePlan(plan.id)}
-                        className="p-1.5 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                        onClick={() => handleDeletePlan(plan)}
+                        className="p-1.5 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors disabled:opacity-50"
                         title="Удалить"
+                        disabled={isWorkflowSaving}
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>

--- a/src/data/hooks/useClinicalWorkflow.ts
+++ b/src/data/hooks/useClinicalWorkflow.ts
@@ -8,7 +8,8 @@ import { useTenant } from '../../contexts/TenantContext';
 import { isSupabaseConfigured } from '../../lib/supabaseClient';
 import type {
   ApplyToothStatusChangeInput,
-  CreateTreatmentPlanFromFindingsInput
+  CreateTreatmentPlanFromFindingsInput,
+  DeleteTreatmentPlanWithCleanupInput
 } from '../orchestrators/ClinicalWorkflowOrchestrator';
 import type { DentalChart, TreatmentPlan } from '../../types';
 
@@ -76,10 +77,25 @@ export function useClinicalWorkflow() {
     }
   }, [orchestrator]);
 
+  const deleteTreatmentPlanWithCleanup = useCallback(async (input: DeleteTreatmentPlanWithCleanupInput): Promise<void> => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await orchestrator.deleteTreatmentPlanWithCleanup(input);
+    } catch (e) {
+      const parsedError = e instanceof Error ? e : new Error(String(e));
+      setSaveError(parsedError);
+      throw parsedError;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [orchestrator]);
+
   return {
     isSaving,
     saveError,
     applyToothStatusChange,
     createTreatmentPlanFromFindings,
+    deleteTreatmentPlanWithCleanup,
   };
 }

--- a/src/data/hooks/useTreatmentPlans.ts
+++ b/src/data/hooks/useTreatmentPlans.ts
@@ -76,20 +76,7 @@ export function useTreatmentPlans(patientId: string) {
     }
   }, [patientId, repository, refetch]);
 
-  const deleteTreatmentPlan = useCallback(async (planId: string): Promise<void> => {
-    setIsSaving(true);
-    setSaveError(null);
-    try {
-      await repository.deleteTreatmentPlan(patientId, planId);
-      await refetch();
-    } catch (e) {
-      const parsedError = e instanceof Error ? e : new Error(String(e));
-      setSaveError(parsedError);
-      throw parsedError;
-    } finally {
-      setIsSaving(false);
-    }
-  }, [patientId, repository, refetch]);
+
 
   return {
     treatmentPlans: treatmentPlans || [],
@@ -100,7 +87,6 @@ export function useTreatmentPlans(patientId: string) {
     saveError,
     createTreatmentPlan,
     updateTreatmentPlan,
-    deleteTreatmentPlan,
     refetch,
   };
 }

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
@@ -605,6 +605,7 @@ describe('ClinicalWorkflowOrchestrator', () => {
         backend: 'supabase'
       });
 
+      const validPatientId = crypto.randomUUID();
       const validPlanId = crypto.randomUUID();
 
       const plan: TreatmentPlan = {
@@ -612,9 +613,9 @@ describe('ClinicalWorkflowOrchestrator', () => {
         stages: []
       };
 
-      // Since plan.patientId !== patientId check runs first, we pass the local id to trigger the UUID check
-      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'invalid-local-id', plan }))
-        .rejects.toThrow('Invalid patient UUID for Supabase deletion');
+      // Since UUID checks run before mismatch checks now, we pass valid patientId to trigger the plan.patientId UUID error
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: validPatientId, plan }))
+        .rejects.toThrow('Invalid plan patient UUID for Supabase deletion');
 
       expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).not.toHaveBeenCalled();
       expect(fakeFindingsRepository.updateFinding).not.toHaveBeenCalled();

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
@@ -433,6 +433,126 @@ describe('ClinicalWorkflowOrchestrator', () => {
     });
   });
 
+  describe('deleteTreatmentPlanWithCleanup', () => {
+    it('deletes treatment plan and restores linked findings successfully', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+      });
+
+      findings = [
+        { id: 'f1', patientId: 'p1', category: 'caries', title: 'F1', severity: 'medium', status: 'included_in_plan', isChiefComplaintRelated: false, includeInTreatmentPlan: true, createdAt: '', updatedAt: '', description: '' },
+        { id: 'f2', patientId: 'p1', category: 'caries', title: 'F2', severity: 'medium', status: 'included_in_plan', isChiefComplaintRelated: false, includeInTreatmentPlan: true, createdAt: '', updatedAt: '', description: '' },
+        { id: 'f3', patientId: 'p1', category: 'pain', title: 'F3', severity: 'low', status: 'discovered', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '', description: '' }, // Not in plan
+      ];
+
+      const plan: TreatmentPlan = {
+        id: 'plan_1',
+        patientId: 'p1',
+        title: 'Plan 1',
+        status: 'draft',
+        totalPrice: 0,
+        createdAt: '',
+        updatedAt: '',
+        stages: [
+          { id: 's1', title: 'Stage 1', teeth: [], description: '', price: 0, status: 'planned', findingIds: ['f1', 'f2'] },
+          { id: 's2', title: 'Stage 2', teeth: [], description: '', price: 0, status: 'planned', findingIds: ['f1'] } // duplicate findingId
+        ]
+      };
+
+      await orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'p1', plan });
+
+      // Verify Plan deleted
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).toHaveBeenCalledOnce();
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).toHaveBeenCalledWith('p1', 'plan_1');
+
+      // Verify Findings restored (only f1 and f2 exactly once each due to deduplication)
+      expect(fakeFindingsRepository.listFindingsByPatient).toHaveBeenCalledOnce();
+      expect(fakeFindingsRepository.updateFinding).toHaveBeenCalledTimes(2);
+
+      const f1Update = updatedFindings.find(f => f.id === 'f1');
+      const f2Update = updatedFindings.find(f => f.id === 'f2');
+      const f3Update = updatedFindings.find(f => f.id === 'f3');
+
+      expect(f1Update?.status).toBe('discovered');
+      expect(f1Update?.includeInTreatmentPlan).toBe(false);
+
+      expect(f2Update?.status).toBe('discovered');
+      expect(f2Update?.includeInTreatmentPlan).toBe(false);
+
+      expect(f3Update).toBeUndefined(); // f3 was not updated
+    });
+
+    it('rejects if delete fails and does not update findings', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+      });
+
+      fakeTreatmentPlansRepository.deleteTreatmentPlan = vi.fn().mockRejectedValue(new Error('Delete Error'));
+
+      const plan: TreatmentPlan = {
+        id: 'plan_1', patientId: 'p1', title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        stages: [{ id: 's1', title: '', teeth: [], description: '', price: 0, status: 'planned', findingIds: ['f1'] }]
+      };
+
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'p1', plan })).rejects.toThrow('Delete Error');
+
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).toHaveBeenCalledOnce();
+      expect(fakeFindingsRepository.updateFinding).not.toHaveBeenCalled();
+    });
+
+    it('throws combined error if finding restore fails after plan deletion', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+      });
+
+      findings = [
+        { id: 'f1', patientId: 'p1', category: 'caries', title: 'F1', severity: 'medium', status: 'included_in_plan', isChiefComplaintRelated: false, includeInTreatmentPlan: true, createdAt: '', updatedAt: '', description: '' },
+      ];
+
+      fakeFindingsRepository.updateFinding = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+      const plan: TreatmentPlan = {
+        id: 'plan_1', patientId: 'p1', title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        stages: [{ id: 's1', title: '', teeth: [], description: '', price: 0, status: 'planned', findingIds: ['f1'] }]
+      };
+
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'p1', plan }))
+        .rejects.toThrow(/Treatment plan was deleted successfully, but failed to restore linked findings: \nFinding f1: Update failed/);
+
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).toHaveBeenCalledOnce();
+      expect(fakeFindingsRepository.updateFinding).toHaveBeenCalledOnce();
+    });
+
+    it('validates UUIDs in supabase backend', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase'
+      });
+
+      const plan: TreatmentPlan = {
+        id: 'invalid-id', patientId: 'p1', title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        stages: []
+      };
+
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'p1', plan }))
+        .rejects.toThrow('Invalid patient UUID for Supabase deletion');
+        
+      const validPatientId = crypto.randomUUID();
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: validPatientId, plan }))
+        .rejects.toThrow(`Invalid plan UUID for Supabase deletion: invalid-id`);
+        
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Exports', () => {
     it('exports LocalStorageClinicalWorkflowOrchestrator', () => {
       expect(LocalStorageClinicalWorkflowOrchestrator).toBeDefined();

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
@@ -476,10 +476,10 @@ describe('ClinicalWorkflowOrchestrator', () => {
       const f3Update = updatedFindings.find(f => f.id === 'f3');
 
       expect(f1Update?.status).toBe('discovered');
-      expect(f1Update?.includeInTreatmentPlan).toBe(false);
+      expect(f1Update?.includeInTreatmentPlan).toBe(true);
 
       expect(f2Update?.status).toBe('discovered');
-      expect(f2Update?.includeInTreatmentPlan).toBe(false);
+      expect(f2Update?.includeInTreatmentPlan).toBe(true);
 
       expect(f3Update).toBeUndefined(); // f3 was not updated
     });

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts
@@ -537,19 +537,87 @@ describe('ClinicalWorkflowOrchestrator', () => {
         backend: 'supabase'
       });
 
+      const validPatientId = crypto.randomUUID();
+
       const plan: TreatmentPlan = {
-        id: 'invalid-id', patientId: 'p1', title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        id: 'invalid-id', patientId: validPatientId, title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
         stages: []
       };
 
-      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'p1', plan }))
-        .rejects.toThrow('Invalid patient UUID for Supabase deletion');
-        
-      const validPatientId = crypto.randomUUID();
       await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: validPatientId, plan }))
         .rejects.toThrow(`Invalid plan UUID for Supabase deletion: invalid-id`);
         
       expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).not.toHaveBeenCalled();
+    });
+
+    it('rejects in Supabase mode if findingId is invalid UUID', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase'
+      });
+
+      const validPatientId = crypto.randomUUID();
+      const validPlanId = crypto.randomUUID();
+
+      const plan: TreatmentPlan = {
+        id: validPlanId, patientId: validPatientId, title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        stages: [{ id: 's1', title: '', teeth: [], description: '', price: 0, status: 'planned', findingIds: ['f1'] }]
+      };
+
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: validPatientId, plan }))
+        .rejects.toThrow('Invalid finding UUID for Supabase deletion cleanup: f1');
+
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).not.toHaveBeenCalled();
+      expect(fakeFindingsRepository.updateFinding).not.toHaveBeenCalled();
+    });
+
+    it('rejects in Supabase mode if plan.patientId mismatches input patientId', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase'
+      });
+
+      const patientIdA = crypto.randomUUID();
+      const patientIdB = crypto.randomUUID();
+      const validPlanId = crypto.randomUUID();
+
+      const plan: TreatmentPlan = {
+        id: validPlanId, patientId: patientIdB, title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        stages: []
+      };
+
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: patientIdA, plan }))
+        .rejects.toThrow(`Treatment plan patient mismatch: expected ${patientIdA}, got ${patientIdB}`);
+
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).not.toHaveBeenCalled();
+      expect(fakeFindingsRepository.updateFinding).not.toHaveBeenCalled();
+    });
+
+    it('rejects in Supabase mode if plan.patientId is invalid UUID', async () => {
+      const orchestrator = createClinicalWorkflowOrchestrator({
+        dentalChartRepository: fakeDentalChartRepository,
+        findingsRepository: fakeFindingsRepository,
+        treatmentPlansRepository: fakeTreatmentPlansRepository,
+        backend: 'supabase'
+      });
+
+      const validPlanId = crypto.randomUUID();
+
+      const plan: TreatmentPlan = {
+        id: validPlanId, patientId: 'invalid-local-id', title: '', status: 'draft', totalPrice: 0, createdAt: '', updatedAt: '',
+        stages: []
+      };
+
+      // Since plan.patientId !== patientId check runs first, we pass the local id to trigger the UUID check
+      await expect(orchestrator.deleteTreatmentPlanWithCleanup({ patientId: 'invalid-local-id', plan }))
+        .rejects.toThrow('Invalid patient UUID for Supabase deletion');
+
+      expect(fakeTreatmentPlansRepository.deleteTreatmentPlan).not.toHaveBeenCalled();
+      expect(fakeFindingsRepository.updateFinding).not.toHaveBeenCalled();
     });
   });
 

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -255,7 +255,7 @@ export function createClinicalWorkflowOrchestrator(
           await findingsRepository.updateFinding(patientId, {
             ...finding,
             status: 'discovered',
-            includeInTreatmentPlan: false,
+            includeInTreatmentPlan: true,
             updatedAt: nowIso,
           });
         } catch (e) {

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -198,9 +198,20 @@ export function createClinicalWorkflowOrchestrator(
     async deleteTreatmentPlanWithCleanup(input: DeleteTreatmentPlanWithCleanupInput): Promise<void> {
       const { patientId, plan } = input;
 
+      if (!plan.patientId) {
+        throw new Error('Treatment plan is missing patientId');
+      }
+
+      if (plan.patientId !== patientId) {
+        throw new Error(`Treatment plan patient mismatch: expected ${patientId}, got ${plan.patientId}`);
+      }
+
       if (backend === 'supabase') {
         if (!validateUuid(patientId)) {
           throw new Error('Invalid patient UUID for Supabase deletion');
+        }
+        if (!validateUuid(plan.patientId)) {
+          throw new Error('Invalid plan patient UUID for Supabase deletion');
         }
         if (!validateUuid(plan.id)) {
           throw new Error(`Invalid plan UUID for Supabase deletion: ${plan.id}`);
@@ -214,8 +225,7 @@ export function createClinicalWorkflowOrchestrator(
           for (const id of stage.findingIds) {
             if (id) {
               if (backend === 'supabase' && !validateUuid(id)) {
-                // We skip invalid UUIDs safely, as they wouldn't have been valid links anyway
-                continue;
+                throw new Error(`Invalid finding UUID for Supabase deletion cleanup: ${id}`);
               }
               findingIdsSet.add(id);
             }

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -31,9 +31,15 @@ export interface CreateTreatmentPlanFromFindingsInput {
   now?: Date;
 }
 
+export interface DeleteTreatmentPlanWithCleanupInput {
+  patientId: string;
+  plan: TreatmentPlan;
+}
+
 export interface ClinicalWorkflowOrchestrator {
   applyToothStatusChange(input: ApplyToothStatusChangeInput): Promise<DentalChart>;
   createTreatmentPlanFromFindings(input: CreateTreatmentPlanFromFindingsInput): Promise<TreatmentPlan | null>;
+  deleteTreatmentPlanWithCleanup(input: DeleteTreatmentPlanWithCleanupInput): Promise<void>;
 }
 
 export interface ClinicalWorkflowOrchestratorDependencies {
@@ -187,6 +193,72 @@ export function createClinicalWorkflowOrchestrator(
       }
 
       return plan;
+    },
+
+    async deleteTreatmentPlanWithCleanup(input: DeleteTreatmentPlanWithCleanupInput): Promise<void> {
+      const { patientId, plan } = input;
+
+      if (backend === 'supabase') {
+        if (!validateUuid(patientId)) {
+          throw new Error('Invalid patient UUID for Supabase deletion');
+        }
+        if (!validateUuid(plan.id)) {
+          throw new Error(`Invalid plan UUID for Supabase deletion: ${plan.id}`);
+        }
+      }
+
+      // 1. Collect and deduplicate finding IDs from all stages
+      const findingIdsSet = new Set<string>();
+      for (const stage of plan.stages) {
+        if (stage.findingIds && Array.isArray(stage.findingIds)) {
+          for (const id of stage.findingIds) {
+            if (id) {
+              if (backend === 'supabase' && !validateUuid(id)) {
+                // We skip invalid UUIDs safely, as they wouldn't have been valid links anyway
+                continue;
+              }
+              findingIdsSet.add(id);
+            }
+          }
+        }
+      }
+      const uniqueFindingIds = Array.from(findingIdsSet);
+
+      let findingsToRestore: DentalFinding[] = [];
+      if (uniqueFindingIds.length > 0) {
+        // We fetch the current findings to ensure we only update what exists and keep existing data intact
+        const allFindings = await findingsRepository.listFindingsByPatient(patientId);
+        findingsToRestore = allFindings.filter(f => uniqueFindingIds.includes(f.id));
+      }
+
+      // 2. Delete the treatment plan first. Stages are deleted via ON DELETE CASCADE in DB.
+      await treatmentPlansRepository.deleteTreatmentPlan(patientId, plan.id);
+
+      // 3. Only after successful plan deletion, restore linked findings.
+      const nowIso = new Date().toISOString();
+      const failedRestores: string[] = [];
+
+      for (const finding of findingsToRestore) {
+        try {
+          // If the finding was included in a plan, we revert it to 'discovered'.
+          // We could use its previous state if we tracked it, but 'discovered' is safe.
+          await findingsRepository.updateFinding(patientId, {
+            ...finding,
+            status: 'discovered',
+            includeInTreatmentPlan: false,
+            updatedAt: nowIso,
+          });
+        } catch (e) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          failedRestores.push(`Finding ${finding.id}: ${errMsg}`);
+        }
+      }
+
+      // If any finding cleanup failed, we throw a clear error.
+      // Note: Transaction limitation: The plan is already deleted.
+      if (failedRestores.length > 0) {
+        throw new Error(`Treatment plan was deleted successfully, but failed to restore linked findings: \n${failedRestores.join('\n')}`);
+      }
     }
   };
 }

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -202,10 +202,6 @@ export function createClinicalWorkflowOrchestrator(
         throw new Error('Treatment plan is missing patientId');
       }
 
-      if (plan.patientId !== patientId) {
-        throw new Error(`Treatment plan patient mismatch: expected ${patientId}, got ${plan.patientId}`);
-      }
-
       if (backend === 'supabase') {
         if (!validateUuid(patientId)) {
           throw new Error('Invalid patient UUID for Supabase deletion');
@@ -216,6 +212,10 @@ export function createClinicalWorkflowOrchestrator(
         if (!validateUuid(plan.id)) {
           throw new Error(`Invalid plan UUID for Supabase deletion: ${plan.id}`);
         }
+      }
+
+      if (plan.patientId !== patientId) {
+        throw new Error(`Treatment plan patient mismatch: expected ${patientId}, got ${plan.patientId}`);
       }
 
       // 1. Collect and deduplicate finding IDs from all stages


### PR DESCRIPTION
## TREATMENT-DELETE-REAL-001A

This PR implements the Supabase-safe treatment plan deletion and cleanup workflow.

### Summary
Added a safe, orchestrated treatment plan deletion workflow. A new method `deleteTreatmentPlanWithCleanup` was added to `ClinicalWorkflowOrchestrator` to coordinate the physical deletion of the plan and the restoration of linked finding statuses/eligibility. `TreatmentPlansTab.tsx` was updated to use this orchestrated flow instead of direct repository hooks, and delete failures are surfaced to the user through a clear browser alert instead of silent console-only failure.

### Changed Files
- `src/data/orchestrators/ClinicalWorkflowOrchestrator.ts`
- `src/data/orchestrators/ClinicalWorkflowOrchestrator.test.ts`
- `src/data/hooks/useClinicalWorkflow.ts`
- `src/components/treatment/TreatmentPlansTab.tsx`
- `src/data/hooks/useTreatmentPlans.ts`
- `_ai_work/REPORTS/TREATMENT-DELETE-REAL-001A_supabase_safe_treatment_plan_deletion_implementation.md`

### Previous Bug Fixed
Previously, findings linked via `finding_ids` in treatment stages could be abandoned in `included_in_plan` state when a treatment plan was deleted, leaving them invisible for future treatment plan generation and corrupting clinical workflow state.

### Delete Workflow Sequence
1. Validates input and treatment plan ownership.
2. In Supabase backend mode, fail-fast validates UUIDs for `patientId`, `plan.patientId`, `plan.id`, and every linked `findingId` before any repository write.
3. Requires `plan.patientId === patientId` before deleting.
4. Collects and deduplicates `findingIds` from the treatment plan stages safely.
5. Issues deletion to `TreatmentPlansRepository`. Supabase cleans up `treatment_stages` through the existing `ON DELETE CASCADE` constraint.
6. After successful deletion, restores each linked finding to `status: 'discovered'` and `includeInTreatmentPlan: true`, returning it to the eligible treatment planning pool.
7. Throws if any restoration errors occur, aggregating error strings.

### Findings Cleanup Behavior
Findings are restored only after the parent treatment plan is successfully deleted. Restored findings are returned to the active treatment planning candidate pool with:

- `status: 'discovered'`
- `includeInTreatmentPlan: true`

This prevents findings from remaining stuck as `included_in_plan` or becoming invisible to the create-plan workflow after plan deletion.

### Role/Permission UX Behavior
Non-admins/non-owners may still hit Supabase RLS rejection on delete, but the error is now caught by the UI and surfaced through a clear browser `alert()` instead of silently failing through console-only behavior.

### Tenant/Patient/RLS Safety
Repository functions enforce tenant and patient filters. The orchestrator routes through these repository abstractions and adds Supabase-mode fail-fast validation for UUID inputs and patient ownership before delete or cleanup writes are attempted.

### Tests Added/Updated
Seven orchestrator test blocks cover:
- Deletes treatment plan and restores linked findings successfully.
- Rejects if delete fails and does not update findings.
- Throws combined error if finding restore fails after plan deletion.
- Validates UUIDs in Supabase backend.
- Rejects in Supabase mode if findingId is invalid UUID.
- Rejects in Supabase mode if plan.patientId mismatches input patientId.
- Rejects in Supabase mode if plan.patientId is invalid UUID.

### Commands Run & Results
- `npm run lint`: **PASS**
- `npm run build`: **PASS**
- `npm test -- --run`: **PASS** (158 tests passed)

### Known Limitations
There is no atomic transaction/RPC across the delete and finding-restore REST calls. If finding restoration fails after successful plan deletion, the user receives an error/alert warning about cleanup failure, while the plan itself remains deleted.

### Explicit Statements
- **NO** migrations were changed.
- **NO** RLS policies were changed.
- **NO** seed data was changed.
- **NO** package files were changed.
- **NO** `.env` files were committed.
- **NO** screenshots were committed.
- **NO** credentials/tokens/API keys were committed.
- **NO** documents were implemented.
- **NO** billing/payment logic was implemented.
- **NO** appointments were implemented.
- **NO** completed services were implemented.

### Final Verdict
**READY FOR REVIEW**

### Recommended Next Task
**TREATMENT-DELETE-REAL-001B — Real browser QA for Supabase-safe treatment plan deletion cleanup**