### PR TITLE
DENTALCHART-UX-REAL-001A: Redesign dental chart UI and tooth interaction

### DIFF
--- a/_ai_work/REPORTS/DENTALCHART-UX-REAL-001A_dental_chart_ui_and_tooth_interaction_redesign.md
+++ b/_ai_work/REPORTS/DENTALCHART-UX-REAL-001A_dental_chart_ui_and_tooth_interaction_redesign.md
@@ -1,0 +1,89 @@
+# DENTALCHART-UX-REAL-001A: Redesign dental chart UI and tooth interaction
+
+## 1. Summary
+Performed a focused UX redesign of the dental chart to transform it into a more intuitive, doctor-facing working tool. The primary objective was to replace the tiny square click targets with larger, clearer tooth representations and introduce a strong visual selected state. This redesign lays the foundation for future region-based structured editing.
+
+## 2. Scope
+- Increased the size of tooth interaction targets in the grid.
+- Implemented a clear visual `selected` state for the currently active tooth.
+- Restructured `ToothItem` layout for better readability and hover interactions.
+- Maintained existing data flows and modal opening behaviors.
+
+## 3. Strategic decision
+Paused documents/contracts/admin-task implementation to prioritize the doctor-facing dental chart usability. A usable, clear clinical base is required before moving into complex business forms or region-level data entry.
+
+## 4. Files inspected
+- `src/components/dental/DentalChartTab.tsx`
+- `src/components/dental/ToothGrid.tsx`
+- `src/components/dental/ToothEditorModal.tsx`
+
+## 5. Files changed
+- `src/components/dental/DentalChartTab.tsx`
+- `src/components/dental/ToothGrid.tsx`
+
+## 6. Previous problem
+- Tiny square click targets (`w-8 h-10`) made selecting a specific tooth inconvenient.
+- No visual indication of the currently "selected" or active tooth on the grid.
+- The chart felt less like a professional tool and more like a basic UI diagram.
+
+## 7. New dental chart interaction model
+- Tooth targets are now substantially larger (`w-10 h-14` on mobile, `w-12 h-16` on larger screens).
+- The clickable area (`<button>`) encompasses the tooth number and the tooth body.
+- Hovering over any part of the tooth scales the element slightly and highlights the tooth number, confirming it is interactive.
+
+## 8. Visual usability improvements
+- Increased gap between upper and lower jaws, and between left and right quadrants to improve readability of the FDI numbering system.
+- Added a more robust shadow and border to interactive tooth elements.
+
+## 9. Selected tooth behavior
+- Clicking a tooth sets it as active, rendering it with a strong blue background (`bg-blue-50`), a prominent blue outline (`ring-2 ring-blue-500`), scaling it up (`scale-105`), and bringing it to the front (`z-10`).
+- The `selectedTooth` is tracked in `DentalChartTab` and passed down to `ToothGrid` as `selectedToothNumber`.
+
+## 10. Modal opening behavior
+- Clicking a tooth still opens `ToothEditorModal` exactly as before. 
+- The selected state on the grid persists while the modal is open (and after, as a reference point) to clearly indicate which tooth is currently being edited or viewed.
+
+## 11. Compatibility with existing data flow
+- No changes to `applyToothStatusChange` or existing hooks.
+- Existing save, reset, and form validation flows remain completely untouched and functional.
+
+## 12. Foundation for next phase
+- The larger footprint and dedicated `isSelected` state provide the exact UI structure needed for the next phase, where clicking a tooth might load a complex "Structured Editing Panel" (for crown, root, gum, surfaces) instead of a simple modal. The visual real estate is now prepared.
+
+## 13. Tests added/updated
+- No specific tests needed to be updated as the core logic (calling `onToothClick`) remained the same, and UI modifications were exclusively styling/CSS class alterations.
+
+## 14. Commands run
+- `npm run lint`
+- `npm run build`
+- `npm test -- --run`
+
+## 15. Command results
+- **npm run lint:** PASS
+- **npm run build:** PASS
+- **npm test:** FAIL (1 unrelated test failed: `src/contexts/AuthContext.test.tsx` expected `authMode` to be `'dev'`, but received `'supabase-active'`. This is a lingering side-effect in `.env` from a previous QA step. Per strict instructions, it was documented but NOT fixed).
+
+## 16. What was NOT changed
+- No documents were implemented.
+- No print/export was implemented.
+- No billing/payment logic was implemented.
+- No completed services were implemented.
+- No admin task logic was implemented.
+- No appointment logic was changed.
+- No Header changes were made.
+- No full patient card redesign was performed.
+- No contracts were implemented.
+- No Supabase RLS policies were changed.
+- No seed data was changed.
+- No package files were changed.
+- No `.env` files were committed.
+- No browser QA was performed.
+
+## 17. Known limitations
+- The selected state persists after the modal closes. This is an intentional step towards a split-pane layout for the next task but might feel slightly unusual while the modal interaction paradigm is still in place.
+
+## 18. Final verdict
+**READY FOR REVIEW**
+
+## 19. Recommended next task
+**DENTALCHART-UX-REAL-001B — Add structured tooth regions and clinical sections (surfaces, crown, gum, canals/roots, bone, notes)**

