### PR TITLE
DENTALCHART-VISUAL-REAL-001C: Improve tooth visual representation

### DIFF
--- a/_ai_work/REPORTS/DENTALCHART-VISUAL-REAL-001C_tooth_visual_representation.md
+++ b/_ai_work/REPORTS/DENTALCHART-VISUAL-REAL-001C_tooth_visual_representation.md
@@ -9,9 +9,11 @@ This task was strictly limited to visual and CSS-based updates to `ToothGrid.tsx
 ## 3. Files inspected
 - `src/components/dental/ToothGrid.tsx`
 - `src/components/dental/ToothGrid.test.tsx`
+- `src/components/dental/ToothEditorModal.test.tsx`
 
 ## 4. Files changed
 - `src/components/dental/ToothGrid.tsx`
+- `src/components/dental/ToothEditorModal.test.tsx`
 
 ## 5. Previous visual problem
 Teeth were rendered as simple, flat, pill-shaped blocks (`w-10 h-14` / `w-12 h-16` with rounded tops and bottoms). They did not anatomically resemble teeth, reducing the professional feel of the chart.

--- a/_ai_work/REPORTS/DENTALCHART-VISUAL-REAL-001C_tooth_visual_representation.md
+++ b/_ai_work/REPORTS/DENTALCHART-VISUAL-REAL-001C_tooth_visual_representation.md
@@ -1,0 +1,80 @@
+# TASK: DENTALCHART-VISUAL-REAL-001C — Improve tooth visual representation on dental chart
+
+## 1. Summary
+Improved the visual representation of teeth in the dental chart grid. Replaced the simple rectangular pill shape with a clear, CSS-based tooth silhouette featuring anatomically suggestive crown and root sections, separated and oriented correctly for upper and lower jaws. This enhancement significantly increases the clinical feel of the chart while fully preserving usability, hit areas, and existing data logic.
+
+## 2. Scope
+This task was strictly limited to visual and CSS-based updates to `ToothGrid.tsx`. No changes were made to the tooth editor modal, findings logic, or any backend configuration.
+
+## 3. Files inspected
+- `src/components/dental/ToothGrid.tsx`
+- `src/components/dental/ToothGrid.test.tsx`
+
+## 4. Files changed
+- `src/components/dental/ToothGrid.tsx`
+
+## 5. Previous visual problem
+Teeth were rendered as simple, flat, pill-shaped blocks (`w-10 h-14` / `w-12 h-16` with rounded tops and bottoms). They did not anatomically resemble teeth, reducing the professional feel of the chart.
+
+## 6. New tooth visual representation
+A CSS-based composite silhouette is now used:
+- **Split Structure:** Each tooth is visually divided into a "Crown" (taking up `~65%` of the height) and "Roots" (taking up `~35%` with a split down the middle).
+- **Anatomical Orientation:**
+  - **Upper Teeth (18-11, 21-28):** Roots point UP. The tooth number sits above the tooth.
+  - **Lower Teeth (48-41, 31-38):** Roots point DOWN. The tooth number sits below the tooth.
+- **Styling:** Retained existing clinical state coloring (`bg-blue-100`, `bg-orange-100`, etc.) applied seamlessly across both crown and roots.
+
+## 7. Click target preservation
+The entire tooth container remains an interactive `<button>`. Dimensions were kept mostly identical (`w-9 h-12 sm:w-11 sm:h-14` for the tooth body, plus text) keeping hit areas large and comfortable for doctors.
+
+## 8. Selected/hover state preservation
+- **Hover:** Retained the `scale-105` transformation and background highlights.
+- **Selected:** Retained the distinct `bg-blue-50`, `ring-2 ring-blue-500`, and `scale-105 z-10` elevation states. The selected state successfully wraps the entire newly structured component.
+
+## 9. Tooth number readability
+FDI numbering remains bold and clearly legible, dynamically positioned above upper teeth and below lower teeth to align with standard clinical charts.
+
+## 10. Status visual behavior
+Status abbreviations (C, F, P, etc.) and color coding driven by `getToothColor()` remain untouched and are accurately projected onto the new crown shapes.
+
+## 11. Tests added/updated
+No new tests were required. Existing `ToothGrid.test.tsx` accurately asserted rendering, click behaviors, and the application of `bg-blue-50` / `ring-2 ring-blue-500` classes to the outer button shell, which remain completely structurally unchanged.
+
+## 12. Commands run
+- `npm run lint`
+- `npm run build`
+- `npm test -- --run`
+
+## 13. Command results
+- **Lint**: Pass
+- **Build**: Pass
+- **Test**: Pass (except for 1 unrelated `AuthContext` test, expected due to local `supabase-active` env setup).
+
+## 14. What was NOT changed
+- No tooth editor modal redesign was performed.
+- No clinical fields were changed.
+- No findings logic was changed.
+- No treatment plan logic was changed.
+- No documents/contracts were implemented.
+- No print/export was implemented.
+- No billing/payment logic was implemented.
+- No completed services were implemented.
+- No admin task logic was implemented.
+- No appointment logic was changed.
+- No Header changes were made.
+- No Supabase migrations were changed.
+- No RLS policies were changed.
+- No seed data was changed.
+- No package files were changed.
+- No `.env` files were committed.
+- No new dependencies were added.
+- No browser QA was performed.
+
+## 15. Known limitations
+The root shapes are simplified using `border-radius` and percentages. While visually distinct, they do not accurately map the number of roots for specific molars vs incisors (which would require complex, specific SVG maps), but this is acceptable for a rapid clinical overview map.
+
+## 16. Final verdict
+**READY FOR REVIEW**
+
+## 17. Recommended next small visual step, if any
+*No further standalone visual steps are immediately required for the chart grid.* Next logical step would be transitioning to clinical logic features (`DENTALCHART-CLINICAL-REAL-001C`).

--- a/src/components/dental/ToothEditorModal.test.tsx
+++ b/src/components/dental/ToothEditorModal.test.tsx
@@ -1,14 +1,13 @@
 /** @vitest-environment jsdom */
-import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { ToothEditorModal } from './ToothEditorModal';
-import { ToothRecord } from '../../types';
+import type { ToothRecord } from '../../types';
 
 describe('ToothEditorModal', () => {
-  let container: HTMLDivElement | null = null;
-  let root: ReturnType<typeof createRoot> | null = null;
+  let container: HTMLDivElement;
+  let root: Root;
 
   beforeEach(() => {
     container = document.createElement('div');
@@ -20,8 +19,7 @@ describe('ToothEditorModal', () => {
     act(() => {
       root.unmount();
     });
-    container?.remove();
-    container = null;
+    container.remove();
     vi.clearAllMocks();
   });
 
@@ -45,7 +43,7 @@ describe('ToothEditorModal', () => {
       );
     });
 
-    const html = container!.innerHTML;
+    const html = container.innerHTML;
     expect(html).toContain('Основное состояние');
     expect(html).toContain('Коронка / Реставрация');
     expect(html).toContain('Десна / Мягкие ткани');
@@ -69,19 +67,19 @@ describe('ToothEditorModal', () => {
       );
     });
 
-    const select = container!.querySelector('select[name="condition"]') as HTMLSelectElement;
+    const select = container.querySelector('select[name="condition"]') as HTMLSelectElement;
     expect(select).not.toBeNull();
     expect(select.value).toBe('healthy');
-    expect(container!.innerHTML).not.toContain('Поверхности');
+    expect(container.innerHTML).not.toContain('Поверхности');
 
     await act(async () => {
       select.value = 'caries';
       select.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
-    expect(container!.innerHTML).toContain('Поверхности');
-    expect(container!.innerHTML).toContain('Жевательная');
-    expect(container!.innerHTML).toContain('Мезиальная');
+    expect(container.innerHTML).toContain('Поверхности');
+    expect(container.innerHTML).toContain('Жевательная');
+    expect(container.innerHTML).toContain('Мезиальная');
   });
 
   it('save and reset buttons remain available', async () => {
@@ -98,8 +96,8 @@ describe('ToothEditorModal', () => {
       );
     });
 
-    const saveButton = container!.querySelector('button[type="submit"]');
-    const resetText = container!.innerHTML;
+    const saveButton = container.querySelector('button[type="submit"]');
+    const resetText = container.innerHTML;
     
     expect(saveButton).not.toBeNull();
     expect(saveButton!.textContent).toBe('Сохранить');

--- a/src/components/dental/ToothGrid.tsx
+++ b/src/components/dental/ToothGrid.tsx
@@ -44,6 +44,7 @@ const getConditionAbbr = (condition: string) => {
 };
 
 const ToothItem = ({ tooth, findings = [], isSelected, onClick }: { tooth: ToothRecord, findings: DentalFinding[], isSelected?: boolean, onClick: () => void }) => {
+  const isUpper = (tooth?.toothNumber || 0) < 30;
 
   const getIndicator = () => {
     if (!findings || findings.length === 0) return null;
@@ -55,36 +56,73 @@ const ToothItem = ({ tooth, findings = [], isSelected, onClick }: { tooth: Tooth
     const isObservingOnly = active.every(f => f.status === 'observing');
 
     if (hasHighOrUrgent) {
-      return <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-red-500 rounded-full border-2 border-white shadow-sm z-20"></div>;
+      return <div className={`absolute ${isUpper ? '-bottom-1.5' : '-top-1.5'} -right-1.5 w-3 h-3 bg-red-500 rounded-full border-2 border-white shadow-sm z-20`}></div>;
     }
 
     if (isObservingOnly) {
-      return <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-slate-400 rounded-full border-2 border-white shadow-sm opacity-80 z-20"></div>;
+      return <div className={`absolute ${isUpper ? '-bottom-1.5' : '-top-1.5'} -right-1.5 w-3 h-3 bg-slate-400 rounded-full border-2 border-white shadow-sm opacity-80 z-20`}></div>;
     }
 
-    return <div className="absolute -top-1.5 -right-1.5 w-3 h-3 bg-blue-500 rounded-full border-2 border-white shadow-sm z-20"></div>;
+    return <div className={`absolute ${isUpper ? '-bottom-1.5' : '-top-1.5'} -right-1.5 w-3 h-3 bg-blue-500 rounded-full border-2 border-white shadow-sm z-20`}></div>;
   };
+
+  const toothNumberEl = (
+    <div className={`text-sm font-bold transition-colors ${isSelected ? 'text-blue-700' : 'text-slate-600 group-hover:text-blue-600'}`}>
+      {tooth?.toothNumber}
+    </div>
+  );
+
+  const conditionClasses = getToothColor(tooth?.condition || 'healthy');
+  const bgColorClass = conditionClasses.split(' ').find(c => c.startsWith('bg-')) || 'bg-white';
+  const borderColorClass = conditionClasses.split(' ').find(c => c.startsWith('border-')) || 'border-slate-300';
+  const textColorClass = conditionClasses.split(' ').find(c => c.startsWith('text-')) || '';
+  
+  const hoverBorder = isSelected ? 'border-blue-500' : 'group-hover:border-blue-400';
 
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label={`Редактировать зуб ${tooth?.toothNumber}`}
-      className={`flex flex-col items-center gap-1.5 p-1.5 sm:p-2 cursor-pointer group relative focus:outline-none transition-all rounded-xl ${
+      className={`flex flex-col items-center gap-1.5 p-1 sm:p-1.5 cursor-pointer group relative focus:outline-none transition-all rounded-xl ${
         isSelected 
           ? 'bg-blue-50 ring-2 ring-blue-500 shadow-md scale-105 z-10' 
           : 'hover:bg-slate-100 hover:scale-105'
       }`}
     >
-      <div className={`text-sm font-bold transition-colors ${isSelected ? 'text-blue-700' : 'text-slate-600 group-hover:text-blue-600'}`}>
-        {tooth?.toothNumber}
-      </div>
-      <div className={`w-10 h-14 sm:w-12 sm:h-16 rounded-t-md rounded-b-2xl border-2 flex items-center justify-center transition-all shadow-sm ${getToothColor(tooth?.condition)} ${
-        isSelected ? 'border-blue-500 shadow-md' : 'group-hover:shadow-md'
-      } relative`}>
+      {isUpper && toothNumberEl}
+
+      <div className="w-9 h-12 sm:w-11 sm:h-14 flex flex-col relative transition-all drop-shadow-sm group-hover:drop-shadow-md">
         {getIndicator()}
-        <span className="text-sm font-bold">{getConditionAbbr(tooth?.condition || 'healthy')}</span>
+        
+        {isUpper ? (
+          <>
+            {/* Upper Roots */}
+            <div className="h-[35%] flex justify-between px-[15%] -mb-[2px] relative z-0">
+              <div className={`w-[35%] h-full rounded-t-full border-2 border-b-0 ${bgColorClass} ${borderColorClass} ${hoverBorder} transition-colors`}></div>
+              <div className={`w-[35%] h-full rounded-t-full border-2 border-b-0 ${bgColorClass} ${borderColorClass} ${hoverBorder} transition-colors`}></div>
+            </div>
+            {/* Upper Crown */}
+            <div className={`flex-1 rounded-b-[40%] rounded-t-sm border-2 flex items-center justify-center relative z-10 ${bgColorClass} ${borderColorClass} ${hoverBorder} ${textColorClass} transition-colors`}>
+              <span className="text-xs font-bold leading-none">{getConditionAbbr(tooth?.condition || 'healthy')}</span>
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Lower Crown */}
+            <div className={`flex-1 rounded-t-[40%] rounded-b-sm border-2 flex items-center justify-center relative z-10 ${bgColorClass} ${borderColorClass} ${hoverBorder} ${textColorClass} transition-colors`}>
+              <span className="text-xs font-bold leading-none">{getConditionAbbr(tooth?.condition || 'healthy')}</span>
+            </div>
+            {/* Lower Roots */}
+            <div className="h-[35%] flex justify-between px-[15%] -mt-[2px] relative z-0">
+              <div className={`w-[35%] h-full rounded-b-full border-2 border-t-0 ${bgColorClass} ${borderColorClass} ${hoverBorder} transition-colors`}></div>
+              <div className={`w-[35%] h-full rounded-b-full border-2 border-t-0 ${bgColorClass} ${borderColorClass} ${hoverBorder} transition-colors`}></div>
+            </div>
+          </>
+        )}
       </div>
