### PR TITLE
CLINICAL-SUMMARY-BACKEND-001A: make patient overview summary backend-aware

### DIFF
--- a/_ai_work/REPORTS/CLINICAL-SUMMARY-BACKEND-001A_backend_aware_patient_summary.md
+++ b/_ai_work/REPORTS/CLINICAL-SUMMARY-BACKEND-001A_backend_aware_patient_summary.md
@@ -7,7 +7,7 @@ The Patient Overview medical summary has been made backend-aware, removing hard-
 `feature/clinical-summary-backend-001a`
 
 ## Commit Hash
-**PR head reviewed**: `b00d5586cb4746a93bf9d8328038c7c6bdde08f0`
+**PR head reviewed**: `59c8a07693fa04b634e27e99e3ab4bf41ea16178`
 **Report update commit**: `N/A because the report commit cannot reference itself before creation`
 
 ## PR URL
@@ -15,9 +15,9 @@ https://github.com/NckNA/codex-test/pull/262
 
 ## Changed Files Summary
 - `src/data/aggregators/ClinicalSummaryAggregator.ts`: Refactored to accept a `ClinicalSummaryRepositoryConfig` and use factory methods (`createDentalChartRepository`, etc.) instead of hard-coded `LocalStorage*` classes.
-- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`: Updated tests to pass `{ backend: 'local' }` where appropriate and added tests for `supabase` backend behavior, including early return when no `tenantId` is present.
+- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`: Updated tests to pass `{ backend: 'local' }` where appropriate and added tests for `supabase` backend behavior, including early return when no `tenantId` is present and explicit error propagation from Supabase repositories.
 - `src/data/hooks/usePatientMedicalSummary.ts`: Connected to `useAuth()` and `useTenant()` to compute the correct `backend` (supabase or local) and injected this into the aggregator.
-- `src/data/hooks/usePatientMedicalSummary.test.tsx`: Created new hook tests verifying proper backend resolution matrix (dev, supabase-active, missing tenant).
+- `src/data/hooks/usePatientMedicalSummary.test.tsx`: Created new hook tests verifying proper backend resolution matrix (dev, supabase-active with/without tenant, and unconfigured Supabase routing).
 
 ## Backend Selection Design
 - `usePatientMedicalSummary` dynamically derives the backend configuration based on the same pattern used by other hooks:
@@ -48,7 +48,7 @@ The code establishes two distinct boundaries to handle missing tenants safely:
 
 ## Tests Run and Results
 - `npm run test -- --run`
-- **Results**: 32 passed, 223 total assertions passed. Tests confirm all local, Supabase, and no-tenant routing conditions.
+- **Results**: 32 passed, 225 total assertions passed. Tests confirm all local, Supabase, unconfigured hook routing, and no-tenant routing conditions, as well as explicit Supabase error propagation.
 
 ## Browser Smoke Steps and Results
 - Started the application using `npm run dev`.

