### PR TITLE
DENTALCHART-TOOTHGRID-UX-001: improve tooth grid readability

### DIFF
--- a/src/components/dental/ToothGrid.test.tsx
+++ b/src/components/dental/ToothGrid.test.tsx
@@ -38,7 +38,7 @@ describe('ToothGrid', () => {
   const UPPER_JAW = [18, 17, 16, 15, 14, 13, 12, 11, 21, 22, 23, 24, 25, 26, 27, 28];
   const LOWER_JAW = [48, 47, 46, 45, 44, 43, 42, 41, 31, 32, 33, 34, 35, 36, 37, 38];
   const allToothNumbers = [...UPPER_JAW, ...LOWER_JAW];
-  
+
   const fullMockTeeth = allToothNumbers.map(num => {
     const existing = mockTeeth.find(t => t.toothNumber === num);
     return existing || {
@@ -55,6 +55,10 @@ describe('ToothGrid', () => {
     };
   }) as ToothRecord[];
 
+  const findToothButton = (container: HTMLElement, toothNumber: number) => (
+    Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label')?.startsWith(`Редактировать зуб ${toothNumber}`))
+  );
+
   it('renders tooth buttons correctly', async () => {
     const handleToothClick = vi.fn();
     const container = document.createElement('div');
@@ -64,9 +68,30 @@ describe('ToothGrid', () => {
       root.render(<ToothGrid teeth={fullMockTeeth} onToothClick={handleToothClick} />);
     });
 
-    const button18 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 18');
+    const button18 = findToothButton(container, 18);
     expect(button18).not.toBeNull();
+    expect(button18?.getAttribute('aria-label')).toBe('Редактировать зуб 18: Здоров');
     expect(button18?.textContent).toContain('18');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('renders jaw labels and condition legend', async () => {
+    const handleToothClick = vi.fn();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ToothGrid teeth={fullMockTeeth} onToothClick={handleToothClick} />);
+    });
+
+    expect(container.textContent).toContain('Верхняя челюсть');
+    expect(container.textContent).toContain('Нижняя челюсть');
+    expect(container.textContent).toContain('Легенда зубной карты');
+    expect(container.textContent).toContain('Кариес');
+    expect(container.textContent).toContain('Активная находка');
 
     await act(async () => {
       root.unmount();
@@ -82,7 +107,7 @@ describe('ToothGrid', () => {
       root.render(<ToothGrid teeth={fullMockTeeth} onToothClick={handleToothClick} />);
     });
 
-    const button17 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 17');
+    const button17 = findToothButton(container, 17);
     expect(button17).not.toBeNull();
 
     await act(async () => {
@@ -107,22 +132,22 @@ describe('ToothGrid', () => {
 
     await act(async () => {
       root.render(
-        <ToothGrid 
-          teeth={fullMockTeeth} 
-          onToothClick={handleToothClick} 
-          selectedToothNumber={18} 
+        <ToothGrid
+          teeth={fullMockTeeth}
+          onToothClick={handleToothClick}
+          selectedToothNumber={18}
         />
       );
     });
 
-    const button18 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 18');
-    expect(button18?.className).toContain('bg-blue-50/50');
-    expect(button18?.className).toContain('ring-1');
-    expect(button18?.className).toContain('ring-blue-300');
+    const button18 = findToothButton(container, 18);
+    expect(button18?.className).toContain('bg-blue-50');
+    expect(button18?.className).toContain('ring-2');
+    expect(button18?.className).toContain('ring-blue-400');
 
-    const button17 = Array.from(container.querySelectorAll('button')).find(btn => btn.getAttribute('aria-label') === 'Редактировать зуб 17');
-    expect(button17?.className).not.toContain('bg-blue-50/50');
-    expect(button17?.className).not.toContain('ring-1');
+    const button17 = findToothButton(container, 17);
+    expect(button17?.className).not.toContain('ring-blue-400');
+    expect(button17?.className).toContain('hover:bg-slate-50');
 
     await act(async () => {
       root.unmount();

--- a/src/components/dental/ToothGrid.tsx
+++ b/src/components/dental/ToothGrid.tsx
@@ -1,4 +1,4 @@
-import type { ToothNumber, ToothRecord, DentalFinding } from '../../types';
+import type { ToothNumber, ToothRecord, DentalFinding, ToothCondition } from '../../types';
 import { AnatomicalTooth } from './icons/AnatomicalTeeth';
 import { SurfaceRing } from './icons/SurfaceRing';
 import type { SurfaceType } from './icons/SurfaceRing';
@@ -12,6 +12,29 @@ interface ToothGridProps {
 
 const UPPER_JAW: ToothNumber[] = [18, 17, 16, 15, 14, 13, 12, 11, 21, 22, 23, 24, 25, 26, 27, 28];
 const LOWER_JAW: ToothNumber[] = [48, 47, 46, 45, 44, 43, 42, 41, 31, 32, 33, 34, 35, 36, 37, 38];
+
+const TOOTH_CONDITION_LABELS: Record<ToothCondition, string> = {
+  healthy: 'Здоров',
+  caries: 'Кариес',
+  filled: 'Пломба',
+  missing: 'Отсутствует',
+  crown: 'Коронка',
+  implant: 'Имплант',
+  root: 'Корень',
+  pulpitis: 'Пульпит',
+  periodontitis: 'Периодонтит',
+  needs_treatment: 'Требует лечения',
+};
+
+const LEGEND_CONDITIONS: ToothCondition[] = [
+  'healthy',
+  'caries',
+  'filled',
+  'crown',
+  'implant',
+  'missing',
+  'needs_treatment',
+];
 
 const getToothColors = (condition: string) => {
   switch (condition) {
@@ -29,61 +52,98 @@ const getToothColors = (condition: string) => {
   }
 };
 
+const getConditionLabel = (condition: string) => (
+  TOOTH_CONDITION_LABELS[condition as ToothCondition] ?? 'Неизвестно'
+);
+
+const getActiveFindings = (findings: DentalFinding[]) => (
+  findings.filter(f => ['discovered', 'recommended', 'included_in_plan', 'observing'].includes(f.status))
+);
+
+const ToothTooltip = ({ tooth, activeFindings, isUpper }: { tooth: ToothRecord, activeFindings: DentalFinding[], isUpper: boolean }) => {
+  const diagnosesCount = tooth.diagnoses?.length ?? 0;
+  const plannedWorksCount = tooth.plannedWorkRecords?.length ?? tooth.plannedWorks?.length ?? 0;
+  const tooltipPosition = isUpper ? 'top-full mt-3' : 'bottom-full mb-3';
+
+  return (
+    <div
+      className={`pointer-events-none absolute left-1/2 ${tooltipPosition} z-30 w-56 -translate-x-1/2 rounded-xl border border-slate-200 bg-white/95 px-3 py-2 text-left text-xs text-slate-700 opacity-0 shadow-xl shadow-slate-900/10 backdrop-blur transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100`}
+      role="tooltip"
+    >
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="font-semibold text-slate-900">Зуб {tooth.toothNumber}</span>
+        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">
+          {getConditionLabel(tooth.visualState ?? tooth.condition)}
+        </span>
+      </div>
+      <div className="space-y-1 text-[11px] leading-4">
+        <div>Диагнозы: <span className="font-medium text-slate-900">{diagnosesCount}</span></div>
+        <div>Работы: <span className="font-medium text-slate-900">{plannedWorksCount}</span></div>
+        <div>Находки: <span className="font-medium text-slate-900">{activeFindings.length}</span></div>
+      </div>
+    </div>
+  );
+};
+
 const ToothColumn = ({ tooth, findings = [], isSelected, onClick }: { tooth: ToothRecord, findings: DentalFinding[], isSelected?: boolean, onClick: () => void }) => {
   const isUpper = (tooth?.toothNumber || 0) < 30;
-  
+  const activeFindings = getActiveFindings(findings);
+
   const getIndicator = () => {
-    if (!findings || findings.length === 0) return null;
-    const active = findings.filter(f => ['discovered', 'recommended', 'included_in_plan', 'observing'].includes(f.status));
-    if (active.length === 0) return null;
-    const hasHighOrUrgent = active.some(f => f.severity === 'high' || f.severity === 'urgent');
-    const isObservingOnly = active.every(f => f.status === 'observing');
+    if (activeFindings.length === 0) return null;
+
+    const hasHighOrUrgent = activeFindings.some(f => f.severity === 'high' || f.severity === 'urgent');
+    const isObservingOnly = activeFindings.every(f => f.status === 'observing');
 
     if (hasHighOrUrgent) {
-      return <div className="absolute top-0 right-0 w-3 h-3 bg-red-500 rounded-full border-2 border-white shadow-sm z-20"></div>;
+      return <div className="absolute right-0 top-0 z-20 h-3 w-3 rounded-full border-2 border-white bg-red-500 shadow-sm" title="Есть срочная/важная находка"></div>;
     }
     if (isObservingOnly) {
-      return <div className="absolute top-0 right-0 w-3 h-3 bg-slate-400 rounded-full border-2 border-white shadow-sm opacity-80 z-20"></div>;
+      return <div className="absolute right-0 top-0 z-20 h-3 w-3 rounded-full border-2 border-white bg-slate-400 opacity-80 shadow-sm" title="На наблюдении"></div>;
     }
-    return <div className="absolute top-0 right-0 w-3 h-3 bg-blue-500 rounded-full border-2 border-white shadow-sm z-20"></div>;
+    return <div className="absolute right-0 top-0 z-20 h-3 w-3 rounded-full border-2 border-white bg-blue-500 shadow-sm" title="Есть активная находка"></div>;
   };
 
-  const colors = getToothColors(tooth?.condition || 'healthy');
-  const isMissing = tooth?.condition === 'missing';
-  
+  const visualCondition = tooth.visualState ?? tooth.condition ?? 'healthy';
+  const colors = getToothColors(visualCondition);
+  const isMissing = visualCondition === 'missing';
+
   // Extract surfaces from tooth data
   const surfaces = (tooth.surfaces as unknown as SurfaceType[]) || [];
+  const selectedClasses = isSelected
+    ? 'z-10 scale-105 rounded-xl bg-blue-50 shadow-md ring-2 ring-blue-400 ring-offset-2 ring-offset-white'
+    : 'rounded-xl hover:bg-slate-50 hover:shadow-sm hover:scale-105 focus-visible:bg-slate-50 focus-visible:ring-2 focus-visible:ring-blue-300';
 
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label={`Редактировать зуб ${tooth?.toothNumber}`}
-      className={`flex flex-col items-center group relative focus:outline-none transition-all ${
-        isSelected ? 'bg-blue-50/50 rounded-lg shadow-sm scale-105 z-10 ring-1 ring-blue-300' : 'hover:bg-slate-50 hover:scale-105 rounded-lg'
-      } p-1`}
+      aria-label={`Редактировать зуб ${tooth?.toothNumber}: ${getConditionLabel(visualCondition)}`}
+      className={`group relative flex flex-col items-center p-1.5 transition-all focus:outline-none ${selectedClasses}`}
     >
+      <ToothTooltip tooth={tooth} activeFindings={activeFindings} isUpper={isUpper} />
+
       {isUpper && (
         <>
           {/* Upper Anatomical Tooth */}
-          <div className="relative w-7 h-16 sm:w-9 sm:h-20 flex justify-center drop-shadow-sm group-hover:drop-shadow-md">
+          <div className="relative flex h-16 w-7 justify-center drop-shadow-sm transition-all group-hover:drop-shadow-md sm:h-20 sm:w-9">
             {getIndicator()}
             {/* Gum line background band for upper teeth (behind roots) */}
-            <div className="absolute top-2 w-[120%] h-4 bg-pink-100/60 -z-10"></div>
-            <div className={`w-full h-full transition-all ${isMissing ? 'opacity-40 grayscale' : ''}`}>
-               <AnatomicalTooth 
-                 toothNumber={tooth.toothNumber} 
-                 fillColor={colors.fill} 
-                 strokeColor={isSelected ? '#3B82F6' : colors.stroke} 
-               />
+            <div className="absolute top-2 -z-10 h-4 w-[120%] rounded-full bg-pink-100/70"></div>
+            <div className={`h-full w-full transition-all ${isMissing ? 'grayscale opacity-40' : ''}`}>
+              <AnatomicalTooth
+                toothNumber={tooth.toothNumber}
+                fillColor={colors.fill}
+                strokeColor={isSelected ? '#2563EB' : colors.stroke}
+              />
             </div>
           </div>
           {/* Upper Surface Ring */}
-          <div className="w-5 h-5 sm:w-6 sm:h-6 mt-1 mb-1 opacity-90">
-             <SurfaceRing surfaces={surfaces} strokeColor={colors.stroke} filledColor={colors.stroke} />
+          <div className="mb-1 mt-1 h-5 w-5 opacity-90 sm:h-6 sm:w-6">
+            <SurfaceRing surfaces={surfaces} strokeColor={colors.stroke} filledColor={colors.stroke} />
           </div>
           {/* Upper Tooth Number */}
-          <div className={`text-xs sm:text-sm font-bold ${isSelected ? 'text-blue-700' : 'text-slate-600'}`}>
+          <div className={`text-xs font-bold sm:text-sm ${isSelected ? 'text-blue-700' : 'text-slate-600'}`}>
             {tooth?.toothNumber}
           </div>
         </>
@@ -92,24 +152,24 @@ const ToothColumn = ({ tooth, findings = [], isSelected, onClick }: { tooth: Too
       {!isUpper && (
         <>
           {/* Lower Tooth Number */}
-          <div className={`text-xs sm:text-sm font-bold ${isSelected ? 'text-blue-700' : 'text-slate-600'}`}>
+          <div className={`text-xs font-bold sm:text-sm ${isSelected ? 'text-blue-700' : 'text-slate-600'}`}>
             {tooth?.toothNumber}
           </div>
           {/* Lower Surface Ring */}
-          <div className="w-5 h-5 sm:w-6 sm:h-6 mt-1 mb-1 opacity-90">
-             <SurfaceRing surfaces={surfaces} strokeColor={colors.stroke} filledColor={colors.stroke} />
+          <div className="mb-1 mt-1 h-5 w-5 opacity-90 sm:h-6 sm:w-6">
+            <SurfaceRing surfaces={surfaces} strokeColor={colors.stroke} filledColor={colors.stroke} />
           </div>
           {/* Lower Anatomical Tooth (Flipped) */}
-          <div className="relative w-7 h-16 sm:w-9 sm:h-20 flex justify-center drop-shadow-sm group-hover:drop-shadow-md rotate-180">
+          <div className="relative flex h-16 w-7 rotate-180 justify-center drop-shadow-sm transition-all group-hover:drop-shadow-md sm:h-20 sm:w-9">
             {getIndicator()}
             {/* Gum line background band for lower teeth (behind roots, now at bottom because flipped) */}
-            <div className="absolute top-2 w-[120%] h-4 bg-pink-100/60 -z-10"></div>
-            <div className={`w-full h-full transition-all ${isMissing ? 'opacity-40 grayscale' : ''}`}>
-               <AnatomicalTooth 
-                 toothNumber={tooth.toothNumber} 
-                 fillColor={colors.fill} 
-                 strokeColor={isSelected ? '#3B82F6' : colors.stroke} 
-               />
+            <div className="absolute top-2 -z-10 h-4 w-[120%] rounded-full bg-pink-100/70"></div>
+            <div className={`h-full w-full transition-all ${isMissing ? 'grayscale opacity-40' : ''}`}>
+              <AnatomicalTooth
+                toothNumber={tooth.toothNumber}
+                fillColor={colors.fill}
+                strokeColor={isSelected ? '#2563EB' : colors.stroke}
+              />
             </div>
           </div>
         </>
@@ -118,40 +178,88 @@ const ToothColumn = ({ tooth, findings = [], isSelected, onClick }: { tooth: Too
   );
 };
 
+const JawLabel = ({ title, subtitle }: { title: string, subtitle: string }) => (
+  <div className="mb-3 flex items-center justify-center gap-3 text-center">
+    <div className="h-px w-20 bg-gradient-to-r from-transparent to-slate-200" />
+    <div>
+      <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">{title}</div>
+      <div className="text-[11px] text-slate-400">{subtitle}</div>
+    </div>
+    <div className="h-px w-20 bg-gradient-to-l from-transparent to-slate-200" />
+  </div>
+);
+
+const ToothLegend = () => (
+  <div className="mt-6 rounded-2xl border border-slate-100 bg-slate-50/80 px-4 py-3">
+    <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">Легенда зубной карты</div>
+    <div className="flex flex-wrap gap-2">
+      {LEGEND_CONDITIONS.map(condition => {
+        const colors = getToothColors(condition);
+        return (
+          <div key={condition} className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-600 shadow-sm">
+            <span
+              className="h-3 w-3 rounded-full border"
+              style={{ backgroundColor: colors.fill, borderColor: colors.stroke }}
+              aria-hidden="true"
+            />
+            {TOOTH_CONDITION_LABELS[condition]}
+          </div>
+        );
+      })}
+      <div className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-600 shadow-sm">
+        <span className="h-3 w-3 rounded-full border-2 border-white bg-blue-500 shadow-sm" aria-hidden="true" />
+        Активная находка
+      </div>
+      <div className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-600 shadow-sm">
+        <span className="h-3 w-3 rounded-full border-2 border-white bg-red-500 shadow-sm" aria-hidden="true" />
+        Срочно
+      </div>
+    </div>
+  </div>
+);
+
 export function ToothGrid({ teeth, findings = [], onToothClick, selectedToothNumber }: ToothGridProps) {
   const getTooth = (num: number) => teeth.find(t => t.toothNumber === num) as ToothRecord;
   const getFindingsForTooth = (num: number) => findings.filter(f => f.toothNumber === num);
 
   return (
-    <div className="w-max min-w-max mx-auto flex flex-col gap-10 sm:gap-14 py-6 px-4 bg-white rounded-xl">
-      {/* Upper Jaw Row */}
-      <div className="flex justify-center items-center gap-4 sm:gap-6 relative">
-        <div className="flex gap-1 sm:gap-1.5">
-          {UPPER_JAW.slice(0, 8).map(num => (
-            <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
-          ))}
+    <div className="mx-auto w-max min-w-max rounded-3xl border border-slate-100 bg-white px-5 py-5 shadow-sm shadow-slate-900/5">
+      <div className="rounded-2xl bg-gradient-to-b from-white via-white to-slate-50 px-4 py-5">
+        <JawLabel title="Верхняя челюсть" subtitle="FDI 18–28" />
+        {/* Upper Jaw Row */}
+        <div className="relative flex items-center justify-center gap-4 sm:gap-6">
+          <div className="flex gap-1 sm:gap-1.5">
+            {UPPER_JAW.slice(0, 8).map(num => (
+              <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
+            ))}
+          </div>
+          <div className="h-32 w-[2px] shrink-0 rounded-full bg-slate-200"></div>
+          <div className="flex gap-1 sm:gap-1.5">
+            {UPPER_JAW.slice(8, 16).map(num => (
+              <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
+            ))}
+          </div>
         </div>
-        <div className="w-[2px] h-32 bg-slate-200 rounded-full shrink-0"></div>
-        <div className="flex gap-1 sm:gap-1.5">
-          {UPPER_JAW.slice(8, 16).map(num => (
-            <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
-          ))}
-        </div>
-      </div>
 
-      {/* Lower Jaw Row */}
-      <div className="flex justify-center items-center gap-4 sm:gap-6 relative">
-        <div className="flex gap-1 sm:gap-1.5">
-          {LOWER_JAW.slice(0, 8).map(num => (
-            <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
-          ))}
+        <div className="my-6 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+        <JawLabel title="Нижняя челюсть" subtitle="FDI 48–38" />
+        {/* Lower Jaw Row */}
+        <div className="relative flex items-center justify-center gap-4 sm:gap-6">
+          <div className="flex gap-1 sm:gap-1.5">
+            {LOWER_JAW.slice(0, 8).map(num => (
+              <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
+            ))}
+          </div>
+          <div className="h-32 w-[2px] shrink-0 rounded-full bg-slate-200"></div>
+          <div className="flex gap-1 sm:gap-1.5">
+            {LOWER_JAW.slice(8, 16).map(num => (
+              <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
+            ))}
+          </div>
         </div>
-        <div className="w-[2px] h-32 bg-slate-200 rounded-full shrink-0"></div>
-        <div className="flex gap-1 sm:gap-1.5">
-          {LOWER_JAW.slice(8, 16).map(num => (
-            <ToothColumn key={num} tooth={getTooth(num)} findings={getFindingsForTooth(num)} isSelected={selectedToothNumber === num} onClick={() => onToothClick(getTooth(num))} />
-          ))}
-        </div>
+
+        <ToothLegend />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Improves the dental chart grid readability around the existing tooth SVG rendering.

## What changed
- Added upper/lower jaw labels with FDI ranges.
- Added a compact dental chart legend for tooth states and finding indicators.
- Added hover/focus tooltips per tooth with condition, diagnoses, planned works, and active findings counts.
- Strengthened selected tooth highlighting.
- Kept existing click behavior and tooth color mapping.

## Scope boundaries
- No editor modal changes.
- No Supabase changes.
- No migrations.
- No dictionary changes.
- No package changes.
- No persistence changes.

## Checks
- GitHub CI pending.