+
+      {!isUpper && toothNumberEl}
     </button>
   );
 };


### PR DESCRIPTION
## Summary
Improved the visual representation of teeth in the dental chart grid. Replaced the simple rectangular pill shape with a clear, CSS-based tooth silhouette featuring anatomically suggestive crown and root sections, separated and oriented correctly for upper and lower jaws. This enhancement significantly increases the clinical feel of the chart while fully preserving usability, hit areas, and existing data logic.

*Also fixes TypeScript compile errors in `ToothEditorModal.test.tsx` inherited from merged PR #195: removed unused React import, changed ToothRecord to type-only import, and made React root non-null in tests.*

## Changed Files
- `src/components/dental/ToothGrid.tsx`
- `src/components/dental/ToothEditorModal.test.tsx`
- `_ai_work/REPORTS/DENTALCHART-VISUAL-REAL-001C_tooth_visual_representation.md`

## Previous Visual Problem
Teeth were rendered as simple, flat, pill-shaped blocks. They did not anatomically resemble teeth, reducing the professional feel of the chart.

## New Visual Approach
A CSS-based composite silhouette is now used:
- **Split Structure:** Each tooth is visually divided into a "Crown" and "Roots" (with a split down the middle).
- **Anatomical Orientation:** Upper Teeth (18-11, 21-28) have roots pointing UP and the tooth number above. Lower Teeth (48-41, 31-38) have roots pointing DOWN and the tooth number below.
- **Styling:** Retained existing clinical state coloring (`bg-blue-100`, `bg-orange-100`, etc.) applied seamlessly across both crown and roots.

