### PR TITLE
DENTALCHART-ZONE-MODEL-001: immutable status zones

### DIFF
--- a/src/components/dental/ToothEditorModal.test.tsx
+++ b/src/components/dental/ToothEditorModal.test.tsx
@@ -105,9 +105,11 @@ describe('ToothEditorModal', () => {
     });
 
     const html = container.innerHTML;
-    expect(html).toContain('Планирование');
+    expect(html).toContain('Десна');
     expect(html).toContain('Кость');
-    expect(html).toContain('Отсутствие зуба');
+    expect(html).toContain('Ортопедия');
+    expect(html).not.toContain('Планирование');
+    expect(html).not.toContain('Отсутствие зуба'); // hidden because planning tab is gone
     expect(html).not.toContain('Каналы');
   });
 

--- a/src/config/__tests__/clinicalDictionaries.test.ts
+++ b/src/config/__tests__/clinicalDictionaries.test.ts
@@ -78,8 +78,9 @@ describe('clinical dictionaries', () => {
     ]));
 
     expect(getAvailableZonesForPresence('missing')).toEqual(expect.arrayContaining([
-      'planning',
+      'periodontium',
       'bone',
+      'orthopedics',
     ]));
 
     expect(getAvailableZonesForPresence('implant')).toEqual(expect.arrayContaining([

--- a/src/config/clinicalDictionaries.ts
+++ b/src/config/clinicalDictionaries.ts
@@ -449,8 +449,8 @@ export const STATUS_TO_ZONES_MAP: Record<ToothPresenceStatus, ClinicalZone[]> = 
   deciduous: ['crown', 'endodontics', 'root', 'periodontium'],
   root_remnant: ['root', 'periodontium', 'bone', 'orthopedics'],
   implant: ['periodontium', 'orthopedics', 'bone'],
-  missing: ['planning', 'periodontium', 'bone', 'orthopedics'],
-  impacted: ['planning', 'crown', 'root', 'periodontium', 'bone'],
+  missing: ['periodontium', 'bone', 'orthopedics'],
+  impacted: ['crown', 'root', 'periodontium', 'bone'],
 };
 
 export function getAvailableZonesForPresence(

--- a/src/config/clinicalDictionaries.ts
+++ b/src/config/clinicalDictionaries.ts
@@ -444,24 +444,17 @@ export function getWorksByDiagnoses(
   });
 }
 
+export const STATUS_TO_ZONES_MAP: Record<ToothPresenceStatus, ClinicalZone[]> = {
+  natural: ['crown', 'endodontics', 'root', 'periodontium', 'orthopedics'],
+  deciduous: ['crown', 'endodontics', 'root', 'periodontium'],
+  root_remnant: ['root', 'periodontium', 'bone', 'orthopedics'],
+  implant: ['periodontium', 'orthopedics', 'bone'],
+  missing: ['planning', 'periodontium', 'bone', 'orthopedics'],
+  impacted: ['planning', 'crown', 'root', 'periodontium', 'bone'],
+};
+
 export function getAvailableZonesForPresence(
   presenceStatus: ToothPresenceStatus,
-  diagnoses: ClinicalDiagnosis[] = defaultDiagnoses,
-  works: ClinicalWork[] = defaultClinicalWorks,
 ): ClinicalZone[] {
-  const zones = new Set<ClinicalZone>();
-
-  for (const diagnosis of diagnoses) {
-    if (diagnosis.allowedPresenceStatuses.includes(presenceStatus)) {
-      diagnosis.allowedZones.forEach((zone) => zones.add(zone));
-    }
-  }
-
-  for (const work of works) {
-    if (work.allowedPresenceStatuses.includes(presenceStatus)) {
-      work.allowedZones.forEach((zone) => zones.add(zone));
-    }
-  }
-
-  return Array.from(zones);
+  return STATUS_TO_ZONES_MAP[presenceStatus] || [];
 }


### PR DESCRIPTION
## Summary

Implements Issue #241 by introducing an immutable `STATUS_TO_ZONES_MAP` for dental chart tooth-position statuses.

## Scope

- Keeps clinical zones as system-controlled UI structure.
- Stops editable dictionary content from determining which tabs/zones are shown.
- Preserves legacy dictionary records that still use `planning`, without creating a `planning` tab.
- Updates tests for the new status-to-zone mapping.

## Explicitly out of scope

- Supabase migrations
- backend
- package files
- billing
- discounts
- RBAC
- treatment plans
- Storage/files/photos/documents

Fixes #241