### PR TITLE
DENTALCHART-EDITOR-PROTOTYPE-001: migrate tooth editor to clinical dictionary UI

### DIFF
--- a/src/components/dental/ToothEditorModal.test.tsx
+++ b/src/components/dental/ToothEditorModal.test.tsx
@@ -26,11 +26,11 @@ describe('ToothEditorModal', () => {
   const mockTooth: ToothRecord = {
     toothNumber: 11,
     condition: 'healthy',
-    updatedAt: new Date().toISOString()
+    updatedAt: new Date().toISOString(),
   };
 
-  it('renders all structured clinical section headers without requiring tab switching', async () => {
-    await act(async () => {
+  function renderModal(onSave = vi.fn()) {
+    act(() => {
       root.render(
         <ToothEditorModal
           isOpen={true}
@@ -38,106 +38,123 @@ describe('ToothEditorModal', () => {
           patientId="p1"
           existingFindings={[]}
           onClose={() => {}}
-          onSave={() => {}}
+          onSave={onSave}
         />
       );
+    });
+
+    return onSave;
+  }
+
+  function getSelectByValue(value: string): HTMLSelectElement {
+    const select = Array.from(container.querySelectorAll('select')).find((item) => item.value === value) as HTMLSelectElement | undefined;
+    expect(select).toBeTruthy();
+    return select!;
+  }
+
+  function clickByText(text: string) {
+    const element = Array.from(container.querySelectorAll('button, label')).find((item) => item.textContent?.includes(text));
+    expect(element).toBeTruthy();
+
+    act(() => {
+      element!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+  }
+
+  it('renders the prototype editor shell with anatomical status, visual state, notes, and dictionary zones', () => {
+    renderModal();
+
+    const html = container.innerHTML;
+    expect(html).toContain('Анатомический статус');
+    expect(html).toContain('Отображение на формуле');
+    expect(html).toContain('Общие заметки');
+    expect(html).toContain('Создать клиническую проблему');
+    expect(html).toContain('Коронка');
+    expect(html).toContain('Каналы');
+    expect(html).toContain('Десна');
+    expect(html).toContain('Диагнозы / состояния');
+  });
+
+  it('changes available tabs when anatomical status changes', () => {
+    renderModal();
+
+    const presenceSelect = getSelectByValue('natural');
+
+    act(() => {
+      presenceSelect.value = 'missing';
+      presenceSelect.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
     const html = container.innerHTML;
-    expect(html).toContain('Основное состояние');
-    expect(html).toContain('Коронка / Реставрация');
-    expect(html).toContain('Корни / Каналы');
-    expect(html).toContain('Десна / Мягкие ткани');
-    expect(html).toContain('Костная ткань');
-    expect(html).toContain('Клинические заметки');
-    expect(html).toContain('Создать или обновить проблему по этому зубу');
+    expect(html).toContain('Планирование');
+    expect(html).toContain('Кость');
+    expect(html).toContain('Отсутствие зуба');
+    expect(html).not.toContain('Каналы');
   });
 
-  it('zone tabs highlight sections but do not hide other clinical sections', async () => {
-    await act(async () => {
-      root.render(
-        <ToothEditorModal
-          isOpen={true}
-          tooth={mockTooth}
-          patientId="p1"
-          existingFindings={[]}
-          onClose={() => {}}
-          onSave={() => {}}
-        />
-      );
-    });
+  it('shows treatment works after selecting a diagnosis', () => {
+    renderModal();
 
-    await act(async () => {
-      const rootTab = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Каналы');
-      rootTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
+    expect(container.innerHTML).toContain('Выберите диагноз выше');
+    clickByText('Кариес эмали');
 
-    let html = container.innerHTML;
-    expect(html).toContain('Коронка / Реставрация');
-    expect(html).toContain('Корни / Каналы');
-    expect(html).toContain('Десна / Мягкие ткани');
-    expect(html).toContain('Костная ткань');
-
-    await act(async () => {
-      const gumTab = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Десна');
-      gumTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    html = container.innerHTML;
-    expect(html).toContain('Коронка / Реставрация');
-    expect(html).toContain('Корни / Каналы');
-    expect(html).toContain('Десна / Мягкие ткани');
-    expect(html).toContain('Костная ткань');
+    const html = container.innerHTML;
+    expect(html).toContain('Пломба 1 поверхность');
   });
 
-  it('condition select works and shows surfaces when condition requires treatment', async () => {
-    await act(async () => {
-      root.render(
-        <ToothEditorModal
-          isOpen={true}
-          tooth={mockTooth}
-          patientId="p1"
-          existingFindings={[]}
-          onClose={() => {}}
-          onSave={() => {}}
-        />
-      );
+  it('saves compatibility fields without creating a finding by default', () => {
+    const onSave = renderModal();
+
+    clickByText('Кариес эмали');
+    clickByText('Пломба 1 поверхность');
+    clickByText('Сохранить изменения');
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const [savedTooth, findingPayload] = onSave.mock.calls[0] as [ToothRecord, unknown];
+
+    expect(savedTooth.presenceStatus).toBe('natural');
+    expect(savedTooth.diagnoses).toContain('dx_caries_enamel');
+    expect(savedTooth.plannedWorks).toContain('work_filling_1_surface');
+    expect(savedTooth.plannedWorkRecords?.[0]).toMatchObject({
+      workId: 'work_filling_1_surface',
+      zone: 'crown',
+      status: 'planned',
     });
-
-    const select = container.querySelector('select[name="condition"]') as HTMLSelectElement;
-    expect(select).not.toBeNull();
-    expect(select.value).toBe('healthy');
-    expect(container.innerHTML).not.toContain('Поверхности');
-
-    await act(async () => {
-      select.value = 'caries';
-      select.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    expect(container.innerHTML).toContain('Поверхности');
-    expect(container.innerHTML).toContain('Жевательная');
-    expect(container.innerHTML).toContain('Мезиальная');
+    expect(savedTooth.visualState).toBe('caries');
+    expect(savedTooth.condition).toBe('caries');
+    expect(findingPayload).toBeNull();
   });
 
-  it('save and reset buttons remain available', async () => {
-    await act(async () => {
-      root.render(
-        <ToothEditorModal
-          isOpen={true}
-          tooth={mockTooth}
-          patientId="p1"
-          existingFindings={[]}
-          onClose={() => {}}
-          onSave={() => {}}
-        />
-      );
+  it('creates a finding payload when requested', () => {
+    const onSave = renderModal();
+
+    clickByText('Создать клиническую проблему');
+    clickByText('Кариес эмали');
+    clickByText('Сохранить изменения');
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const [, findingPayload] = onSave.mock.calls[0] as [ToothRecord, { title?: string; description?: string }];
+
+    expect(findingPayload.title).toContain('зуб 11');
+    expect(findingPayload.description).toContain('Кариес эмали');
+  });
+
+  it('supports manual visual state override and reset', () => {
+    renderModal();
+
+    clickByText('Изменить вручную');
+    const visualSelect = getSelectByValue('healthy');
+
+    act(() => {
+      visualSelect.value = 'filled';
+      visualSelect.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
-    const saveButton = container.querySelector('button[type="submit"]');
-    const resetText = container.innerHTML;
+    expect(container.innerHTML).toContain('Вернуть автоматический расчёт');
+    clickByText('Сбросить');
 
-    expect(saveButton).not.toBeNull();
-    expect(saveButton!.textContent).toBe('Сохранить');
-    expect(resetText).toContain('Сбросить (Здоров)');
+    const html = container.innerHTML;
+    expect(html).toContain('Расчётное состояние');
+    expect(html).not.toContain('Вернуть автоматический расчёт');
   });
 });

--- a/src/components/dental/ToothEditorModal.tsx
+++ b/src/components/dental/ToothEditorModal.tsx
@@ -1,8 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import { X, RefreshCcw } from 'lucide-react';
-import { SuggestionInput } from './SuggestionInput';
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, BookOpen, Plus, RefreshCcw, Save, X } from 'lucide-react';
+import type {
+  ClinicalZone,
+  DentalFinding,
+  FindingCategory,
+  FindingSeverity,
+  FindingStatus,
+  PlannedWorkRecord,
+  ToothPresenceStatus,
+  ToothRecord,
+  ToothVisualState,
+} from '../../types';
 import type { ToothZone } from './ToothZoneSelectorModal';
-import type { ToothRecord, ToothCondition, ToothSurface, DentalFinding, FindingCategory, FindingSeverity, FindingStatus } from '../../types';
+import { normalizeToothRecord } from '../../utils/dentalChartNormalization';
+import {
+  defaultClinicalWorks,
+  defaultDiagnoses,
+  getAvailableZonesForPresence,
+  getBaseWorksByPresenceAndZone,
+  getDiagnosesByPresenceAndZone,
+  getWorksByDiagnoses,
+  getWorksByPresenceAndZone,
+  type ClinicalDiagnosis,
+  type ClinicalWork,
+} from '../../config/clinicalDictionaries';
 
 interface ToothEditorModalProps {
   isOpen: boolean;
@@ -14,11 +35,20 @@ interface ToothEditorModalProps {
   onSave: (tooth: ToothRecord, findingData: Partial<DentalFinding> | null) => void;
 }
 
-const CONDITIONS: { value: ToothCondition; label: string }[] = [
+const PRESENCE_STATUSES: { value: ToothPresenceStatus; label: string; hint: string }[] = [
+  { value: 'natural', label: 'Естественный зуб', hint: 'Обычный постоянный зуб' },
+  { value: 'missing', label: 'Отсутствует', hint: 'Зуб удалён или отсутствует' },
+  { value: 'implant', label: 'Имплант', hint: 'Установлен имплант' },
+  { value: 'root_remnant', label: 'Остаток корня', hint: 'Коронковая часть отсутствует' },
+  { value: 'deciduous', label: 'Молочный зуб', hint: 'Временный зуб' },
+  { value: 'impacted', label: 'Ретинированный', hint: 'Не прорезался / расположен неправильно' },
+];
+
+const VISUAL_STATES: { value: ToothVisualState; label: string }[] = [
   { value: 'healthy', label: 'Здоров' },
   { value: 'caries', label: 'Кариес' },
   { value: 'filled', label: 'Пломба' },
-  { value: 'missing', label: 'Удалён' },
+  { value: 'missing', label: 'Удалён / отсутствует' },
   { value: 'crown', label: 'Коронка' },
   { value: 'implant', label: 'Имплант' },
   { value: 'root', label: 'Корень' },
@@ -27,111 +57,310 @@ const CONDITIONS: { value: ToothCondition; label: string }[] = [
   { value: 'needs_treatment', label: 'Требует лечения' },
 ];
 
-const SURFACES: { value: ToothSurface; label: string }[] = [
-  { value: 'occlusal', label: 'Жевательная (O)' },
-  { value: 'mesial', label: 'Мезиальная (M)' },
-  { value: 'distal', label: 'Дистальная (D)' },
-  { value: 'vestibular', label: 'Вестибулярная (V)' },
-  { value: 'oral', label: 'Оральная (L/P)' },
-];
+const ZONE_LABELS: Record<ClinicalZone, string> = {
+  crown: 'Коронка',
+  endodontics: 'Каналы',
+  root: 'Корень',
+  periodontium: 'Десна',
+  bone: 'Кость',
+  orthopedics: 'Ортопедия',
+  planning: 'Планирование',
+};
+
+const ZONE_HINTS: Record<ClinicalZone, string> = {
+  crown: 'Диагнозы и работы по коронковой части зуба',
+  endodontics: 'Эндодонтия, пульпа и корневые каналы',
+  root: 'Корень, верхушка корня и периапикальные изменения',
+  periodontium: 'Десна, пародонт и мягкие ткани',
+  bone: 'Костная ткань и хирургическое планирование',
+  orthopedics: 'Ортопедические конструкции и протезирование',
+  planning: 'Планирование восстановления отсутствующего зуба',
+};
+
+function mapToClinicalZone(zone?: ToothZone): ClinicalZone {
+  if (zone === 'gum') return 'periodontium';
+  if (zone === 'root') return 'endodontics';
+  if (zone === 'bone') return 'bone';
+  return 'crown';
+}
+
+function createRecordId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `planned_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+function getFirstAvailableZone(presenceStatus: ToothPresenceStatus, preferredZone?: ClinicalZone): ClinicalZone {
+  const availableZones = getAvailableZonesForPresence(presenceStatus);
+
+  if (preferredZone && availableZones.includes(preferredZone)) {
+    return preferredZone;
+  }
+
+  return availableZones[0] || 'crown';
+}
+
+function deriveVisualState(
+  presenceStatus: ToothPresenceStatus,
+  diagnosisIds: string[],
+  plannedWorkIds: string[],
+  fallbackCondition: ToothVisualState,
+): ToothVisualState {
+  if (presenceStatus === 'missing') return 'missing';
+  if (presenceStatus === 'implant') return 'implant';
+  if (presenceStatus === 'root_remnant') return 'root';
+
+  const diagnosisSet = new Set(diagnosisIds);
+  const workSet = new Set(plannedWorkIds);
+
+  if ([
+    'dx_irreversible_pulpitis',
+    'dx_reversible_pulpitis',
+    'dx_pulp_necrosis',
+  ].some((id) => diagnosisSet.has(id))) {
+    return 'pulpitis';
+  }
+
+  if ([
+    'dx_apical_periodontitis',
+    'dx_periodontal_pocket',
+    'dx_peri_implantitis',
+    'dx_radicular_cyst',
+  ].some((id) => diagnosisSet.has(id))) {
+    return 'periodontitis';
+  }
+
+  if ([
+    'dx_caries_initial',
+    'dx_caries_enamel',
+    'dx_caries_dentin',
+    'dx_deep_caries',
+    'dx_root_caries',
+  ].some((id) => diagnosisSet.has(id))) {
+    return 'caries';
+  }
+
+  if ([
+    'work_implant_crown',
+    'work_crown',
+  ].some((id) => workSet.has(id))) {
+    return 'crown';
+  }
+
+  if (fallbackCondition !== 'healthy') {
+    return fallbackCondition;
+  }
+
+  return diagnosisIds.length > 0 || plannedWorkIds.length > 0 ? 'needs_treatment' : 'healthy';
+}
+
+function formatPrice(price?: number): string | null {
+  if (typeof price !== 'number') return null;
+  return `${price.toLocaleString('ru-RU')} ₸`;
+}
+
+function getWorkIds(records: PlannedWorkRecord[]): string[] {
+  return [...new Set(records.map((record) => record.workId))];
+}
+
+function getZoneWorkIds(records: PlannedWorkRecord[], zone: ClinicalZone): string[] {
+  return records.filter((record) => record.zone === zone).map((record) => record.workId);
+}
+
+function ClinicalCheckboxList({
+  items,
+  selectedIds,
+  onToggle,
+}: {
+  items: Array<{ id: string; name: string; description?: string; price?: number }>;
+  selectedIds: string[];
+  onToggle: (id: string) => void;
+}) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {items.map((item) => {
+        const isSelected = selectedIds.includes(item.id);
+        const price = formatPrice(item.price);
+
+        return (
+          <label
+            key={item.id}
+            className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors cursor-pointer ${
+              isSelected
+                ? 'border-blue-300 bg-blue-50 text-blue-950'
+                : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+            }`}
+          >
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => onToggle(item.id)}
+              className="mt-0.5 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="flex-1">
+              <span className="font-medium">{item.name}</span>
+              {item.description && <span className="block text-xs text-slate-500 mt-0.5">{item.description}</span>}
+              {price && <span className="block text-xs font-semibold text-slate-500 mt-1">{price}</span>}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
 
 export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }: ToothEditorModalProps) {
-  const [formData, setFormData] = useState<Partial<ToothRecord>>({});
-  const [activeZone, setActiveZone] = useState<ToothZone>('crown');
-
+  const [formData, setFormData] = useState<ToothRecord | null>(null);
+  const [activeZone, setActiveZone] = useState<ClinicalZone>('crown');
+  const [manualVisualState, setManualVisualState] = useState(false);
   const [createFinding, setCreateFinding] = useState(false);
-  const [findingData, setFindingData] = useState<Partial<DentalFinding>>({
-    title: '',
-    category: 'other',
-    severity: 'medium',
-    description: '',
-    riskDescription: '',
-    recommendation: '',
-    isChiefComplaintRelated: false,
-    includeInTreatmentPlan: false,
-    status: 'discovered'
-  });
 
   useEffect(() => {
     if (isOpen && tooth) {
+      const normalizedTooth = normalizeToothRecord(tooth);
+      const preferredZone = mapToClinicalZone(defaultZone);
+      const nextZone = getFirstAvailableZone(normalizedTooth.presenceStatus || 'natural', preferredZone);
+
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setActiveZone(defaultZone || 'crown');
+      setFormData(normalizedTooth);
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setFormData({ ...tooth, surfaces: tooth.surfaces || [] });
+      setActiveZone(nextZone);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setManualVisualState(Boolean(normalizedTooth.visualStateOverride));
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setCreateFinding(false);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setFindingData({
-        title: '',
-        category: 'other',
-        severity: 'medium',
-        description: '',
-        riskDescription: '',
-        recommendation: '',
-        isChiefComplaintRelated: false,
-        includeInTreatmentPlan: false,
-        status: 'discovered'
-      });
     }
   }, [isOpen, tooth, defaultZone]);
 
-  if (!isOpen || !tooth) return null;
+  const currentPresence = formData?.presenceStatus || 'natural';
+  const availableZones = useMemo(() => getAvailableZonesForPresence(currentPresence), [currentPresence]);
+  const currentZone = availableZones.includes(activeZone) ? activeZone : getFirstAvailableZone(currentPresence);
+  const diagnosisIds = formData?.diagnoses || [];
+  const plannedWorkRecords = formData?.plannedWorkRecords || [];
+  const plannedWorkIds = getWorkIds(plannedWorkRecords);
+  const currentZoneWorkIds = getZoneWorkIds(plannedWorkRecords, currentZone);
 
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+  const availableDiagnoses = useMemo(
+    () => getDiagnosesByPresenceAndZone(currentPresence, currentZone),
+    [currentPresence, currentZone],
+  );
 
-    if (name === 'condition' && tooth) {
-      applyDefaultFindingSuggestion(value as ToothCondition, tooth.toothNumber);
-    }
+  const allZoneWorks = useMemo(
+    () => getWorksByPresenceAndZone(currentPresence, currentZone),
+    [currentPresence, currentZone],
+  );
+
+  const baseWorks = useMemo(
+    () => getBaseWorksByPresenceAndZone(currentPresence, currentZone),
+    [currentPresence, currentZone],
+  );
+
+  const treatmentWorks = useMemo(
+    () => getWorksByDiagnoses(currentPresence, currentZone, diagnosisIds).filter((work) => work.workAccessType === 'requires_diagnosis'),
+    [currentPresence, currentZone, diagnosisIds],
+  );
+
+  if (!isOpen || !tooth || !formData) return null;
+
+  const automaticVisualState = deriveVisualState(
+    currentPresence,
+    diagnosisIds,
+    plannedWorkIds,
+    formData.condition,
+  );
+  const computedVisualState = manualVisualState && formData.visualStateOverride
+    ? formData.visualStateOverride
+    : automaticVisualState;
+
+  const presenceLabel = PRESENCE_STATUSES.find((status) => status.value === currentPresence)?.label || currentPresence;
+  const visualLabel = VISUAL_STATES.find((state) => state.value === computedVisualState)?.label || computedVisualState;
+  const hasZoneData = availableDiagnoses.length > 0 || allZoneWorks.length > 0;
+
+  const setPresenceStatus = (presenceStatus: ToothPresenceStatus) => {
+    const nextZone = getFirstAvailableZone(presenceStatus);
+
+    setFormData((prev) => {
+      if (!prev) return prev;
+
+      return {
+        ...prev,
+        presenceStatus,
+        diagnoses: [],
+        plannedWorks: [],
+        plannedWorkRecords: [],
+        visualStateOverride: undefined,
+      };
+    });
+    setManualVisualState(false);
+    setActiveZone(nextZone);
   };
 
-  const applyDefaultFindingSuggestion = (condition: ToothCondition, toothNumber: number) => {
-    if (condition === 'caries') {
-      setFindingData(prev => ({ ...prev, category: 'caries', title: `Кариес ${toothNumber} зуба`, severity: 'medium', description: 'Выявлено кариозное поражение.', recommendation: 'Рекомендовано лечение кариеса.' }));
-    } else if (condition === 'missing') {
-      setFindingData(prev => ({ ...prev, category: 'missing_tooth', title: `Отсутствует ${toothNumber} зуб`, severity: 'medium', description: 'Зуб отсутствует.', recommendation: 'Рекомендована консультация по восстановлению зубного ряда.' }));
-    } else if (condition === 'pulpitis') {
-      setFindingData(prev => ({ ...prev, category: 'pain', title: `Подозрение на пульпит ${toothNumber} зуба`, severity: 'high', description: 'Требуется клиническая оценка и лечение каналов по показаниям.', recommendation: 'Рекомендовано лечение у врача-стоматолога.' }));
-    } else if (condition === 'periodontitis') {
-      setFindingData(prev => ({ ...prev, category: 'root_problem', title: `Проблема корня / периодонта ${toothNumber} зуба`, severity: 'high', description: 'Выявлены признаки проблемы в области корня/периодонта.', recommendation: 'Рекомендована дополнительная диагностика и лечение по показаниям.' }));
-    } else if (condition === 'needs_treatment') {
-      setFindingData(prev => ({ ...prev, category: 'other', title: `Требует лечения ${toothNumber} зуб`, severity: 'medium', description: 'Зуб требует внимания врача.', recommendation: 'Рекомендовано включить в план лечения.' }));
-    } else {
-      setFindingData(prev => ({ ...prev, title: '', description: '', recommendation: '' }));
-    }
+  const toggleDiagnosis = (diagnosisId: string) => {
+    setFormData((prev) => {
+      if (!prev) return prev;
+
+      const nextDiagnosisIds = prev.diagnoses?.includes(diagnosisId)
+        ? prev.diagnoses.filter((id) => id !== diagnosisId)
+        : [...(prev.diagnoses || []), diagnosisId];
+
+      const allowedWorkIds = new Set(
+        getWorksByDiagnoses(prev.presenceStatus || 'natural', currentZone, nextDiagnosisIds).map((work) => work.id),
+      );
+      const nextRecords = (prev.plannedWorkRecords || []).filter((record) => (
+        record.zone !== currentZone || allowedWorkIds.has(record.workId)
+      ));
+
+      return {
+        ...prev,
+        diagnoses: nextDiagnosisIds,
+        plannedWorkRecords: nextRecords,
+        plannedWorks: getWorkIds(nextRecords),
+      };
+    });
   };
 
-  const handleSurfaceToggle = (surface: ToothSurface) => {
-    const current = formData.surfaces || [];
-    if (current.includes(surface)) {
-      setFormData(prev => ({ ...prev, surfaces: current.filter(s => s !== surface) }));
-    } else {
-      setFormData(prev => ({ ...prev, surfaces: [...current, surface] }));
-    }
+  const toggleWork = (work: ClinicalWork) => {
+    setFormData((prev) => {
+      if (!prev) return prev;
+
+      const currentRecords = prev.plannedWorkRecords || [];
+      const hasWork = currentRecords.some((record) => record.zone === currentZone && record.workId === work.id);
+      const now = new Date().toISOString();
+      const nextRecords = hasWork
+        ? currentRecords.filter((record) => !(record.zone === currentZone && record.workId === work.id))
+        : [
+          ...currentRecords,
+          {
+            id: createRecordId(),
+            workId: work.id,
+            zone: currentZone,
+            status: 'planned',
+            createdAt: now,
+            updatedAt: now,
+          },
+        ];
+
+      return {
+        ...prev,
+        plannedWorkRecords: nextRecords,
+        plannedWorks: getWorkIds(nextRecords),
+      };
+    });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    let findingPayload: Partial<DentalFinding> | null = null;
-    if (createFinding) {
-      findingPayload = { ...findingData };
-      if (findingPayload.includeInTreatmentPlan) {
-        findingPayload.status = 'recommended';
-      }
-    }
-
-    onSave({
-      ...tooth,
-      ...formData,
-      updatedAt: new Date().toISOString()
-    } as ToothRecord, findingPayload);
+  const setVisualStateOverride = (visualState: ToothVisualState) => {
+    setFormData((prev) => prev ? { ...prev, visualStateOverride: visualState } : prev);
   };
 
-  const handleReset = () => {
+  const resetToHealthy = () => {
+    const now = new Date().toISOString();
+
     setFormData({
-      toothNumber: tooth.toothNumber,
+      ...formData,
       condition: 'healthy',
       surfaces: [],
       crown: '',
@@ -144,336 +373,261 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       workBone: '',
       canal: '',
       workCanal: '',
-      notes: ''
+      notes: '',
+      presenceStatus: 'natural',
+      visualState: 'healthy',
+      visualStateOverride: undefined,
+      diagnoses: [],
+      plannedWorks: [],
+      plannedWorkRecords: [],
+      completedWorks: [],
+      updatedAt: now,
     });
+    setManualVisualState(false);
+    setActiveZone('crown');
+    setCreateFinding(false);
   };
 
-  const zoneSectionClass = (zone: ToothZone, ringClass: string) =>
-    `space-y-6 rounded-xl transition-shadow ${activeZone === zone ? `ring-2 ${ringClass} p-3 -m-3` : ''}`;
+  const buildFindingPayload = (): Partial<DentalFinding> | null => {
+    if (!createFinding) return null;
 
-  const inputChangeHandler = handleChange as unknown as (e: React.ChangeEvent<HTMLInputElement>) => void;
+    const selectedDiagnosisNames = diagnosisIds
+      .map((id) => defaultDiagnoses.find((diagnosis) => diagnosis.id === id)?.name || id);
+    const selectedWorkNames = plannedWorkIds
+      .map((id) => defaultClinicalWorks.find((work) => work.id === id)?.name || id);
+
+    return {
+      title: `Клиническая запись: зуб ${tooth.toothNumber}`,
+      category: 'other' as FindingCategory,
+      severity: 'medium' as FindingSeverity,
+      description: [
+        `Анатомический статус: ${presenceLabel}`,
+        `Зона: ${ZONE_LABELS[currentZone]}`,
+        selectedDiagnosisNames.length > 0 ? `Диагнозы: ${selectedDiagnosisNames.join(', ')}` : '',
+        selectedWorkNames.length > 0 ? `Работы: ${selectedWorkNames.join(', ')}` : '',
+        formData.notes ? `Заметка: ${formData.notes}` : '',
+      ].filter(Boolean).join(' | '),
+      status: 'discovered' as FindingStatus,
+      isChiefComplaintRelated: false,
+      includeInTreatmentPlan: selectedWorkNames.length > 0,
+    };
+  };
+
+  const handleSave = () => {
+    const nextTooth: ToothRecord = {
+      ...formData,
+      condition: computedVisualState,
+      visualState: computedVisualState,
+      visualStateOverride: manualVisualState ? formData.visualStateOverride || computedVisualState : undefined,
+      plannedWorks: getWorkIds(formData.plannedWorkRecords || []),
+      updatedAt: new Date().toISOString(),
+    };
+
+    onSave(nextTooth, buildFindingPayload());
+  };
 
   return (
-    <div className="fixed inset-0 bg-slate-900/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-3xl max-h-[90vh] flex flex-col">
-        <div className="flex items-center justify-between p-4 border-b border-slate-200">
-          <h2 className="text-lg font-semibold text-slate-800 flex items-center gap-2">
-            Редактирование зуба <span className="bg-blue-100 text-blue-700 px-2 py-0.5 rounded-md">{tooth.toothNumber}</span>
-          </h2>
-          <button onClick={onClose} className="p-1 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+    <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-5xl max-h-[90vh] flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200 bg-slate-50/70">
+          <div>
+            <h2 className="text-xl font-bold text-slate-800 flex items-center gap-2">
+              Зуб <span className="bg-blue-100 text-blue-700 px-2 py-0.5 rounded-md">{tooth.toothNumber}</span>
+            </h2>
+            <p className="text-sm text-slate-500 mt-1">Клиническая запись · {presenceLabel}</p>
+          </div>
+          <button onClick={onClose} className="p-2 text-slate-400 hover:text-slate-600 rounded-full hover:bg-slate-100 transition-colors">
             <X className="w-5 h-5" />
           </button>
         </div>
 
-        <div className="flex border-b border-slate-200">
-          <button type="button" onClick={() => setActiveZone('crown')} className={`flex-1 py-3 text-sm font-semibold border-b-2 transition-colors ${activeZone === 'crown' ? 'border-blue-500 text-blue-700 bg-blue-50/30' : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'}`}>Коронка</button>
-          <button type="button" onClick={() => setActiveZone('root')} className={`flex-1 py-3 text-sm font-semibold border-b-2 transition-colors ${activeZone === 'root' ? 'border-purple-500 text-purple-700 bg-purple-50/30' : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'}`}>Каналы</button>
-          <button type="button" onClick={() => setActiveZone('gum')} className={`flex-1 py-3 text-sm font-semibold border-b-2 transition-colors ${activeZone === 'gum' ? 'border-rose-500 text-rose-700 bg-rose-50/30' : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'}`}>Десна</button>
-          <button type="button" onClick={() => setActiveZone('bone')} className={`flex-1 py-3 text-sm font-semibold border-b-2 transition-colors ${activeZone === 'bone' ? 'border-amber-500 text-amber-700 bg-amber-50/30' : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'}`}>Кость</button>
-        </div>
-
-        <div className="px-4 py-2 text-xs text-slate-500 border-b border-slate-100 bg-slate-50/60">
-          Вкладки подсвечивают выбранную область. Все клинические разделы ниже остаются видимыми.
-        </div>
-
-        <div className="flex-1 overflow-y-auto p-4">
-          <form id="tooth-form" onSubmit={handleSubmit} className="space-y-8">
-            <div className={zoneSectionClass('crown', 'ring-blue-100')}>
-              <div className="bg-slate-50 p-4 rounded-xl border border-slate-200">
-                <label className="block text-sm font-semibold text-slate-800 mb-2">Основное состояние зуба</label>
+        <div className="flex-1 overflow-y-auto p-6 grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
+          <aside className="space-y-5">
+            <section className="bg-blue-50/60 p-4 rounded-xl border border-blue-100 space-y-4">
+              <div>
+                <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wider mb-1.5">Анатомический статус</label>
                 <select
-                  name="condition"
-                  value={formData.condition || 'healthy'}
-                  onChange={handleChange}
-                  className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm font-medium bg-white shadow-sm"
+                  value={currentPresence}
+                  onChange={(event) => setPresenceStatus(event.target.value as ToothPresenceStatus)}
+                  className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
-                  {CONDITIONS.map(c => (
-                    <option key={c.value} value={c.value}>{c.label}</option>
+                  {PRESENCE_STATUSES.map((status) => (
+                    <option key={status.value} value={status.value}>{status.label}</option>
                   ))}
                 </select>
+                <p className="mt-1 text-xs text-blue-700/80">
+                  {PRESENCE_STATUSES.find((status) => status.value === currentPresence)?.hint}
+                </p>
               </div>
 
-              {['caries', 'filled', 'needs_treatment'].includes(formData.condition || '') && (
-                <div className="bg-white p-4 rounded-xl border border-slate-200 shadow-sm">
-                  <label className="block text-sm font-semibold text-slate-800 mb-3">Поверхности</label>
-                  <div className="flex flex-wrap gap-2">
-                    {SURFACES.map(s => (
-                      <button
-                        key={s.value}
-                        type="button"
-                        onClick={() => handleSurfaceToggle(s.value)}
-                        className={`px-4 py-2 text-sm rounded-lg border transition-all ${
-                          (formData.surfaces || []).includes(s.value)
-                            ? 'bg-blue-50 border-blue-500 text-blue-700 font-semibold shadow-inner'
-                            : 'bg-white border-slate-200 text-slate-600 hover:bg-slate-50'
-                        }`}
-                      >
-                        {s.label}
-                      </button>
-                    ))}
+              <div>
+                <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wider mb-1.5">Отображение на формуле</label>
+                {!manualVisualState ? (
+                  <div className="p-3 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 space-y-2">
+                    <div>
+                      Расчётное состояние: <span className="font-semibold">{visualLabel}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setManualVisualState(true);
+                        setVisualStateOverride(computedVisualState);
+                      }}
+                      className="text-xs font-medium text-blue-600 hover:text-blue-800 underline"
+                    >
+                      Изменить вручную
+                    </button>
                   </div>
-                </div>
-              )}
-
-              <SuggestionInput
-                label="Проблема: Коронка / Реставрация"
-                name="crown"
-                value={formData.crown || ''}
-                onChange={inputChangeHandler}
-                placeholder="Материал, дефекты..."
-                suggestions={[
-                  'Кариес эмали', 'Кариес дентина', 'Глубокий кариес',
-                  'Скол эмали', 'Скол коронки', 'Дефект пломбы', 'Вторичный кариес'
-                ]}
-              />
-
-              <SuggestionInput
-                label="Запланированная работа (Коронка)"
-                name="workCrown"
-                value={formData.workCrown || ''}
-                onChange={inputChangeHandler}
-                placeholder="План лечения..."
-                suggestions={[
-                  'Фотополимерная реставрация', 'Керамическая вкладка',
-                  'Металлокерамическая коронка', 'Циркониевая коронка', 'Винир'
-                ]}
-              />
-            </div>
-
-            <div className={zoneSectionClass('root', 'ring-purple-100')}>
-              <SuggestionInput
-                label="Проблема: Корни / Каналы"
-                name="canal"
-                value={formData.canal || ''}
-                onChange={inputChangeHandler}
-                placeholder="Пломбировка, изменения..."
-                suggestions={[
-                  'Каналы запломбированы до верхушки', 'Каналы недопломбированы',
-                  'Пустой канал', 'Анкерный штифт', 'Стекловолоконный штифт',
-                  'Обломок инструмента', 'Перфорация'
-                ]}
-              />
-              <SuggestionInput
-                label="Запланированная работа (Каналы)"
-                name="workCanal"
-                value={formData.workCanal || ''}
-                onChange={inputChangeHandler}
-                placeholder="План лечения..."
-                suggestions={[
-                  'Механическая и медикаментозная обработка', 'Распломбировка каналов',
-                  'Пломбировка гуттаперчей', 'Установка СВШ'
-                ]}
-              />
-            </div>
-
-            <div className={zoneSectionClass('gum', 'ring-rose-100')}>
-              <SuggestionInput
-                label="Проблема: Десна / Мягкие ткани"
-                name="gum"
-                value={formData.gum || ''}
-                onChange={inputChangeHandler}
-                placeholder="Рецессия, воспаление..."
-                suggestions={[
-                  'Гингивит', 'Рецессия десны', 'Кровоточивость при зондировании',
-                  'Пародонтальный карман', 'Свищ', 'Отек'
-                ]}
-              />
-              <SuggestionInput
-                label="Запланированная работа (Десна)"
-                name="workGum"
-                value={formData.workGum || ''}
-                onChange={inputChangeHandler}
-                placeholder="План лечения..."
-                suggestions={[
-                  'Закрытый кюретаж', 'Открытый кюретаж', 'Вектор-терапия',
-                  'Пластика десны', 'Удаление зубных отложений'
-                ]}
-              />
-            </div>
-
-            <div className={zoneSectionClass('bone', 'ring-amber-100')}>
-              <SuggestionInput
-                label="Проблема: Костная ткань"
-                name="bone"
-                value={formData.bone || ''}
-                onChange={inputChangeHandler}
-                placeholder="Резорбция, карманы..."
-                suggestions={[
-                  'Без видимых изменений', 'Убыль костной ткани 1/3',
-                  'Убыль костной ткани 1/2', 'Киста', 'Гранулема', 'Остеосклероз'
-                ]}
-              />
-              <SuggestionInput
-                label="Запланированная работа (Костная ткань)"
-                name="workBone"
-                value={formData.workBone || ''}
-                onChange={inputChangeHandler}
-                placeholder="План лечения..."
-                suggestions={[
-                  'Резекция верхушки корня', 'Цистотомия',
-                  'Направленная костная регенерация', 'Удаление зуба'
-                ]}
-              />
-            </div>
-
-            <div className="bg-white p-4 rounded-xl border border-slate-200 shadow-sm">
-              <label className="block text-sm font-semibold text-slate-800 mb-2">Клинические заметки</label>
-              <textarea
-                name="notes"
-                value={formData.notes || ''}
-                onChange={handleChange}
-                rows={3}
-                placeholder="Дополнительная информация о зубе для врача..."
-                className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm resize-none bg-slate-50 hover:bg-white transition-colors"
-              ></textarea>
-            </div>
-
-            <div className="pt-2">
-              <div className="bg-blue-50/50 p-4 rounded-xl border border-blue-100">
-                <label className="flex items-center gap-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={createFinding}
-                    onChange={(e) => setCreateFinding(e.target.checked)}
-                    className="w-5 h-5 rounded border-blue-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span className="text-sm font-semibold text-blue-900">Создать или обновить проблему по этому зубу</span>
-                </label>
-
-                {createFinding && (
-                  <div className="mt-5 space-y-5 bg-white p-5 rounded-xl border border-blue-100 shadow-sm">
-                    <label className="flex items-center gap-2 cursor-pointer pb-2 border-b border-slate-100">
-                      <input
-                        type="checkbox"
-                        checked={findingData.isChiefComplaintRelated}
-                        onChange={(e) => setFindingData({ ...findingData, isChiefComplaintRelated: e.target.checked })}
-                        className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                      />
-                      <span className="text-sm font-medium text-slate-700">Связано с основной жалобой</span>
-                    </label>
-
-                    <div>
-                      <label className="block text-xs font-semibold text-slate-700 mb-1.5">Название проблемы <span className="text-red-500">*</span></label>
-                      <input
-                        type="text"
-                        value={findingData.title || ''}
-                        onChange={(e) => setFindingData({ ...findingData, title: e.target.value })}
-                        required
-                        placeholder="Например: Глубокий кариес"
-                        className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm bg-slate-50 hover:bg-white transition-colors"
-                      />
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-xs font-semibold text-slate-700 mb-1.5">Категория <span className="text-red-500">*</span></label>
-                        <select
-                          value={findingData.category}
-                          onChange={(e) => setFindingData({ ...findingData, category: e.target.value as FindingCategory })}
-                          required
-                          className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm bg-slate-50 hover:bg-white transition-colors"
-                        >
-                          <option value="caries">Кариес</option>
-                          <option value="missing_tooth">Отсутствующий зуб</option>
-                          <option value="gum_problem">Проблема десны</option>
-                          <option value="root_problem">Проблема корня</option>
-                          <option value="bite_problem">Проблема прикуса</option>
-                          <option value="aesthetic_problem">Эстетическая проблема</option>
-                          <option value="pain">Боль</option>
-                          <option value="risk_zone">Зона риска</option>
-                          <option value="hygiene">Гигиена</option>
-                          <option value="prosthetics">Протезирование</option>
-                          <option value="implantology">Имплантация</option>
-                          <option value="other">Другое</option>
-                        </select>
-                      </div>
-                      <div>
-                        <label className="block text-xs font-semibold text-slate-700 mb-1.5">Серьезность <span className="text-red-500">*</span></label>
-                        <select
-                          value={findingData.severity}
-                          onChange={(e) => setFindingData({ ...findingData, severity: e.target.value as FindingSeverity })}
-                          required
-                          className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm bg-slate-50 hover:bg-white transition-colors"
-                        >
-                          <option value="low">Низкая</option>
-                          <option value="medium">Средняя</option>
-                          <option value="high">Высокая</option>
-                          <option value="urgent">Срочно</option>
-                        </select>
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-xs font-semibold text-slate-700 mb-1.5">Статус <span className="text-red-500">*</span></label>
-                        <select
-                          value={findingData.status}
-                          onChange={(e) => setFindingData({ ...findingData, status: e.target.value as FindingStatus })}
-                          required
-                          className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm bg-slate-50 hover:bg-white transition-colors"
-                        >
-                          <option value="discovered">Выявлено</option>
-                          <option value="recommended">Рекомендовано</option>
-                          <option value="included_in_plan">Включено в план</option>
-                          <option value="observing">Наблюдение</option>
-                          <option value="declined_by_patient">Пациент отказался</option>
-                          <option value="completed">Завершено</option>
-                        </select>
-                      </div>
-                      <div className="flex items-center pt-6">
-                        <label className="flex items-center gap-2 cursor-pointer bg-blue-50 px-3 py-2 rounded-lg border border-blue-100 w-full hover:bg-blue-100 transition-colors">
-                          <input
-                            type="checkbox"
-                            checked={findingData.includeInTreatmentPlan}
-                            onChange={(e) => setFindingData({ ...findingData, includeInTreatmentPlan: e.target.checked })}
-                            className="rounded border-blue-300 text-blue-600 focus:ring-blue-500"
-                          />
-                          <span className="text-sm font-semibold text-blue-800">В план лечения</span>
-                        </label>
-                      </div>
-                    </div>
-
-                    <div>
-                      <label className="block text-xs font-semibold text-slate-700 mb-1.5">Описание (для врача)</label>
-                      <textarea
-                        value={findingData.description || ''}
-                        onChange={(e) => setFindingData({ ...findingData, description: e.target.value })}
-                        rows={2}
-                        className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm resize-none bg-slate-50 hover:bg-white transition-colors"
-                      ></textarea>
-                    </div>
-                    <div>
-                      <label className="block text-xs font-semibold text-slate-700 mb-1.5">Описание рисков (пациенту)</label>
-                      <textarea
-                        value={findingData.riskDescription || ''}
-                        onChange={(e) => setFindingData({ ...findingData, riskDescription: e.target.value })}
-                        rows={2}
-                        className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm resize-none bg-slate-50 hover:bg-white transition-colors"
-                      ></textarea>
-                    </div>
-                    <div>
-                      <label className="block text-xs font-semibold text-slate-700 mb-1.5">Рекомендация</label>
-                      <input
-                        type="text"
-                        value={findingData.recommendation || ''}
-                        onChange={(e) => setFindingData({ ...findingData, recommendation: e.target.value })}
-                        className="w-full p-2.5 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm bg-slate-50 hover:bg-white transition-colors"
-                      />
-                    </div>
+                ) : (
+                  <div className="space-y-2">
+                    <select
+                      value={formData.visualStateOverride || computedVisualState}
+                      onChange={(event) => setVisualStateOverride(event.target.value as ToothVisualState)}
+                      className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      {VISUAL_STATES.map((state) => (
+                        <option key={state.value} value={state.value}>{state.label}</option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setManualVisualState(false);
+                        setFormData((prev) => prev ? { ...prev, visualStateOverride: undefined } : prev);
+                      }}
+                      className="text-xs font-medium text-slate-500 hover:text-slate-700 underline"
+                    >
+                      Вернуть автоматический расчёт
+                    </button>
                   </div>
                 )}
               </div>
+            </section>
+
+            <section>
+              <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1.5">Общие заметки</label>
+              <textarea
+                value={formData.notes || ''}
+                onChange={(event) => setFormData({ ...formData, notes: event.target.value })}
+                className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[110px] resize-none"
+                placeholder="Дополнительные комментарии врача..."
+              />
+            </section>
+
+            <section className="bg-orange-50 p-4 rounded-xl border border-orange-100">
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={createFinding}
+                  onChange={(event) => setCreateFinding(event.target.checked)}
+                  className="mt-0.5 h-4 w-4 text-orange-500 border-slate-300 rounded focus:ring-orange-500"
+                />
+                <span>
+                  <span className="block text-sm font-semibold text-orange-900">Создать клиническую проблему</span>
+                  <span className="block text-xs text-orange-700 mt-1">Находка будет создана по выбранным диагнозам, зоне и заметке врача.</span>
+                </span>
+              </label>
+            </section>
+          </aside>
+
+          <main className="min-w-0 flex flex-col">
+            <div className="flex overflow-x-auto border-b border-slate-200 mb-4" style={{ scrollbarWidth: 'none' }}>
+              {availableZones.map((zone) => (
+                <button
+                  key={zone}
+                  type="button"
+                  onClick={() => setActiveZone(zone)}
+                  className={`px-4 py-2.5 text-sm font-semibold whitespace-nowrap border-b-2 transition-colors ${
+                    currentZone === zone
+                      ? 'border-blue-500 text-blue-700 bg-blue-50/40'
+                      : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'
+                  }`}
+                >
+                  {ZONE_LABELS[zone]}
+                </button>
+              ))}
             </div>
-          </form>
+
+            <div className="mb-4 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <h3 className="text-sm font-semibold text-slate-800">{ZONE_LABELS[currentZone]}</h3>
+              <p className="text-xs text-slate-500 mt-0.5">{ZONE_HINTS[currentZone]}</p>
+            </div>
+
+            {!hasZoneData ? (
+              <div className="bg-slate-50 border border-slate-200 rounded-xl p-8 text-center">
+                <BookOpen className="w-8 h-8 text-slate-300 mx-auto mb-2" />
+                <p className="text-sm font-semibold text-slate-600">Справочник не настроен для этой зоны</p>
+                <p className="text-xs text-slate-400 mt-1">Диагнозы и работы появятся после настройки справочников.</p>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                {availableDiagnoses.length > 0 && (
+                  <section className="bg-slate-50 p-4 rounded-xl border border-slate-100">
+                    <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-2">
+                      <AlertCircle className="w-3.5 h-3.5 text-red-400" />
+                      Диагнозы / состояния
+                    </h3>
+                    <ClinicalCheckboxList
+                      items={availableDiagnoses.map((diagnosis: ClinicalDiagnosis) => ({
+                        id: diagnosis.id,
+                        name: diagnosis.name,
+                        description: diagnosis.description,
+                      }))}
+                      selectedIds={diagnosisIds}
+                      onToggle={toggleDiagnosis}
+                    />
+                  </section>
+                )}
+
+                {baseWorks.length > 0 && (
+                  <section className="bg-blue-50/40 p-4 rounded-xl border border-blue-100">
+                    <h3 className="text-xs font-bold text-blue-600 uppercase tracking-wider mb-3 flex items-center gap-2">
+                      <Plus className="w-3.5 h-3.5" />
+                      Базовые / доступные работы
+                    </h3>
+                    <ClinicalCheckboxList
+                      items={baseWorks.map((work) => ({ id: work.id, name: work.name, description: work.description, price: work.price }))}
+                      selectedIds={currentZoneWorkIds}
+                      onToggle={(id) => {
+                        const work = baseWorks.find((item) => item.id === id);
+                        if (work) toggleWork(work);
+                      }}
+                    />
+                  </section>
+                )}
+
+                <section className="bg-emerald-50/40 p-4 rounded-xl border border-emerald-100">
+                  <h3 className="text-xs font-bold text-emerald-600 uppercase tracking-wider mb-3 flex items-center gap-2">
+                    <Plus className="w-3.5 h-3.5" />
+                    Лечебные работы
+                  </h3>
+                  {allZoneWorks.some((work) => work.workAccessType === 'requires_diagnosis') && diagnosisIds.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">Выберите диагноз выше, чтобы увидеть доступные лечебные работы.</p>
+                  ) : treatmentWorks.length === 0 ? (
+                    <p className="text-xs text-slate-500 italic">Нет лечебных работ для выбранных диагнозов в этой зоне.</p>
+                  ) : (
+                    <ClinicalCheckboxList
+                      items={treatmentWorks.map((work) => ({ id: work.id, name: work.name, description: work.description, price: work.price }))}
+                      selectedIds={currentZoneWorkIds}
+                      onToggle={(id) => {
+                        const work = treatmentWorks.find((item) => item.id === id);
+                        if (work) toggleWork(work);
+                      }}
+                    />
+                  )}
+                </section>
+              </div>
+            )}
+          </main>
         </div>
 
-        <div className="flex items-center justify-between p-4 border-t border-slate-200 bg-slate-50 rounded-b-xl">
+        <div className="flex items-center justify-between gap-3 p-4 border-t border-slate-200 bg-slate-50">
           <button
             type="button"
-            onClick={handleReset}
+            onClick={resetToHealthy}
             className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-200 rounded-lg transition-colors"
           >
-            <RefreshCcw className="w-4 h-4" /> Сбросить (Здоров)
+            <RefreshCcw className="w-4 h-4" /> Сбросить
           </button>
           <div className="flex gap-2">
             <button
@@ -484,11 +638,12 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
               Отмена
             </button>
             <button
-              type="submit"
-              form="tooth-form"
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
+              type="button"
+              onClick={handleSave}
+              className="flex items-center gap-2 px-5 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
             >
-              Сохранить
+              <Save className="w-4 h-4" />
+              Сохранить изменения
             </button>
           </div>
         </div>

--- a/src/components/dental/ToothEditorModal.tsx
+++ b/src/components/dental/ToothEditorModal.tsx
@@ -11,8 +11,8 @@ import type {
   ToothRecord,
   ToothVisualState,
 } from '../../types';
-import type { ToothZone } from './ToothZoneSelectorModal';
 import { normalizeToothRecord } from '../../utils/dentalChartNormalization';
+import type { ToothZone } from './ToothZoneSelectorModal';
 import {
   defaultClinicalWorks,
   defaultDiagnoses,
@@ -21,7 +21,6 @@ import {
   getDiagnosesByPresenceAndZone,
   getWorksByDiagnoses,
   getWorksByPresenceAndZone,
-  type ClinicalDiagnosis,
   type ClinicalWork,
 } from '../../config/clinicalDictionaries';
 
@@ -77,11 +76,24 @@ const ZONE_HINTS: Record<ClinicalZone, string> = {
   planning: 'Планирование восстановления отсутствующего зуба',
 };
 
+type CheckboxItem = {
+  id: string;
+  name: string;
+  description?: string;
+  price?: number;
+};
+
 function mapToClinicalZone(zone?: ToothZone): ClinicalZone {
   if (zone === 'gum') return 'periodontium';
   if (zone === 'root') return 'endodontics';
   if (zone === 'bone') return 'bone';
   return 'crown';
+}
+
+function clearVisualOverride(tooth: ToothRecord): ToothRecord {
+  const nextTooth = { ...tooth };
+  delete nextTooth.visualStateOverride;
+  return nextTooth;
 }
 
 function createRecordId(): string {
@@ -115,44 +127,23 @@ function deriveVisualState(
   const diagnosisSet = new Set(diagnosisIds);
   const workSet = new Set(plannedWorkIds);
 
-  if ([
-    'dx_irreversible_pulpitis',
-    'dx_reversible_pulpitis',
-    'dx_pulp_necrosis',
-  ].some((id) => diagnosisSet.has(id))) {
+  if (['dx_irreversible_pulpitis', 'dx_reversible_pulpitis', 'dx_pulp_necrosis'].some((id) => diagnosisSet.has(id))) {
     return 'pulpitis';
   }
 
-  if ([
-    'dx_apical_periodontitis',
-    'dx_periodontal_pocket',
-    'dx_peri_implantitis',
-    'dx_radicular_cyst',
-  ].some((id) => diagnosisSet.has(id))) {
+  if (['dx_apical_periodontitis', 'dx_periodontal_pocket', 'dx_peri_implantitis', 'dx_radicular_cyst'].some((id) => diagnosisSet.has(id))) {
     return 'periodontitis';
   }
 
-  if ([
-    'dx_caries_initial',
-    'dx_caries_enamel',
-    'dx_caries_dentin',
-    'dx_deep_caries',
-    'dx_root_caries',
-  ].some((id) => diagnosisSet.has(id))) {
+  if (['dx_caries_initial', 'dx_caries_enamel', 'dx_caries_dentin', 'dx_deep_caries', 'dx_root_caries'].some((id) => diagnosisSet.has(id))) {
     return 'caries';
   }
 
-  if ([
-    'work_implant_crown',
-    'work_crown',
-  ].some((id) => workSet.has(id))) {
+  if (['work_implant_crown', 'work_crown'].some((id) => workSet.has(id))) {
     return 'crown';
   }
 
-  if (fallbackCondition !== 'healthy') {
-    return fallbackCondition;
-  }
-
+  if (fallbackCondition !== 'healthy') return fallbackCondition;
   return diagnosisIds.length > 0 || plannedWorkIds.length > 0 ? 'needs_treatment' : 'healthy';
 }
 
@@ -169,12 +160,24 @@ function getZoneWorkIds(records: PlannedWorkRecord[], zone: ClinicalZone): strin
   return records.filter((record) => record.zone === zone).map((record) => record.workId);
 }
 
+function toCheckboxItem(item: { id: string; name: string; description?: string; price?: number }): CheckboxItem {
+  const checkboxItem: CheckboxItem = {
+    id: item.id,
+    name: item.name,
+  };
+
+  if (item.description) checkboxItem.description = item.description;
+  if (typeof item.price === 'number') checkboxItem.price = item.price;
+
+  return checkboxItem;
+}
+
 function ClinicalCheckboxList({
   items,
   selectedIds,
   onToggle,
 }: {
-  items: Array<{ id: string; name: string; description?: string; price?: number }>;
+  items: CheckboxItem[];
   selectedIds: string[];
   onToggle: (id: string) => void;
 }) {
@@ -266,12 +269,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
   if (!isOpen || !tooth || !formData) return null;
 
-  const automaticVisualState = deriveVisualState(
-    currentPresence,
-    diagnosisIds,
-    plannedWorkIds,
-    formData.condition,
-  );
+  const automaticVisualState = deriveVisualState(currentPresence, diagnosisIds, plannedWorkIds, formData.condition);
   const computedVisualState = manualVisualState && formData.visualStateOverride
     ? formData.visualStateOverride
     : automaticVisualState;
@@ -285,10 +283,8 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
     setFormData((prev) => {
       if (!prev) return prev;
-      const { visualStateOverride: _visualStateOverride, ...rest } = prev;
-
       return {
-        ...rest,
+        ...clearVisualOverride(prev),
         presenceStatus,
         diagnoses: [],
         plannedWorks: [],
@@ -306,7 +302,6 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       const nextDiagnosisIds = prev.diagnoses?.includes(diagnosisId)
         ? prev.diagnoses.filter((id) => id !== diagnosisId)
         : [...(prev.diagnoses || []), diagnosisId];
-
       const allowedWorkIds = new Set(
         getWorksByDiagnoses(prev.presenceStatus || 'natural', currentZone, nextDiagnosisIds).map((work) => work.id),
       );
@@ -332,17 +327,14 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       const now = new Date().toISOString();
       const nextRecords = hasWork
         ? currentRecords.filter((record) => !(record.zone === currentZone && record.workId === work.id))
-        : [
-          ...currentRecords,
-          {
-            id: createRecordId(),
-            workId: work.id,
-            zone: currentZone,
-            status: 'planned',
-            createdAt: now,
-            updatedAt: now,
-          },
-        ];
+        : [...currentRecords, {
+          id: createRecordId(),
+          workId: work.id,
+          zone: currentZone,
+          status: 'planned',
+          createdAt: now,
+          updatedAt: now,
+        }];
 
       return {
         ...prev,
@@ -358,10 +350,9 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
   const resetToHealthy = () => {
     const now = new Date().toISOString();
-    const { visualStateOverride: _visualStateOverride, ...toothWithoutOverride } = formData;
 
     setFormData({
-      ...toothWithoutOverride,
+      ...clearVisualOverride(formData),
       condition: 'healthy',
       surfaces: [],
       crown: '',
@@ -391,10 +382,8 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
   const buildFindingPayload = (): Partial<DentalFinding> | null => {
     if (!createFinding) return null;
 
-    const selectedDiagnosisNames = diagnosisIds
-      .map((id) => defaultDiagnoses.find((diagnosis) => diagnosis.id === id)?.name || id);
-    const selectedWorkNames = plannedWorkIds
-      .map((id) => defaultClinicalWorks.find((work) => work.id === id)?.name || id);
+    const selectedDiagnosisNames = diagnosisIds.map((id) => defaultDiagnoses.find((diagnosis) => diagnosis.id === id)?.name || id);
+    const selectedWorkNames = plannedWorkIds.map((id) => defaultClinicalWorks.find((work) => work.id === id)?.name || id);
 
     return {
       title: `Клиническая запись: зуб ${tooth.toothNumber}`,
@@ -415,13 +404,13 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
   const handleSave = () => {
     const nextToothBase: ToothRecord = {
-      ...formData,
+      ...clearVisualOverride(formData),
       condition: computedVisualState,
       visualState: computedVisualState,
       plannedWorks: getWorkIds(formData.plannedWorkRecords || []),
       updatedAt: new Date().toISOString(),
     };
-    const nextTooth: ToothRecord = manualVisualState
+    const nextTooth = manualVisualState
       ? { ...nextToothBase, visualStateOverride: formData.visualStateOverride || computedVisualState }
       : nextToothBase;
 
@@ -495,11 +484,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
                       type="button"
                       onClick={() => {
                         setManualVisualState(false);
-                        setFormData((prev) => {
-                          if (!prev) return prev;
-                          const { visualStateOverride: _visualStateOverride, ...rest } = prev;
-                          return rest;
-                        });
+                        setFormData((prev) => prev ? clearVisualOverride(prev) : prev);
                       }}
                       className="text-xs font-medium text-slate-500 hover:text-slate-700 underline"
                     >
@@ -574,11 +559,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
                       Диагнозы / состояния
                     </h3>
                     <ClinicalCheckboxList
-                      items={availableDiagnoses.map((diagnosis: ClinicalDiagnosis) => ({
-                        id: diagnosis.id,
-                        name: diagnosis.name,
-                        description: diagnosis.description,
-                      }))}
+                      items={availableDiagnoses.map(toCheckboxItem)}
                       selectedIds={diagnosisIds}
                       onToggle={toggleDiagnosis}
                     />
@@ -592,7 +573,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
                       Базовые / доступные работы
                     </h3>
                     <ClinicalCheckboxList
-                      items={baseWorks.map((work) => ({ id: work.id, name: work.name, description: work.description, price: work.price }))}
+                      items={baseWorks.map(toCheckboxItem)}
                       selectedIds={currentZoneWorkIds}
                       onToggle={(id) => {
                         const work = baseWorks.find((item) => item.id === id);
@@ -613,7 +594,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
                     <p className="text-xs text-slate-500 italic">Нет лечебных работ для выбранных диагнозов в этой зоне.</p>
                   ) : (
                     <ClinicalCheckboxList
-                      items={treatmentWorks.map((work) => ({ id: work.id, name: work.name, description: work.description, price: work.price }))}
+                      items={treatmentWorks.map(toCheckboxItem)}
                       selectedIds={currentZoneWorkIds}
                       onToggle={(id) => {
                         const work = treatmentWorks.find((item) => item.id === id);

--- a/src/components/dental/ToothEditorModal.tsx
+++ b/src/components/dental/ToothEditorModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { AlertCircle, BookOpen, Plus, RefreshCcw, Save, X } from 'lucide-react';
 import type {
   ClinicalZone,
@@ -285,14 +285,14 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
     setFormData((prev) => {
       if (!prev) return prev;
+      const { visualStateOverride: _visualStateOverride, ...rest } = prev;
 
       return {
-        ...prev,
+        ...rest,
         presenceStatus,
         diagnoses: [],
         plannedWorks: [],
         plannedWorkRecords: [],
-        visualStateOverride: undefined,
       };
     });
     setManualVisualState(false);
@@ -358,9 +358,10 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
   const resetToHealthy = () => {
     const now = new Date().toISOString();
+    const { visualStateOverride: _visualStateOverride, ...toothWithoutOverride } = formData;
 
     setFormData({
-      ...formData,
+      ...toothWithoutOverride,
       condition: 'healthy',
       surfaces: [],
       crown: '',
@@ -376,7 +377,6 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       notes: '',
       presenceStatus: 'natural',
       visualState: 'healthy',
-      visualStateOverride: undefined,
       diagnoses: [],
       plannedWorks: [],
       plannedWorkRecords: [],
@@ -414,14 +414,16 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
   };
 
   const handleSave = () => {
-    const nextTooth: ToothRecord = {
+    const nextToothBase: ToothRecord = {
       ...formData,
       condition: computedVisualState,
       visualState: computedVisualState,
-      visualStateOverride: manualVisualState ? formData.visualStateOverride || computedVisualState : undefined,
       plannedWorks: getWorkIds(formData.plannedWorkRecords || []),
       updatedAt: new Date().toISOString(),
     };
+    const nextTooth: ToothRecord = manualVisualState
+      ? { ...nextToothBase, visualStateOverride: formData.visualStateOverride || computedVisualState }
+      : nextToothBase;
 
     onSave(nextTooth, buildFindingPayload());
   };
@@ -493,7 +495,11 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
                       type="button"
                       onClick={() => {
                         setManualVisualState(false);
-                        setFormData((prev) => prev ? { ...prev, visualStateOverride: undefined } : prev);
+                        setFormData((prev) => {
+                          if (!prev) return prev;
+                          const { visualStateOverride: _visualStateOverride, ...rest } = prev;
+                          return rest;
+                        });
                       }}
                       className="text-xs font-medium text-slate-500 hover:text-slate-700 underline"
                     >

--- a/src/components/dental/ToothEditorModal.tsx
+++ b/src/components/dental/ToothEditorModal.tsx
@@ -97,20 +97,26 @@ function clearVisualOverride(tooth: ToothRecord): ToothRecord {
 }
 
 function createRecordId(): string {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
-    return crypto.randomUUID();
-  }
-
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
   return `planned_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+function createPlannedWorkRecord(work: ClinicalWork, zone: ClinicalZone): PlannedWorkRecord {
+  const now = new Date().toISOString();
+
+  return {
+    id: createRecordId(),
+    workId: work.id,
+    zone,
+    status: 'planned',
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 function getFirstAvailableZone(presenceStatus: ToothPresenceStatus, preferredZone?: ClinicalZone): ClinicalZone {
   const availableZones = getAvailableZonesForPresence(presenceStatus);
-
-  if (preferredZone && availableZones.includes(preferredZone)) {
-    return preferredZone;
-  }
-
+  if (preferredZone && availableZones.includes(preferredZone)) return preferredZone;
   return availableZones[0] || 'crown';
 }
 
@@ -127,22 +133,10 @@ function deriveVisualState(
   const diagnosisSet = new Set(diagnosisIds);
   const workSet = new Set(plannedWorkIds);
 
-  if (['dx_irreversible_pulpitis', 'dx_reversible_pulpitis', 'dx_pulp_necrosis'].some((id) => diagnosisSet.has(id))) {
-    return 'pulpitis';
-  }
-
-  if (['dx_apical_periodontitis', 'dx_periodontal_pocket', 'dx_peri_implantitis', 'dx_radicular_cyst'].some((id) => diagnosisSet.has(id))) {
-    return 'periodontitis';
-  }
-
-  if (['dx_caries_initial', 'dx_caries_enamel', 'dx_caries_dentin', 'dx_deep_caries', 'dx_root_caries'].some((id) => diagnosisSet.has(id))) {
-    return 'caries';
-  }
-
-  if (['work_implant_crown', 'work_crown'].some((id) => workSet.has(id))) {
-    return 'crown';
-  }
-
+  if (['dx_irreversible_pulpitis', 'dx_reversible_pulpitis', 'dx_pulp_necrosis'].some((id) => diagnosisSet.has(id))) return 'pulpitis';
+  if (['dx_apical_periodontitis', 'dx_periodontal_pocket', 'dx_peri_implantitis', 'dx_radicular_cyst'].some((id) => diagnosisSet.has(id))) return 'periodontitis';
+  if (['dx_caries_initial', 'dx_caries_enamel', 'dx_caries_dentin', 'dx_deep_caries', 'dx_root_caries'].some((id) => diagnosisSet.has(id))) return 'caries';
+  if (['work_implant_crown', 'work_crown'].some((id) => workSet.has(id))) return 'crown';
   if (fallbackCondition !== 'healthy') return fallbackCondition;
   return diagnosisIds.length > 0 || plannedWorkIds.length > 0 ? 'needs_treatment' : 'healthy';
 }
@@ -161,26 +155,13 @@ function getZoneWorkIds(records: PlannedWorkRecord[], zone: ClinicalZone): strin
 }
 
 function toCheckboxItem(item: { id: string; name: string; description?: string; price?: number }): CheckboxItem {
-  const checkboxItem: CheckboxItem = {
-    id: item.id,
-    name: item.name,
-  };
-
+  const checkboxItem: CheckboxItem = { id: item.id, name: item.name };
   if (item.description) checkboxItem.description = item.description;
   if (typeof item.price === 'number') checkboxItem.price = item.price;
-
   return checkboxItem;
 }
 
-function ClinicalCheckboxList({
-  items,
-  selectedIds,
-  onToggle,
-}: {
-  items: CheckboxItem[];
-  selectedIds: string[];
-  onToggle: (id: string) => void;
-}) {
+function ClinicalCheckboxList({ items, selectedIds, onToggle }: { items: CheckboxItem[]; selectedIds: string[]; onToggle: (id: string) => void }) {
   if (items.length === 0) return null;
 
   return (
@@ -190,20 +171,8 @@ function ClinicalCheckboxList({
         const price = formatPrice(item.price);
 
         return (
-          <label
-            key={item.id}
-            className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors cursor-pointer ${
-              isSelected
-                ? 'border-blue-300 bg-blue-50 text-blue-950'
-                : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
-            }`}
-          >
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={() => onToggle(item.id)}
-              className="mt-0.5 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-            />
+          <label key={item.id} className={`flex items-start gap-3 rounded-lg border p-3 text-sm transition-colors cursor-pointer ${isSelected ? 'border-blue-300 bg-blue-50 text-blue-950' : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'}`}>
+            <input type="checkbox" checked={isSelected} onChange={() => onToggle(item.id)} className="mt-0.5 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
             <span className="flex-1">
               <span className="font-medium">{item.name}</span>
               {item.description && <span className="block text-xs text-slate-500 mt-0.5">{item.description}</span>}
@@ -247,50 +216,28 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
   const plannedWorkIds = getWorkIds(plannedWorkRecords);
   const currentZoneWorkIds = getZoneWorkIds(plannedWorkRecords, currentZone);
 
-  const availableDiagnoses = useMemo(
-    () => getDiagnosesByPresenceAndZone(currentPresence, currentZone),
-    [currentPresence, currentZone],
-  );
-
-  const allZoneWorks = useMemo(
-    () => getWorksByPresenceAndZone(currentPresence, currentZone),
-    [currentPresence, currentZone],
-  );
-
-  const baseWorks = useMemo(
-    () => getBaseWorksByPresenceAndZone(currentPresence, currentZone),
-    [currentPresence, currentZone],
-  );
-
-  const treatmentWorks = useMemo(
-    () => getWorksByDiagnoses(currentPresence, currentZone, diagnosisIds).filter((work) => work.workAccessType === 'requires_diagnosis'),
-    [currentPresence, currentZone, diagnosisIds],
-  );
+  const availableDiagnoses = useMemo(() => getDiagnosesByPresenceAndZone(currentPresence, currentZone), [currentPresence, currentZone]);
+  const allZoneWorks = useMemo(() => getWorksByPresenceAndZone(currentPresence, currentZone), [currentPresence, currentZone]);
+  const baseWorks = useMemo(() => getBaseWorksByPresenceAndZone(currentPresence, currentZone), [currentPresence, currentZone]);
+  const treatmentWorks = useMemo(() => getWorksByDiagnoses(currentPresence, currentZone, diagnosisIds).filter((work) => work.workAccessType === 'requires_diagnosis'), [currentPresence, currentZone, diagnosisIds]);
 
   if (!isOpen || !tooth || !formData) return null;
 
   const automaticVisualState = deriveVisualState(currentPresence, diagnosisIds, plannedWorkIds, formData.condition);
-  const computedVisualState = manualVisualState && formData.visualStateOverride
-    ? formData.visualStateOverride
-    : automaticVisualState;
-
+  const computedVisualState = manualVisualState && formData.visualStateOverride ? formData.visualStateOverride : automaticVisualState;
   const presenceLabel = PRESENCE_STATUSES.find((status) => status.value === currentPresence)?.label || currentPresence;
   const visualLabel = VISUAL_STATES.find((state) => state.value === computedVisualState)?.label || computedVisualState;
   const hasZoneData = availableDiagnoses.length > 0 || allZoneWorks.length > 0;
 
   const setPresenceStatus = (presenceStatus: ToothPresenceStatus) => {
     const nextZone = getFirstAvailableZone(presenceStatus);
-
-    setFormData((prev) => {
-      if (!prev) return prev;
-      return {
-        ...clearVisualOverride(prev),
-        presenceStatus,
-        diagnoses: [],
-        plannedWorks: [],
-        plannedWorkRecords: [],
-      };
-    });
+    setFormData((prev) => prev ? {
+      ...clearVisualOverride(prev),
+      presenceStatus,
+      diagnoses: [],
+      plannedWorks: [],
+      plannedWorkRecords: [],
+    } : prev);
     setManualVisualState(false);
     setActiveZone(nextZone);
   };
@@ -298,49 +245,24 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
   const toggleDiagnosis = (diagnosisId: string) => {
     setFormData((prev) => {
       if (!prev) return prev;
+      const nextDiagnosisIds = prev.diagnoses?.includes(diagnosisId) ? prev.diagnoses.filter((id) => id !== diagnosisId) : [...(prev.diagnoses || []), diagnosisId];
+      const allowedWorkIds = new Set(getWorksByDiagnoses(prev.presenceStatus || 'natural', currentZone, nextDiagnosisIds).map((work) => work.id));
+      const nextRecords = (prev.plannedWorkRecords || []).filter((record) => record.zone !== currentZone || allowedWorkIds.has(record.workId));
 
-      const nextDiagnosisIds = prev.diagnoses?.includes(diagnosisId)
-        ? prev.diagnoses.filter((id) => id !== diagnosisId)
-        : [...(prev.diagnoses || []), diagnosisId];
-      const allowedWorkIds = new Set(
-        getWorksByDiagnoses(prev.presenceStatus || 'natural', currentZone, nextDiagnosisIds).map((work) => work.id),
-      );
-      const nextRecords = (prev.plannedWorkRecords || []).filter((record) => (
-        record.zone !== currentZone || allowedWorkIds.has(record.workId)
-      ));
-
-      return {
-        ...prev,
-        diagnoses: nextDiagnosisIds,
-        plannedWorkRecords: nextRecords,
-        plannedWorks: getWorkIds(nextRecords),
-      };
+      return { ...prev, diagnoses: nextDiagnosisIds, plannedWorkRecords: nextRecords, plannedWorks: getWorkIds(nextRecords) };
     });
   };
 
   const toggleWork = (work: ClinicalWork) => {
     setFormData((prev) => {
       if (!prev) return prev;
-
       const currentRecords = prev.plannedWorkRecords || [];
       const hasWork = currentRecords.some((record) => record.zone === currentZone && record.workId === work.id);
-      const now = new Date().toISOString();
-      const nextRecords = hasWork
+      const nextRecords: PlannedWorkRecord[] = hasWork
         ? currentRecords.filter((record) => !(record.zone === currentZone && record.workId === work.id))
-        : [...currentRecords, {
-          id: createRecordId(),
-          workId: work.id,
-          zone: currentZone,
-          status: 'planned',
-          createdAt: now,
-          updatedAt: now,
-        }];
+        : [...currentRecords, createPlannedWorkRecord(work, currentZone)];
 
-      return {
-        ...prev,
-        plannedWorkRecords: nextRecords,
-        plannedWorks: getWorkIds(nextRecords),
-      };
+      return { ...prev, plannedWorkRecords: nextRecords, plannedWorks: getWorkIds(nextRecords) };
     });
   };
 
@@ -349,8 +271,6 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
   };
 
   const resetToHealthy = () => {
-    const now = new Date().toISOString();
-
     setFormData({
       ...clearVisualOverride(formData),
       condition: 'healthy',
@@ -372,7 +292,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       plannedWorks: [],
       plannedWorkRecords: [],
       completedWorks: [],
-      updatedAt: now,
+      updatedAt: new Date().toISOString(),
     });
     setManualVisualState(false);
     setActiveZone('crown');
@@ -381,7 +301,6 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
   const buildFindingPayload = (): Partial<DentalFinding> | null => {
     if (!createFinding) return null;
-
     const selectedDiagnosisNames = diagnosisIds.map((id) => defaultDiagnoses.find((diagnosis) => diagnosis.id === id)?.name || id);
     const selectedWorkNames = plannedWorkIds.map((id) => defaultClinicalWorks.find((work) => work.id === id)?.name || id);
 
@@ -410,10 +329,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       plannedWorks: getWorkIds(formData.plannedWorkRecords || []),
       updatedAt: new Date().toISOString(),
     };
-    const nextTooth = manualVisualState
-      ? { ...nextToothBase, visualStateOverride: formData.visualStateOverride || computedVisualState }
-      : nextToothBase;
-
+    const nextTooth = manualVisualState ? { ...nextToothBase, visualStateOverride: formData.visualStateOverride || computedVisualState } : nextToothBase;
     onSave(nextTooth, buildFindingPayload());
   };
 
@@ -437,59 +353,25 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
             <section className="bg-blue-50/60 p-4 rounded-xl border border-blue-100 space-y-4">
               <div>
                 <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wider mb-1.5">Анатомический статус</label>
-                <select
-                  value={currentPresence}
-                  onChange={(event) => setPresenceStatus(event.target.value as ToothPresenceStatus)}
-                  className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  {PRESENCE_STATUSES.map((status) => (
-                    <option key={status.value} value={status.value}>{status.label}</option>
-                  ))}
+                <select value={currentPresence} onChange={(event) => setPresenceStatus(event.target.value as ToothPresenceStatus)} className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  {PRESENCE_STATUSES.map((status) => <option key={status.value} value={status.value}>{status.label}</option>)}
                 </select>
-                <p className="mt-1 text-xs text-blue-700/80">
-                  {PRESENCE_STATUSES.find((status) => status.value === currentPresence)?.hint}
-                </p>
+                <p className="mt-1 text-xs text-blue-700/80">{PRESENCE_STATUSES.find((status) => status.value === currentPresence)?.hint}</p>
               </div>
 
               <div>
                 <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wider mb-1.5">Отображение на формуле</label>
                 {!manualVisualState ? (
                   <div className="p-3 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 space-y-2">
-                    <div>
-                      Расчётное состояние: <span className="font-semibold">{visualLabel}</span>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setManualVisualState(true);
-                        setVisualStateOverride(computedVisualState);
-                      }}
-                      className="text-xs font-medium text-blue-600 hover:text-blue-800 underline"
-                    >
-                      Изменить вручную
-                    </button>
+                    <div>Расчётное состояние: <span className="font-semibold">{visualLabel}</span></div>
+                    <button type="button" onClick={() => { setManualVisualState(true); setVisualStateOverride(computedVisualState); }} className="text-xs font-medium text-blue-600 hover:text-blue-800 underline">Изменить вручную</button>
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    <select
-                      value={formData.visualStateOverride || computedVisualState}
-                      onChange={(event) => setVisualStateOverride(event.target.value as ToothVisualState)}
-                      className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    >
-                      {VISUAL_STATES.map((state) => (
-                        <option key={state.value} value={state.value}>{state.label}</option>
-                      ))}
+                    <select value={formData.visualStateOverride || computedVisualState} onChange={(event) => setVisualStateOverride(event.target.value as ToothVisualState)} className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                      {VISUAL_STATES.map((state) => <option key={state.value} value={state.value}>{state.label}</option>)}
                     </select>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setManualVisualState(false);
-                        setFormData((prev) => prev ? clearVisualOverride(prev) : prev);
-                      }}
-                      className="text-xs font-medium text-slate-500 hover:text-slate-700 underline"
-                    >
-                      Вернуть автоматический расчёт
-                    </button>
+                    <button type="button" onClick={() => { setManualVisualState(false); setFormData((prev) => prev ? clearVisualOverride(prev) : prev); }} className="text-xs font-medium text-slate-500 hover:text-slate-700 underline">Вернуть автоматический расчёт</button>
                   </div>
                 )}
               </div>
@@ -497,22 +379,12 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
 
             <section>
               <label className="block text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1.5">Общие заметки</label>
-              <textarea
-                value={formData.notes || ''}
-                onChange={(event) => setFormData({ ...formData, notes: event.target.value })}
-                className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[110px] resize-none"
-                placeholder="Дополнительные комментарии врача..."
-              />
+              <textarea value={formData.notes || ''} onChange={(event) => setFormData({ ...formData, notes: event.target.value })} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[110px] resize-none" placeholder="Дополнительные комментарии врача..." />
             </section>
 
             <section className="bg-orange-50 p-4 rounded-xl border border-orange-100">
               <label className="flex items-start gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={createFinding}
-                  onChange={(event) => setCreateFinding(event.target.checked)}
-                  className="mt-0.5 h-4 w-4 text-orange-500 border-slate-300 rounded focus:ring-orange-500"
-                />
+                <input type="checkbox" checked={createFinding} onChange={(event) => setCreateFinding(event.target.checked)} className="mt-0.5 h-4 w-4 text-orange-500 border-slate-300 rounded focus:ring-orange-500" />
                 <span>
                   <span className="block text-sm font-semibold text-orange-900">Создать клиническую проблему</span>
                   <span className="block text-xs text-orange-700 mt-1">Находка будет создана по выбранным диагнозам, зоне и заметке врача.</span>
@@ -524,18 +396,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
           <main className="min-w-0 flex flex-col">
             <div className="flex overflow-x-auto border-b border-slate-200 mb-4" style={{ scrollbarWidth: 'none' }}>
               {availableZones.map((zone) => (
-                <button
-                  key={zone}
-                  type="button"
-                  onClick={() => setActiveZone(zone)}
-                  className={`px-4 py-2.5 text-sm font-semibold whitespace-nowrap border-b-2 transition-colors ${
-                    currentZone === zone
-                      ? 'border-blue-500 text-blue-700 bg-blue-50/40'
-                      : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'
-                  }`}
-                >
-                  {ZONE_LABELS[zone]}
-                </button>
+                <button key={zone} type="button" onClick={() => setActiveZone(zone)} className={`px-4 py-2.5 text-sm font-semibold whitespace-nowrap border-b-2 transition-colors ${currentZone === zone ? 'border-blue-500 text-blue-700 bg-blue-50/40' : 'border-transparent text-slate-500 hover:text-slate-800 hover:bg-slate-50'}`}>{ZONE_LABELS[zone]}</button>
               ))}
             </div>
 
@@ -554,53 +415,26 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
               <div className="space-y-5">
                 {availableDiagnoses.length > 0 && (
                   <section className="bg-slate-50 p-4 rounded-xl border border-slate-100">
-                    <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-2">
-                      <AlertCircle className="w-3.5 h-3.5 text-red-400" />
-                      Диагнозы / состояния
-                    </h3>
-                    <ClinicalCheckboxList
-                      items={availableDiagnoses.map(toCheckboxItem)}
-                      selectedIds={diagnosisIds}
-                      onToggle={toggleDiagnosis}
-                    />
+                    <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-2"><AlertCircle className="w-3.5 h-3.5 text-red-400" />Диагнозы / состояния</h3>
+                    <ClinicalCheckboxList items={availableDiagnoses.map(toCheckboxItem)} selectedIds={diagnosisIds} onToggle={toggleDiagnosis} />
                   </section>
                 )}
 
                 {baseWorks.length > 0 && (
                   <section className="bg-blue-50/40 p-4 rounded-xl border border-blue-100">
-                    <h3 className="text-xs font-bold text-blue-600 uppercase tracking-wider mb-3 flex items-center gap-2">
-                      <Plus className="w-3.5 h-3.5" />
-                      Базовые / доступные работы
-                    </h3>
-                    <ClinicalCheckboxList
-                      items={baseWorks.map(toCheckboxItem)}
-                      selectedIds={currentZoneWorkIds}
-                      onToggle={(id) => {
-                        const work = baseWorks.find((item) => item.id === id);
-                        if (work) toggleWork(work);
-                      }}
-                    />
+                    <h3 className="text-xs font-bold text-blue-600 uppercase tracking-wider mb-3 flex items-center gap-2"><Plus className="w-3.5 h-3.5" />Базовые / доступные работы</h3>
+                    <ClinicalCheckboxList items={baseWorks.map(toCheckboxItem)} selectedIds={currentZoneWorkIds} onToggle={(id) => { const work = baseWorks.find((item) => item.id === id); if (work) toggleWork(work); }} />
                   </section>
                 )}
 
                 <section className="bg-emerald-50/40 p-4 rounded-xl border border-emerald-100">
-                  <h3 className="text-xs font-bold text-emerald-600 uppercase tracking-wider mb-3 flex items-center gap-2">
-                    <Plus className="w-3.5 h-3.5" />
-                    Лечебные работы
-                  </h3>
+                  <h3 className="text-xs font-bold text-emerald-600 uppercase tracking-wider mb-3 flex items-center gap-2"><Plus className="w-3.5 h-3.5" />Лечебные работы</h3>
                   {allZoneWorks.some((work) => work.workAccessType === 'requires_diagnosis') && diagnosisIds.length === 0 ? (
                     <p className="text-xs text-slate-500 italic">Выберите диагноз выше, чтобы увидеть доступные лечебные работы.</p>
                   ) : treatmentWorks.length === 0 ? (
                     <p className="text-xs text-slate-500 italic">Нет лечебных работ для выбранных диагнозов в этой зоне.</p>
                   ) : (
-                    <ClinicalCheckboxList
-                      items={treatmentWorks.map(toCheckboxItem)}
-                      selectedIds={currentZoneWorkIds}
-                      onToggle={(id) => {
-                        const work = treatmentWorks.find((item) => item.id === id);
-                        if (work) toggleWork(work);
-                      }}
-                    />
+                    <ClinicalCheckboxList items={treatmentWorks.map(toCheckboxItem)} selectedIds={currentZoneWorkIds} onToggle={(id) => { const work = treatmentWorks.find((item) => item.id === id); if (work) toggleWork(work); }} />
                   )}
                 </section>
               </div>
@@ -609,29 +443,10 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
         </div>
 
         <div className="flex items-center justify-between gap-3 p-4 border-t border-slate-200 bg-slate-50">
-          <button
-            type="button"
-            onClick={resetToHealthy}
-            className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-200 rounded-lg transition-colors"
-          >
-            <RefreshCcw className="w-4 h-4" /> Сбросить
-          </button>
+          <button type="button" onClick={resetToHealthy} className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 hover:bg-slate-200 rounded-lg transition-colors"><RefreshCcw className="w-4 h-4" /> Сбросить</button>
           <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200 bg-slate-100 rounded-lg transition-colors"
-            >
-              Отмена
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              className="flex items-center gap-2 px-5 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
-            >
-              <Save className="w-4 h-4" />
-              Сохранить изменения
-            </button>
+            <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200 bg-slate-100 rounded-lg transition-colors">Отмена</button>
+            <button type="button" onClick={handleSave} className="flex items-center gap-2 px-5 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"><Save className="w-4 h-4" />Сохранить изменения</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Migrates the tooth editor modal toward the saved clinical prototype UI, now built on top of the merged dental chart compatibility model and clinical dictionaries.

## What changed
- Rebuilt `ToothEditorModal` around anatomical status, calculated/manual visual state, notes, clinical findings, zone tabs, diagnoses, and works.
- Uses existing `clinicalDictionaries` helpers instead of hard-coded legacy suggestion lists.
- Saves forward-compatible tooth fields: `presenceStatus`, `visualState`, `visualStateOverride`, `diagnoses`, `plannedWorks`, `plannedWorkRecords`.
- Keeps old `condition` updated from the computed visual state so the existing dental chart rendering still works.
- Updates modal tests for the new prototype workflow.

## Scope boundaries
- No Supabase schema/migration changes.
- No package changes.
- No new admin pages.
- No dental chart SVG/rendering rewrite.
- No clinical dictionary seed changes.

## Checks
- GitHub CI pending.

## Browser QA
- Not performed in this environment.