--- a/_ai_work/REPORTS/CLINICAL-SUMMARY-BACKEND-001A_backend_aware_patient_summary.md
+++ b/_ai_work/REPORTS/CLINICAL-SUMMARY-BACKEND-001A_backend_aware_patient_summary.md
@@ -1,0 +1,77 @@
+# CLINICAL-SUMMARY-BACKEND-001A Implementation Report
+
+## Summary
+The Patient Overview medical summary has been made backend-aware, removing hard-coded `LocalStorage` dependencies when the application is running in `supabase-active` mode with an active tenant.
+
+## Branch
+`feature/clinical-summary-backend-001a`
+
+## Commit Hash
+**PR head reviewed**: `19eb19a6d48dcff80cf0eb8204618e47228a4cc3` *(will be the final commit pushed)*
+**Report update commit**: `N/A because the report commit cannot reference itself before creation`
+
+## PR URL
+*(To be created)*
+
+## Changed Files Summary
+- `src/data/aggregators/ClinicalSummaryAggregator.ts`: Refactored to accept a `ClinicalSummaryRepositoryConfig` and use factory methods (`createDentalChartRepository`, etc.) instead of hard-coded `LocalStorage*` classes.
+- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`: Updated tests to pass `{ backend: 'local' }` where appropriate and added tests for `supabase` backend behavior, including early return when no `tenantId` is present.
+- `src/data/hooks/usePatientMedicalSummary.ts`: Connected to `useAuth()` and `useTenant()` to compute the correct `backend` (supabase or local) and injected this into the aggregator.
+- `src/data/hooks/usePatientMedicalSummary.test.tsx`: Created new hook tests verifying proper backend resolution matrix (dev, supabase-active, missing tenant).
+
+## Backend Selection Design
+- `usePatientMedicalSummary` dynamically derives the backend configuration based on the same pattern used by other hooks:
+  - If `authMode === 'supabase-active'`, `activeTenant?.tenantId` exists, and `isSupabaseConfigured` is `true`, then `backend = 'supabase'`.
+  - Otherwise, `backend = 'local'`.
+- Configuration is memorized via `useMemo` to prevent unnecessary re-evaluations.
+
+## Repository Factory / Dependency Design
+- The aggregator now delegates instantiation of repositories to factory functions (`createDentalChartRepository`, `createTreatmentPlansRepository`, `createChiefComplaintRepository`, `createFindingsRepository`, `createAppointmentRepository`).
+- It passes down the `backend` and `tenantId` configuration.
+
+## Local Fallback Behavior
+- Dev environments and logged-out states continue to route to `'local'` backend correctly.
+- Hardcoded class usage has been completely removed from the production path in favor of the factory pattern, which seamlessly supports both local and remote scenarios.
+
+## Supabase Behavior
+- In `supabase-active` mode with a valid tenant, the aggregator fetches all required records via Supabase-backed repository instances.
+- If no tenant is available in `supabase` mode, the aggregator returns an empty summary without issuing queries, avoiding both false local fallback data and Supabase 400 errors.
+
+## Error Propagation Behavior
+- Since Supabase repositories are now correctly instantiated, any network or database-level errors thrown by `Promise.all` inside `getPatientMedicalSummary` are properly surfaced to the `useAsyncQuery` wrapper.
+- These errors will reflect in the `isError` and `error` states returned by `usePatientMedicalSummary` instead of silently ignoring the remote failure and showing stale local storage data.
+
+## Preserved Summary Metrics
+- All metrics (needsTreatment, missing, activePlans, totalAmount, chiefComplaintText, highUrgentFindings, notIncludedFindings, monitoringFindings, lastVisit, nextVisit) have been preserved exactly as before.
+- Summary calculations rigorously follow the canonical finding statuses, specifically excluding `archived`, `declined_by_patient`, and `completed` findings from active counts.
+
+## Tests Run and Results
+- `npm run test -- --run`
+- **Results**: 32 passed, 223 total assertions passed. Tests confirm all local, Supabase, and no-tenant routing conditions.
+
+## Browser Smoke Steps and Results
+- Started the application using `npm run dev`.
+- Connected to the running instance via real Chrome DevTools MCP.
+- Navigated to `http://localhost:5173/patients/p1`.
+- Verified the Patient Overview tab loaded correctly and displayed standard summary values (e.g. `Требуют лечения: 0`, `Удалены: 0`).
+- Switched to "Проблемы и риски", "Зубная карта", and "План лечения" tabs.
+- Switched back to "Обзор" without any application crashes, white screens, or uncontrolled refetch loops.
+- Checked console logs, confirming no repository or fetching errors were raised during the workflow.
+- **Note**: This was run in `dev`/`local` mode. Supabase mode smoke testing is marked **SMOKE PARTIAL** because a properly seeded Supabase local fixture/tenant was not available in this environment. The Supabase routing was rigorously verified via unit tests instead.
+
+## Console/Network Issues
+- Only a minor UI structural warning was present (`A form field element should have an id or name attribute`), completely unrelated to this task.
+- Zero network or repository errors.
+
+## What Was Intentionally NOT Fixed
+- No RLS redesign or Supabase SQL migrations were touched.
+- No repository internal rewrites.
+- No treatment plan architecture changes.
+- No audit trail or transactional orchestration added.
+- No UI changes in `PatientOverviewTab` other than ensuring the component successfully digests the hook's output.
+
+## Remaining Risks
+- The `getPatientMedicalSummary` fires five concurrent `Promise.all` requests. While perfectly fine in `local` mode, this might result in a slightly larger payload footprint in `supabase` mode over time. Future optimization could consider a specialized Supabase edge function or RPC if the waterfall becomes a bottleneck.
+
+## Final Verdict
+**PASS**. The patient overview summary is now fully backend-aware, closing the gap where production Supabase users might see stale local data. The PR is safe to merge.

