### PR TITLE
DENTALFLOW-CLINICAL-DICTIONARY-NAV-UX-001: rename medical section

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -25,7 +25,7 @@ const navItems = [
   { to: '/documents', icon: FileText, label: 'Документы' },
   { to: '/patients', icon: UserSquare2, label: 'Пациенты' },
   { to: '/doctors', icon: Stethoscope, label: 'Врачи' },
-  { to: '/medical', icon: HeartPulse, label: 'Врачебная часть' },
+  { to: '/medical', icon: HeartPulse, label: 'Клинические справочники' },
   { to: '/finance', icon: Banknote, label: 'Финансы' },
   { to: '/warehouse', icon: Package, label: 'Склад' },
   { to: '/statistics', icon: BarChart3, label: 'Статистика' },

--- a/src/pages/MedicalPage.tsx
+++ b/src/pages/MedicalPage.tsx
@@ -106,8 +106,8 @@ export function MedicalPage() {
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">Врачебная часть</h1>
-        <p className="mt-1 text-slate-500">Редактор клинических справочников</p>
+        <h1 className="text-2xl font-bold text-slate-900">Клинические справочники</h1>
+        <p className="mt-1 text-slate-500">Настройка диагнозов, работ, цен и связей для зубной карты</p>
       </div>
 
       <div className="flex space-x-2 border-b border-slate-200">


### PR DESCRIPTION
## Summary

Fixes #255.

Renames the visible UI wording for the current `/medical` section from “Врачебная часть” to “Клинические справочники”.

## Scope

- Sidebar label updated
- `/medical` page title updated
- `/medical` subtitle clarified
- Route `/medical` preserved
- No internal keys, enums, zone model, clinical dictionary model, or dental chart logic changed

## Changed files

- `src/components/layout/Sidebar.tsx`
- `src/pages/MedicalPage.tsx`

## Verification from agent report

- `npm run lint` — passed
- `npm run test` — 208 / 208 passed
- `npm run build` — passed
- Manual QA: sidebar label, page title/subtitle, and existing dictionary editing flow checked

## Out of scope confirmation

No changes to Supabase, backend, migrations, package files, billing, discounts, RBAC, treatment plans, Storage, photos/documents, patients, appointments, doctor workspace, dental chart logic, `STATUS_TO_ZONES_MAP`, or internal route names.