### PR TITLE
TREATMENT-STAGES-SYNC-TRANSACTION-001: fix treatment stage sync and atomic persistence

### DIFF
--- a/_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
+++ b/_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
@@ -6,7 +6,7 @@ This report documents the implementation and validation of atomic treatment plan
 
 - **Branch name**: `fix/treatment-stages-sync-transaction-001`
 - **PR URL**: https://github.com/NckNA/codex-test/pull/280
-- **PR head reviewed before final report update**: `56efdad1758c0678a1f87ddfeee7c59ec84594c2`
+- **PR head reviewed before final report update**: `7c35e6adb3174a0ffd59fb041cf8893e370ba556`
 - **Report update commit**: N/A because the final report update commit cannot reference itself before creation.
 
 ---
@@ -136,7 +136,7 @@ The repository test suite in [TreatmentPlansRepository.test.ts](file:///d:/Users
 - `npm run lint`: **PASS** (Zero warnings or errors).
 - `npm run test -- --run`: **PASS** (All 268 tests pass).
 - `npm run build`: **PASS** (Project builds cleanly).
-- `GitHub Actions CI result`: **PASS** (Workflow CI, run #372, run id 27535613813, head 56efdad1758c0678a1f87ddfeee7c59ec84594c2).
+- `GitHub Actions CI result`: **PASS** (Workflow CI, run #373, run id 27535676421, head 7c35e6adb3174a0ffd59fb041cf8893e370ba556).
 
 ---
 

--- a/_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
+++ b/_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
@@ -1,0 +1,151 @@
+# TREATMENT-STAGES-SYNC-TRANSACTION-001: Fix Supabase treatment plan stage synchronization and transactional persistence
+
+## Summary
+
+This report documents the implementation and validation of atomic treatment plan and stages persistence. In Supabase mode, saving a treatment plan and its stages is now atomic, and stages removed in the UI are deleted from the database.
+
+- **Branch name**: `fix/treatment-stages-sync-transaction-001`
+- **PR URL**: https://github.com/NckNA/codex-test/pull/280
+- **PR head reviewed before final report update**: `56efdad1758c0678a1f87ddfeee7c59ec84594c2`
+- **Report update commit**: N/A because the final report update commit cannot reference itself before creation.
+
+---
+
+## Changed Files Summary
+
+- `src/data/repositories/TreatmentPlansRepository.ts`
+- `src/data/repositories/TreatmentPlansRepository.test.ts`
+- `supabase/migrations/0006_treatment_plan_stage_sync_rpc.sql`
+- `_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md`
+
+---
+
+## Root Cause
+
+In Supabase-active mode:
+1. `updateTreatmentPlan` updated existing stages and inserted new ones, but did NOT delete stages that were removed from the submitted plan. After a page reload, deleted stages reappeared.
+2. `createTreatmentPlan` inserted the plan first, then inserted stages separately, making creation non-transactional and leaving partial data if stages insertion failed.
+
+---
+
+## Migration Added
+
+- **Filename**: [0006_treatment_plan_stage_sync_rpc.sql](file:///d:/Users/User/Documents/GitHub/codex-test/supabase/migrations/0006_treatment_plan_stage_sync_rpc.sql)
+- **Function Name**: `save_treatment_plan_with_stages`
+- **Security Context**: `SECURITY INVOKER` (runs under the calling client's context, respecting table RLS policies).
+- **Search Path**: Explicitly set to `public`.
+- **Access Privilege**: Default public execute privilege is revoked; execution is granted only to the `authenticated` role.
+- **No SECURITY DEFINER**: Verified (no security definer advisor warnings created).
+
+---
+
+## Repository Changes
+
+`SupabaseTreatmentPlansRepository` was modified to use the database-side RPC:
+- **`createTreatmentPlan`**:
+  - Validates the patient ID UUID.
+  - Automatically generates safe UUIDs for local/temporary plan and stage IDs.
+  - Filters out invalid/non-UUID finding IDs.
+  - Calls `save_treatment_plan_with_stages` RPC in a single operation.
+- **`updateTreatmentPlan`**:
+  - Validates the plan and patient UUIDs.
+  - Converts stage IDs (generating safe UUIDs for new stages).
+  - Calls the same `save_treatment_plan_with_stages` RPC in a single operation.
+- **LocalStorage Repository**: Remains completely unchanged, maintaining dev fallback behavior.
+- **Delete Logic**: The existing foreign key cascade remains in place to delete stages when a plan is deleted.
+
+---
+
+## Transaction/Sync Behavior
+
+- **Deletion**: Stages absent from the submitted payload are deleted from the database.
+- **Update**: Existing stages belonging to the same tenant and plan are updated.
+- **Insertion**: New stages are inserted, keeping their `order_index` consistent with the submitted array order.
+- **Ownership**: The RPC validates plan/tenant ownership and rejects stage IDs belonging to another tenant or plan.
+
+---
+
+## Tests Added/Updated
+
+The repository test suite in [TreatmentPlansRepository.test.ts](file:///d:/Users/User/Documents/GitHub/codex-test/src/data/repositories/TreatmentPlansRepository.test.ts) was updated:
+1. **Supabase create**: Verifies that the new RPC is invoked once with correctly mapped params, safe UUIDs are generated for local IDs, and invalid finding IDs are filtered out.
+2. **Supabase update**: Verifies that the RPC is called once with the submitted stages, and throws if the RPC returns an error.
+3. **Stage deletion regression**: Verifies that updating a plan with a subset of stages passes only the submitted stages to the RPC, delegating deletion of the missing ones.
+4. **LocalStorage**: Verifies that local persistence remains intact.
+5. **Mapping**: Verifies that listing plans sorts stages by `order_index`.
+
+---
+
+## Local Supabase Validation
+
+- Ran `npx supabase db reset` to apply all migrations including `0006_treatment_plan_stage_sync_rpc.sql`.
+- **Create validation**: Called the RPC directly via SQL using a test plan ID and two stages. Verified both stages were inserted correctly.
+- **Update validation**: Updated the test plan with only one stage. Verified that the missing stage was deleted from the database.
+- **Insert validation**: Updated the test plan again with the existing stage and one new stage. Verified correct order indices and row counts.
+- **Cascade validation**: Deleted the plan and confirmed both stages were deleted automatically.
+
+---
+
+## Browser Smoke Validation
+
+- Logged in as Admin A (`qa.admin.a@example.local` — local QA password used, not documented).
+- Navigated to `/patients/44444444-4444-4444-4444-444444444444` (John Doe).
+- Opened **Планы лечения** (Treatment plans) tab.
+- Clicked **Новый план**, filled in title `"Plan X"`, and added two stages:
+  - Stage 1: price `5000`
+  - Stage 2: price `7000`
+- Clicked **Сохранить**. Verified "Plan X" renders with `2` stages and sum `12 000 ₸`.
+- Clicked **Редактировать** on "Plan X", clicked delete on Stage 2, and clicked **Сохранить**. Verified "Plan X" renders with `1` stage and sum `5 000 ₸`.
+- Reloaded the page, switched to the Plans tab, and verified that Stage 2 did NOT reappear.
+- Clicked **Удалить** on "Plan X" and accepted the confirmation dialog. Verified it was deleted.
+
+---
+
+## Cloud Safety
+
+- Migration `0006` was **NOT** applied to the Supabase cloud instance.
+- No cloud database writes were executed.
+
+---
+
+## What was intentionally NOT changed
+
+- No changes or redesigns in UI components (`TreatmentPlanModal`, etc.).
+- No changes to hooks (`useTreatmentPlans`, etc.).
+- No changes to `supabase/seed.sql` or database schema.
+- No unrelated RLS changes.
+
+---
+
+## Remaining Known Issues
+
+- Cloud migration `0006` needs to be applied in a follow-up task.
+- Advisor warnings about other `SECURITY DEFINER` functions in the initial schema.
+- Global role label displaying "Администратор" for doctors (tracked as `ROLE-LABEL-UX-001`).
+
+---
+
+## Checks
+
+- `git status --short`:
+  ```
+  M src/data/repositories/TreatmentPlansRepository.test.ts
+  M src/data/repositories/TreatmentPlansRepository.ts
+  ?? supabase/migrations/0006_treatment_plan_stage_sync_rpc.sql
+  ```
+- `npm run lint`: **PASS** (Zero warnings or errors).
+- `npm run test -- --run`: **PASS** (All 268 tests pass).
+- `npm run build`: **PASS** (Project builds cleanly).
+- `GitHub Actions CI result`: **PASS** (Workflow CI, run #372, run id 27535613813, head 56efdad1758c0678a1f87ddfeee7c59ec84594c2).
+
+---
+
+## Final Verdict
+
+**READY FOR REVIEW**
+
+---
+
+## Recommended Next Task
+
+**SUPABASE-CLOUD-APPLY-0006-TREATMENT-STAGES-001**: Apply migration 0006 to dev/test cloud after preflight confirmation.

--- a/_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
+++ b/_ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
@@ -6,7 +6,7 @@ This report documents the implementation and validation of atomic treatment plan
 
 - **Branch name**: `fix/treatment-stages-sync-transaction-001`
 - **PR URL**: https://github.com/NckNA/codex-test/pull/280
-- **PR head reviewed before final report update**: `7c35e6adb3174a0ffd59fb041cf8893e370ba556`
+- **PR head reviewed before final report update**: `d5b76fc2eadcc67bed3497931dbb8085e996d0c9`
 - **Report update commit**: N/A because the final report update commit cannot reference itself before creation.
 
 ---
@@ -129,14 +129,12 @@ The repository test suite in [TreatmentPlansRepository.test.ts](file:///d:/Users
 
 - `git status --short`:
   ```
-  M src/data/repositories/TreatmentPlansRepository.test.ts
-  M src/data/repositories/TreatmentPlansRepository.ts
-  ?? supabase/migrations/0006_treatment_plan_stage_sync_rpc.sql
+  M _ai_work/REPORTS/TREATMENT-STAGES-SYNC-TRANSACTION-001_stage_sync_transaction.md
   ```
 - `npm run lint`: **PASS** (Zero warnings or errors).
-- `npm run test -- --run`: **PASS** (All 268 tests pass).
+- `npm run test -- --run`: **PASS** (All 268 tests pass with `.env.local` temporarily moved during tests).
 - `npm run build`: **PASS** (Project builds cleanly).
-- `GitHub Actions CI result`: **PASS** (Workflow CI, run #373, run id 27535676421, head 7c35e6adb3174a0ffd59fb041cf8893e370ba556).
+- `GitHub Actions CI result`: **PASS** (Workflow CI, run #375, run id 27535774702, head d5b76fc2eadcc67bed3497931dbb8085e996d0c9).
 
 ---
 

--- a/src/data/repositories/TreatmentPlansRepository.test.ts
+++ b/src/data/repositories/TreatmentPlansRepository.test.ts
@@ -195,7 +195,15 @@ describe('TreatmentPlansRepository', () => {
       expect(mockSupabase.rpc).toHaveBeenCalledOnce();
       expect(mockSupabase.rpc).toHaveBeenCalledWith('save_treatment_plan_with_stages', expect.any(Object));
 
-      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as Record<string, any>;
+      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as {
+        p_tenant_id: string;
+        p_patient_id: string;
+        p_plan_id: string;
+        p_title: string;
+        p_status: string;
+        p_total_price: number;
+        p_stages: { id: string; title: string; teeth: number[]; price: number; status: string; findingIds: string[] }[];
+      };
       expect(rpcArgs.p_tenant_id).toBe('tenant_1');
       expect(rpcArgs.p_patient_id).toBe(validUuid);
       expect(rpcArgs.p_plan_id).not.toBe('local_plan_1');
@@ -272,7 +280,15 @@ describe('TreatmentPlansRepository', () => {
       await repo.updateTreatmentPlan(validUuid, plan);
 
       expect(mockSupabase.rpc).toHaveBeenCalledOnce();
-      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as Record<string, any>;
+      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as {
+        p_tenant_id: string;
+        p_patient_id: string;
+        p_plan_id: string;
+        p_title: string;
+        p_status: string;
+        p_total_price: number;
+        p_stages: { id: string; title: string; teeth: number[]; price: number; status: string; findingIds: string[] }[];
+      };
       expect(rpcArgs.p_plan_id).toBe(validPlanUuid);
       expect(rpcArgs.p_stages).toHaveLength(3);
 
@@ -308,7 +324,15 @@ describe('TreatmentPlansRepository', () => {
       await repo.updateTreatmentPlan(validUuid, plan);
 
       expect(mockSupabase.rpc).toHaveBeenCalledOnce();
-      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as Record<string, any>;
+      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as {
+        p_tenant_id: string;
+        p_patient_id: string;
+        p_plan_id: string;
+        p_title: string;
+        p_status: string;
+        p_total_price: number;
+        p_stages: { id: string; title: string; teeth: number[]; price: number; status: string; findingIds: string[] }[];
+      };
       expect(rpcArgs.p_stages).toHaveLength(1);
       expect(rpcArgs.p_stages[0].id).toBe(validStageUuid);
     });

--- a/src/data/repositories/TreatmentPlansRepository.test.ts
+++ b/src/data/repositories/TreatmentPlansRepository.test.ts
@@ -28,7 +28,8 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
   return {
     mockQueryBuilder: qb,
     mockSupabase: {
-      from: vi.fn(() => qb)
+      from: vi.fn(() => qb),
+      rpc: vi.fn().mockImplementation(() => Promise.resolve({ data: [], error: null })),
     }
   };
 });
@@ -44,6 +45,7 @@ describe('TreatmentPlansRepository', () => {
     
     // Default success mock for supabase
     mockQueryBuilder.then.mockImplementation((resolve: (value: unknown) => void) => resolve({ data: [], error: null }));
+    mockSupabase.rpc.mockResolvedValue({ data: [], error: null });
   });
 
   describe('LocalStorageTreatmentPlansRepository', () => {
@@ -164,10 +166,10 @@ describe('TreatmentPlansRepository', () => {
     it('createTreatmentPlan throws on invalid patient UUID before Supabase call', async () => {
       const plan: TreatmentPlan = { id: validPlanUuid, patientId: invalidUuid, title: 'A', status: 'draft', stages: [], totalPrice: 0, createdAt: '', updatedAt: '' };
       await expect(repo.createTreatmentPlan(invalidUuid, plan)).rejects.toThrow('Invalid patient UUID');
-      expect(mockQueryBuilder.insert).not.toHaveBeenCalled();
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
     });
 
-    it('createTreatmentPlan inserts plan and stages with tenant_id, order_index, and safely handles local IDs', async () => {
+    it('createTreatmentPlan invokes save_treatment_plan_with_stages RPC once with mapped params', async () => {
       const plan: TreatmentPlan = {
         id: 'local_plan_1', // Invalid UUID
         patientId: validUuid,
@@ -190,30 +192,33 @@ describe('TreatmentPlansRepository', () => {
 
       await repo.createTreatmentPlan(validUuid, plan);
 
-      expect(mockSupabase.from).toHaveBeenCalledWith('treatment_plans');
-      expect(mockQueryBuilder.insert).toHaveBeenCalledTimes(2); // once for plan, once for stages
+      expect(mockSupabase.rpc).toHaveBeenCalledOnce();
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('save_treatment_plan_with_stages', expect.any(Object));
 
-      // Plan insertion check
-      const planInsertArgs = mockQueryBuilder.insert.mock.calls[0][0];
-      expect(planInsertArgs.id).not.toBe('local_plan_1');
-      expect(planInsertArgs.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
-      expect(planInsertArgs.tenant_id).toBe('tenant_1');
-      expect(planInsertArgs.patient_id).toBe(validUuid);
+      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as Record<string, any>;
+      expect(rpcArgs.p_tenant_id).toBe('tenant_1');
+      expect(rpcArgs.p_patient_id).toBe(validUuid);
+      expect(rpcArgs.p_plan_id).not.toBe('local_plan_1');
+      expect(rpcArgs.p_plan_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(rpcArgs.p_title).toBe('Plan');
+      expect(rpcArgs.p_status).toBe('draft');
+      expect(rpcArgs.p_total_price).toBe(100);
 
-      // Stages insertion check
-      const stagesInsertArgs = mockQueryBuilder.insert.mock.calls[1][0];
-      expect(stagesInsertArgs).toHaveLength(1);
-      expect(stagesInsertArgs[0].id).not.toBe('local_stage_1');
-      expect(stagesInsertArgs[0].tenant_id).toBe('tenant_1');
-      expect(stagesInsertArgs[0].treatment_plan_id).toBe(planInsertArgs.id);
-      expect(stagesInsertArgs[0].order_index).toBe(0);
-      expect(stagesInsertArgs[0].finding_ids).toEqual([validUuid]); // 'f1' and 'f2' filtered out
+      expect(rpcArgs.p_stages).toHaveLength(1);
+      const stage = rpcArgs.p_stages[0];
+      expect(stage.id).not.toBe('local_stage_1');
+      expect(stage.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(stage.title).toBe('Stage 1');
+      expect(stage.teeth).toEqual([11]);
+      expect(stage.price).toBe(50);
+      expect(stage.status).toBe('planned');
+      expect(stage.findingIds).toEqual([validUuid]);
     });
 
-    it('createTreatmentPlan throws on Supabase error', async () => {
-      mockQueryBuilder.then.mockImplementationOnce((resolve: (value: unknown) => void) => resolve({ data: null, error: { message: 'DB Error' } }));
+    it('createTreatmentPlan throws on Supabase RPC error', async () => {
+      mockSupabase.rpc.mockResolvedValueOnce({ data: null, error: { message: 'RPC DB Error' } });
       const plan: TreatmentPlan = { id: validPlanUuid, patientId: validUuid, title: 'A', status: 'draft', stages: [], totalPrice: 0, createdAt: '', updatedAt: '' };
-      await expect(repo.createTreatmentPlan(validUuid, plan)).rejects.toThrow('Failed to create treatment plan in Supabase: DB Error');
+      await expect(repo.createTreatmentPlan(validUuid, plan)).rejects.toThrow('Failed to create treatment plan in Supabase: RPC DB Error');
     });
 
     it('updateTreatmentPlan throws on invalid plan UUID', async () => {
@@ -221,17 +226,9 @@ describe('TreatmentPlansRepository', () => {
       await expect(repo.updateTreatmentPlan(validUuid, plan)).rejects.toThrow('Invalid plan UUID');
     });
 
-    it('updateTreatmentPlan updates plan and uses select + safe update/insert logic for stages', async () => {
+    it('updateTreatmentPlan invokes save_treatment_plan_with_stages RPC once with submitted stages', async () => {
       const validStageUuid = '111e6543-e21b-12d3-a456-426614174000';
       const externalStageUuid = '222e6543-e21b-12d3-a456-426614174000';
-      
-      // Mock the plan update success first, then the select existing stages to return only validStageUuid
-      mockQueryBuilder.then
-        .mockImplementationOnce((resolve: (value: unknown) => void) => resolve({ data: [], error: null }))
-        .mockImplementationOnce((resolve: (value: unknown) => void) => resolve({
-          data: [{ id: validStageUuid }],
-          error: null
-        }));
 
       const plan: TreatmentPlan = {
         id: validPlanUuid,
@@ -243,7 +240,7 @@ describe('TreatmentPlansRepository', () => {
         updatedAt: '2023-01-01',
         stages: [
           {
-            id: validStageUuid, // Owned stage
+            id: validStageUuid,
             title: 'Stage 1',
             teeth: [12],
             price: 100,
@@ -252,7 +249,7 @@ describe('TreatmentPlansRepository', () => {
             description: '',
           } as TreatmentStage,
           {
-            id: externalStageUuid, // External/unowned stage
+            id: externalStageUuid,
             title: 'Stage 2',
             teeth: [13],
             price: 50,
@@ -261,7 +258,7 @@ describe('TreatmentPlansRepository', () => {
             description: '',
           } as TreatmentStage,
           {
-            id: 'local_stage_1', // Local unassigned stage
+            id: 'local_stage_1',
             title: 'Stage 3',
             teeth: [14],
             price: 50,
@@ -274,30 +271,46 @@ describe('TreatmentPlansRepository', () => {
 
       await repo.updateTreatmentPlan(validUuid, plan);
 
-      // Verifying plan update filtering
-      expect(mockQueryBuilder.update).toHaveBeenCalled();
-      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('tenant_id', 'tenant_1');
-      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('patient_id', validUuid);
-      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', validPlanUuid);
+      expect(mockSupabase.rpc).toHaveBeenCalledOnce();
+      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as Record<string, any>;
+      expect(rpcArgs.p_plan_id).toBe(validPlanUuid);
+      expect(rpcArgs.p_stages).toHaveLength(3);
 
-      // Verifying stage select logic
-      expect(mockSupabase.from).toHaveBeenCalledWith('treatment_stages');
-      expect(mockQueryBuilder.select).toHaveBeenCalledWith('id');
-      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('treatment_plan_id', validPlanUuid);
+      expect(rpcArgs.p_stages[0].id).toBe(validStageUuid);
+      expect(rpcArgs.p_stages[1].id).toBe(externalStageUuid); // Sent to RPC to handle ownership rejection
+      expect(rpcArgs.p_stages[2].id).not.toBe('local_stage_1');
+      expect(rpcArgs.p_stages[2].id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    });
 
-      // Valid stage should be updated
-      expect(mockQueryBuilder.update).toHaveBeenCalledWith(expect.objectContaining({ id: validStageUuid }));
-      
-      // External stage and local stage should be inserted with new generated UUIDs
-      // The insert should be called twice (for the external stage and local stage)
-      expect(mockQueryBuilder.insert).toHaveBeenCalledTimes(2);
-      const firstInsert = mockQueryBuilder.insert.mock.calls[0][0];
-      const secondInsert = mockQueryBuilder.insert.mock.calls[1][0];
+    it('updateTreatmentPlan delegates stage deletion by sending only submitted stages', async () => {
+      const validStageUuid = '111e6543-e21b-12d3-a456-426614174000';
+      const plan: TreatmentPlan = {
+        id: validPlanUuid,
+        patientId: validUuid,
+        title: 'Updated',
+        status: 'approved',
+        totalPrice: 100,
+        createdAt: '2023-01-01',
+        updatedAt: '2023-01-01',
+        stages: [
+          {
+            id: validStageUuid,
+            title: 'Stage 1',
+            teeth: [12],
+            price: 100,
+            status: 'planned',
+            findingIds: [],
+            description: '',
+          } as TreatmentStage
+        ]
+      };
 
-      expect(firstInsert.id).not.toBe(externalStageUuid);
-      expect(secondInsert.id).not.toBe('local_stage_1');
-      expect(firstInsert.treatment_plan_id).toBe(validPlanUuid);
-      expect(secondInsert.treatment_plan_id).toBe(validPlanUuid);
+      await repo.updateTreatmentPlan(validUuid, plan);
+
+      expect(mockSupabase.rpc).toHaveBeenCalledOnce();
+      const rpcArgs = mockSupabase.rpc.mock.calls[0][1] as Record<string, any>;
+      expect(rpcArgs.p_stages).toHaveLength(1);
+      expect(rpcArgs.p_stages[0].id).toBe(validStageUuid);
     });
 
     it('deleteTreatmentPlan proves delete Supabase error is thrown for non-admin', async () => {

--- a/src/data/repositories/TreatmentPlansRepository.ts
+++ b/src/data/repositories/TreatmentPlansRepository.ts
@@ -75,137 +75,49 @@ export class SupabaseTreatmentPlansRepository implements TreatmentPlansRepositor
     }));
   }
 
-  async createTreatmentPlan(patientId: string, plan: TreatmentPlan): Promise<void> {
+  private async savePlanWithStages(patientId: string, plan: TreatmentPlan, isUpdate: boolean): Promise<void> {
     if (!this.validateUuid(patientId)) throw new Error(`Invalid patient UUID: ${patientId}`);
     
-    // We must generate safe UUIDs for Supabase if the frontend generated local string IDs
-    const planId = this.validateUuid(plan.id) ? plan.id : crypto.randomUUID();
+    const planId = plan.id;
+    if (isUpdate && !this.validateUuid(planId)) throw new Error(`Invalid plan UUID: ${planId}`);
+    const finalPlanId = this.validateUuid(planId) ? planId : crypto.randomUUID();
 
-    const planRow = {
-      id: planId,
-      tenant_id: this.tenantId,
-      patient_id: patientId,
-      title: plan.title,
-      status: plan.status,
-      total_price: plan.totalPrice,
-      created_at: plan.createdAt || new Date().toISOString(),
-      updated_at: plan.updatedAt || new Date().toISOString(),
-    };
+    const mappedStages = (plan.stages || []).map((stage) => {
+      const safeFindingIds = (stage.findingIds || []).filter(id => this.validateUuid(id));
+      return {
+        id: this.validateUuid(stage.id) ? stage.id : crypto.randomUUID(),
+        title: stage.title,
+        description: stage.description || null,
+        price: typeof stage.price === 'number' ? stage.price : 0,
+        status: stage.status || 'planned',
+        teeth: stage.teeth || [],
+        findingIds: safeFindingIds,
+        source: stage.source || null,
+      };
+    });
 
-    const { error: planError } = await supabase!
-      .from('treatment_plans')
-      .insert(planRow);
+    const { error } = await supabase!.rpc('save_treatment_plan_with_stages', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: patientId,
+      p_plan_id: finalPlanId,
+      p_title: plan.title,
+      p_status: plan.status,
+      p_total_price: plan.totalPrice,
+      p_stages: mappedStages,
+    });
 
-    if (planError) {
-      throw new Error(`Failed to create treatment plan in Supabase: ${planError.message}`);
-    }
-
-    if (plan.stages.length > 0) {
-      const stageRows = plan.stages.map((stage, index) => {
-        const safeFindingIds = (stage.findingIds || []).filter(id => this.validateUuid(id));
-        return {
-          id: this.validateUuid(stage.id) ? stage.id : crypto.randomUUID(),
-          tenant_id: this.tenantId,
-          treatment_plan_id: planId,
-          title: stage.title,
-          teeth: stage.teeth,
-          description: stage.description || null,
-          price: stage.price,
-          status: stage.status,
-          finding_ids: safeFindingIds.length > 0 ? safeFindingIds : null,
-          source: stage.source || null,
-          order_index: index,
-        };
-      });
-
-      const { error: stagesError } = await supabase!
-        .from('treatment_stages')
-        .insert(stageRows);
-
-      if (stagesError) {
-        throw new Error(`Failed to create treatment stages in Supabase: ${stagesError.message}`);
-      }
+    if (error) {
+      const operationName = isUpdate ? 'update' : 'create';
+      throw new Error(`Failed to ${operationName} treatment plan in Supabase: ${error.message}`);
     }
   }
 
+  async createTreatmentPlan(patientId: string, plan: TreatmentPlan): Promise<void> {
+    await this.savePlanWithStages(patientId, plan, false);
+  }
+
   async updateTreatmentPlan(patientId: string, plan: TreatmentPlan): Promise<void> {
-    if (!this.validateUuid(patientId)) throw new Error(`Invalid patient UUID: ${patientId}`);
-    const planId = plan.id;
-    if (!this.validateUuid(planId)) throw new Error(`Invalid plan UUID: ${planId}`);
-
-    const planRow = {
-      title: plan.title,
-      status: plan.status,
-      total_price: plan.totalPrice,
-      updated_at: new Date().toISOString(),
-    };
-
-    const { error: planError } = await supabase!
-      .from('treatment_plans')
-      .update(planRow)
-      .eq('tenant_id', this.tenantId)
-      .eq('patient_id', patientId)
-      .eq('id', planId);
-
-    if (planError) {
-      throw new Error(`Failed to update treatment plan in Supabase: ${planError.message}`);
-    }
-
-    // Fetch existing stage IDs for this exact plan to verify ownership
-    const { data: existingStages, error: existingStagesError } = await supabase!
-      .from('treatment_stages')
-      .select('id')
-      .eq('tenant_id', this.tenantId)
-      .eq('treatment_plan_id', planId);
-
-    if (existingStagesError) {
-      throw new Error(`Failed to fetch existing stages: ${existingStagesError.message}`);
-    }
-
-    const validStageIds = new Set(existingStages?.map(s => s.id) || []);
-
-    // Process each stage securely
-    for (const [index, stage] of plan.stages.entries()) {
-      const isExistingValidStage = this.validateUuid(stage.id) && validStageIds.has(stage.id);
-      const stageIdToUse = isExistingValidStage ? stage.id : crypto.randomUUID();
-
-      const stageRow = {
-        id: stageIdToUse,
-        tenant_id: this.tenantId,
-        treatment_plan_id: planId,
-        title: stage.title,
-        description: stage.description || null,
-        teeth: stage.teeth?.length ? stage.teeth : null,
-        price: typeof stage.price === 'number' ? stage.price : null,
-        status: stage.status || 'planned',
-        finding_ids: (stage.findingIds || []).filter(id => this.validateUuid(id)),
-        order_index: index,
-        source: stage.source || null,
-      };
-
-      if (isExistingValidStage) {
-        // Safe update for stages proven to belong to this plan
-        const { error: updateStageError } = await supabase!
-          .from('treatment_stages')
-          .update(stageRow)
-          .eq('tenant_id', this.tenantId)
-          .eq('treatment_plan_id', planId)
-          .eq('id', stage.id);
-        
-        if (updateStageError) {
-          throw new Error(`Failed to update treatment stage in Supabase: ${updateStageError.message}`);
-        }
-      } else {
-        // Safe insert for new or external/invalid stages
-        const { error: insertStageError } = await supabase!
-          .from('treatment_stages')
-          .insert(stageRow);
-
-        if (insertStageError) {
-          throw new Error(`Failed to insert treatment stage in Supabase: ${insertStageError.message}`);
-        }
-      }
-    }
+    await this.savePlanWithStages(patientId, plan, true);
   }
 
   async deleteTreatmentPlan(patientId: string, planId: string): Promise<void> {

--- a/supabase/migrations/0006_treatment_plan_stage_sync_rpc.sql
+++ b/supabase/migrations/0006_treatment_plan_stage_sync_rpc.sql
@@ -1,0 +1,115 @@
+-- Migration: Add transactional RPC for saving treatment plan and synchronizing its stages
+-- Filename: 0006_treatment_plan_stage_sync_rpc.sql
+
+CREATE OR REPLACE FUNCTION save_treatment_plan_with_stages(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_plan_id uuid,
+  p_title text,
+  p_status text,
+  p_total_price numeric,
+  p_stages jsonb
+) RETURNS uuid AS $$
+DECLARE
+  stage_item jsonb;
+  stage_id uuid;
+  stage_title text;
+  stage_teeth integer[];
+  stage_description text;
+  stage_price numeric;
+  stage_status text;
+  stage_finding_ids uuid[];
+  stage_source text;
+  stage_order_index integer;
+  submitted_stage_ids uuid[] := '{}';
+BEGIN
+  -- 1. Validate plan ownership if plan exists
+  IF EXISTS (
+    SELECT 1 FROM treatment_plans 
+    WHERE id = p_plan_id AND (tenant_id <> p_tenant_id OR patient_id <> p_patient_id)
+  ) THEN
+    RAISE EXCEPTION 'Invalid plan/tenant/patient ownership';
+  END IF;
+
+  -- 2. Insert or update the plan
+  INSERT INTO treatment_plans (id, tenant_id, patient_id, title, status, total_price, updated_at)
+  VALUES (p_plan_id, p_tenant_id, p_patient_id, p_title, p_status, p_total_price, now())
+  ON CONFLICT (id) DO UPDATE 
+  SET title = EXCLUDED.title,
+      status = EXCLUDED.status,
+      total_price = EXCLUDED.total_price,
+      updated_at = now();
+
+  -- 3. Process each stage in the JSON payload
+  IF p_stages IS NOT NULL AND jsonb_typeof(p_stages) = 'array' THEN
+    FOR stage_order_index IN 0 .. jsonb_array_length(p_stages) - 1 LOOP
+      stage_item := p_stages -> stage_order_index;
+      
+      -- Extract fields from JSON
+      stage_id := (stage_item ->> 'id')::uuid;
+      stage_title := stage_item ->> 'title';
+      stage_description := stage_item ->> 'description';
+      stage_price := COALESCE((stage_item ->> 'price')::numeric, 0);
+      stage_status := COALESCE(stage_item ->> 'status', 'planned');
+      stage_source := stage_item ->> 'source';
+      
+      -- Convert teeth (which is a JSON array of ints) to integer[]
+      IF stage_item -> 'teeth' IS NOT NULL AND jsonb_typeof(stage_item -> 'teeth') = 'array' THEN
+        SELECT COALESCE(array_agg(val::integer), '{}'::integer[]) INTO stage_teeth
+        FROM jsonb_array_elements_text(stage_item -> 'teeth') AS val;
+      ELSE
+        stage_teeth := '{}'::integer[];
+      END IF;
+
+      -- Convert findingIds (which is a JSON array of uuids) to uuid[]
+      IF stage_item -> 'findingIds' IS NOT NULL AND jsonb_typeof(stage_item -> 'findingIds') = 'array' THEN
+        SELECT array_agg(val::uuid) INTO stage_finding_ids
+        FROM jsonb_array_elements_text(stage_item -> 'findingIds') AS val;
+      ELSE
+        stage_finding_ids := NULL;
+      END IF;
+
+      -- Keep track of submitted stage IDs to delete the missing ones later
+      submitted_stage_ids := array_append(submitted_stage_ids, stage_id);
+
+      -- Validate stage ownership if stage exists
+      IF EXISTS (
+        SELECT 1 FROM treatment_stages 
+        WHERE id = stage_id AND (tenant_id <> p_tenant_id OR treatment_plan_id <> p_plan_id)
+      ) THEN
+        RAISE EXCEPTION 'Invalid stage ownership';
+      END IF;
+
+      -- Insert or update stage
+      INSERT INTO treatment_stages (
+        id, tenant_id, treatment_plan_id, title, teeth, description, price, status, finding_ids, source, order_index, updated_at
+      ) VALUES (
+        stage_id, p_tenant_id, p_plan_id, stage_title, stage_teeth, stage_description, stage_price, stage_status, stage_finding_ids, stage_source, stage_order_index, now()
+      ) ON CONFLICT (id) DO UPDATE
+      SET title = EXCLUDED.title,
+          teeth = EXCLUDED.teeth,
+          description = EXCLUDED.description,
+          price = EXCLUDED.price,
+          status = EXCLUDED.status,
+          finding_ids = EXCLUDED.finding_ids,
+          source = EXCLUDED.source,
+          order_index = EXCLUDED.order_index,
+          updated_at = now();
+    END LOOP;
+  END IF;
+
+  -- 4. Delete any stages belonging to this plan that are NOT in the submitted payload
+  DELETE FROM treatment_stages
+  WHERE tenant_id = p_tenant_id 
+    AND treatment_plan_id = p_plan_id 
+    AND NOT (id = ANY(submitted_stage_ids));
+
+  RETURN p_plan_id;
+END;
+$$ LANGUAGE plpgsql SECURITY INVOKER SET search_path = public;
+
+-- Revoke default broad execution privilege from public
+REVOKE EXECUTE ON FUNCTION save_treatment_plan_with_stages(uuid, uuid, uuid, text, text, numeric, jsonb) FROM public;
+
+-- Grant execution privilege only to authenticated users
+GRANT EXECUTE ON FUNCTION save_treatment_plan_with_stages(uuid, uuid, uuid, text, text, numeric, jsonb) TO authenticated;


### PR DESCRIPTION
This PR implements database-side RPC function and updates SupabaseTreatmentPlansRepository to use it for atomic treatment plan/stages persistence, ensuring removed stages are deleted.