--- a/_ai_work/REPORTS/CLINICAL-SUMMARY-BACKEND-001A_backend_aware_patient_summary.md
+++ b/_ai_work/REPORTS/CLINICAL-SUMMARY-BACKEND-001A_backend_aware_patient_summary.md
@@ -7,11 +7,11 @@ The Patient Overview medical summary has been made backend-aware, removing hard-
 `feature/clinical-summary-backend-001a`
 
 ## Commit Hash
-**PR head reviewed**: `19eb19a6d48dcff80cf0eb8204618e47228a4cc3` *(will be the final commit pushed)*
+**PR head reviewed**: `b00d5586cb4746a93bf9d8328038c7c6bdde08f0`
 **Report update commit**: `N/A because the report commit cannot reference itself before creation`
 
 ## PR URL
-*(To be created)*
+https://github.com/NckNA/codex-test/pull/262
 
 ## Changed Files Summary
 - `src/data/aggregators/ClinicalSummaryAggregator.ts`: Refactored to accept a `ClinicalSummaryRepositoryConfig` and use factory methods (`createDentalChartRepository`, etc.) instead of hard-coded `LocalStorage*` classes.
@@ -33,9 +33,10 @@ The Patient Overview medical summary has been made backend-aware, removing hard-
 - Dev environments and logged-out states continue to route to `'local'` backend correctly.
 - Hardcoded class usage has been completely removed from the production path in favor of the factory pattern, which seamlessly supports both local and remote scenarios.
 
-## Supabase Behavior
-- In `supabase-active` mode with a valid tenant, the aggregator fetches all required records via Supabase-backed repository instances.
-- If no tenant is available in `supabase` mode, the aggregator returns an empty summary without issuing queries, avoiding both false local fallback data and Supabase 400 errors.
+## No-Tenant Behavior
+The code establishes two distinct boundaries to handle missing tenants safely:
+1. **Hook Boundary**: `usePatientMedicalSummary` gracefully falls back to routing queries to the local storage backend (`backend = 'local'`) if `activeTenant` is missing while in `supabase-active` mode. This ensures local dev mode / uninitialized environments don't break.
+2. **Aggregator Boundary**: As a direct misuse guard, `getPatientMedicalSummary` enforces that if `backend` is explicitly set to `supabase` but no `tenantId` is provided, it returns an empty summary immediately. This guarantees that we never accidentally query Supabase without a tenant, thereby avoiding 400 errors or leaked records.
 
 ## Error Propagation Behavior
 - Since Supabase repositories are now correctly instantiated, any network or database-level errors thrown by `Promise.all` inside `getPatientMedicalSummary` are properly surfaced to the `useAsyncQuery` wrapper.

