### PR TITLE
DENTALCHART-SUPABASE-FALLBACK-001: retry legacy tooth save when editor columns are missing

### DIFF
--- a/src/data/repositories/DentalChartRepository.test.ts
+++ b/src/data/repositories/DentalChartRepository.test.ts
@@ -343,6 +343,141 @@ describe('DentalChartRepository', () => {
       });
     });
 
+    it('saveDentalChart retries legacy tooth rows when editor columns are missing', async () => {
+      const mockSelect = vi.fn().mockReturnThis();
+      const mockEq = vi.fn().mockReturnThis();
+      const mockMaybeSingle = vi.fn().mockResolvedValue({ data: { id: 'uuid-stable' }, error: null });
+
+      const missingColumnError = {
+        code: 'PGRST204',
+        message: "Could not find the 'presence_status' column of 'tooth_states' in the schema cache",
+      };
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      const mockTeethUpsert = vi.fn()
+        .mockResolvedValueOnce({ error: missingColumnError })
+        .mockResolvedValueOnce({ error: null });
+
+      const mockClient = {
+        from: vi.fn((table) => {
+          if (table === 'dental_charts') {
+            return { select: mockSelect, eq: mockEq, maybeSingle: mockMaybeSingle, upsert: mockUpsert };
+          }
+          if (table === 'tooth_states') {
+            return { upsert: mockTeethUpsert };
+          }
+        })
+      } as unknown as SupabaseClient;
+
+      const plannedWorkRecord = {
+        id: 'pwr-1',
+        workId: 'work_filling_1_surface',
+        zone: 'crown' as const,
+        status: 'planned' as const,
+        createdAt: '2026-06-11T00:00:00.000Z',
+        updatedAt: '2026-06-11T00:00:00.000Z',
+      };
+
+      const repo = new SupabaseDentalChartRepository('t1', mockClient);
+      const chart: DentalChart = {
+        id: 'chart_p1',
+        patientId: 'p1',
+        teeth: [{
+          toothNumber: 11,
+          condition: 'caries',
+          surfaces: ['occlusal'],
+          crown: 'old crown note',
+          root: 'old root note',
+          gum: 'old gum note',
+          bone: 'old bone note',
+          canal: 'old canal note',
+          notes: 'general note',
+          presenceStatus: 'natural',
+          visualStateOverride: 'filled',
+          diagnoses: ['dx_caries_enamel'],
+          plannedWorks: ['work_filling_1_surface'],
+          plannedWorkRecords: [plannedWorkRecord],
+          completedWorks: ['work_polishing'],
+          updatedAt: 'now'
+        }],
+        createdAt: 'now',
+        updatedAt: 'now'
+      };
+
+      await repo.saveDentalChart('p1', chart);
+
+      expect(mockTeethUpsert).toHaveBeenCalledTimes(2);
+
+      const firstAttemptRow = mockTeethUpsert.mock.calls[0][0][0];
+      expect(firstAttemptRow).toMatchObject({
+        condition: 'caries',
+        presence_status: 'natural',
+        visual_state: 'filled',
+        visual_state_override: 'filled',
+        diagnoses: ['dx_caries_enamel'],
+        planned_works: ['work_filling_1_surface'],
+        planned_work_records: [plannedWorkRecord],
+        completed_works: ['work_polishing'],
+      });
+
+      const fallbackRow = mockTeethUpsert.mock.calls[1][0][0];
+      expect(fallbackRow).toMatchObject({
+        tenant_id: 't1',
+        dental_chart_id: 'uuid-stable',
+        tooth_number: 11,
+        condition: 'caries',
+        surfaces: ['occlusal'],
+        crown: 'old crown note',
+        root: 'old root note',
+        gum: 'old gum note',
+        bone: 'old bone note',
+        canal: 'old canal note',
+        notes: 'general note',
+      });
+      expect(fallbackRow).not.toHaveProperty('presence_status');
+      expect(fallbackRow).not.toHaveProperty('visual_state');
+      expect(fallbackRow).not.toHaveProperty('visual_state_override');
+      expect(fallbackRow).not.toHaveProperty('diagnoses');
+      expect(fallbackRow).not.toHaveProperty('planned_works');
+      expect(fallbackRow).not.toHaveProperty('planned_work_records');
+      expect(fallbackRow).not.toHaveProperty('completed_works');
+    });
+
+    it('saveDentalChart does not swallow unrelated tooth upsert errors', async () => {
+      const mockSelect = vi.fn().mockReturnThis();
+      const mockEq = vi.fn().mockReturnThis();
+      const mockMaybeSingle = vi.fn().mockResolvedValue({ data: { id: 'uuid-stable' }, error: null });
+
+      const unrelatedError = {
+        code: '23514',
+        message: 'new row for relation tooth_states violates check constraint',
+      };
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      const mockTeethUpsert = vi.fn().mockResolvedValue({ error: unrelatedError });
+
+      const mockClient = {
+        from: vi.fn((table) => {
+          if (table === 'dental_charts') {
+            return { select: mockSelect, eq: mockEq, maybeSingle: mockMaybeSingle, upsert: mockUpsert };
+          }
+          if (table === 'tooth_states') {
+            return { upsert: mockTeethUpsert };
+          }
+        })
+      } as unknown as SupabaseClient;
+
+      const repo = new SupabaseDentalChartRepository('t1', mockClient);
+      const chart: DentalChart = {
+        id: 'chart_p1',
+        patientId: 'p1',
+        teeth: [{ toothNumber: 11, condition: 'healthy', updatedAt: 'now' }],
+        createdAt: 'now',
+        updatedAt: 'now'
+      };
+
+      await expect(repo.saveDentalChart('p1', chart)).rejects.toEqual(unrelatedError);
+      expect(mockTeethUpsert).toHaveBeenCalledTimes(1);
+    });
+
     it('saveDentalChart creates new UUID if no existing chart', async () => {
       const mockSelect = vi.fn().mockReturnThis();
       const mockEq = vi.fn().mockReturnThis();

--- a/src/data/repositories/DentalChartRepository.ts
+++ b/src/data/repositories/DentalChartRepository.ts
@@ -16,6 +16,16 @@ export interface CreateDentalChartRepositoryOptions {
   backend: DentalChartRepositoryBackend;
 }
 
+const DENTAL_CHART_EDITOR_COLUMN_NAMES = [
+  'presence_status',
+  'visual_state',
+  'visual_state_override',
+  'diagnoses',
+  'planned_works',
+  'planned_work_records',
+  'completed_works',
+] as const;
+
 const readStringArray = (value: unknown): string[] => {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 };
@@ -23,6 +33,58 @@ const readStringArray = (value: unknown): string[] => {
 const readPlannedWorkRecords = (value: unknown): ToothRecord['plannedWorkRecords'] => {
   return Array.isArray(value) ? value as ToothRecord['plannedWorkRecords'] : [];
 };
+
+const errorText = (error: unknown): string => {
+  if (!error || typeof error !== 'object') return '';
+
+  const candidate = error as { message?: unknown; details?: unknown; hint?: unknown };
+
+  return [candidate.message, candidate.details, candidate.hint]
+    .filter((part): part is string => typeof part === 'string')
+    .join(' ')
+    .toLowerCase();
+};
+
+const isMissingEditorColumnError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+
+  const candidate = error as { code?: unknown };
+  const code = typeof candidate.code === 'string' ? candidate.code : '';
+  const text = errorText(error);
+  const mentionsEditorColumn = DENTAL_CHART_EDITOR_COLUMN_NAMES.some(column => text.includes(column));
+
+  if (!mentionsEditorColumn) return false;
+
+  return code === 'PGRST204'
+    || code === '42703'
+    || text.includes('schema cache')
+    || text.includes('column');
+};
+
+const createLegacyToothStateRow = (tenantId: string, chartId: string, tooth: ToothRecord) => ({
+  tenant_id: tenantId,
+  dental_chart_id: chartId,
+  tooth_number: tooth.toothNumber,
+  condition: tooth.condition,
+  surfaces: tooth.surfaces || [],
+  crown: tooth.crown || null,
+  root: tooth.root || null,
+  gum: tooth.gum || null,
+  bone: tooth.bone || null,
+  canal: tooth.canal || null,
+  notes: tooth.notes || null,
+});
+
+const createEditorToothStateRow = (tenantId: string, chartId: string, tooth: ToothRecord) => ({
+  ...createLegacyToothStateRow(tenantId, chartId, tooth),
+  presence_status: tooth.presenceStatus || null,
+  visual_state: tooth.visualState || null,
+  visual_state_override: tooth.visualStateOverride || null,
+  diagnoses: tooth.diagnoses || [],
+  planned_works: tooth.plannedWorks || [],
+  planned_work_records: tooth.plannedWorkRecords || [],
+  completed_works: tooth.completedWorks || [],
+});
 
 export const LocalStorageDentalChartRepository: DentalChartRepository = {
   async getDentalChart(patientId: string): Promise<DentalChart> {
@@ -148,26 +210,7 @@ export class SupabaseDentalChartRepository implements DentalChartRepository {
     if (chartError) throw chartError;
 
     // 5. Save tooth_states using that same stable chartId.
-    const teethRows = normalizedChart.teeth.map(t => ({
-      tenant_id: this.tenantId,
-      dental_chart_id: chartId,
-      tooth_number: t.toothNumber,
-      condition: t.condition,
-      surfaces: t.surfaces || [],
-      crown: t.crown || null,
-      root: t.root || null,
-      gum: t.gum || null,
-      bone: t.bone || null,
-      canal: t.canal || null,
-      notes: t.notes || null,
-      presence_status: t.presenceStatus || null,
-      visual_state: t.visualState || null,
-      visual_state_override: t.visualStateOverride || null,
-      diagnoses: t.diagnoses || [],
-      planned_works: t.plannedWorks || [],
-      planned_work_records: t.plannedWorkRecords || [],
-      completed_works: t.completedWorks || [],
-    }));
+    const teethRows = normalizedChart.teeth.map(t => createEditorToothStateRow(this.tenantId, chartId, t));
 
     const { error: teethError } = await this.client
       .from('tooth_states')
@@ -175,7 +218,20 @@ export class SupabaseDentalChartRepository implements DentalChartRepository {
         onConflict: 'dental_chart_id,tooth_number'
       });
 
-    if (teethError) throw teethError;
+    if (teethError) {
+      if (!isMissingEditorColumnError(teethError)) {
+        throw teethError;
+      }
+
+      const legacyTeethRows = normalizedChart.teeth.map(t => createLegacyToothStateRow(this.tenantId, chartId, t));
+      const { error: legacyTeethError } = await this.client
+        .from('tooth_states')
+        .upsert(legacyTeethRows, {
+          onConflict: 'dental_chart_id,tooth_number'
+        });
+
+      if (legacyTeethError) throw legacyTeethError;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Adds a safe Supabase fallback for dental chart saves when the live database has not yet applied the editor-field migration.

## What changed
- Extracted legacy and editor tooth_state row builders.
- Detects missing editor-column/schema-cache errors for new dental chart fields.
- Retries tooth_states upsert with legacy fields only when editor columns are missing.
- Keeps unrelated Supabase errors visible instead of swallowing them.
- Added tests for fallback retry and non-fallback errors.

## Scope boundaries
- No UI changes.
- No migration changes.
- No dictionary changes.
- No package changes.
- No seed changes.
- Existing editor-field persistence remains the primary path.

## Checks
- Pending CI.