### PR TITLE
DENTALCHART-COMPAT-001: add dental chart normalization layer

### DIFF
--- a/src/data/repositories/DentalChartRepository.ts
+++ b/src/data/repositories/DentalChartRepository.ts
@@ -1,4 +1,5 @@
 import { storage } from '../../utils/storage';
+import { normalizeDentalChart, normalizeToothRecord } from '../../utils/dentalChartNormalization';
 import type { DentalChart, ToothRecord, ToothNumber, ToothCondition, ToothSurface } from '../../types';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -17,11 +18,11 @@ export interface CreateDentalChartRepositoryOptions {
 
 export const LocalStorageDentalChartRepository: DentalChartRepository = {
   async getDentalChart(patientId: string): Promise<DentalChart> {
-    return storage.getDentalChart(patientId);
+    return normalizeDentalChart(storage.getDentalChart(patientId));
   },
 
   async saveDentalChart(patientId: string, chart: DentalChart): Promise<void> {
-    storage.saveDentalChart(patientId, chart);
+    storage.saveDentalChart(patientId, normalizeDentalChart(chart));
   },
 };
 
@@ -62,7 +63,7 @@ export class SupabaseDentalChartRepository implements DentalChartRepository {
     const dbTeethMap = new Map<number, ToothRecord>();
 
     (teethData || []).forEach(row => {
-      dbTeethMap.set(row.tooth_number, {
+      dbTeethMap.set(row.tooth_number, normalizeToothRecord({
         toothNumber: row.tooth_number as ToothNumber,
         condition: row.condition as ToothCondition,
         surfaces: (row.surfaces || []) as ToothSurface[],
@@ -73,14 +74,14 @@ export class SupabaseDentalChartRepository implements DentalChartRepository {
         canal: row.canal || undefined,
         notes: row.notes || undefined,
         updatedAt: row.updated_at,
-      });
+      }));
     });
 
-    const mergedTeeth = defaultChart.teeth.map(defaultTooth => 
+    const mergedTeeth = defaultChart.teeth.map(defaultTooth =>
       dbTeethMap.get(defaultTooth.toothNumber) || defaultTooth
     );
 
-    return {
+    return normalizeDentalChart({
       id: chartData.id,
       patientId: chartData.patient_id,
       teeth: mergedTeeth,
@@ -88,10 +89,12 @@ export class SupabaseDentalChartRepository implements DentalChartRepository {
       diagnosis: chartData.diagnosis || undefined,
       createdAt: chartData.created_at,
       updatedAt: chartData.updated_at,
-    };
+    });
   }
 
   async saveDentalChart(patientId: string, chart: DentalChart): Promise<void> {
+    const normalizedChart = normalizeDentalChart(chart);
+
     // 1. First select existing dental_charts row by tenant_id + patient_id
     const { data: existingChart, error: fetchError } = await this.client
       .from('dental_charts')
@@ -119,16 +122,17 @@ export class SupabaseDentalChartRepository implements DentalChartRepository {
         id: chartId,
         tenant_id: this.tenantId,
         patient_id: patientId,
-        complaints: chart.complaints || null,
-        diagnosis: chart.diagnosis || null,
+        complaints: normalizedChart.complaints || null,
+        diagnosis: normalizedChart.diagnosis || null,
       }, {
         onConflict: 'tenant_id,patient_id'
       });
 
     if (chartError) throw chartError;
 
-    // 5. Save tooth_states using that same stable chartId
-    const teethRows = chart.teeth.map(t => ({
+    // 5. Save tooth_states using that same stable chartId.
+    // Forward-compatible fields are normalized in memory only until DB schema supports them.
+    const teethRows = normalizedChart.teeth.map(t => ({
       tenant_id: this.tenantId,
       dental_chart_id: chartId,
       tooth_number: t.toothNumber,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,41 @@ export type ToothCondition =
   | 'periodontitis'
   | 'needs_treatment';
 
+export type ToothPresenceStatus =
+  | 'natural'
+  | 'missing'
+  | 'implant'
+  | 'root_remnant'
+  | 'deciduous'
+  | 'impacted';
+
+export type ToothVisualState = ToothCondition;
+
+export type ClinicalZone =
+  | 'crown'
+  | 'endodontics'
+  | 'root'
+  | 'periodontium'
+  | 'bone'
+  | 'orthopedics'
+  | 'planning';
+
+export type PlannedWorkRecordStatus =
+  | 'planned'
+  | 'approved'
+  | 'in_progress'
+  | 'completed'
+  | 'cancelled';
+
+export interface PlannedWorkRecord {
+  id: string;
+  workId: string;
+  zone: ClinicalZone;
+  status: PlannedWorkRecordStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export type ToothSurface = 'occlusal' | 'mesial' | 'distal' | 'vestibular' | 'oral';
 
 export interface ToothRecord {
@@ -104,6 +139,13 @@ export interface ToothRecord {
   workCanal?: string;
   notes?: string;
   updatedAt: string;
+  presenceStatus?: ToothPresenceStatus;
+  visualState?: ToothVisualState;
+  visualStateOverride?: ToothVisualState;
+  diagnoses?: string[];
+  plannedWorks?: string[];
+  plannedWorkRecords?: PlannedWorkRecord[];
+  completedWorks?: string[];
 }
 
 export interface DentalChart {

--- a/src/utils/__tests__/dentalChartNormalization.test.ts
+++ b/src/utils/__tests__/dentalChartNormalization.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { DentalChart, ToothRecord } from '../../types';
+import {
+  derivePresenceStatusFromCondition,
+  deriveVisualStateFromTooth,
+  normalizeDentalChart,
+  normalizeToothRecord,
+} from '../dentalChartNormalization';
+
+const baseTooth: ToothRecord = {
+  toothNumber: 11,
+  condition: 'healthy',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function createChart(tooth: ToothRecord): DentalChart {
+  return {
+    id: 'chart_patient_1',
+    patientId: 'patient_1',
+    teeth: [tooth],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('dental chart normalization', () => {
+  it('adds forward-compatible defaults to an old healthy tooth record', () => {
+    const normalized = normalizeToothRecord(baseTooth);
+
+    expect(normalized.presenceStatus).toBe('natural');
+    expect(normalized.visualState).toBe('healthy');
+    expect(normalized.diagnoses).toEqual([]);
+    expect(normalized.plannedWorks).toEqual([]);
+    expect(normalized.plannedWorkRecords).toEqual([]);
+    expect(normalized.completedWorks).toEqual([]);
+    expect(normalized.surfaces).toEqual([]);
+  });
+
+  it('derives missing presence status from condition', () => {
+    expect(derivePresenceStatusFromCondition('missing')).toBe('missing');
+    expect(normalizeToothRecord({ ...baseTooth, condition: 'missing' }).presenceStatus).toBe('missing');
+  });
+
+  it('derives implant presence status from condition', () => {
+    expect(derivePresenceStatusFromCondition('implant')).toBe('implant');
+    expect(normalizeToothRecord({ ...baseTooth, condition: 'implant' }).presenceStatus).toBe('implant');
+  });
+
+  it('derives root remnant presence status from root condition', () => {
+    expect(derivePresenceStatusFromCondition('root')).toBe('root_remnant');
+    expect(normalizeToothRecord({ ...baseTooth, condition: 'root' }).presenceStatus).toBe('root_remnant');
+  });
+
+  it('uses visualStateOverride before visualState and condition', () => {
+    const tooth: ToothRecord = {
+      ...baseTooth,
+      condition: 'healthy',
+      visualState: 'caries',
+      visualStateOverride: 'crown',
+    };
+
+    expect(deriveVisualStateFromTooth(tooth)).toBe('crown');
+    expect(normalizeToothRecord(tooth).visualState).toBe('crown');
+  });
+
+  it('does not mutate original dental chart input', () => {
+    const original = createChart(baseTooth);
+    const snapshot = JSON.parse(JSON.stringify(original));
+
+    const normalized = normalizeDentalChart(original);
+
+    expect(original).toEqual(snapshot);
+    expect(normalized).not.toBe(original);
+    expect(normalized.teeth[0]).not.toBe(original.teeth[0]);
+  });
+
+  it('preserves existing forward-compatible fields', () => {
+    const tooth: ToothRecord = {
+      ...baseTooth,
+      condition: 'healthy',
+      surfaces: ['occlusal'],
+      presenceStatus: 'impacted',
+      visualState: 'filled',
+      diagnoses: ['dx_1'],
+      plannedWorks: ['work_1'],
+      plannedWorkRecords: [{
+        id: 'planned_1',
+        workId: 'work_1',
+        zone: 'crown',
+        status: 'planned',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }],
+      completedWorks: ['work_done_1'],
+    };
+
+    const normalized = normalizeToothRecord(tooth);
+
+    expect(normalized.presenceStatus).toBe('impacted');
+    expect(normalized.visualState).toBe('filled');
+    expect(normalized.surfaces).toEqual(['occlusal']);
+    expect(normalized.diagnoses).toEqual(['dx_1']);
+    expect(normalized.plannedWorks).toEqual(['work_1']);
+    expect(normalized.plannedWorkRecords).toEqual(tooth.plannedWorkRecords);
+    expect(normalized.completedWorks).toEqual(['work_done_1']);
+  });
+
+  it('defaults surfaces to an empty array when absent', () => {
+    const normalized = normalizeToothRecord({
+      toothNumber: 12,
+      condition: 'healthy',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(normalized.surfaces).toEqual([]);
+  });
+
+  it('falls back to healthy when a legacy record has an invalid condition', () => {
+    const invalidTooth = {
+      toothNumber: 13,
+      condition: 'legacy_unknown',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } as unknown as ToothRecord;
+
+    const normalized = normalizeToothRecord(invalidTooth);
+
+    expect(normalized.condition).toBe('healthy');
+    expect(normalized.presenceStatus).toBe('natural');
+    expect(normalized.visualState).toBe('healthy');
+  });
+});

--- a/src/utils/dentalChartNormalization.ts
+++ b/src/utils/dentalChartNormalization.ts
@@ -1,0 +1,78 @@
+import type {
+  DentalChart,
+  ToothCondition,
+  ToothPresenceStatus,
+  ToothRecord,
+  ToothVisualState,
+} from '../types';
+
+const TOOTH_CONDITIONS: ToothCondition[] = [
+  'healthy',
+  'caries',
+  'filled',
+  'missing',
+  'crown',
+  'implant',
+  'root',
+  'pulpitis',
+  'periodontitis',
+  'needs_treatment',
+];
+
+const TOOTH_CONDITION_SET = new Set<string>(TOOTH_CONDITIONS);
+
+function isToothCondition(value: unknown): value is ToothCondition {
+  return typeof value === 'string' && TOOTH_CONDITION_SET.has(value);
+}
+
+function getSafeCondition(value: unknown): ToothCondition {
+  return isToothCondition(value) ? value : 'healthy';
+}
+
+export function derivePresenceStatusFromCondition(condition: ToothCondition): ToothPresenceStatus {
+  if (condition === 'missing') return 'missing';
+  if (condition === 'implant') return 'implant';
+  if (condition === 'root') return 'root_remnant';
+
+  return 'natural';
+}
+
+export function deriveVisualStateFromTooth(tooth: ToothRecord): ToothVisualState {
+  if (isToothCondition(tooth.visualStateOverride)) {
+    return tooth.visualStateOverride;
+  }
+
+  if (isToothCondition(tooth.visualState)) {
+    return tooth.visualState;
+  }
+
+  return getSafeCondition(tooth.condition);
+}
+
+export function normalizeToothRecord(tooth: ToothRecord): ToothRecord {
+  const condition = getSafeCondition((tooth as { condition?: unknown }).condition);
+  const safeTooth: ToothRecord = {
+    ...tooth,
+    condition,
+  };
+
+  return {
+    ...tooth,
+    condition,
+    surfaces: tooth.surfaces ?? [],
+    presenceStatus: tooth.presenceStatus ?? derivePresenceStatusFromCondition(condition),
+    visualState: deriveVisualStateFromTooth(safeTooth),
+    diagnoses: tooth.diagnoses ?? [],
+    plannedWorks: tooth.plannedWorks ?? [],
+    plannedWorkRecords: tooth.plannedWorkRecords ?? [],
+    completedWorks: tooth.completedWorks ?? [],
+    updatedAt: tooth.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+export function normalizeDentalChart(chart: DentalChart): DentalChart {
+  return {
+    ...chart,
+    teeth: chart.teeth.map(normalizeToothRecord),
+  };
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,6 @@
 import type { Patient, Doctor, Appointment, DentalChart, TreatmentPlan, ToothNumber, ToothRecord, ChiefComplaint, DentalFinding } from '../types';
 import { demoDoctors, demoPatients, demoAppointments, demoChiefComplaints, demoDentalFindings } from '../data/seed';
+import { normalizeDentalChart, normalizeToothRecord } from './dentalChartNormalization';
 
 const STORAGE_KEYS = {
   INITIALIZED: 'df_initialized',
@@ -93,19 +94,20 @@ export const storage = {
       31,32,33,34,35,36,37,38
     ];
 
-    const teeth: ToothRecord[] = teethNumbers.map(num => ({
+    const now = new Date().toISOString();
+    const teeth: ToothRecord[] = teethNumbers.map(num => normalizeToothRecord({
       toothNumber: num,
       condition: 'healthy',
-      updatedAt: new Date().toISOString()
+      updatedAt: now
     }));
 
-    return {
+    return normalizeDentalChart({
       id: `chart_${patientId}`,
       patientId,
       teeth,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
+      createdAt: now,
+      updatedAt: now
+    });
   },
 
   getAllDentalCharts: (): Record<string, DentalChart> => {
@@ -119,12 +121,12 @@ export const storage = {
       storage.saveDentalChart(patientId, defaultChart);
       return defaultChart;
     }
-    return charts[patientId];
+    return normalizeDentalChart(charts[patientId]);
   },
 
   saveDentalChart: (patientId: string, chart: DentalChart) => {
     const charts = storage.getAllDentalCharts();
-    charts[patientId] = chart;
+    charts[patientId] = normalizeDentalChart(chart);
     localStorage.setItem(STORAGE_KEYS.DENTAL_CHARTS, JSON.stringify(charts));
   },
 


### PR DESCRIPTION
## Summary
Adds forward-compatible dental chart tooth fields and a normalization layer before migrating the new dental chart editor UI.

## What changed
- Added optional compatibility fields to ToothRecord.
- Added pure dental chart normalization helpers.
- Normalized localStorage dental chart load/save.
- Normalized Supabase dental chart read/save boundaries.
- Added unit tests for old tooth records and future-compatible fields.

## Scope boundaries
- No UI rewrite.
- No clinical dictionaries.
- No schema/migration/seed changes.
- No package changes.
- No new admin pages.
- Supabase still persists only existing tooth_state fields.

## Checks
- npm run lint: not run locally in this environment
- npm run test: not run locally in this environment
- npm run build: not run locally in this environment

## Changed files
- src/types/index.ts
- src/utils/dentalChartNormalization.ts
- src/utils/storage.ts
- src/data/repositories/DentalChartRepository.ts
- src/utils/__tests__/dentalChartNormalization.test.ts

Do not merge until CI is green and diff is reviewed.