--- a/src/data/aggregators/ClinicalSummaryAggregator.test.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getPatientMedicalSummary } from './ClinicalSummaryAggregator';
+import * as FindingsRepositoryModule from '../repositories/FindingsRepository';
+import * as DentalChartRepositoryModule from '../repositories/DentalChartRepository';
+import * as TreatmentPlansRepositoryModule from '../repositories/TreatmentPlansRepository';
+import * as ChiefComplaintRepositoryModule from '../repositories/ChiefComplaintRepository';
+import * as AppointmentRepositoryModule from '../repositories/AppointmentRepository';
 import type { DentalChart, TreatmentPlan, DentalFinding, Appointment, ChiefComplaint, ToothRecord } from '../../types';
 
 describe('ClinicalSummaryAggregator', () => {
@@ -110,6 +115,30 @@ describe('ClinicalSummaryAggregator', () => {
       expect(summary.dentalSummary.needsTreatment).toBe(0);
       expect(summary.dentalSummary.missing).toBe(0);
       // It should not have queried local storage or anything
+    });
+
+    it('propagates Supabase errors instead of falling back to local storage', async () => {
+      vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository').mockReturnValue({
+        listFindingsByPatient: vi.fn().mockRejectedValue(new Error('Supabase network error')),
+      } as unknown as ReturnType<typeof FindingsRepositoryModule.createFindingsRepository>);
+      
+      vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository').mockReturnValue({
+        getDentalChart: vi.fn().mockResolvedValue({ teeth: [] }),
+      } as unknown as ReturnType<typeof DentalChartRepositoryModule.createDentalChartRepository>);
+      
+      vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository').mockReturnValue({
+        listTreatmentPlansByPatient: vi.fn().mockResolvedValue([]),
+      } as unknown as ReturnType<typeof TreatmentPlansRepositoryModule.createTreatmentPlansRepository>);
+      
+      vi.spyOn(ChiefComplaintRepositoryModule, 'createChiefComplaintRepository').mockReturnValue({
+        getChiefComplaint: vi.fn().mockResolvedValue(null),
+      } as unknown as ReturnType<typeof ChiefComplaintRepositoryModule.createChiefComplaintRepository>);
+      
+      vi.spyOn(AppointmentRepositoryModule, 'createAppointmentRepository').mockReturnValue({
+        listAppointments: vi.fn().mockResolvedValue([]),
+      } as unknown as ReturnType<typeof AppointmentRepositoryModule.createAppointmentRepository>);
+
+      await expect(getPatientMedicalSummary('patient_1', { backend: 'supabase', tenantId: 't1' })).rejects.toThrow('Supabase network error');
     });
   });
 });

