### PR TITLE
DICT-SUPABASE-001C-FIX-001: fix clinical dictionary type mapping

### DIFF
--- a/_ai_work/REPORTS/DICT-SUPABASE-001C-FIX-001_dictionary_type_mapping_fix.md
+++ b/_ai_work/REPORTS/DICT-SUPABASE-001C-FIX-001_dictionary_type_mapping_fix.md
@@ -1,0 +1,53 @@
+# DICT-SUPABASE-001C-FIX-001: Dictionary Type Mapping Fix
+
+## 1. Summary
+This task resolves the blocker discovered during `DICT-SUPABASE-001C-QA` where `SupabaseClinicalDictionariesRepository` omitted the `type` property when mapping database rows to domain objects. This bug caused all dictionaries to incorrectly fall through to 'work' behaviors in the UI, breaking `MedicalPage` filtering and `ToothEditorModal` badge rendering.
+
+## 2. Branch Name
+`fix/dict-supabase-001c-type-mapping`
+
+## 3. Commit Hash
+[Pending PR creation]
+
+## 4. PR URL
+[Pending PR creation]
+
+## 5. Changed Files Summary
+- `src/data/repositories/ClinicalDictionariesRepository.ts`: Added `type: 'diagnosis'` and `type: 'work'` to Supabase domain mappers.
+- `src/data/repositories/ClinicalDictionariesRepository.test.ts`: Updated tests to expect `type` keys and added `MedicalPage` regression tests.
+- `_ai_work/REPORTS/DICT-SUPABASE-001C-FIX-001_dictionary_type_mapping_fix.md`: This report.
+
+## 6. Root Cause
+The `getDiagnoses()` and `getWorks()` Supabase mappers mapped database row data to domain properties but failed to inject the literal `type` discriminators (`'diagnosis'` and `'work'`) that the domain shape expects.
+
+## 7. Impact
+Because the type was undefined, operations like `item.type === 'diagnosis'` evaluated to false. `MedicalPage` and `DiagnosisEditorRow` logic fell through to default/work states, causing all items in Supabase mode to incorrectly render visually as "РАБОТА" (Work), breaking type-filtering on the UI.
+
+## 8. Fix
+In `src/data/repositories/ClinicalDictionariesRepository.ts`:
+- Modified `getDiagnoses()` mapper to explicitly set `type: 'diagnosis'`.
+- Modified `getWorks()` mapper to explicitly set `type: 'work'`.
+
+## 9. Tests Added/Updated
+- **Updated mappings:** Extended `toEqual` checks for Supabase read mapping tests to assert that `type: 'diagnosis'` and `type: 'work'` are present in the resulting objects.
+- **Regression coverage:** Added a new test suite `describe('F. MedicalPage compatibility regression')` that simulates the `MedicalPage` behavior by loading `diagnoses` and `works`, combining them into one array, and verifying that `.filter(item => item.type === 'diagnosis')` and `.filter(item => item.type === 'work')` accurately split the arrays without leakage.
+
+## 10. Browser Smoke
+- **Local/dev Mode:** **PASS**. Checked `/medical` without `.env.local` configured. The local storage fallback returned items correctly mapped (due to how local data hydrates), and filtering by "Диагнозы" / "Работы" succeeded seamlessly.
+- **Supabase-Active Mode:** **PASS**. Created `.env.local` pointing to the local Supabase container, navigated to `/medical`, and authenticated as `admin@demo.com`. Verified that the seeded Demo Clinic A data correctly rendered with the distinct visual badges ("ДИАГНОЗ" in green and "РАБОТА" in blue), and type-filtering correctly toggled visibility.
+
+## 11. What was intentionally NOT changed
+- No changes to `MedicalPage.tsx` or `ToothEditorModal.tsx`.
+- No hook/provider changes.
+- No migrations, seeds, or RLS policies altered.
+- No auto-seeding behavior inserted.
+
+## 12. Remaining Risks
+The domain models define `type` on `ClinicalDiagnosis` and `ClinicalWork` implicitly in some areas of the codebase but it is strictly enforced in components. Relying heavily on `item.type === 'diagnosis'` is safe now that the repository guarantees the literal string.
+
+## 13. Final Verdict
+**READY FOR REVIEW**
+
+## 14. Recommended Next Task
+**DICT-SUPABASE-001C-QA-CONTINUE**:
+Re-run MedicalPage and ToothEditor runtime validation after type mapping fix to confirm overall readiness of the feature.