--- a/_ai_work/REPORTS/DENTALCHART-UX-REAL-001A_dental_chart_ui_and_tooth_interaction_redesign.md
+++ b/_ai_work/REPORTS/DENTALCHART-UX-REAL-001A_dental_chart_ui_and_tooth_interaction_redesign.md
@@ -20,6 +20,7 @@ Paused documents/contracts/admin-task implementation to prioritize the doctor-fa
 ## 5. Files changed
 - `src/components/dental/DentalChartTab.tsx`
 - `src/components/dental/ToothGrid.tsx`
+- `src/components/dental/ToothGrid.test.tsx` (NEW)
 
 ## 6. Previous problem
 - Tiny square click targets (`w-8 h-10`) made selecting a specific tooth inconvenient.
@@ -51,7 +52,12 @@ Paused documents/contracts/admin-task implementation to prioritize the doctor-fa
 - The larger footprint and dedicated `isSelected` state provide the exact UI structure needed for the next phase, where clicking a tooth might load a complex "Structured Editing Panel" (for crown, root, gum, surfaces) instead of a simple modal. The visual real estate is now prepared.
 
 ## 13. Tests added/updated
-- No specific tests needed to be updated as the core logic (calling `onToothClick`) remained the same, and UI modifications were exclusively styling/CSS class alterations.
+- Added `src/components/dental/ToothGrid.test.tsx` to assert that:
+  - `ToothGrid` properly renders tooth buttons with appropriate labels.
+  - Clicking a tooth correctly triggers the click handler with the expected tooth object.
+  - The currently selected tooth receives the proper visual classes (e.g. `bg-blue-50`, `ring-2`), while unselected teeth do not.
+- Note: A full integration test for `DentalChartTab` modal opening was not added because testing `DentalChartTab` requires extremely expensive mocking of the complex `useDentalChart`, `usePatientFindings`, and `useClinicalWorkflow` hooks in the current testing setup. However, the core visual and interaction logic is safely tested at the `ToothGrid` layer.
+- The unrelated `DOCUMENTS-RECON-001` report file was successfully removed from PR #194 to ensure a clean, isolated scope.
 
 ## 14. Commands run
 - `npm run lint`

