### PR TITLE
DENTALCHART-FINDING-LINK-001: link tooth editor selections to findings

### DIFF
--- a/src/components/dental/DentalChartTab.tsx
+++ b/src/components/dental/DentalChartTab.tsx
@@ -30,6 +30,10 @@ function normalizeFindingPayload(
     isChiefComplaintRelated: findingPayload.isChiefComplaintRelated,
     includeInTreatmentPlan: findingPayload.includeInTreatmentPlan,
     status: findingPayload.status,
+    clinicalZone: findingPayload.clinicalZone,
+    diagnosisIds: findingPayload.diagnosisIds,
+    plannedWorkIds: findingPayload.plannedWorkIds,
+    plannedWorkRecordIds: findingPayload.plannedWorkRecordIds,
   };
 }
 

--- a/src/components/dental/ToothEditorModal.test.tsx
+++ b/src/components/dental/ToothEditorModal.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { ToothEditorModal } from './ToothEditorModal';
-import type { ToothRecord } from '../../types';
+import type { DentalFinding, ToothRecord } from '../../types';
 
 describe('ToothEditorModal', () => {
   let container: HTMLDivElement;
@@ -167,18 +167,28 @@ describe('ToothEditorModal', () => {
     expect(findingPayload).toBeNull();
   });
 
-  it('creates a finding payload when requested', () => {
+  it('creates a structured finding payload when requested', () => {
     const onSave = renderModal();
 
     clickByText('Создать клиническую проблему');
     clickByText('Кариес эмали');
+    clickByText('Пломба 1 поверхность');
     clickByText('Сохранить изменения');
 
     expect(onSave).toHaveBeenCalledTimes(1);
-    const [, findingPayload] = onSave.mock.calls[0] as [ToothRecord, { title?: string; description?: string }];
+    const [, findingPayload] = onSave.mock.calls[0] as [ToothRecord, Partial<DentalFinding>];
 
     expect(findingPayload.title).toContain('зуб 11');
+    expect(findingPayload.title).toContain('Коронка');
+    expect(findingPayload.category).toBe('caries');
+    expect(findingPayload.severity).toBe('medium');
     expect(findingPayload.description).toContain('Кариес эмали');
+    expect(findingPayload.description).toContain('Пломба 1 поверхность');
+    expect(findingPayload.clinicalZone).toBe('crown');
+    expect(findingPayload.diagnosisIds).toEqual(['dx_caries_enamel']);
+    expect(findingPayload.plannedWorkIds).toEqual(['work_filling_1_surface']);
+    expect(findingPayload.plannedWorkRecordIds).toHaveLength(1);
+    expect(findingPayload.includeInTreatmentPlan).toBe(true);
   });
 
   it('supports manual visual state override and reset', () => {

--- a/src/components/dental/ToothEditorModal.tsx
+++ b/src/components/dental/ToothEditorModal.tsx
@@ -151,6 +151,34 @@ function deriveVisualState(
   return diagnosisIds.length > 0 || plannedWorkIds.length > 0 ? 'needs_treatment' : 'healthy';
 }
 
+function deriveFindingCategory(
+  presenceStatus: ToothPresenceStatus,
+  zone: ClinicalZone,
+  diagnosisIds: string[],
+): FindingCategory {
+  const diagnosisSet = new Set(diagnosisIds);
+
+  if (presenceStatus === 'missing') return 'missing_tooth';
+  if (presenceStatus === 'implant') return 'implantology';
+  if (['dx_caries_initial', 'dx_caries_enamel', 'dx_caries_dentin', 'dx_deep_caries', 'dx_root_caries'].some((id) => diagnosisSet.has(id))) return 'caries';
+  if (['dx_irreversible_pulpitis', 'dx_reversible_pulpitis', 'dx_pulp_necrosis'].some((id) => diagnosisSet.has(id))) return 'pain';
+  if (['dx_apical_periodontitis', 'dx_radicular_cyst'].some((id) => diagnosisSet.has(id))) return 'root_problem';
+  if (['dx_periodontal_pocket', 'dx_peri_implantitis'].some((id) => diagnosisSet.has(id))) return 'gum_problem';
+
+  if (zone === 'endodontics' || zone === 'root') return 'root_problem';
+  if (zone === 'periodontium') return 'gum_problem';
+  if (zone === 'bone') return 'risk_zone';
+  if (zone === 'orthopedics' || zone === 'planning') return 'prosthetics';
+  return 'other';
+}
+
+function deriveFindingSeverity(diagnosisIds: string[]): FindingSeverity {
+  const diagnosisSet = new Set(diagnosisIds);
+  if (['dx_irreversible_pulpitis', 'dx_pulp_necrosis', 'dx_apical_periodontitis'].some((id) => diagnosisSet.has(id))) return 'high';
+  if (['dx_deep_caries', 'dx_radicular_cyst', 'dx_peri_implantitis'].some((id) => diagnosisSet.has(id))) return 'medium';
+  return 'medium';
+}
+
 function formatPrice(price?: number): string | null {
   if (typeof price !== 'number') return null;
   return `${price.toLocaleString('ru-RU')} ₸`;
@@ -366,9 +394,9 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
     const selectedWorkNames = plannedWorkIds.map((id) => defaultClinicalWorks.find((work) => work.id === id)?.name || id);
 
     return {
-      title: `Клиническая запись: зуб ${tooth.toothNumber}`,
-      category: 'other' as FindingCategory,
-      severity: 'medium' as FindingSeverity,
+      title: `Клиническая запись: зуб ${tooth.toothNumber} · ${ZONE_LABELS[currentZone]}`,
+      category: deriveFindingCategory(currentPresence, currentZone, diagnosisIds),
+      severity: deriveFindingSeverity(diagnosisIds),
       description: [
         `Анатомический статус: ${presenceLabel}`,
         `Зона: ${ZONE_LABELS[currentZone]}`,
@@ -379,6 +407,10 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       status: 'discovered' as FindingStatus,
       isChiefComplaintRelated: false,
       includeInTreatmentPlan: selectedWorkNames.length > 0,
+      clinicalZone: currentZone,
+      diagnosisIds,
+      plannedWorkIds,
+      plannedWorkRecordIds: plannedWorkRecords.map((record) => record.id),
     };
   };
 

--- a/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
+++ b/src/data/orchestrators/ClinicalWorkflowOrchestrator.ts
@@ -16,6 +16,10 @@ export type ToothStatusFindingInput =
     | 'isChiefComplaintRelated'
     | 'includeInTreatmentPlan'
     | 'status'
+    | 'clinicalZone'
+    | 'diagnosisIds'
+    | 'plannedWorkIds'
+    | 'plannedWorkRecordIds'
   >>;
 
 export interface ApplyToothStatusChangeInput {
@@ -49,12 +53,50 @@ export interface ClinicalWorkflowOrchestratorDependencies {
   backend?: 'local' | 'supabase';
 }
 
-
 function buildStageDescription(finding: DentalFinding): string {
   return [
     finding.description,
     finding.recommendation ? `Рекомендация: ${finding.recommendation}` : '',
   ].filter(Boolean).join('\n\n');
+}
+
+function activeFindingMatches(
+  finding: DentalFinding,
+  updatedTooth: ToothRecord,
+  findingPayload: ToothStatusFindingInput,
+  activeStatuses: string[],
+): boolean {
+  if (finding.toothNumber !== updatedTooth.toothNumber) return false;
+  if (finding.category !== findingPayload.category) return false;
+  if (!activeStatuses.includes(finding.status)) return false;
+
+  if (findingPayload.clinicalZone && finding.clinicalZone && finding.clinicalZone !== findingPayload.clinicalZone) {
+    return false;
+  }
+
+  return true;
+}
+
+function applyFindingPayload(
+  baseFinding: DentalFinding,
+  findingPayload: ToothStatusFindingInput,
+): DentalFinding {
+  return {
+    ...baseFinding,
+    title: findingPayload.title,
+    category: findingPayload.category,
+    severity: findingPayload.severity,
+    description: findingPayload.description || '',
+    riskDescription: findingPayload.riskDescription || '',
+    recommendation: findingPayload.recommendation || '',
+    isChiefComplaintRelated: findingPayload.isChiefComplaintRelated || false,
+    includeInTreatmentPlan: findingPayload.includeInTreatmentPlan || false,
+    status: findingPayload.status || baseFinding.status,
+    clinicalZone: findingPayload.clinicalZone,
+    diagnosisIds: findingPayload.diagnosisIds || [],
+    plannedWorkIds: findingPayload.plannedWorkIds || [],
+    plannedWorkRecordIds: findingPayload.plannedWorkRecordIds || [],
+  };
 }
 
 export function createClinicalWorkflowOrchestrator(
@@ -87,25 +129,10 @@ export function createClinicalWorkflowOrchestrator(
       const findings = await findingsRepository.listFindingsByPatient(patientId);
       const activeStatuses = ['discovered', 'recommended', 'included_in_plan', 'observing'];
       
-      const existingActiveFinding = findings.find(f => 
-        f.toothNumber === updatedTooth.toothNumber &&
-        f.category === findingPayload.category &&
-        activeStatuses.includes(f.status)
-      );
+      const existingActiveFinding = findings.find(f => activeFindingMatches(f, updatedTooth, findingPayload, activeStatuses));
 
       if (existingActiveFinding) {
-        await findingsRepository.updateFinding(patientId, {
-          ...existingActiveFinding,
-          title: findingPayload.title,
-          category: findingPayload.category,
-          severity: findingPayload.severity,
-          description: findingPayload.description || '',
-          riskDescription: findingPayload.riskDescription || '',
-          recommendation: findingPayload.recommendation || '',
-          isChiefComplaintRelated: findingPayload.isChiefComplaintRelated || false,
-          includeInTreatmentPlan: findingPayload.includeInTreatmentPlan || false,
-          status: findingPayload.status || existingActiveFinding.status,
-        });
+        await findingsRepository.updateFinding(patientId, applyFindingPayload(existingActiveFinding, findingPayload));
       } else {
         const createFindingInput: CreateFindingInput = {
           toothNumber: updatedTooth.toothNumber,
@@ -118,6 +145,10 @@ export function createClinicalWorkflowOrchestrator(
           isChiefComplaintRelated: findingPayload.isChiefComplaintRelated || false,
           includeInTreatmentPlan: findingPayload.includeInTreatmentPlan || false,
           status: findingPayload.status || 'discovered',
+          clinicalZone: findingPayload.clinicalZone,
+          diagnosisIds: findingPayload.diagnosisIds || [],
+          plannedWorkIds: findingPayload.plannedWorkIds || [],
+          plannedWorkRecordIds: findingPayload.plannedWorkRecordIds || [],
         };
         await findingsRepository.createFinding(patientId, createFindingInput);
       }

--- a/src/data/repositories/FindingsRepository.test.ts
+++ b/src/data/repositories/FindingsRepository.test.ts
@@ -35,7 +35,11 @@ describe('FindingsRepository', () => {
         severity: 'high',
         isChiefComplaintRelated: false,
         includeInTreatmentPlan: false,
-        status: 'discovered'
+        status: 'discovered',
+        clinicalZone: 'crown',
+        diagnosisIds: ['dx_caries_dentin'],
+        plannedWorkIds: ['work_filling_1_surface'],
+        plannedWorkRecordIds: ['record_1'],
       };
 
       await LocalStorageFindingsRepository.createFinding('patient_1', findingDraft);
@@ -50,6 +54,10 @@ describe('FindingsRepository', () => {
       expect(typeof saved.updatedAt).toBe('string');
       expect(saved.title).toBe('Caries');
       expect(saved.status).toBe('discovered');
+      expect(saved.clinicalZone).toBe('crown');
+      expect(saved.diagnosisIds).toEqual(['dx_caries_dentin']);
+      expect(saved.plannedWorkIds).toEqual(['work_filling_1_surface']);
+      expect(saved.plannedWorkRecordIds).toEqual(['record_1']);
     });
 
     it('updateFinding updates only matching patient/finding', async () => {
@@ -158,6 +166,10 @@ describe('FindingsRepository', () => {
           is_chief_complaint_related: true,
           include_in_treatment_plan: false,
           status: 'discovered',
+          clinical_zone: 'periodontium',
+          diagnosis_ids: ['dx_gingivitis'],
+          planned_work_ids: ['work_hygiene_instruction'],
+          planned_work_record_ids: ['record_1'],
           created_at: '2020',
           updated_at: '2020',
         }],
@@ -180,12 +192,46 @@ describe('FindingsRepository', () => {
         isChiefComplaintRelated: true,
         includeInTreatmentPlan: false,
         status: 'discovered',
+        clinicalZone: 'periodontium',
+        diagnosisIds: ['dx_gingivitis'],
+        plannedWorkIds: ['work_hygiene_instruction'],
+        plannedWorkRecordIds: ['record_1'],
         createdAt: '2020',
         updatedAt: '2020',
       });
     });
 
-    it('createFinding maps inputs properly and generates UUID', async () => {
+    it('listFindingsByPatient defaults link arrays for old rows without link fields', async () => {
+      mockOrder.mockResolvedValue({
+        data: [{
+          id: 'uuid-1',
+          patient_id: 'patient1',
+          tooth_number: 11,
+          title: 'Old finding',
+          category: 'caries',
+          severity: 'medium',
+          description: 'desc',
+          risk_description: null,
+          recommendation: null,
+          is_chief_complaint_related: false,
+          include_in_treatment_plan: false,
+          status: 'discovered',
+          created_at: '2020',
+          updated_at: '2020',
+        }],
+        error: null,
+      });
+
+      const repo = new SupabaseFindingsRepository('tenant1', mockClient);
+      const res = await repo.listFindingsByPatient('patient1');
+
+      expect(res[0].clinicalZone).toBeUndefined();
+      expect(res[0].diagnosisIds).toEqual([]);
+      expect(res[0].plannedWorkIds).toEqual([]);
+      expect(res[0].plannedWorkRecordIds).toEqual([]);
+    });
+
+    it('createFinding maps inputs properly and includes structured link fields', async () => {
       const repo = new SupabaseFindingsRepository('tenant1', mockClient);
       await repo.createFinding('patient1', {
         toothNumber: undefined,
@@ -196,6 +242,10 @@ describe('FindingsRepository', () => {
         isChiefComplaintRelated: false,
         includeInTreatmentPlan: false,
         status: 'discovered',
+        clinicalZone: 'periodontium',
+        diagnosisIds: ['dx_gingivitis'],
+        plannedWorkIds: ['work_hygiene_instruction'],
+        plannedWorkRecordIds: ['record_1'],
       });
 
       expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
@@ -212,7 +262,36 @@ describe('FindingsRepository', () => {
         is_chief_complaint_related: false,
         include_in_treatment_plan: false,
         status: 'discovered',
+        clinical_zone: 'periodontium',
+        diagnosis_ids: ['dx_gingivitis'],
+        planned_work_ids: ['work_hygiene_instruction'],
+        planned_work_record_ids: ['record_1'],
       }));
+    });
+
+    it('createFinding falls back to legacy payload if link columns are missing', async () => {
+      mockInsert
+        .mockReturnValueOnce({ error: { message: "Could not find the 'clinical_zone' column of 'findings' in the schema cache" } })
+        .mockReturnValueOnce({ error: null });
+
+      const repo = new SupabaseFindingsRepository('tenant1', mockClient);
+      await repo.createFinding('patient1', {
+        toothNumber: 11,
+        title: 'Legacy compatible',
+        category: 'caries',
+        severity: 'medium',
+        description: 'desc',
+        isChiefComplaintRelated: false,
+        includeInTreatmentPlan: false,
+        status: 'discovered',
+        clinicalZone: 'crown',
+        diagnosisIds: ['dx_caries_enamel'],
+      });
+
+      expect(mockInsert).toHaveBeenCalledTimes(2);
+      expect(mockInsert.mock.calls[0][0]).toHaveProperty('clinical_zone', 'crown');
+      expect(mockInsert.mock.calls[1][0]).not.toHaveProperty('clinical_zone');
+      expect(mockInsert.mock.calls[1][0]).not.toHaveProperty('diagnosis_ids');
     });
 
     it('updateFinding maps and filters by tenant_id', async () => {
@@ -233,6 +312,10 @@ describe('FindingsRepository', () => {
         isChiefComplaintRelated: true,
         includeInTreatmentPlan: true,
         status: 'completed',
+        clinicalZone: 'crown',
+        diagnosisIds: ['dx_caries_enamel'],
+        plannedWorkIds: ['work_filling_1_surface'],
+        plannedWorkRecordIds: ['record_1'],
         createdAt: '2020',
         updatedAt: '2020',
       });
@@ -242,6 +325,10 @@ describe('FindingsRepository', () => {
         status: 'completed',
         is_chief_complaint_related: true,
         include_in_treatment_plan: true,
+        clinical_zone: 'crown',
+        diagnosis_ids: ['dx_caries_enamel'],
+        planned_work_ids: ['work_filling_1_surface'],
+        planned_work_record_ids: ['record_1'],
       }));
       expect(mockEq).toHaveBeenCalledWith('tenant_id', 'tenant1');
       expect(mockEq).toHaveBeenCalledWith('patient_id', 'patient1');

--- a/src/data/repositories/FindingsRepository.ts
+++ b/src/data/repositories/FindingsRepository.ts
@@ -1,5 +1,5 @@
 import { storage } from '../../utils/storage';
-import type { DentalFinding } from '../../types';
+import type { ClinicalZone, DentalFinding } from '../../types';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { FindingCategory, FindingSeverity, FindingStatus } from '../../types';
@@ -31,6 +31,87 @@ export const LocalStorageFindingsRepository: FindingsRepository = {
   },
 };
 
+function getErrorMessage(error: unknown): string {
+  if (!error) return '';
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' ? message : String(message || '');
+  }
+  return String(error);
+}
+
+function isMissingFindingLinkColumnError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes('clinical_zone') ||
+    message.includes('diagnosis_ids') ||
+    message.includes('planned_work_ids') ||
+    message.includes('planned_work_record_ids') ||
+    message.includes('schema cache')
+  ) && (
+    message.includes('column') ||
+    message.includes('schema cache')
+  );
+}
+
+function mapFindingRow(row: Record<string, unknown>): DentalFinding {
+  return {
+    id: String(row.id),
+    patientId: String(row.patient_id),
+    toothNumber: row.tooth_number === null || row.tooth_number === undefined ? undefined : Number(row.tooth_number),
+    title: String(row.title),
+    category: row.category as FindingCategory,
+    severity: row.severity as FindingSeverity,
+    description: String(row.description || ''),
+    riskDescription: row.risk_description ? String(row.risk_description) : undefined,
+    recommendation: row.recommendation ? String(row.recommendation) : undefined,
+    isChiefComplaintRelated: Boolean(row.is_chief_complaint_related),
+    includeInTreatmentPlan: Boolean(row.include_in_treatment_plan),
+    status: row.status as FindingStatus,
+    clinicalZone: row.clinical_zone ? row.clinical_zone as ClinicalZone : undefined,
+    diagnosisIds: Array.isArray(row.diagnosis_ids) ? row.diagnosis_ids.map(String) : [],
+    plannedWorkIds: Array.isArray(row.planned_work_ids) ? row.planned_work_ids.map(String) : [],
+    plannedWorkRecordIds: Array.isArray(row.planned_work_record_ids) ? row.planned_work_record_ids.map(String) : [],
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+function buildFindingPayload(
+  tenantId: string,
+  patientId: string,
+  finding: CreateFindingInput | DentalFinding,
+  includeLinkFields: boolean,
+  id?: string,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    tenant_id: tenantId,
+    patient_id: patientId,
+    tooth_number: finding.toothNumber ?? null,
+    title: finding.title,
+    category: finding.category,
+    severity: finding.severity,
+    description: finding.description,
+    risk_description: finding.riskDescription ?? null,
+    recommendation: finding.recommendation ?? null,
+    is_chief_complaint_related: finding.isChiefComplaintRelated ?? false,
+    include_in_treatment_plan: finding.includeInTreatmentPlan ?? false,
+    status: finding.status,
+  };
+
+  if (id) payload.id = id;
+
+  if (includeLinkFields) {
+    payload.clinical_zone = finding.clinicalZone ?? null;
+    payload.diagnosis_ids = finding.diagnosisIds ?? [];
+    payload.planned_work_ids = finding.plannedWorkIds ?? [];
+    payload.planned_work_record_ids = finding.plannedWorkRecordIds ?? [];
+  }
+
+  return payload;
+}
+
 export class SupabaseFindingsRepository implements FindingsRepository {
   private readonly tenantId: string;
   private readonly client: SupabaseClient;
@@ -52,43 +133,20 @@ export class SupabaseFindingsRepository implements FindingsRepository {
       throw error;
     }
 
-    return (data || []).map(row => ({
-      id: row.id,
-      patientId: row.patient_id,
-      toothNumber: row.tooth_number === null ? undefined : row.tooth_number,
-      title: row.title,
-      category: row.category as FindingCategory,
-      severity: row.severity as FindingSeverity,
-      description: row.description,
-      riskDescription: row.risk_description || undefined,
-      recommendation: row.recommendation || undefined,
-      isChiefComplaintRelated: row.is_chief_complaint_related,
-      includeInTreatmentPlan: row.include_in_treatment_plan,
-      status: row.status as FindingStatus,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    }));
+    return (data || []).map((row) => mapFindingRow(row as Record<string, unknown>));
   }
 
   async createFinding(patientId: string, finding: CreateFindingInput): Promise<void> {
     const id = crypto.randomUUID();
-    const { error } = await this.client
+    const insertFinding = async (includeLinkFields: boolean) => this.client
       .from('findings')
-      .insert({
-        id,
-        tenant_id: this.tenantId,
-        patient_id: patientId,
-        tooth_number: finding.toothNumber ?? null,
-        title: finding.title,
-        category: finding.category,
-        severity: finding.severity,
-        description: finding.description,
-        risk_description: finding.riskDescription ?? null,
-        recommendation: finding.recommendation ?? null,
-        is_chief_complaint_related: finding.isChiefComplaintRelated ?? false,
-        include_in_treatment_plan: finding.includeInTreatmentPlan ?? false,
-        status: finding.status,
-      });
+      .insert(buildFindingPayload(this.tenantId, patientId, finding, includeLinkFields, id));
+
+    let { error } = await insertFinding(true);
+
+    if (error && isMissingFindingLinkColumnError(error)) {
+      ({ error } = await insertFinding(false));
+    }
 
     if (error) {
       throw error;
@@ -96,24 +154,21 @@ export class SupabaseFindingsRepository implements FindingsRepository {
   }
 
   async updateFinding(patientId: string, finding: DentalFinding): Promise<void> {
-    const { error } = await this.client
+    const updateFinding = async (includeLinkFields: boolean) => this.client
       .from('findings')
       .update({
-        tooth_number: finding.toothNumber ?? null,
-        title: finding.title,
-        category: finding.category,
-        severity: finding.severity,
-        description: finding.description,
-        risk_description: finding.riskDescription ?? null,
-        recommendation: finding.recommendation ?? null,
-        is_chief_complaint_related: finding.isChiefComplaintRelated ?? false,
-        include_in_treatment_plan: finding.includeInTreatmentPlan ?? false,
-        status: finding.status,
+        ...buildFindingPayload(this.tenantId, patientId, finding, includeLinkFields),
         updated_at: new Date().toISOString(),
       })
       .eq('tenant_id', this.tenantId)
       .eq('patient_id', patientId)
       .eq('id', finding.id);
+
+    let { error } = await updateFinding(true);
+
+    if (error && isMissingFindingLinkColumnError(error)) {
+      ({ error } = await updateFinding(false));
+    }
 
     if (error) {
       throw error;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,6 +195,10 @@ export interface DentalFinding {
   isChiefComplaintRelated: boolean;
   includeInTreatmentPlan: boolean;
   status: FindingStatus;
+  clinicalZone?: ClinicalZone;
+  diagnosisIds?: string[];
+  plannedWorkIds?: string[];
+  plannedWorkRecordIds?: string[];
   createdAt: string;
   updatedAt: string;
 }

--- a/supabase/migrations/0003_add_dental_chart_links_to_findings.sql
+++ b/supabase/migrations/0003_add_dental_chart_links_to_findings.sql
@@ -1,0 +1,33 @@
+-- DENTALCHART-FINDING-LINK-001
+-- Adds structured links from findings back to dental chart editor selections.
+-- Existing rows remain valid; all new fields are nullable/defaulted.
+
+ALTER TABLE findings
+  ADD COLUMN IF NOT EXISTS clinical_zone text,
+  ADD COLUMN IF NOT EXISTS diagnosis_ids text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS planned_work_ids text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS planned_work_record_ids text[] NOT NULL DEFAULT '{}';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'findings_clinical_zone_check'
+  ) THEN
+    ALTER TABLE findings
+      ADD CONSTRAINT findings_clinical_zone_check
+      CHECK (
+        clinical_zone IS NULL OR clinical_zone IN (
+          'crown',
+          'endodontics',
+          'root',
+          'periodontium',
+          'bone',
+          'orthopedics',
+          'planning'
+        )
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_findings_tenant_patient_tooth_zone
+  ON findings(tenant_id, patient_id, tooth_number, clinical_zone);


### PR DESCRIPTION
## Summary
Adds structured links between dental chart editor selections and clinical findings.

## What changed
- Added optional structured finding link fields:
  - clinicalZone
  - diagnosisIds
  - plannedWorkIds
  - plannedWorkRecordIds
- Added Supabase migration for findings link columns.
- Updated ToothEditorModal to include zone/diagnosis/work IDs in finding payloads.
- Updated DentalChartTab and ClinicalWorkflowOrchestrator to preserve structured finding payload fields.
- Updated SupabaseFindingsRepository read/write mapping with fallback for old DB schemas without the new columns.
- Updated editor tests for structured finding payloads.

## Scope boundaries
- No treatment plan generation rewrite.
- No dictionary changes.
- No package changes.
- No seed changes.
- No dental chart persistence changes.
- Existing findings remain valid.
- Old Supabase schema falls back to legacy finding fields if new columns are missing.

## Checks
- CI pending.