--- a/src/data/aggregators/ClinicalSummaryAggregator.test.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.test.ts
@@ -9,7 +9,7 @@ describe('ClinicalSummaryAggregator', () => {
   });
 
   it('returns empty/default summary for empty patientId', async () => {
-    const summary = await getPatientMedicalSummary('');
+    const summary = await getPatientMedicalSummary('', { backend: 'local' });
     expect(summary.dentalSummary.needsTreatment).toBe(0);
     expect(summary.dentalSummary.missing).toBe(0);
     expect(summary.lastVisit).toBeUndefined();
@@ -51,7 +51,7 @@ describe('ClinicalSummaryAggregator', () => {
     ];
     localStorage.setItem('df_dental_findings', JSON.stringify(findings));
 
-    const summary = await getPatientMedicalSummary('patient_1');
+    const summary = await getPatientMedicalSummary('patient_1', { backend: 'local' });
 
     expect(summary.dentalSummary.needsTreatment).toBe(2); // caries + pulpitis
     expect(summary.dentalSummary.missing).toBe(1);
@@ -82,7 +82,7 @@ describe('ClinicalSummaryAggregator', () => {
     ];
     localStorage.setItem('df_appointments', JSON.stringify(appts));
 
-    const summary = await getPatientMedicalSummary('patient_1');
+    const summary = await getPatientMedicalSummary('patient_1', { backend: 'local' });
 
     expect(summary.lastVisit?.toISOString()).toBe(pastDate);
     expect(summary.nextVisit?.toISOString()).toBe(futureDate);
@@ -98,9 +98,18 @@ describe('ClinicalSummaryAggregator', () => {
     localStorage.setItem('df_dental_findings', findingsData);
     localStorage.setItem('df_treatment_plans', plansData);
 
-    await getPatientMedicalSummary('patient_1');
+    await getPatientMedicalSummary('patient_1', { backend: 'local' });
 
     expect(localStorage.getItem('df_dental_findings')).toBe(findingsData);
     expect(localStorage.getItem('df_treatment_plans')).toBe(plansData);
+  });
+
+  describe('Supabase backend behavior', () => {
+    it('returns empty summary if backend is supabase but no tenantId is provided', async () => {
+      const summary = await getPatientMedicalSummary('patient_1', { backend: 'supabase' });
+      expect(summary.dentalSummary.needsTreatment).toBe(0);
+      expect(summary.dentalSummary.missing).toBe(0);
+      // It should not have queried local storage or anything
+    });
   });
 });

--- a/src/data/aggregators/ClinicalSummaryAggregator.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.ts
@@ -1,8 +1,8 @@
-import { LocalStorageDentalChartRepository } from '../repositories/DentalChartRepository';
-import { LocalStorageTreatmentPlansRepository } from '../repositories/TreatmentPlansRepository';
-import { LocalStorageChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
-import { LocalStorageFindingsRepository } from '../repositories/FindingsRepository';
-import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
+import { createDentalChartRepository } from '../repositories/DentalChartRepository';
+import { createTreatmentPlansRepository } from '../repositories/TreatmentPlansRepository';
+import { createChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
+import { createFindingsRepository } from '../repositories/FindingsRepository';
+import { createAppointmentRepository } from '../repositories/AppointmentRepository';
 import { ACTIVE_FINDING_STATUSES } from '../../domain/findingStatus';
 
 export interface PatientDentalSummary {
@@ -22,6 +22,11 @@ export interface PatientMedicalSummaryData {
   nextVisit?: Date;
 }
 
+export interface ClinicalSummaryRepositoryConfig {
+  backend: 'local' | 'supabase';
+  tenantId?: string;
+}
+
 export const EMPTY_PATIENT_DENTAL_SUMMARY: PatientDentalSummary = {
   needsTreatment: 0,
   missing: 0,
@@ -37,17 +42,28 @@ export const EMPTY_PATIENT_MEDICAL_SUMMARY: PatientMedicalSummaryData = {
   dentalSummary: EMPTY_PATIENT_DENTAL_SUMMARY,
 };
 
-export async function getPatientMedicalSummary(patientId: string): Promise<PatientMedicalSummaryData> {
+export async function getPatientMedicalSummary(patientId: string, config: ClinicalSummaryRepositoryConfig): Promise<PatientMedicalSummaryData> {
   if (!patientId) {
     return EMPTY_PATIENT_MEDICAL_SUMMARY;
   }
 
+  if (config.backend === 'supabase' && !config.tenantId) {
+    // Cannot query supabase without tenantId
+    return EMPTY_PATIENT_MEDICAL_SUMMARY;
+  }
+
+  const chartRepo = createDentalChartRepository(config);
+  const plansRepo = createTreatmentPlansRepository(config);
+  const complaintRepo = createChiefComplaintRepository(config);
+  const findingsRepo = createFindingsRepository(config);
+  const appointmentRepo = createAppointmentRepository(config);
+
   const [chart, plans, complaint, findings, allAppointments] = await Promise.all([
-    LocalStorageDentalChartRepository.getDentalChart(patientId),
-    LocalStorageTreatmentPlansRepository.listTreatmentPlansByPatient(patientId),
-    LocalStorageChiefComplaintRepository.getChiefComplaint(patientId),
-    LocalStorageFindingsRepository.listFindingsByPatient(patientId),
-    LocalStorageAppointmentRepository.listAppointments(),
+    chartRepo.getDentalChart(patientId),
+    plansRepo.listTreatmentPlansByPatient(patientId),
+    complaintRepo.getChiefComplaint(patientId),
+    findingsRepo.listFindingsByPatient(patientId),
+    appointmentRepo.listAppointments(),
   ]);
 
   const patientAppointments = allAppointments

--- a/src/data/hooks/usePatientMedicalSummary.test.tsx
+++ b/src/data/hooks/usePatientMedicalSummary.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { usePatientMedicalSummary } from './usePatientMedicalSummary';
+import * as ClinicalSummaryAggregatorModule from '../aggregators/ClinicalSummaryAggregator';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {},
+  isSupabaseConfigured: true,
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../contexts/TenantContext', () => ({
+  useTenant: vi.fn(),
+}));
+
+describe('usePatientMedicalSummary', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes to supabase backend when authMode is supabase-active, activeTenant exists, and supabase is configured', async () => {
+    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+
+    const TestComponent = () => {
+      usePatientMedicalSummary('patient_1');
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+
+    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'supabase', tenantId: 'real-tenant-id' }));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('routes to local backend when authMode is supabase-active but activeTenant is missing', async () => {
+    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as unknown as ReturnType<typeof useTenant>);
+
+    const TestComponent = () => {
+      usePatientMedicalSummary('patient_1');
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+
+    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'local' }));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('routes to local backend when authMode is dev', async () => {
+    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: '123', tenantName: 'Dev' } } as unknown as ReturnType<typeof useTenant>);
+
+    const TestComponent = () => {
+      usePatientMedicalSummary('patient_1');
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+
+    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'local', tenantId: '123' }));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/src/data/hooks/usePatientMedicalSummary.test.tsx
+++ b/src/data/hooks/usePatientMedicalSummary.test.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import { usePatientMedicalSummary } from './usePatientMedicalSummary';
 import * as ClinicalSummaryAggregatorModule from '../aggregators/ClinicalSummaryAggregator';
