### PR TITLE
DENTALCHART-CLINICAL-DICTIONARY-REGISTRY-UX-001: unified registry

### DIFF
--- a/src/pages/MedicalPage.tsx
+++ b/src/pages/MedicalPage.tsx
@@ -99,52 +99,213 @@ function StatusZoneSelector({
 
 export function MedicalPage() {
   const { diagnoses, works, loading, saveDiagnosis, saveWork, refresh } = useDictionaries();
-  const [activeTab, setActiveTab] = useState<'diagnoses' | 'works'>('diagnoses');
   
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterType, setFilterType] = useState<'all' | 'diagnosis' | 'work'>('all');
+  const [filterActivity, setFilterActivity] = useState<'all' | 'active' | 'disabled'>('all');
+  const [filterZone, setFilterZone] = useState<'all' | ClinicalZone>('all');
+  const [filterStatus, setFilterStatus] = useState<'all' | ToothPresenceStatus>('all');
+  
+  const [newItemType, setNewItemType] = useState<'diagnosis' | 'work' | null>(null);
+
+  // Works currently require `setEditingId` to ensure only one is edited at a time in the old design,
+  // but DiagnosisEditorRow used local state. To avoid rewriting their internal logic unnecessarily,
+  // we will continue using local state for Diagnosis, and maybe lift state for Works if we want, or just let them be.
+  // The user requested: "если текущий локальный editing state работает безопасно, не надо насильно выносить его наружу".
+  // So we'll let WorkEditorRow keep its own `isEditing` prop, which we can manage at the page level like before.
+  const [editingWorkId, setEditingWorkId] = useState<string | null>(null);
+
+  const filteredItems = useMemo(() => {
+    const allItems = [...diagnoses, ...works];
+    
+    return allItems.filter(item => {
+      // Type
+      if (filterType !== 'all' && item.type !== filterType) return false;
+      
+      // Activity
+      if (filterActivity === 'active' && item.isActive === false) return false;
+      if (filterActivity === 'disabled' && item.isActive !== false) return false;
+      
+      // Zone
+      if (filterZone !== 'all' && !item.allowedZones.includes(filterZone)) return false;
+      
+      // Status
+      if (filterStatus !== 'all' && !item.allowedPresenceStatuses.includes(filterStatus)) return false;
+      
+      // Search
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        const matchName = item.name.toLowerCase().includes(q);
+        const matchId = item.id.toLowerCase().includes(q);
+        const matchZone = item.allowedZones.some(z => CLINICAL_ZONE_LABELS[z]?.toLowerCase().includes(q));
+        const matchStatus = item.allowedPresenceStatuses.some(s => PRESENCE_STATUS_LABELS[s]?.toLowerCase().includes(q));
+        
+        if (!matchName && !matchId && !matchZone && !matchStatus) return false;
+      }
+      
+      return true;
+    });
+  }, [diagnoses, works, searchQuery, filterType, filterActivity, filterZone, filterStatus]);
+
   if (loading) return <div className="p-8 text-slate-500">Загрузка справочников...</div>;
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-8">
-      <div>
-        <h1 className="text-2xl font-bold text-slate-900">Клинические справочники</h1>
-        <p className="mt-1 text-slate-500">Настройка диагнозов, работ, цен и связей для зубной карты</p>
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Клинические справочники</h1>
+          <p className="mt-1 text-slate-500">Настройка диагнозов, работ, цен и связей для зубной карты</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setNewItemType('diagnosis')}
+            className="rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-700"
+          >
+            + Диагноз
+          </button>
+          <button
+            onClick={() => setNewItemType('work')}
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+          >
+            + Работа
+          </button>
+          <button
+            onClick={refresh}
+            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50"
+          >
+            Обновить
+          </button>
+        </div>
       </div>
 