--- a/src/components/dental/DentalChartTab.tsx
+++ b/src/components/dental/DentalChartTab.tsx
@@ -128,7 +128,12 @@ export function DentalChartTab({ patientId }: DentalChartTabProps) {
 
       <div className="flex flex-col lg:flex-row">
         <div className="flex-1 p-6 bg-slate-50 overflow-x-auto border-b lg:border-b-0 lg:border-r border-slate-200">
-          <ToothGrid teeth={dentalChart.teeth} findings={findings} onToothClick={handleToothClick} />
+          <ToothGrid 
+            teeth={dentalChart.teeth} 
+            findings={findings} 
+            onToothClick={handleToothClick}
+            selectedToothNumber={selectedTooth?.toothNumber}
+          />
         </div>
 
         <div className="w-full lg:w-64 bg-white p-5 shrink-0 flex flex-col">

--- a/src/components/dental/ToothGrid.test.tsx
+++ b/src/components/dental/ToothGrid.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { ToothGrid } from './ToothGrid';
+import type { ToothRecord } from '../../types';
+
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('ToothGrid', () => {
+  const mockTeeth: ToothRecord[] = [
+    {
+      toothNumber: 18,
+      condition: 'healthy',
+      surfaces: [],
+      crown: '',
+      root: '',
+      gum: '',
+      bone: '',
+      canal: '',
+      notes: '',
+      updatedAt: '2023-01-01T00:00:00.000Z'
+    },
+    {
+      toothNumber: 17,
+      condition: 'caries',
+      surfaces: ['occlusal'],
+      crown: '',
+      root: '',
+      gum: '',
+      bone: '',
+      canal: '',
+      notes: '',
+      updatedAt: '2023-01-01T00:00:00.000Z'
+    }
+  ];
+
+  const UPPER_JAW = [18, 17, 16, 15, 14, 13, 12, 11, 21, 22, 23, 24, 25, 26, 27, 28];
+  const LOWER_JAW = [48, 47, 46, 45, 44, 43, 42, 41, 31, 32, 33, 34, 35, 36, 37, 38];
+  const allToothNumbers = [...UPPER_JAW, ...LOWER_JAW];
+  
+  const fullMockTeeth = allToothNumbers.map(num => {
+    const existing = mockTeeth.find(t => t.toothNumber === num);
+    return existing || {
+      toothNumber: num,
+      condition: 'healthy',
+      surfaces: [],
+      crown: '',
+      root: '',
+      gum: '',
+      bone: '',
+      canal: '',
+      notes: '',
+      updatedAt: '2023-01-01T00:00:00.000Z'
+    };
+  }) as ToothRecord[];
+
+  it('renders tooth buttons correctly', async () => {
+    const handleToothClick = vi.fn();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ToothGrid teeth={fullMockTeeth} onToothClick={handleToothClick} />);
+    });
+
+    const button18 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 18');
+    expect(button18).not.toBeNull();
+    expect(button18?.textContent).toContain('18');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('calls onToothClick when a tooth is clicked', async () => {
+    const handleToothClick = vi.fn();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ToothGrid teeth={fullMockTeeth} onToothClick={handleToothClick} />);
+    });
+
+    const button17 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 17');
+    expect(button17).not.toBeNull();
+
+    await act(async () => {
+      button17?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(handleToothClick).toHaveBeenCalledTimes(1);
+    expect(handleToothClick).toHaveBeenCalledWith(expect.objectContaining({
+      toothNumber: 17,
+      condition: 'caries'
+    }));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('applies selected-state classes when a tooth is selected', async () => {
+    const handleToothClick = vi.fn();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <ToothGrid 
+          teeth={fullMockTeeth} 
+          onToothClick={handleToothClick} 
+          selectedToothNumber={18} 
+        />
+      );
+    });
+
+    const button18 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 18');
+    expect(button18?.className).toContain('bg-blue-50');
+    expect(button18?.className).toContain('ring-2');
+    expect(button18?.className).toContain('ring-blue-500');
+
+    const button17 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 17');
+    expect(button17?.className).not.toContain('bg-blue-50');
+    expect(button17?.className).not.toContain('ring-2');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/src/components/dental/ToothGrid.tsx
+++ b/src/components/dental/ToothGrid.tsx
@@ -5,6 +5,7 @@ interface ToothGridProps {
   teeth: ToothRecord[];
   findings?: DentalFinding[];
   onToothClick: (tooth: ToothRecord) => void;
+  selectedToothNumber?: number;
 }
 
 const UPPER_JAW: ToothNumber[] = [18, 17, 16, 15, 14, 13, 12, 11, 21, 22, 23, 24, 25, 26, 27, 28];
@@ -42,7 +43,7 @@ const getConditionAbbr = (condition: string) => {
   }
 };
 
-const ToothItem = ({ tooth, findings = [], onClick }: { tooth: ToothRecord, findings: DentalFinding[], onClick: () => void }) => {
+const ToothItem = ({ tooth, findings = [], isSelected, onClick }: { tooth: ToothRecord, findings: DentalFinding[], isSelected?: boolean, onClick: () => void }) => {
 
   const getIndicator = () => {
     if (!findings || findings.length === 0) return null;
@@ -54,14 +55,14 @@ const ToothItem = ({ tooth, findings = [], onClick }: { tooth: ToothRecord, find
     const isObservingOnly = active.every(f => f.status === 'observing');
 
     if (hasHighOrUrgent) {
-      return <div className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-white shadow-sm"></div>;
+      return <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full border-2 border-white shadow-sm z-20"></div>;
     }
 
     if (isObservingOnly) {
-      return <div className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-slate-400 rounded-full border-2 border-white shadow-sm opacity-60"></div>;
+      return <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-slate-400 rounded-full border-2 border-white shadow-sm opacity-80 z-20"></div>;
     }
 
-    return <div className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-blue-500 rounded-full border-2 border-white shadow-sm"></div>;
+    return <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-blue-500 rounded-full border-2 border-white shadow-sm z-20"></div>;
   };
 
   return (
@@ -69,61 +70,67 @@ const ToothItem = ({ tooth, findings = [], onClick }: { tooth: ToothRecord, find
       type="button"
       onClick={onClick}
       aria-label={`Редактировать зуб ${tooth?.toothNumber}`}
-      className="flex flex-col items-center gap-1 cursor-pointer group relative focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded-lg"
+      className={`flex flex-col items-center gap-1.5 p-1.5 sm:p-2 cursor-pointer group relative focus:outline-none transition-all rounded-xl ${
+        isSelected 
+          ? 'bg-blue-50 ring-2 ring-blue-500 shadow-md scale-105 z-10' 
+          : 'hover:bg-slate-100 hover:scale-105'
+      }`}
     >
-      <div className="text-xs font-semibold text-slate-600 group-hover:text-blue-600 transition-colors">
+      <div className={`text-sm font-bold transition-colors ${isSelected ? 'text-blue-700' : 'text-slate-600 group-hover:text-blue-600'}`}>
         {tooth?.toothNumber}
       </div>
-      <div className={`w-8 h-10 rounded-t-md rounded-b-xl border-2 flex items-center justify-center transition-all shadow-sm ${getToothColor(tooth?.condition)} group-hover:shadow-md group-hover:-translate-y-0.5 relative`}>
+      <div className={`w-10 h-14 sm:w-12 sm:h-16 rounded-t-md rounded-b-2xl border-2 flex items-center justify-center transition-all shadow-sm ${getToothColor(tooth?.condition)} ${
+        isSelected ? 'border-blue-500 shadow-md' : 'group-hover:shadow-md'
+      } relative`}>
         {getIndicator()}
-        <span className="text-xs font-bold">{getConditionAbbr(tooth?.condition || 'healthy')}</span>
+        <span className="text-sm font-bold">{getConditionAbbr(tooth?.condition || 'healthy')}</span>
       </div>
     </button>
   );
 };
 
-export function ToothGrid({ teeth, findings = [], onToothClick }: ToothGridProps) {
+export function ToothGrid({ teeth, findings = [], onToothClick, selectedToothNumber }: ToothGridProps) {
   const getTooth = (num: number) => teeth.find(t => t.toothNumber === num) as ToothRecord;
   const getFindingsForTooth = (num: number) => findings.filter(f => f.toothNumber === num);
 
   return (
-    <div className="w-max min-w-max mx-auto flex flex-col gap-8 py-4 px-2">
+    <div className="w-max min-w-max mx-auto flex flex-col gap-10 sm:gap-12 py-6 px-4">
       {/* Upper Jaw */}
-      <div className="flex justify-center items-center gap-4 sm:gap-6">
+      <div className="flex justify-center items-center gap-6 sm:gap-8">
         {/* Right side (patient's right, left on screen: 18-11) */}
-        <div className="flex gap-1.5">
+        <div className="flex gap-2 sm:gap-3">
           {UPPER_JAW.slice(0, 8).map(num => (
-            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} onClick={() => onToothClick(getTooth(num))} />
+            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
           ))}
         </div>
 
         {/* Midline */}
-        <div className="w-0.5 h-16 bg-slate-300 rounded-full"></div>
+        <div className="w-0.5 h-20 bg-slate-300 rounded-full"></div>
 
         {/* Left side (patient's left, right on screen: 21-28) */}
-        <div className="flex gap-1.5">
+        <div className="flex gap-2 sm:gap-3">
           {UPPER_JAW.slice(8, 16).map(num => (
-            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} onClick={() => onToothClick(getTooth(num))} />
+            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
           ))}
         </div>
       </div>
 
       {/* Lower Jaw */}
-      <div className="flex justify-center items-center gap-4 sm:gap-6">
+      <div className="flex justify-center items-center gap-6 sm:gap-8">
         {/* Right side (patient's right, left on screen: 48-41) */}
-        <div className="flex gap-1.5">
+        <div className="flex gap-2 sm:gap-3">
           {LOWER_JAW.slice(0, 8).map(num => (
-            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} onClick={() => onToothClick(getTooth(num))} />
+            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
           ))}
         </div>
 
         {/* Midline */}
-        <div className="w-0.5 h-16 bg-slate-300 rounded-full"></div>
+        <div className="w-0.5 h-20 bg-slate-300 rounded-full"></div>
 
         {/* Left side (patient's left, right on screen: 31-38) */}
-        <div className="flex gap-1.5">
+        <div className="flex gap-2 sm:gap-3">
           {LOWER_JAW.slice(8, 16).map(num => (
-            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} onClick={() => onToothClick(getTooth(num))} />
+            <ToothItem key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
Performed a focused UX redesign of the dental chart to transform it into a more intuitive, doctor-facing working tool. The primary objective was to replace the tiny square click targets with larger, clearer tooth representations and introduce a strong visual selected state. This redesign lays the foundation for future region-based structured editing.

## Changed Files
- `src/components/dental/DentalChartTab.tsx`
- `src/components/dental/ToothGrid.tsx`
- `src/components/dental/ToothGrid.test.tsx`
- `_ai_work/REPORTS/DENTALCHART-UX-REAL-001A_dental_chart_ui_and_tooth_interaction_redesign.md`

## Previous Usability Problem
- Tiny square click targets (`w-8 h-10`) made selecting a specific tooth inconvenient.
- No visual indication of the currently "selected" or active tooth on the grid.
- The chart felt less like a professional tool and more like a basic UI diagram.

## New Interaction Model
- Tooth targets are now substantially larger (`w-10 h-14` on mobile, `w-12 h-16` on larger screens).
- The clickable area (`<button>`) encompasses the tooth number and the tooth body.
- Hovering over any part of the tooth scales the element slightly and highlights the tooth number, confirming it is interactive.
- Clicking a tooth sets it as active, rendering it with a strong blue background (`bg-blue-50`), a prominent blue outline (`ring-2 ring-blue-500`), scaling it up (`scale-105`), and bringing it to the front (`z-10`).
- The `selectedTooth` is tracked in `DentalChartTab` and passed down to `ToothGrid` as `selectedToothNumber`.

## Tests Added
- Added `src/components/dental/ToothGrid.test.tsx`
- Covers render, click handler, and selected tooth visual state.
- DentalChartTab modal integration test was intentionally skipped because it requires expensive mocking of `useDentalChart`, `usePatientFindings`, and `useClinicalWorkflow`; this limitation is documented in the report.

## Commands Run
- `npm run lint`
- `npm run build`
- `npm test -- --run`

## Command Results
- **npm run lint:** PASS
- **npm run build:** PASS
- **npm test:** FAIL (1 unrelated test failed: `src/contexts/AuthContext.test.tsx` expected `authMode` to be `'dev'`, but received `'supabase-active'`. This is a lingering side-effect in `.env` from a previous QA step. Per strict instructions, it was documented but NOT fixed).

## Known Limitations
- The selected state persists after the modal closes. This is an intentional step towards a split-pane layout for the next task but might feel slightly unusual while the modal interaction paradigm is still in place.

## Explicit Statement
- No documents were implemented.
- No print/export was implemented.
- No billing/payment logic was implemented.
- No completed services were implemented.
- No admin task logic was implemented.
- No full patient card redesign was performed.
- No contracts were implemented.
- No package files were changed.
- No `.env` files were committed.
- No Supabase RLS policies or migrations were changed.

## Final Verdict
**READY FOR REVIEW**

## Recommended Next Task
**DENTALCHART-UX-REAL-001B — Add structured tooth regions and clinical sections (surfaces, crown, gum, canals/roots, bone, notes)**