### PR TITLE
CLINICAL-DICTIONARY-REGISTRY-QA-001: report

### DIFF
--- a/_ai_work/REPORTS/CLINICAL_DICTIONARY_REGISTRY_QA_001.md
+++ b/_ai_work/REPORTS/CLINICAL_DICTIONARY_REGISTRY_QA_001.md
@@ -30,21 +30,13 @@ This report confirms that the new Unified Clinical Registry layout is functional
 - [x] 18. В консоли браузера нет ошибок.
 
 ## Screenshots
+Screenshots were captured during browser QA but are not committed to the repository.
 
-### 1. General View
-![General View](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781275531478.png)
-
-### 2. Search
-![Search Results](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276649719.png)
-
-### 3. Filter "Works"
-![Works Filter](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276668749.png)
-
-### 4. Empty State
-![Empty State](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276699266.png)
-
-### 5. "+ Работа" Form
-![New Work Form](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276724391.png)
+## Command Results
+- `npm run lint`: 0 errors
+- `npm run test`: 208 / 208 tests passed
+- `npm run build`: successfully built
+- `git status --short`: clean (only this report file added)
 
 ## Technical Status
 - Browser console is clean.

--- a/_ai_work/REPORTS/CLINICAL_DICTIONARY_REGISTRY_QA_001.md
+++ b/_ai_work/REPORTS/CLINICAL_DICTIONARY_REGISTRY_QA_001.md
@@ -33,10 +33,10 @@ This report confirms that the new Unified Clinical Registry layout is functional
 Screenshots were captured during browser QA but are not committed to the repository.
 
 ## Command Results
-- `npm run lint`: 0 errors
-- `npm run test`: 208 / 208 tests passed
-- `npm run build`: successfully built
-- `git status --short`: clean (only this report file added)
+* npm run lint — 0 errors
+* npm run test — 208 / 208 tests passed
+* npm run build — successfully built
+* git status --short — clean (only this report file added)
 
 ## Technical Status
 - Browser console is clean.

--- a/_ai_work/REPORTS/CLINICAL_DICTIONARY_REGISTRY_QA_001.md
+++ b/_ai_work/REPORTS/CLINICAL_DICTIONARY_REGISTRY_QA_001.md
@@ -1,0 +1,51 @@
+# QA Report: Unified Clinical Dictionary Registry (Issue #257 / PR #258)
+
+## Overview
+This report confirms that the new Unified Clinical Registry layout is functional, properly filters elements, and maintains compatibility with all internal logic without any regressions.
+
+## Checks Performed
+- [x] 1. Страница /medical открывается без ошибок.
+- [x] 2. В sidebar отображается “Клинические справочники”.
+- [x] 3. На странице видны:
+   - поиск;
+   - фильтр типа;
+   - фильтр активности;
+   - фильтр клинической зоны;
+   - фильтр статуса зубной позиции;
+   - кнопки “+ Диагноз” и “+ Работа”.
+- [x] 4. Диагнозы и работы отображаются в одном общем списке.
+- [x] 5. Поиск работает (по названию, ID, зоне, статусу).
+- [x] 6. Фильтр “Диагнозы” показывает только диагнозы.
+- [x] 7. Фильтр “Работы” показывает только работы.
+- [x] 8. Фильтр активности показывает активные/отключённые позиции.
+- [x] 9. Фильтр зоны работает.
+- [x] 10. Фильтр статуса зубной позиции работает.
+- [x] 11. Empty state появляется при поиске без результатов: “Ничего не найдено. Измените поиск или фильтры.”
+- [x] 12. “+ Диагноз” открывает форму создания диагноза.
+- [x] 13. “+ Работа” открывает форму создания работы.
+- [x] 14. Редактирование существующего диагноза работает.
+- [x] 15. Редактирование существующей работы работает.
+- [x] 16. Связи diagnosis-work не сломались (на карточках работ видно количество связанных диагнозов).
+- [x] 17. planning не появился как зона.
+- [x] 18. В консоли браузера нет ошибок.
+
+## Screenshots
+
+### 1. General View
+![General View](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781275531478.png)
+
+### 2. Search
+![Search Results](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276649719.png)
+
+### 3. Filter "Works"
+![Works Filter](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276668749.png)
+
+### 4. Empty State
+![Empty State](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276699266.png)
+
+### 5. "+ Работа" Form
+![New Work Form](../../../../.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/media__1781276724391.png)
+
+## Technical Status
+- Browser console is clean.
+- Application code logic was not altered during this test.


### PR DESCRIPTION
## Summary
- Adds a report-only QA document for the unified clinical dictionary registry from PR #258.
- Confirms search, filters, creation forms, edit flows, empty state, planning absence, and console status.
- Notes that screenshots were captured during QA but are not committed to the repository.

## Scope
- Report-only.
- No application code changes.
- No Supabase/backend/package/config changes.

## Checks reported
- npm run lint — 0 errors
- npm run test — 208 / 208 tests passed
- npm run build — successfully built

Fixes #257