-      <div className="flex space-x-2 border-b border-slate-200">
-        <button
-          className={`px-4 py-2 text-sm font-medium ${activeTab === 'diagnoses' ? 'border-b-2 border-blue-500 text-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
-          onClick={() => setActiveTab('diagnoses')}
-        >
-          Диагнозы
-        </button>
-        <button
-          className={`px-4 py-2 text-sm font-medium ${activeTab === 'works' ? 'border-b-2 border-blue-500 text-blue-600' : 'text-slate-500 hover:text-slate-700'}`}
-          onClick={() => setActiveTab('works')}
-        >
-          Работы и Цены
-        </button>
-        <div className="flex-1" />
-        <button
-          onClick={refresh}
-          className="text-sm text-slate-500 hover:text-slate-700"
-        >
-          Обновить
-        </button>
-      </div>
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
+          <div className="lg:col-span-1">
+            <label className="block text-xs font-medium text-slate-700 mb-1">Поиск</label>
+            <input
+              type="text"
+              placeholder="Название, ID, зона..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1">Тип</label>
+            <select
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value as any)}
+              className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
+            >
+              <option value="all">Все типы</option>
+              <option value="diagnosis">Диагнозы</option>
+              <option value="work">Работы</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1">Активность</label>
+            <select
+              value={filterActivity}
+              onChange={(e) => setFilterActivity(e.target.value as any)}
+              className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
+            >
+              <option value="all">Все</option>
+              <option value="active">Активные</option>
+              <option value="disabled">Отключённые</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1">Клиническая зона</label>
+            <select
+              value={filterZone}
+              onChange={(e) => setFilterZone(e.target.value as any)}
+              className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
+            >
+              <option value="all">Все зоны</option>
+              {(Object.entries(CLINICAL_ZONE_LABELS) as [ClinicalZone, string][]).map(([val, label]) => (
+                <option key={val} value={val}>{label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-700 mb-1">Статус зуба</label>
+            <select
+              value={filterStatus}
+              onChange={(e) => setFilterStatus(e.target.value as any)}
+              className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
+            >
+              <option value="all">Все статусы</option>
+              {(Object.entries(PRESENCE_STATUS_LABELS) as [ToothPresenceStatus, string][]).map(([val, label]) => (
+                <option key={val} value={val}>{label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-        {activeTab === 'diagnoses' ? (
-          <DiagnosesEditor diagnoses={diagnoses} onSave={saveDiagnosis} />
-        ) : (
-          <WorksEditor works={works} diagnoses={diagnoses} onSave={saveWork} />
-        )}
+        <div className="space-y-3 pt-4 border-t border-slate-100">
+          {newItemType === 'diagnosis' && (
+            <NewDiagnosisForm 
+              onSave={(d) => { saveDiagnosis(d); setNewItemType(null); }} 
+              onCancel={() => setNewItemType(null)} 
+            />
+          )}
+
+          {newItemType === 'work' && (
+            <WorkEditorRow 
+              work={{
+                id: `work_${Date.now()}`,
+                type: 'work',
+                name: '',
+                price: 0,
+                allowedPresenceStatuses: ['natural', 'deciduous'],
+                allowedZones: ['crown'],
+                allowedDiagnosisIds: [],
+                workAccessType: 'requires_diagnosis',
+                isActive: true,
+              }}
+              diagnoses={diagnoses}
+              onSave={(newWork) => { saveWork(newWork); setNewItemType(null); }}
+              isEditing={true}
+              setEditing={() => setNewItemType(null)}
+              isNew={true}
+            />
+          )}
+
+          {filteredItems.length === 0 && !newItemType && (
+            <div className="py-12 text-center">
+              <p className="text-slate-500">Ничего не найдено. Измените поиск или фильтры.</p>
+            </div>
+          )}
+
+          {filteredItems.map(item => {
+            if (item.type === 'diagnosis') {
+              return (
+                <DiagnosisEditorRow 
+                  key={item.id}
+                  diagnosis={item as ClinicalDiagnosis}
+                  onSave={saveDiagnosis}
+                />
+              );
+            } else {
+              return (
+                <WorkEditorRow 
+                  key={item.id} 
+                  work={item as ClinicalWork} 
+                  diagnoses={diagnoses} 
+                  onSave={saveWork} 
+                  isEditing={editingWorkId === item.id}
+                  setEditing={() => setEditingWorkId(editingWorkId === item.id ? null : item.id)}
+                />
+              );
+            }
+          })}
+        </div>
       </div>
     </div>
   );
 }
 
-function DiagnosesEditor({ diagnoses, onSave }: { diagnoses: ClinicalDiagnosis[], onSave: (d: ClinicalDiagnosis) => void }) {
-  const [isAdding, setIsAdding] = useState(false);
+function NewDiagnosisForm({ onSave, onCancel }: { onSave: (d: ClinicalDiagnosis) => void, onCancel: () => void }) {
   const [newName, setNewName] = useState('');
   const [newStatuses, setNewStatuses] = useState<ToothPresenceStatus[]>(['natural', 'deciduous']);
   const [newZones, setNewZones] = useState<ClinicalZone[]>(['crown']);
@@ -160,51 +321,31 @@ function DiagnosesEditor({ diagnoses, onSave }: { diagnoses: ClinicalDiagnosis[]
       isActive: true,
     };
     onSave(newDiagnosis);
-    setNewName('');
-    setIsAdding(false);
   };
 
   return (
-    <div className="space-y-4">
-      {isAdding ? (
-        <div className="rounded-lg border-2 border-blue-200 bg-blue-50/30 p-4">
-          <h3 className="font-medium text-slate-900 mb-4">Новый диагноз / состояние</h3>
-          <div className="mb-4">
-            <label className="block text-sm font-medium text-slate-700 mb-1">Название</label>
-            <input 
-              type="text" 
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              className="w-full max-w-md rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border mb-4"
-              placeholder="Например: Поверхностный кариес"
-            />
-            <StatusZoneSelector 
-              selectedStatuses={newStatuses} 
-              selectedZones={newZones} 
-              onChangeStatuses={setNewStatuses} 
-              onChangeZones={setNewZones} 
-            />
-          </div>
-          <div className="flex justify-end gap-2 mt-4">
-            <button onClick={() => setIsAdding(false)} className="px-4 py-2 text-sm text-slate-600 hover:text-slate-800">Отмена</button>
-            <button onClick={handleAdd} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700">Добавить</button>
-          </div>
-        </div>
-      ) : (
-        <div className="flex justify-end">
-          <button onClick={() => setIsAdding(true)} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700">
-            + Добавить диагноз
-          </button>
-        </div>
-      )}
-
-      {diagnoses.map(diagnosis => (
-        <DiagnosisEditorRow 
-          key={diagnosis.id}
-          diagnosis={diagnosis}
-          onSave={onSave}
+    <div className="rounded-lg border-2 border-emerald-200 bg-emerald-50/30 p-4 mb-4">
+      <h3 className="font-medium text-slate-900 mb-4">Новый диагноз / состояние</h3>
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-slate-700 mb-1">Название</label>
+        <input 
+          type="text" 
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          className="w-full max-w-md rounded-md border-slate-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm px-3 py-2 border mb-4 bg-white"
+          placeholder="Например: Поверхностный кариес"
         />
-      ))}
+        <StatusZoneSelector 
+          selectedStatuses={newStatuses} 
+          selectedZones={newZones} 
+          onChangeStatuses={setNewStatuses} 
+          onChangeZones={setNewZones} 
+        />
+      </div>
+      <div className="flex justify-end gap-2 mt-4">
+        <button onClick={onCancel} className="px-4 py-2 text-sm text-slate-600 hover:text-slate-800">Отмена</button>
+        <button onClick={handleAdd} className="rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-emerald-700">Добавить</button>
+      </div>
     </div>
   );
 }
@@ -234,7 +375,7 @@ function DiagnosisEditorRow({ diagnosis, onSave }: { diagnosis: ClinicalDiagnosi
             type="text" 
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="w-full max-w-md rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border mb-4"
+            className="w-full max-w-md rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border mb-4 bg-white"
           />
           <StatusZoneSelector 
             selectedStatuses={statuses} 
@@ -253,72 +394,28 @@ function DiagnosisEditorRow({ diagnosis, onSave }: { diagnosis: ClinicalDiagnosi
   }
 
   return (
-    <div className={`flex items-center justify-between rounded-lg border p-3 ${diagnosis.isActive === false ? 'bg-slate-50 opacity-60' : 'bg-white'}`}>
+    <div className={`flex flex-col sm:flex-row sm:items-center justify-between rounded-lg border p-3 gap-3 ${diagnosis.isActive === false ? 'bg-slate-50 opacity-60' : 'bg-white'}`}>
       <div>
-        <h3 className="font-medium text-slate-900">{diagnosis.name}</h3>
-        <p className="text-xs text-slate-500">ID: {diagnosis.id}</p>
+        <div className="flex items-center gap-2 mb-1">
+          <span className="inline-block rounded bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 uppercase tracking-wider">Диагноз</span>
+          <h3 className="font-medium text-slate-900">{diagnosis.name}</h3>
+        </div>
+        <p className="text-xs text-slate-500">ID: {diagnosis.id} • Зон: {diagnosis.allowedZones.length} • Статусов: {diagnosis.allowedPresenceStatuses.length}</p>
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-2 shrink-0">
         <button
           onClick={() => { setName(diagnosis.name); setIsEditing(true); }}
-          className="rounded bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700"
+          className="rounded border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
         >
           Редактировать
         </button>
         <button
           onClick={() => onSave({ ...diagnosis, isActive: diagnosis.isActive === false ? true : false })}
-          className={`rounded px-3 py-1 text-xs font-medium ${diagnosis.isActive === false ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}
+          className={`rounded px-3 py-1.5 text-xs font-medium shadow-sm ${diagnosis.isActive === false ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200' : 'bg-red-50 text-red-600 border border-red-100 hover:bg-red-100'}`}
         >
           {diagnosis.isActive === false ? 'Восстановить' : 'Отключить'}
         </button>
       </div>
-    </div>
-  );
-}
-
-function WorksEditor({ works, diagnoses, onSave }: { works: ClinicalWork[], diagnoses: ClinicalDiagnosis[], onSave: (w: ClinicalWork) => void }) {
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [newWorkId, setNewWorkId] = useState<string | null>(null);
-
-  return (
-    <div className="space-y-4">
-      {newWorkId ? (
-        <WorkEditorRow 
-          work={{
-            id: newWorkId,
-            type: 'work',
-            name: '',
-            price: 0,
-            allowedPresenceStatuses: ['natural', 'deciduous'],
-            allowedZones: ['crown'],
-            allowedDiagnosisIds: [],
-            workAccessType: 'requires_diagnosis',
-            isActive: true,
-          }}
-          diagnoses={diagnoses}
-          onSave={(newWork) => { onSave(newWork); setNewWorkId(null); }}
-          isEditing={true}
-          setEditing={() => setNewWorkId(null)}
-          isNew={true}
-        />
-      ) : (
-        <div className="flex justify-end">
-          <button onClick={() => setNewWorkId(`work_${Date.now()}`)} className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700">
-            + Добавить работу
-          </button>
-        </div>
-      )}
-
-      {works.map(work => (
-        <WorkEditorRow 
-          key={work.id} 
-          work={work} 
-          diagnoses={diagnoses} 
-          onSave={onSave} 
-          isEditing={editingId === work.id}
-          setEditing={() => setEditingId(editingId === work.id ? null : work.id)}
-        />
-      ))}
     </div>
   );
 }
