### PR TITLE
DENTALCHART-TOOTH-POSITION-UI-LABELS-001: clean UI labels

### DIFF
--- a/src/components/dental/ToothEditorModal.test.tsx
+++ b/src/components/dental/ToothEditorModal.test.tsx
@@ -87,13 +87,13 @@ describe('ToothEditorModal', () => {
     renderModal();
 
     const html = container.innerHTML;
-    expect(html).toContain('Анатомический статус');
+    expect(html).toContain('Статус зубной позиции');
     expect(html).toContain('Отображение на формуле');
     expect(html).toContain('Выбранное');
     expect(html).toContain('Пока ничего не выбрано');
     expect(html).toContain('Общие заметки');
     expect(html).toContain('Создать клиническую проблему');
-    expect(html).toContain('Коронка');
+    expect(html).toContain('Коронковая часть');
     expect(html).toContain('Каналы');
     expect(html).toContain('Десна');
     expect(html).toContain('Диагнозы / состояния');
@@ -195,7 +195,7 @@ describe('ToothEditorModal', () => {
     const [, findingPayload] = onSave.mock.calls[0] as [ToothRecord, Partial<DentalFinding>];
 
     expect(findingPayload.title).toContain('зуб 11');
-    expect(findingPayload.title).toContain('Коронка');
+    expect(findingPayload.title).toContain('Коронковая часть');
     expect(findingPayload.category).toBe('caries');
     expect(findingPayload.severity).toBe('medium');
     expect(findingPayload.description).toContain('Кариес эмали');
@@ -229,7 +229,7 @@ describe('ToothEditorModal', () => {
   it('filters zones correctly for natural tooth', () => {
     renderModal();
     const html = container.innerHTML;
-    expect(html).toContain('Коронка');
+    expect(html).toContain('Коронковая часть');
     expect(html).toContain('Каналы');
     expect(html).toContain('Корень');
     expect(html).toContain('Десна');
@@ -249,7 +249,7 @@ describe('ToothEditorModal', () => {
     expect(html).toContain('Десна');
     expect(html).toContain('Ортопедия');
     expect(html).toContain('Кость');
-    expect(html).not.toContain('Коронка');
+    expect(html).not.toContain('Коронковая часть');
     expect(html).not.toContain('Каналы');
     expect(html).not.toContain('Корень');
     expect(html).not.toContain('Планирование');
@@ -266,7 +266,7 @@ describe('ToothEditorModal', () => {
     expect(html).toContain('Десна');
     expect(html).toContain('Кость');
     expect(html).toContain('Ортопедия');
-    expect(html).not.toContain('Коронка');
+    expect(html).not.toContain('Коронковая часть');
     expect(html).not.toContain('Каналы');
     expect(html).not.toContain('Корень');
     expect(html).not.toContain('Планирование');

--- a/src/components/dental/ToothEditorModal.tsx
+++ b/src/components/dental/ToothEditorModal.tsx
@@ -58,7 +58,7 @@ const VISUAL_STATES: { value: ToothVisualState; label: string }[] = [
 ];
 
 const ZONE_LABELS: Record<ClinicalZone, string> = {
-  crown: 'Коронка',
+  crown: 'Коронковая часть',
   endodontics: 'Каналы',
   root: 'Корень',
   periodontium: 'Десна',
@@ -381,7 +381,7 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
       category: deriveFindingCategory(currentPresence, currentZone, diagnosisIds),
       severity: deriveFindingSeverity(diagnosisIds),
       description: [
-        `Анатомический статус: ${presenceLabel}`,
+        `Статус зубной позиции: ${presenceLabel}`,
         `Зона: ${ZONE_LABELS[currentZone]}`,
         selectedDiagnosisNames.length > 0 ? `Диагнозы: ${selectedDiagnosisNames.join(', ')}` : '',
         selectedWorkNames.length > 0 ? `Работы: ${selectedWorkNames.join(', ')}` : '',
@@ -428,10 +428,11 @@ export function ToothEditorModal({ isOpen, tooth, defaultZone, onClose, onSave }
           <aside className="space-y-5">
             <section className="bg-blue-50/60 p-4 rounded-xl border border-blue-100 space-y-4">
               <div>
-                <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wider mb-1.5">Анатомический статус</label>
+                <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wider mb-1.5">Статус зубной позиции</label>
                 <select value={currentPresence} onChange={(event) => setPresenceStatus(event.target.value as ToothPresenceStatus)} className="w-full px-3 py-2 bg-white border border-blue-200 rounded-lg text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
                   {PRESENCE_STATUSES.map((status) => <option key={status.value} value={status.value}>{status.label}</option>)}
                 </select>
+                <p className="mt-1.5 text-[11px] text-blue-600/80 leading-tight">Что находится в позиции зуба: естественный зуб, отсутствует, имплант, остаток корня и т.д.</p>
                 <p className="mt-1 text-xs text-blue-700/80">{PRESENCE_STATUSES.find((status) => status.value === currentPresence)?.hint}</p>
               </div>
 

--- a/src/components/dental/ToothGrid.test.tsx
+++ b/src/components/dental/ToothGrid.test.tsx
@@ -215,7 +215,7 @@ describe('ToothGrid', () => {
     });
 
     expect(container.querySelector('[data-testid="zone-marker-18-crown-planned"]')).not.toBeNull();
-    expect(container.textContent).toContain('Зоны: Коронка (в плане)');
+    expect(container.textContent).toContain('Зоны: Коронковая часть (в плане)');
 
     await act(async () => {
       root.unmount();

--- a/src/components/dental/ToothGrid.tsx
+++ b/src/components/dental/ToothGrid.tsx
@@ -74,7 +74,7 @@ const LEGEND_CONDITIONS: ToothCondition[] = [
 ];
 
 const ZONE_LABELS: Record<ClinicalZone, string> = {
-  crown: 'Коронка',
+  crown: 'Коронковая часть',
   endodontics: 'Каналы',
   root: 'Корень',
   periodontium: 'Десна',

--- a/src/pages/MedicalPage.tsx
+++ b/src/pages/MedicalPage.tsx
@@ -14,7 +14,7 @@ const PRESENCE_STATUS_LABELS: Record<ToothPresenceStatus, string> = {
 };
 
 const CLINICAL_ZONE_LABELS: Record<ClinicalZone, string> = {
-  crown: 'Коронка',
+  crown: 'Коронковая часть',
   endodontics: 'Каналы',
   root: 'Корень',
   periodontium: 'Десна',


### PR DESCRIPTION
## Summary

Implements Issue #248 as UI wording polish only.

Changes:
- Rename visible label `Анатомический статус` to `Статус зубной позиции`.
- Add helper text explaining what the tooth position status means.
- Rename visible clinical zone label `Коронка` to `Коронковая часть` where it refers to the tooth crown zone.
- Keep orthopaedic/visual crown labels unchanged where they refer to crown prosthetics.

## Scope guardrails

This PR intentionally does not change:
- internal keys / enum values;
- `STATUS_TO_ZONES_MAP`;
- clinical zone model logic;
- dictionary persistence;
- Supabase / migrations;
- backend;
- package files;
- billing / discounts / RBAC;
- treatment plans;
- Storage / photos / documents.

## Validation requested

- npm run lint
- npm run test
- npm run build
- manual QA of ToothEditorModal, ToothGrid, and MedicalPage visible labels

Fixes #248