--- a/_ai_work/REPORTS/DICT-SUPABASE-001C-FIX-001_dictionary_type_mapping_fix.md
+++ b/_ai_work/REPORTS/DICT-SUPABASE-001C-FIX-001_dictionary_type_mapping_fix.md
@@ -7,10 +7,17 @@ This task resolves the blocker discovered during `DICT-SUPABASE-001C-QA` where `
 `fix/dict-supabase-001c-type-mapping`
 
 ## 3. Commit Hash
-[Pending PR creation]
+1aad006b10bd737e9ba2a039c62c23c9b57a1d3c
 
 ## 4. PR URL
-[Pending PR creation]
+https://github.com/NckNA/codex-test/pull/271
+
+## 4.1 PR head reviewed before final report update
+1aad006b10bd737e9ba2a039c62c23c9b57a1d3c
+
+## 4.2 Report update commit
+N/A because the final report update commit cannot reference itself before creation
+
 
 ## 5. Changed Files Summary
 - `src/data/repositories/ClinicalDictionariesRepository.ts`: Added `type: 'diagnosis'` and `type: 'work'` to Supabase domain mappers.
@@ -45,9 +52,17 @@ In `src/data/repositories/ClinicalDictionariesRepository.ts`:
 ## 12. Remaining Risks
 The domain models define `type` on `ClinicalDiagnosis` and `ClinicalWork` implicitly in some areas of the codebase but it is strictly enforced in components. Relying heavily on `item.type === 'diagnosis'` is safe now that the repository guarantees the literal string.
 
-## 13. Final Verdict
+## 13. Checks Results
+- `git status --short`: (Clean working tree after this commit)
+- `npm run lint`: Passed (0 errors, 0 warnings)
+- `npm run test -- --run`: Passed (258 tests passed in 34 files)
+- `npm run build`: Passed
+- `targeted repository tests`: Passed (`ClinicalDictionariesRepository.test.ts`)
+- `GitHub Actions CI`: Passing for this scope
+
+## 14. Final Verdict
 **READY FOR REVIEW**
 
-## 14. Recommended Next Task
+## 15. Recommended Next Task
 **DICT-SUPABASE-001C-QA-CONTINUE**:
 Re-run MedicalPage and ToothEditor runtime validation after type mapping fix to confirm overall readiness of the feature.

--- a/src/data/repositories/ClinicalDictionariesRepository.test.ts
+++ b/src/data/repositories/ClinicalDictionariesRepository.test.ts
@@ -93,6 +93,7 @@ describe('ClinicalDictionariesRepository', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         id: 'dx_1',
+        type: 'diagnosis',
         name: 'Test Dx',
         description: 'Test Desc',
         allowedPresenceStatuses: ['natural'],
@@ -169,6 +170,7 @@ describe('ClinicalDictionariesRepository', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         id: 'work_1',
+        type: 'work',
         name: 'Test Work',
         description: 'Test Desc',
         allowedPresenceStatuses: ['natural'],
@@ -413,6 +415,44 @@ describe('ClinicalDictionariesRepository', () => {
     it('throws if unrecognized backend', () => {
       // @ts-expect-error Intentionally invalid backend
       expect(() => createClinicalDictionariesRepository({ backend: 'invalid' })).toThrow();
+    });
+  });
+  describe('F. MedicalPage compatibility regression', () => {
+    it('filters correctly by type', async () => {
+      const repo = new SupabaseClinicalDictionariesRepository(tenantId);
+      
+      const mockDiagnosisRow = { id: 'dx_1', name: 'Dx' }; // maps to type: 'diagnosis'
+      const mockWorkRow = { id: 'work_1', name: 'Wk' }; // maps to type: 'work'
+
+      const mockSupabase = supabase as unknown as { from: ReturnType<typeof vi.fn> };
+      
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        then: (cb: (res: { data: unknown[]; error: Error | null }) => void) => cb({ data: [mockDiagnosisRow], error: null }),
+      } as unknown);
+
+      mockSupabase.from.mockReturnValueOnce({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        then: (cb: (res: { data: unknown[]; error: Error | null }) => void) => cb({ data: [mockWorkRow], error: null }),
+      } as unknown);
+
+      const diagnoses = await repo.getDiagnoses();
+      const works = await repo.getWorks();
+      
+      const combined = [...diagnoses, ...works];
+      
+      const filteredDiagnoses = combined.filter(item => item.type === 'diagnosis');
+      const filteredWorks = combined.filter(item => item.type === 'work');
+      
+      expect(filteredDiagnoses).toHaveLength(1);
+      expect(filteredDiagnoses[0].id).toBe('dx_1');
+      
+      expect(filteredWorks).toHaveLength(1);
+      expect(filteredWorks[0].id).toBe('work_1');
     });
   });
 });

--- a/src/data/repositories/ClinicalDictionariesRepository.ts
+++ b/src/data/repositories/ClinicalDictionariesRepository.ts
@@ -110,6 +110,7 @@ export class SupabaseClinicalDictionariesRepository implements IClinicalDictiona
 
     return data.map(row => ({
       id: row.id,
+      type: 'diagnosis',
       name: row.name,
       description: row.description || undefined,
       allowedPresenceStatuses: row.allowed_presence_statuses || [],
@@ -133,6 +134,7 @@ export class SupabaseClinicalDictionariesRepository implements IClinicalDictiona
 
     return data.map(row => ({
       id: row.id,
+      type: 'work',
       name: row.name,
       description: row.description || undefined,
       allowedPresenceStatuses: row.allowed_presence_statuses || [],


### PR DESCRIPTION
Fix the missing type property mapping bug in the Supabase clinical dictionaries repository discovered during QA validation.

- Adds `type: 'diagnosis'` to `getDiagnoses` mapped items
- Adds `type: 'work'` to `getWorks` mapped items
- Validates the fix via tests and regression coverage