+import * as SupabaseClientModule from '../../lib/supabaseClient';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 
@@ -99,5 +100,34 @@ describe('usePatientMedicalSummary', () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it('routes to local backend when authMode is supabase-active but isSupabaseConfigured is false', async () => {
+    Object.defineProperty(SupabaseClientModule, 'isSupabaseConfigured', { value: false, configurable: true });
+    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+
+    const TestComponent = () => {
+      usePatientMedicalSummary('patient_1');
+      return null;
+    };
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<TestComponent />);
+    });
+
+    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
+
+    await act(async () => {
+      root.unmount();
+    });
+    
+    // Restore
+    Object.defineProperty(SupabaseClientModule, 'isSupabaseConfigured', { value: true, configurable: true });
   });
 });

--- a/src/data/hooks/usePatientMedicalSummary.ts
+++ b/src/data/hooks/usePatientMedicalSummary.ts
@@ -1,13 +1,27 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
 import {
   getPatientMedicalSummary,
   EMPTY_PATIENT_MEDICAL_SUMMARY,
-  type PatientMedicalSummaryData
+  type PatientMedicalSummaryData,
+  type ClinicalSummaryRepositoryConfig
 } from '../aggregators/ClinicalSummaryAggregator';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
 export function usePatientMedicalSummary(patientId: string) {
-  const queryFn = useCallback(() => getPatientMedicalSummary(patientId), [patientId]);
+  const { authMode } = useAuth();
+  const { activeTenant } = useTenant();
+
+  const config = useMemo<ClinicalSummaryRepositoryConfig>(() => {
+    return {
+      backend: authMode === 'supabase-active' && activeTenant?.tenantId && isSupabaseConfigured ? 'supabase' : 'local',
+      tenantId: activeTenant?.tenantId,
+    };
+  }, [authMode, activeTenant?.tenantId]);
+
+  const queryFn = useCallback(() => getPatientMedicalSummary(patientId, config), [patientId, config]);
 
   return useAsyncQuery<PatientMedicalSummaryData>({
     queryFn,


### PR DESCRIPTION
Make the patient Overview medical summary use the same backend mode as the rest of the patient card, utilizing factory functions to support both `local` and `supabase` backends.

Closes CLINICAL-SUMMARY-BACKEND-001A