## Preserved Behavior
- **Click targets:** The entire tooth container remains an interactive `<button>`. Dimensions were kept mostly identical.
- **Selected/hover states:** Retained the `scale-105` transformation, background highlights, `bg-blue-50`, and `ring-2 ring-blue-500` elevation states. The selected state successfully wraps the entire newly structured component.
- **Status visual behavior:** Status abbreviations (C, F, P, etc.) and color coding driven by `getToothColor()` remain untouched.

## Tests Added/Updated
No new tests were required. Existing `ToothGrid.test.tsx` accurately asserted rendering, click behaviors, and the application of `bg-blue-50` / `ring-2 ring-blue-500` classes to the outer button shell, which remain structurally unchanged.
Additionally fixed TypeScript build errors in `ToothEditorModal.test.tsx`.

## Commands Run
- `npm run lint`
- `npm run build`
- `npm test -- --run`

## Command Results
- **Lint**: Pass
- **Build**: Pass
- **Test**: Pass (except for 1 unrelated `AuthContext` test, expected due to local `supabase-active` env setup).

## Explicit Statement
- No clinical fields were changed.
- No documents/contracts were implemented.
- No billing/payment logic was implemented.
- No admin task logic was implemented.
- No package files, `.env` files, or new dependencies were added.
- No migrations or RLS changes were made.

## Known Limitations
The root shapes are simplified using CSS `border-radius` and percentages. They do not accurately map the number of roots for specific molars vs incisors, but this is an acceptable tradeoff for a rapid clinical overview map without introducing heavy SVG dependencies.

## Final Verdict
**READY FOR REVIEW**