@@ -397,35 +494,36 @@ function WorkEditorRow({
 
   if (!isEditing) {
     return (
-      <div className={`rounded-lg border p-3 ${work.isActive === false ? 'bg-slate-50 opacity-60' : 'bg-white'}`}>
-        <div className="flex items-center justify-between">
-          <div>
+      <div className={`flex flex-col sm:flex-row sm:items-center justify-between rounded-lg border p-3 gap-3 ${work.isActive === false ? 'bg-slate-50 opacity-60' : 'bg-white'}`}>
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <span className="inline-block rounded bg-blue-100 px-2 py-0.5 text-[10px] font-semibold text-blue-700 uppercase tracking-wider">Работа</span>
             <h3 className="font-medium text-slate-900">{work.name}</h3>
-            <p className="text-xs text-slate-500">
-              Цена: {work.price ? `${work.price} тг` : 'не указана'} • Связанных диагнозов: {work.allowedDiagnosisIds?.length || 0}
-            </p>
           </div>
-          <div className="flex gap-2">
-            <button
-              onClick={setEditing}
-              className="rounded bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700"
-            >
-              Редактировать
-            </button>
-            <button
-              onClick={() => onSave({ ...work, isActive: work.isActive === false ? true : false })}
-              className={`rounded px-3 py-1 text-xs font-medium ${work.isActive === false ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}
-            >
-              {work.isActive === false ? 'Восстановить' : 'Отключить'}
-            </button>
-          </div>
+          <p className="text-xs text-slate-500">
+            Цена: {work.price ? `${work.price} тг` : 'не указана'} • ID: {work.id} • Связанных диагнозов: {work.allowedDiagnosisIds?.length || 0}
+          </p>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={setEditing}
+            className="rounded border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
+          >
+            Редактировать
+          </button>
+          <button
+            onClick={() => onSave({ ...work, isActive: work.isActive === false ? true : false })}
+            className={`rounded px-3 py-1.5 text-xs font-medium shadow-sm ${work.isActive === false ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200' : 'bg-red-50 text-red-600 border border-red-100 hover:bg-red-100'}`}
+          >
+            {work.isActive === false ? 'Восстановить' : 'Отключить'}
+          </button>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="rounded-lg border-2 border-blue-200 bg-blue-50/30 p-4">
+    <div className="rounded-lg border-2 border-blue-200 bg-blue-50/30 p-4 mb-4">
       <div className="flex justify-between items-start mb-4">
         <h3 className="font-medium text-slate-900">{isNew ? 'Новая работа' : 'Редактирование работы'}</h3>
         <button onClick={setEditing} className="text-slate-400 hover:text-slate-600">✕</button>
@@ -437,7 +535,7 @@ function WorkEditorRow({
           type="text" 
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="w-full max-w-md rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border"
+          className="w-full max-w-md rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border bg-white"
           placeholder="Название работы"
         />
       </div>
@@ -460,7 +558,7 @@ function WorkEditorRow({
           type="number" 
           value={price}
           onChange={(e) => setPrice(Number(e.target.value))}
-          className="w-full max-w-xs rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border"
+          className="w-full max-w-xs rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border bg-white"
         />
       </div>
 

--- a/src/pages/MedicalPage.tsx
+++ b/src/pages/MedicalPage.tsx
@@ -23,6 +23,22 @@ const CLINICAL_ZONE_LABELS: Record<ClinicalZone, string> = {
   planning: 'Планирование',
 };
 
+function isRegistryTypeFilter(value: string): value is 'all' | 'diagnosis' | 'work' {
+  return ['all', 'diagnosis', 'work'].includes(value);
+}
+
+function isActivityFilter(value: string): value is 'all' | 'active' | 'disabled' {
+  return ['all', 'active', 'disabled'].includes(value);
+}
+
+function isClinicalZoneFilter(value: string): value is 'all' | ClinicalZone {
+  return value === 'all' || value in CLINICAL_ZONE_LABELS;
+}
+
+function isPresenceStatusFilter(value: string): value is 'all' | ToothPresenceStatus {
+  return value === 'all' || value in PRESENCE_STATUS_LABELS;
+}
+
 function hasIntersection<T>(a: T[] = [], b: T[] = []) {
   return a.some((item) => b.includes(item));
 }
@@ -194,7 +210,11 @@ export function MedicalPage() {
             <label className="block text-xs font-medium text-slate-700 mb-1">Тип</label>
             <select
               value={filterType}
-              onChange={(e) => setFilterType(e.target.value as any)}
+              onChange={(e) => {
+                if (isRegistryTypeFilter(e.target.value)) {
+                  setFilterType(e.target.value);
+                }
+              }}
               className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
             >
               <option value="all">Все типы</option>
@@ -206,7 +226,11 @@ export function MedicalPage() {
             <label className="block text-xs font-medium text-slate-700 mb-1">Активность</label>
             <select
               value={filterActivity}
-              onChange={(e) => setFilterActivity(e.target.value as any)}
+              onChange={(e) => {
+                if (isActivityFilter(e.target.value)) {
+                  setFilterActivity(e.target.value);
+                }
+              }}
               className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
             >
               <option value="all">Все</option>
@@ -218,7 +242,11 @@ export function MedicalPage() {
             <label className="block text-xs font-medium text-slate-700 mb-1">Клиническая зона</label>
             <select
               value={filterZone}
-              onChange={(e) => setFilterZone(e.target.value as any)}
+              onChange={(e) => {
+                if (isClinicalZoneFilter(e.target.value)) {
+                  setFilterZone(e.target.value);
+                }
+              }}
               className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
             >
               <option value="all">Все зоны</option>
@@ -231,7 +259,11 @@ export function MedicalPage() {
             <label className="block text-xs font-medium text-slate-700 mb-1">Статус зуба</label>
             <select
               value={filterStatus}
-              onChange={(e) => setFilterStatus(e.target.value as any)}
+              onChange={(e) => {
+                if (isPresenceStatusFilter(e.target.value)) {
+                  setFilterStatus(e.target.value);
+                }
+              }}
               className="w-full rounded-md border-slate-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500 border bg-white"
             >
               <option value="all">Все статусы</option>

--- a/src/pages/MedicalPage.tsx
+++ b/src/pages/MedicalPage.tsx
@@ -123,6 +123,7 @@ export function MedicalPage() {
   const [filterStatus, setFilterStatus] = useState<'all' | ToothPresenceStatus>('all');
   
   const [newItemType, setNewItemType] = useState<'diagnosis' | 'work' | null>(null);
+  const [newWorkId, setNewWorkId] = useState<string | null>(null);
 
   // Works currently require `setEditingId` to ensure only one is edited at a time in the old design,
   // but DiagnosisEditorRow used local state. To avoid rewriting their internal logic unnecessarily,
@@ -180,7 +181,7 @@ export function MedicalPage() {
             + Диагноз
           </button>
           <button
-            onClick={() => setNewItemType('work')}
+            onClick={() => { setNewItemType('work'); setNewWorkId(`work_${Date.now()}`); }}
             className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
           >
             + Работа
@@ -282,10 +283,10 @@ export function MedicalPage() {
             />
           )}
 
-          {newItemType === 'work' && (
+          {newItemType === 'work' && newWorkId && (
             <WorkEditorRow 
               work={{
-                id: `work_${Date.now()}`,
+                id: newWorkId,
                 type: 'work',
                 name: '',
                 price: 0,


### PR DESCRIPTION
## Summary
- Replaces the clinical dictionaries tab split with a unified registry view.
- Adds search and filters for item type, activity, clinical zone, and tooth position status.
- Keeps dictionary editing behavior local to existing rows and preserves diagnosis-work compatibility logic.

## Scope
- UI-only changes in `src/pages/MedicalPage.tsx`.
- No route changes, no Supabase/backend/package changes, no dental chart model changes.

Fixes #257