### PR TITLE
FINDINGS-ARCHIVE-UI-CLEANUP-001: clean archived findings UI and plan eligibility

### DIFF
--- a/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
+++ b/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
@@ -1,0 +1,176 @@
+# FINDINGS-ARCHIVE-UI-CLEANUP-001 archived findings UI cleanup
+
+## Summary
+
+Implemented archived finding UI cleanup and treatment-plan eligibility safety.
+
+Archived findings are now treated as history-only records instead of active clinical findings:
+
+- archive wording replaces fake delete wording;
+- archived findings are hidden from active finding sections by default;
+- archived findings are available only behind an explicit archive toggle;
+- archived findings are excluded from create-plan candidates, even when linked to an active plan;
+- clinical summary active counters use explicit active finding status filtering.
+
+## Branch
+
+`feature/findings-archive-ui-cleanup-001`
+
+## PR URL
+
+Pending PR creation.
+
+## PR head reviewed before final report update
+
+Pending PR creation.
+
+## Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## Changed files summary
+
+Expected changed files:
+
+- `src/domain/findingStatus.ts`
+- `src/components/dental/FindingsRisksTab.tsx`
+- `src/components/dental/FindingsRisksTab.test.tsx`
+- `src/components/treatment/CreatePlanFromFindingsModal.tsx`
+- `src/components/treatment/CreatePlanFromFindingsModal.test.tsx`
+- `src/data/aggregators/ClinicalSummaryAggregator.ts`
+- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`
+- `_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md`
+
+## Root cause
+
+Finding repository delete behavior archives records, but the UI still said delete and active workflows could treat archived findings too visibly.
+
+The create-plan modal excluded completed and declined findings but did not explicitly exclude archived findings in all linked-plan cases.
+
+## Domain/helper changes
+
+Updated `src/domain/findingStatus.ts` with explicit helpers:
+
+- `isActiveFindingStatus`
+- `isInactiveFindingStatus`
+- `isArchivedFindingStatus`
+- `isFindingEligibleForTreatmentPlan`
+
+Active statuses:
+
+- `discovered`
+- `planned`
+- `in_treatment`
+- `monitoring`
+
+Inactive statuses:
+
+- `completed`
+- `declined_by_patient`
+- `archived`
+
+Treatment-plan candidate statuses for new selection:
+
+- `discovered`
+- `monitoring`
+
+## Findings UI changes
+
+Updated `src/components/dental/FindingsRisksTab.tsx`:
+
+- archive action wording now says archive;
+- confirm message now explains the record disappears from active lists but remains in history;
+- archived findings are removed from active sections by default;
+- completed and declined findings remain in the inactive/history section;
+- archived findings are shown only after explicit `Показать архивные записи` toggle;
+- archived cards are muted/history-only;
+- archived cards do not show active status action buttons;
+- archived cards do not show the active `В план` badge.
+
+## Create plan modal changes
+
+Updated `src/components/treatment/CreatePlanFromFindingsModal.tsx`:
+
+- archived findings are never visible as selectable create-plan candidates;
+- archived findings linked to active plans are still hidden;
+- completed and declined findings remain excluded;
+- valid active findings linked to an active plan remain visible as disabled;
+- empty-state text now mentions archived findings.
+
+## Clinical summary changes
+
+Updated `src/data/aggregators/ClinicalSummaryAggregator.ts` to calculate active finding counters from `isActiveFindingStatus`.
+
+Archived findings are excluded from active recommendation/risk counters.
+
+## Tests
+
+Updated/added tests:
+
+- `src/components/dental/FindingsRisksTab.test.tsx`
+  - archived findings hidden from active sections by default;
+  - archive toggle shows archived findings only in archive section;
+  - confirm text says archive;
+  - archive action still uses existing `deleteFinding` archive path;
+  - archived cards do not show active status buttons or active plan badge.
+
+- `src/components/treatment/CreatePlanFromFindingsModal.test.tsx`
+  - discovered findings appear;
+  - monitoring findings appear;
+  - completed findings are hidden;
+  - declined findings are hidden;
+  - archived findings are hidden;
+  - archived findings linked to active plan remain hidden;
+  - active linked findings remain visible as disabled;
+  - empty-state text mentions archived findings.
+
+- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`
+  - archived urgent findings are excluded from active high/urgent counters;
+  - completed/declined behavior remains inactive;
+  - unrelated localStorage mutation safety remains covered.
+
+## Browser smoke
+
+Not completed in this run.
+
+Blocker: Chrome DevTools MCP is not available in this tool environment, so I cannot honestly perform the required browser click-through smoke.
+
+## What was intentionally NOT changed
+
+- No DB migration.
+- No cloud apply.
+- No RLS changes.
+- No hard delete.
+- No dictionary/template changes.
+- No `MedicalPage` changes.
+- No repository archive semantics changes.
+- No package/dependency changes.
+
+## Checks
+
+Pending GitHub Actions CI after PR creation.
+
+Local checks not run in this tool environment:
+
+- `npm run lint`
+- `npm run test -- --run`
+- `npm run build`
+- `git status --short`
+
+## Remaining known issues
+
+- role label UX;
+- dental photo upload/storage integration;
+- tenant creation/onboarding flow;
+- documents/payments/stock/subscription features pending;
+- integration_tokens advisor info if still present.
+
+## Final verdict
+
+PARTIAL
+
+Reason: implementation is present, but GitHub Actions CI and browser smoke are still pending.
+
+## Recommended next task
+
+`ROLE-LABEL-UX-001`

--- a/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
+++ b/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
@@ -22,7 +22,7 @@ https://github.com/NckNA/codex-test/pull/289
 
 ## PR head reviewed before final report update
 
-`34e131b0d94a132f50c9dcb44d4d8da40b8482fd`
+`6492471ae7dd2ff5e2fb526e37ac02f752f70e63`
 
 ## Report update commit
 
@@ -129,11 +129,31 @@ Updated/added tests:
   - completed/declined behavior remains inactive;
   - unrelated localStorage mutation safety remains covered.
 
+## GitHub Actions failure root cause and fix
+
+GitHub Actions run `27567348795`, job `81494655312`, failed only in `Run tests`.
+
+Two tests in `src/components/dental/FindingsRisksTab.test.tsx` located the `Архивные записи` heading and then asserted against its immediate parent. The immediate parent contains only the archive heading, explanation, and toggle; archived cards are rendered in the surrounding `<section>`. The production archive behavior was correct, but the assertions searched the wrong DOM scope.
+
+The fix changes both test locators to use `closest('section')`. No production code or archive requirements were weakened.
+
 ## Browser smoke
 
-Not completed in this run.
+Partially completed in local dev fallback mode at `http://127.0.0.1:5177/patients/p1`.
 
-Blocker: Chrome DevTools MCP is not available in this tool environment, so I cannot honestly perform the required browser click-through smoke.
+Confirmed:
+
+- active `Кариес 47 зуба` appears in `Проблемы и риски`;
+- active archive wording is `Архивировать запись Кариес 47 зуба`;
+- `Кариес 47 зуба` and `Начальный кариес 24 зуба` appear in `Создать план из проблем` before archiving.
+
+Blocker:
+
+- clicking the archive action opened the native `window.confirm` dialog;
+- the available in-app browser control timed out while the dialog was open and could not accept or dismiss it;
+- post-confirm disappearance, archive-toggle visibility, create-plan exclusion after archive, and reload persistence could not be honestly verified in this run.
+
+The archive confirmation wording and post-archive UI rules remain covered by automated tests, but this does not replace the blocked browser steps.
 
 ## What was intentionally NOT changed
 
@@ -148,14 +168,21 @@ Blocker: Chrome DevTools MCP is not available in this tool environment, so I can
 
 ## Checks
 
-Pending GitHub Actions CI for report metadata update commit.
+Local working tree before staging:
 
-Local checks not run in this tool environment:
+- modified allowed file: `src/components/dental/FindingsRisksTab.test.tsx`;
+- modified allowed report: this file;
+- pre-existing untracked `_ai_work/scratch/`, `outputs/`, `pr.txt`, `seed_output.sql`, and `temp.md` were not modified or staged.
 
-- `npm run lint`
-- `npm run test -- --run`
-- `npm run build`
-- `git status --short`
+Results:
+
+- `npm run lint`: PASS.
+- focused `npm run test -- --run src/components/dental/FindingsRisksTab.test.tsx`: PASS, 3/3 tests.
+- `npm run test -- --run` with the local `.env.local`: FAIL in the unrelated `AuthContext (Dev Fallback)` test because local Supabase configuration selects `supabase-active` instead of the expected `dev` mode.
+- `npm run test -- --run` in CI-equivalent env-neutral mode: PASS, 36 test files and 279 tests.
+- `npm run build`: PASS. Vite emitted the existing large-chunk warning.
+
+GitHub Actions CI after push: PENDING.
 
 ## Remaining known issues
 
@@ -169,7 +196,7 @@ Local checks not run in this tool environment:
 
 PARTIAL
 
-Reason: implementation is present, but GitHub Actions CI and browser smoke are still pending.
+Reason: the CI test failure has been fixed and all CI-equivalent local checks pass, but the updated branch has not yet completed GitHub Actions and the post-confirm browser archive flow remains blocked.
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
+++ b/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
@@ -22,7 +22,7 @@ https://github.com/NckNA/codex-test/pull/289
 
 ## PR head reviewed before final report update
 
-`6492471ae7dd2ff5e2fb526e37ac02f752f70e63`
+`03f26335297941f3c5384fdb541cc1e59d393f9e`
 
 ## Report update commit
 
@@ -182,7 +182,13 @@ Results:
 - `npm run test -- --run` in CI-equivalent env-neutral mode: PASS, 36 test files and 279 tests.
 - `npm run build`: PASS. Vite emitted the existing large-chunk warning.
 
-GitHub Actions CI after push: PENDING.
+GitHub Actions CI after push: PASS.
+
+- run: `27569863492`;
+- job: `81503251432`;
+- check: `validate`;
+- duration: 47 seconds;
+- tested commit: `03f26335297941f3c5384fdb541cc1e59d393f9e`.
 
 ## Remaining known issues
 
@@ -196,7 +202,7 @@ GitHub Actions CI after push: PENDING.
 
 PARTIAL
 
-Reason: the CI test failure has been fixed and all CI-equivalent local checks pass, but the updated branch has not yet completed GitHub Actions and the post-confirm browser archive flow remains blocked.
+Reason: the CI test failure has been fixed, all CI-equivalent local checks pass, and GitHub Actions is green. The post-confirm browser archive flow remains blocked, so the report cannot honestly be promoted to `READY FOR REVIEW` without Nick accepting the missing browser completion.
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
+++ b/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
@@ -18,11 +18,11 @@ Archived findings are now treated as history-only records instead of active clin
 
 ## PR URL
 
-Pending PR creation.
+https://github.com/NckNA/codex-test/pull/289
 
 ## PR head reviewed before final report update
 
-Pending PR creation.
+`34e131b0d94a132f50c9dcb44d4d8da40b8482fd`
 
 ## Report update commit
 
@@ -30,7 +30,7 @@ N/A because the final report update commit cannot reference itself before creati
 
 ## Changed files summary
 
-Expected changed files:
+Changed files expected in this PR:
 
 - `src/domain/findingStatus.ts`
 - `src/components/dental/FindingsRisksTab.tsx`
@@ -148,7 +148,7 @@ Blocker: Chrome DevTools MCP is not available in this tool environment, so I can
 
 ## Checks
 
-Pending GitHub Actions CI after PR creation.
+Pending GitHub Actions CI for report metadata update commit.
 
 Local checks not run in this tool environment:
 

--- a/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
+++ b/_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md
@@ -22,7 +22,7 @@ https://github.com/NckNA/codex-test/pull/289
 
 ## PR head reviewed before final report update
 
-`03f26335297941f3c5384fdb541cc1e59d393f9e`
+`5f35ac61d183c1a8cba7b1b9e10ad04468d5796c`
 
 ## Report update commit
 
@@ -184,11 +184,10 @@ Results:
 
 GitHub Actions CI after push: PASS.
 
-- run: `27569863492`;
-- job: `81503251432`;
-- check: `validate`;
-- duration: 47 seconds;
-- tested commit: `03f26335297941f3c5384fdb541cc1e59d393f9e`.
+- run id: `27570027075`;
+- workflow: `CI #424`;
+- conclusion: `success`;
+- tested commit: `5f35ac61d183c1a8cba7b1b9e10ad04468d5796c`.
 
 ## Remaining known issues
 
@@ -202,7 +201,7 @@ GitHub Actions CI after push: PASS.
 
 PARTIAL
 
-Reason: the CI test failure has been fixed, all CI-equivalent local checks pass, and GitHub Actions is green. The post-confirm browser archive flow remains blocked, so the report cannot honestly be promoted to `READY FOR REVIEW` without Nick accepting the missing browser completion.
+Reason: GitHub Actions CI is green on tested commit `5f35ac61d183c1a8cba7b1b9e10ad04468d5796c`, and automated coverage validates the archive boundary. The post-confirm browser archive flow remains blocked by the native `window.confirm` / browser tooling limitation, so the report cannot honestly be promoted to `READY FOR REVIEW` without accepting the missing browser completion.
 
 ## Recommended next task
 

--- a/src/components/dental/FindingsRisksTab.test.tsx
+++ b/src/components/dental/FindingsRisksTab.test.tsx
@@ -120,7 +120,8 @@ describe('FindingsRisksTab archived findings behavior', () => {
     });
 
     const archiveSection = Array.from(container.querySelectorAll('h3'))
-      .find(h => h.textContent === 'Архивные записи')?.parentElement;
+      .find(h => h.textContent === 'Архивные записи')
+      ?.closest('section');
     expect(archiveSection?.textContent).toContain('Archived Complaint Problem');
 
     await cleanup(root, container);
@@ -165,7 +166,8 @@ describe('FindingsRisksTab archived findings behavior', () => {
     });
 
     const archiveSection = Array.from(container.querySelectorAll('h3'))
-      .find(h => h.textContent === 'Архивные записи')?.parentElement;
+      .find(h => h.textContent === 'Архивные записи')
+      ?.closest('section');
     expect(archiveSection?.textContent).toContain('Archived finding');
     expect(archiveSection?.textContent).not.toContain('В наблюдение');
     expect(archiveSection?.textContent).not.toContain('Отказ пациента');

--- a/src/components/dental/FindingsRisksTab.test.tsx
+++ b/src/components/dental/FindingsRisksTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createRoot } from 'react-dom/client';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { FindingsRisksTab } from './FindingsRisksTab';
 import type { DentalFinding } from '../../types';
@@ -10,136 +10,168 @@ vi.mock('../../data/hooks/usePatientFindings', () => ({
 }));
 
 vi.mock('../../data/hooks/useChiefComplaint', () => ({
-  useChiefComplaint: vi.fn(() => ({ data: 'Mock complaint' })),
+  useChiefComplaint: vi.fn(() => ({
+    complaint: null,
+    isLoading: false,
+    isSaving: false,
+    saveComplaint: vi.fn(),
+  })),
 }));
 
 vi.mock('./FindingModal', () => ({
-  FindingModal: () => <div data-testid="mock-finding-modal" />,
+  FindingModal: ({ isOpen, finding }: { isOpen: boolean; finding?: DentalFinding | null }) => (
+    isOpen ? <div data-testid="mock-finding-modal">{finding ? `Редактирование: ${finding.title}` : 'Новая проблема'}</div> : null
+  ),
 }));
 
 import { usePatientFindings } from '../../data/hooks/usePatientFindings';
 
-describe('FindingsRisksTab', () => {
+function makeFinding(overrides: Partial<DentalFinding>): DentalFinding {
+  return {
+    id: 'finding-1',
+    patientId: 'p1',
+    toothNumber: 11,
+    title: 'Finding title',
+    category: 'caries',
+    severity: 'high',
+    status: 'discovered',
+    isChiefComplaintRelated: false,
+    includeInTreatmentPlan: true,
+    description: '',
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+function mockFindings(findings: DentalFinding[], overrides: Partial<ReturnType<typeof usePatientFindings>> = {}) {
+  const value = {
+    findings,
+    isLoading: false,
+    isError: false,
+    error: null,
+    isSaving: false,
+    saveError: null,
+    createFinding: vi.fn(),
+    updateFinding: vi.fn(),
+    deleteFinding: vi.fn(),
+    refetch: vi.fn(),
+    ...overrides,
+  };
+
+  vi.mocked(usePatientFindings).mockReturnValue(value as ReturnType<typeof usePatientFindings>);
+  return value;
+}
+
+async function renderTab(findings: DentalFinding[], overrides?: Partial<ReturnType<typeof usePatientFindings>>) {
+  const hookValue = mockFindings(findings, overrides);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<FindingsRisksTab patientId="p1" />);
+  });
+
+  return { container, root, hookValue };
+}
+
+async function cleanup(root: Root, container: HTMLElement) {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+describe('FindingsRisksTab archived findings behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('filters out archived findings from active/chiefComplaintRelated problems', async () => {
-    const findings: DentalFinding[] = [
-      {
-        id: '1',
-        patientId: 'p1',
-        toothNumber: 11,
-        title: 'Active Complaint Problem',
-        category: 'caries',
-        severity: 'high',
-        status: 'discovered',
-        isChiefComplaintRelated: true,
-        includeInTreatmentPlan: false,
-        description: '',
-        createdAt: '',
-        updatedAt: ''
-      },
-      {
-        id: '2',
-        patientId: 'p1',
-        toothNumber: 12,
-        title: 'Archived Complaint Problem',
-        category: 'caries',
-        severity: 'high',
-        status: 'archived',
-        isChiefComplaintRelated: true,
-        includeInTreatmentPlan: false,
-        description: '',
-        createdAt: '',
-        updatedAt: ''
-      }
-    ];
-
-    vi.mocked(usePatientFindings).mockReturnValue({
-      findings,
-      isLoading: false,
-      isError: false,
-      error: null,
-      isSaving: false,
-      saveError: null,
-      createFinding: vi.fn(),
-      updateFinding: vi.fn(),
-      deleteFinding: vi.fn(),
-      refetch: vi.fn(),
-    });
-
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<FindingsRisksTab patientId="p1" />);
-    });
-
-    expect(container.textContent).toContain('Active Complaint Problem');
-    
-    // Check inactive section for Archived Complaint Problem
-    const activeSection = Array.from(container.querySelectorAll('h4')).find(h => h.textContent === 'Проблемы, связанные с жалобой:')?.parentElement;
-    const inactiveSection = Array.from(container.querySelectorAll('h3')).find(h => h.textContent === 'Архив / Отказ / Завершено')?.parentElement;
-
-    expect(activeSection?.textContent).toContain('Active Complaint Problem');
-    expect(activeSection?.textContent).not.toContain('Archived Complaint Problem');
-    expect(inactiveSection?.textContent).toContain('Archived Complaint Problem');
-    
-    await act(async () => {
-      root.unmount();
-    });
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('hides normal workflow action buttons on archived findings', async () => {
-    const findings: DentalFinding[] = [
-      {
-        id: '1',
-        patientId: 'p1',
-        toothNumber: 11,
-        title: 'Archived Problem',
-        category: 'caries',
-        severity: 'high',
-        status: 'archived',
-        isChiefComplaintRelated: false,
-        includeInTreatmentPlan: false,
-        description: '',
-        createdAt: '',
-        updatedAt: ''
-      }
-    ];
+  it('hides archived findings from active sections by default and shows them only behind archive toggle', async () => {
+    const { container, root } = await renderTab([
+      makeFinding({ id: 'active-complaint', title: 'Active Complaint Problem', isChiefComplaintRelated: true }),
+      makeFinding({ id: 'archived-complaint', title: 'Archived Complaint Problem', status: 'archived', isChiefComplaintRelated: true }),
+      makeFinding({ id: 'completed', title: 'Completed Problem', status: 'completed', includeInTreatmentPlan: false }),
+      makeFinding({ id: 'declined', title: 'Declined Problem', status: 'declined_by_patient', includeInTreatmentPlan: false }),
+    ]);
 
-    vi.mocked(usePatientFindings).mockReturnValue({
-      findings,
-      isLoading: false,
-      isError: false,
-      error: null,
-      isSaving: false,
-      saveError: null,
-      createFinding: vi.fn(),
-      updateFinding: vi.fn(),
-      deleteFinding: vi.fn(),
-      refetch: vi.fn(),
-    });
+    const complaintSection = Array.from(container.querySelectorAll('h4'))
+      .find(h => h.textContent === 'Проблемы, связанные с жалобой:')?.parentElement;
+    const inactiveSection = Array.from(container.querySelectorAll('h3'))
+      .find(h => h.textContent === 'Отказ / Завершено')?.parentElement;
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
+    expect(complaintSection?.textContent).toContain('Active Complaint Problem');
+    expect(complaintSection?.textContent).not.toContain('Archived Complaint Problem');
+    expect(inactiveSection?.textContent).toContain('Completed Problem');
+    expect(inactiveSection?.textContent).toContain('Declined Problem');
+    expect(inactiveSection?.textContent).not.toContain('Archived Complaint Problem');
+    expect(container.textContent).not.toContain('Archived Complaint Problem');
+
+    const toggle = Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Показать архивные записи');
+    expect(toggle).toBeTruthy();
 
     await act(async () => {
-      root.render(<FindingsRisksTab patientId="p1" />);
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    const inactiveSection = Array.from(container.querySelectorAll('h3')).find(h => h.textContent === 'Архив / Отказ / Завершено')?.parentElement;
-    
-    expect(inactiveSection?.textContent).toContain('Archived Problem');
-    
-    // It should not contain the normal workflow buttons
-    expect(inactiveSection?.textContent).not.toContain('В наблюдение');
-    expect(inactiveSection?.textContent).not.toContain('Отказ пациента');
-    expect(inactiveSection?.textContent).not.toContain('Завершить');
+    const archiveSection = Array.from(container.querySelectorAll('h3'))
+      .find(h => h.textContent === 'Архивные записи')?.parentElement;
+    expect(archiveSection?.textContent).toContain('Archived Complaint Problem');
+
+    await cleanup(root, container);
+  });
+
+  it('uses archive wording and keeps repository archive path wired to deleteFinding', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const deleteFinding = vi.fn().mockResolvedValue(undefined);
+    const { container, root } = await renderTab([
+      makeFinding({ id: 'active-1', title: 'Active finding' }),
+    ], { deleteFinding });
+
+    const archiveButton = container.querySelector('button[aria-label="Архивировать запись Active finding"]');
+    expect(archiveButton).toBeTruthy();
 
     await act(async () => {
-      root.unmount();
+      archiveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
+
+    expect(confirmSpy).toHaveBeenCalledWith('Архивировать эту запись? Она исчезнет из активных списков, но останется в истории.');
+    expect(deleteFinding).toHaveBeenCalledWith('active-1');
+
+    await cleanup(root, container);
+  });
+
+  it('opens editor for active findings and hides active action controls on archived cards', async () => {
+    const { container, root } = await renderTab([
+      makeFinding({ id: 'editable', title: 'Editable finding' }),
+      makeFinding({ id: 'archived', title: 'Archived finding', status: 'archived' }),
+    ]);
+
+    const editButton = container.querySelector('button[aria-label="Редактировать запись Editable finding"]');
+    await act(async () => {
+      editButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Редактирование: Editable finding');
+
+    const toggle = Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Показать архивные записи');
+    await act(async () => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const archiveSection = Array.from(container.querySelectorAll('h3'))
+      .find(h => h.textContent === 'Архивные записи')?.parentElement;
+    expect(archiveSection?.textContent).toContain('Archived finding');
+    expect(archiveSection?.textContent).not.toContain('В наблюдение');
+    expect(archiveSection?.textContent).not.toContain('Отказ пациента');
+    expect(archiveSection?.textContent).not.toContain('Завершить');
+    expect(archiveSection?.textContent).not.toContain('В план');
+
+    await cleanup(root, container);
   });
 });

--- a/src/components/dental/FindingsRisksTab.tsx
+++ b/src/components/dental/FindingsRisksTab.tsx
@@ -5,7 +5,7 @@ import type { CreateFindingInput } from '../../data/repositories/FindingsReposit
 import { FindingModal } from './FindingModal';
 import { useChiefComplaint } from '../../data/hooks/useChiefComplaint';
 import { usePatientFindings } from '../../data/hooks/usePatientFindings';
-import { ACTIVE_FINDING_STATUSES } from '../../domain/findingStatus';
+import { isActiveFindingStatus, isArchivedFindingStatus } from '../../domain/findingStatus';
 
 interface FindingsRisksTabProps {
   patientId: string;
@@ -55,7 +55,7 @@ const VALID_TEETH = new Set([
   18, 17, 16, 15, 14, 13, 12, 11,
   21, 22, 23, 24, 25, 26, 27, 28,
   48, 47, 46, 45, 44, 43, 42, 41,
-  31, 32, 33, 34, 35, 36, 37, 38
+  31, 32, 33, 34, 35, 36, 37, 38,
 ]);
 
 export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
@@ -73,6 +73,7 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedFinding, setSelectedFinding] = useState<DentalFinding | null>(null);
+  const [showArchivedFindings, setShowArchivedFindings] = useState(false);
 
   const [isSaved, setIsSaved] = useState(false);
 
@@ -117,13 +118,13 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
     setTimeout(() => setIsSaved(false), 3000);
   };
 
-  const handleDelete = async (findingId: string) => {
-    if (!window.confirm('Удалить эту запись?')) return;
+  const handleArchive = async (findingId: string) => {
+    if (!window.confirm('Архивировать эту запись? Она исчезнет из активных списков, но останется в истории.')) return;
 
     try {
       await deleteFinding(findingId);
     } catch (e) {
-      console.error('Failed to delete finding', e);
+      console.error('Failed to archive finding', e);
     }
   };
 
@@ -161,109 +162,126 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
   };
 
   const categorizedFindings = {
-    chiefComplaintRelated: findings.filter(f => f.isChiefComplaintRelated && ACTIVE_FINDING_STATUSES.includes(f.status)),
+    chiefComplaintRelated: findings.filter(f => f.isChiefComplaintRelated && isActiveFindingStatus(f.status)),
     discovered: findings.filter(f => !f.isChiefComplaintRelated && f.status === 'discovered' && f.category !== 'risk_zone'),
-    riskZones: findings.filter(f => !f.isChiefComplaintRelated && (f.category === 'risk_zone' || f.status === 'monitoring') && ACTIVE_FINDING_STATUSES.includes(f.status)),
+    riskZones: findings.filter(f => !f.isChiefComplaintRelated && (f.category === 'risk_zone' || f.status === 'monitoring') && isActiveFindingStatus(f.status)),
     inPlan: findings.filter(f => f.status === 'planned'),
-    other: findings.filter(f => f.status === 'completed' || f.status === 'declined_by_patient' || f.status === 'archived'),
+    inactive: findings.filter(f => f.status === 'completed' || f.status === 'declined_by_patient'),
+    archived: findings.filter(f => isArchivedFindingStatus(f.status)),
   };
 
-  const FindingCard = ({ finding }: { finding: DentalFinding }) => (
-    <div className="group bg-white border border-slate-200 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow">
-      <div className="flex justify-between items-start mb-2">
-        <div className="flex items-center gap-2">
-          {finding.toothNumber && (
-            <span className="bg-blue-100 text-blue-700 px-2 py-0.5 rounded-md text-sm font-bold">
-              {finding.toothNumber}
+  const FindingCard = ({ finding, archivedCard = false }: { finding: DentalFinding; archivedCard?: boolean }) => {
+    const isActive = isActiveFindingStatus(finding.status);
+    const showPlanBadge = finding.includeInTreatmentPlan && isActive && finding.status !== 'planned';
+
+    return (
+      <div className={`group bg-white border border-slate-200 rounded-lg p-4 shadow-sm transition-shadow ${archivedCard ? 'opacity-70' : 'hover:shadow-md'}`}>
+        <div className="flex justify-between items-start mb-2">
+          <div className="flex items-center gap-2">
+            {finding.toothNumber && (
+              <span className="bg-blue-100 text-blue-700 px-2 py-0.5 rounded-md text-sm font-bold">
+                {finding.toothNumber}
+              </span>
+            )}
+            <h4 className="font-semibold text-slate-800">{finding.title}</h4>
+          </div>
+          {!archivedCard && (
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => openModal(finding)}
+                disabled={isFindingsLoading}
+                aria-label={`Редактировать запись ${finding.title}`}
+                title="Редактировать запись"
+                className="p-1.5 text-slate-400 hover:text-blue-600 rounded bg-slate-50 hover:bg-blue-50 transition-colors disabled:opacity-50"
+              >
+                <Edit2 className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => handleArchive(finding.id)}
+                disabled={isFindingsLoading}
+                aria-label={`Архивировать запись ${finding.title}`}
+                title="Архивировать запись"
+                className="p-1.5 text-slate-400 hover:text-red-600 rounded bg-slate-50 hover:bg-red-50 transition-colors disabled:opacity-50"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2 mb-3 text-xs">
+          <span className="px-2 py-1 rounded-full bg-slate-100 text-slate-600 border border-slate-200">
+            {CATEGORY_LABELS[finding.category] || finding.category}
+          </span>
+          <span className={`px-2 py-1 rounded-full font-medium ${SEVERITY_COLORS[finding.severity]}`}>
+            {SEVERITY_LABELS[finding.severity]}
+          </span>
+          <span className="px-2 py-1 rounded-full bg-blue-50 text-blue-700 border border-blue-100">
+            {STATUS_LABELS[finding.status]}
+          </span>
+          {finding.isChiefComplaintRelated && (
+            <span className="px-2 py-1 rounded-full bg-red-50 text-red-700 border border-red-100 flex items-center gap-1">
+              <AlertTriangle className="w-3 h-3" /> По жалобе
             </span>
           )}
-          <h4 className="font-semibold text-slate-800">{finding.title}</h4>
+          {showPlanBadge && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700 border border-emerald-100">
+              <CheckCircle className="w-3 h-3" /> В план
+            </span>
+          )}
         </div>
-        <div className="flex gap-1">
-          <button 
-            onClick={() => openModal(finding)} 
-            disabled={isFindingsLoading}
-            className="p-1.5 text-slate-400 hover:text-blue-600 rounded bg-slate-50 hover:bg-blue-50 transition-colors disabled:opacity-50"
-          >
-            <Edit2 className="w-4 h-4" />
-          </button>
-          <button 
-            onClick={() => handleDelete(finding.id)} 
-            disabled={isFindingsLoading}
-            className="p-1.5 text-slate-400 hover:text-red-600 rounded bg-slate-50 hover:bg-red-50 transition-colors disabled:opacity-50"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
+
+        <div className="space-y-2 text-sm text-slate-600">
+          {finding.description && (
+            <div><span className="font-medium text-slate-700">Описание:</span> {finding.description}</div>
+          )}
+          {finding.riskDescription && (
+            <div><span className="font-medium text-amber-700">Риск:</span> {finding.riskDescription}</div>
+          )}
+          {finding.recommendation && !archivedCard && (
+            <div className="p-2 bg-blue-50 rounded-md border border-blue-100 text-blue-800">
+              <span className="font-medium">Рекомендация:</span> {finding.recommendation}
+            </div>
+          )}
         </div>
-      </div>
 
-      <div className="flex flex-wrap gap-2 mb-3 text-xs">
-        <span className="px-2 py-1 rounded-full bg-slate-100 text-slate-600 border border-slate-200">
-          {CATEGORY_LABELS[finding.category] || finding.category}
-        </span>
-        <span className={`px-2 py-1 rounded-full font-medium ${SEVERITY_COLORS[finding.severity]}`}>
-          {SEVERITY_LABELS[finding.severity]}
-        </span>
-        <span className="px-2 py-1 rounded-full bg-blue-50 text-blue-700 border border-blue-100">
-          {STATUS_LABELS[finding.status]}
-        </span>
-        {finding.isChiefComplaintRelated && (
-          <span className="px-2 py-1 rounded-full bg-red-50 text-red-700 border border-red-100 flex items-center gap-1">
-            <AlertTriangle className="w-3 h-3" /> По жалобе
-          </span>
-        )}
-        {finding.includeInTreatmentPlan && finding.status !== 'planned' && (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700 border border-emerald-100">
-            <CheckCircle className="w-3 h-3" /> В план
-          </span>
-        )}
-      </div>
-
-      <div className="space-y-2 text-sm text-slate-600">
-        {finding.description && (
-          <div><span className="font-medium text-slate-700">Описание:</span> {finding.description}</div>
-        )}
-        {finding.riskDescription && (
-          <div><span className="font-medium text-amber-700">Риск:</span> {finding.riskDescription}</div>
-        )}
-        {finding.recommendation && (
-          <div className="p-2 bg-blue-50 rounded-md border border-blue-100 text-blue-800">
-            <span className="font-medium">Рекомендация:</span> {finding.recommendation}
+        {isActive && finding.status !== 'planned' && !archivedCard && (
+          <div className="flex gap-1 ml-4 opacity-0 group-hover:opacity-100 transition-opacity">
+            {finding.status !== 'monitoring' && (
+              <button
+                type="button"
+                onClick={() => handleStatusChange(finding, 'monitoring')}
+                disabled={isFindingsLoading}
+                className="text-xs px-2 py-1 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded transition-colors disabled:opacity-50"
+              >
+                В наблюдение
+              </button>
+            )}
+            {finding.status !== 'declined_by_patient' && (
+              <button
+                type="button"
+                onClick={() => handleStatusChange(finding, 'declined_by_patient')}
+                disabled={isFindingsLoading}
+                className="text-xs px-2 py-1 bg-rose-50 hover:bg-rose-100 text-rose-700 rounded transition-colors disabled:opacity-50"
+              >
+                Отказ пациента
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => handleStatusChange(finding, 'completed')}
+              disabled={isFindingsLoading}
+              className="text-xs px-2 py-1 bg-emerald-50 hover:bg-emerald-100 text-emerald-700 rounded transition-colors ml-auto disabled:opacity-50"
+            >
+              Завершить
+            </button>
           </div>
         )}
       </div>
-
-      {ACTIVE_FINDING_STATUSES.includes(finding.status) && finding.status !== 'planned' && (
-        <div className="flex gap-1 ml-4 opacity-0 group-hover:opacity-100 transition-opacity">
-          {finding.status !== 'monitoring' && (
-             <button 
-               onClick={() => handleStatusChange(finding, 'monitoring')} 
-               disabled={isFindingsLoading}
-               className="text-xs px-2 py-1 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded transition-colors disabled:opacity-50"
-             >
-               В наблюдение
-             </button>
-          )}
-          {finding.status !== 'declined_by_patient' && (
-             <button 
-               onClick={() => handleStatusChange(finding, 'declined_by_patient')} 
-               disabled={isFindingsLoading}
-               className="text-xs px-2 py-1 bg-rose-50 hover:bg-rose-100 text-rose-700 rounded transition-colors disabled:opacity-50"
-             >
-               Отказ пациента
-             </button>
-          )}
-          <button 
-            onClick={() => handleStatusChange(finding, 'completed')} 
-            disabled={isFindingsLoading}
-            className="text-xs px-2 py-1 bg-emerald-50 hover:bg-emerald-100 text-emerald-700 rounded transition-colors ml-auto disabled:opacity-50"
-          >
-            Завершить
-          </button>
-        </div>
-      )}
-    </div>
-  );
+    );
+  };
 
   return (
     <div className="space-y-6 max-w-5xl">
@@ -275,6 +293,7 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
           </p>
         </div>
         <button
+          type="button"
           onClick={() => openModal()}
           className="flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors shadow-sm shrink-0"
         >
@@ -327,13 +346,14 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
               <CheckCircle className="w-4 h-4" /> Сохранено
             </span>
           )}
-            <button
-              onClick={handleSaveComplaint}
-              disabled={isComplaintLoading || isComplaintSaving}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
-            >
-              {isComplaintSaving ? 'Сохранение...' : 'Сохранить жалобу'}
-            </button>
+          <button
+            type="button"
+            onClick={handleSaveComplaint}
+            disabled={isComplaintLoading || isComplaintSaving}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            {isComplaintSaving ? 'Сохранение...' : 'Сохранить жалобу'}
+          </button>
         </div>
 
         {categorizedFindings.chiefComplaintRelated.length > 0 && (
@@ -382,13 +402,36 @@ export function FindingsRisksTab({ patientId }: FindingsRisksTabProps) {
         </section>
       )}
 
-      {/* Не включено / отказ пациента / завершено */}
-      {categorizedFindings.other.length > 0 && (
+      {/* Отказ пациента / завершено */}
+      {categorizedFindings.inactive.length > 0 && (
         <section className="bg-slate-50 rounded-xl border border-slate-200 shadow-sm p-5">
-          <h3 className="font-semibold text-slate-600 mb-4">Архив / Отказ / Завершено</h3>
+          <h3 className="font-semibold text-slate-600 mb-4">Отказ / Завершено</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 opacity-75">
-            {categorizedFindings.other.map(f => <FindingCard key={f.id} finding={f} />)}
+            {categorizedFindings.inactive.map(f => <FindingCard key={f.id} finding={f} />)}
           </div>
+        </section>
+      )}
+
+      {categorizedFindings.archived.length > 0 && (
+        <section className="bg-slate-50 rounded-xl border border-dashed border-slate-300 shadow-sm p-5">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+            <div>
+              <h3 className="font-semibold text-slate-600">Архивные записи</h3>
+              <p className="text-xs text-slate-500 mt-1">Архивные записи скрыты из активных списков и доступны только как история.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowArchivedFindings(prev => !prev)}
+              className="text-sm px-3 py-2 rounded-lg border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 transition-colors"
+            >
+              {showArchivedFindings ? 'Скрыть архивные записи' : 'Показать архивные записи'}
+            </button>
+          </div>
+          {showArchivedFindings && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {categorizedFindings.archived.map(f => <FindingCard key={f.id} finding={f} archivedCard />)}
+            </div>
+          )}
         </section>
       )}
 

--- a/src/components/treatment/CreatePlanFromFindingsModal.test.tsx
+++ b/src/components/treatment/CreatePlanFromFindingsModal.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { CreatePlanFromFindingsModal } from './CreatePlanFromFindingsModal';
+import type { DentalFinding, TreatmentPlan } from '../../types';
+
+function makeFinding(overrides: Partial<DentalFinding>): DentalFinding {
+  return {
+    id: 'finding-1',
+    patientId: 'patient-1',
+    toothNumber: 11,
+    title: 'Finding title',
+    category: 'caries',
+    severity: 'high',
+    description: '',
+    isChiefComplaintRelated: false,
+    includeInTreatmentPlan: true,
+    status: 'discovered',
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+const activePlan: TreatmentPlan = {
+  id: 'plan-1',
+  patientId: 'patient-1',
+  title: 'Active plan',
+  status: 'draft',
+  stages: [
+    {
+      id: 'stage-1',
+      title: 'Stage',
+      teeth: [],
+      description: '',
+      price: 0,
+      status: 'planned',
+      findingIds: ['linked-active', 'linked-archived'],
+    },
+  ],
+  totalPrice: 0,
+  createdAt: '',
+  updatedAt: '',
+};
+
+async function renderModal(findings: DentalFinding[], treatmentPlans: TreatmentPlan[] = []) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onCreatePlanFromFindings = vi.fn().mockResolvedValue(undefined);
+
+  await act(async () => {
+    root.render(
+      <CreatePlanFromFindingsModal
+        isOpen
+        findings={findings}
+        treatmentPlans={treatmentPlans}
+        onClose={vi.fn()}
+        onCreatePlanFromFindings={onCreatePlanFromFindings}
+      />,
+    );
+  });
+
+  return { container, root, onCreatePlanFromFindings };
+}
+
+async function cleanup(root: Root, container: HTMLElement) {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+describe('CreatePlanFromFindingsModal finding eligibility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows discovered and monitoring findings while excluding completed, declined and archived findings', async () => {
+    const { container, root } = await renderModal([
+      makeFinding({ id: 'discovered', title: 'Discovered eligible', status: 'discovered' }),
+      makeFinding({ id: 'monitoring', title: 'Monitoring eligible', status: 'monitoring' }),
+      makeFinding({ id: 'completed', title: 'Completed hidden', status: 'completed' }),
+      makeFinding({ id: 'declined', title: 'Declined hidden', status: 'declined_by_patient' }),
+      makeFinding({ id: 'archived', title: 'Archived hidden', status: 'archived' }),
+    ]);
+
+    expect(container.textContent).toContain('Discovered eligible');
+    expect(container.textContent).toContain('Monitoring eligible');
+    expect(container.textContent).not.toContain('Completed hidden');
+    expect(container.textContent).not.toContain('Declined hidden');
+    expect(container.textContent).not.toContain('Archived hidden');
+
+    await cleanup(root, container);
+  });
+
+  it('keeps active linked finding visible as disabled but hides archived linked finding', async () => {
+    const { container, root } = await renderModal([
+      makeFinding({ id: 'linked-active', title: 'Linked active finding', status: 'discovered' }),
+      makeFinding({ id: 'linked-archived', title: 'Linked archived finding', status: 'archived' }),
+    ], [activePlan]);
+
+    expect(container.textContent).toContain('Linked active finding');
+    expect(container.textContent).toContain('Уже в плане: Active plan');
+    expect(container.textContent).not.toContain('Linked archived finding');
+
+    const linkedCheckbox = container.querySelector('input[type="checkbox"]');
+    expect(linkedCheckbox).toBeInstanceOf(HTMLInputElement);
+    expect((linkedCheckbox as HTMLInputElement).disabled).toBe(true);
+
+    await cleanup(root, container);
+  });
+
+  it('mentions archived findings in the empty-state explanation', async () => {
+    const { container, root } = await renderModal([
+      makeFinding({ id: 'archived-only', title: 'Archived only', status: 'archived' }),
+    ]);
+
+    expect(container.textContent).toContain('Нет проблем для включения в план лечения');
+    expect(container.textContent).toContain('Проблемы уже завершены, архивированы или пациент отказался от лечения.');
+
+    await cleanup(root, container);
+  });
+});

--- a/src/components/treatment/CreatePlanFromFindingsModal.tsx
+++ b/src/components/treatment/CreatePlanFromFindingsModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from 'react';
 import { CheckCircle, X } from 'lucide-react';
-import type { DentalFinding, FindingStatus, TreatmentPlan, TreatmentPlanStatus } from '../../types';
+import type { DentalFinding, TreatmentPlan, TreatmentPlanStatus } from '../../types';
+import { isActiveFindingStatus, isArchivedFindingStatus, isFindingEligibleForTreatmentPlan, isInactiveFindingStatus } from '../../domain/findingStatus';
 
 interface CreatePlanFromFindingsModalProps {
   isOpen: boolean;
@@ -46,9 +47,9 @@ const STATUS_LABELS: Record<string, string> = {
   monitoring: 'Наблюдение',
   declined_by_patient: 'Отказ',
   completed: 'Завершено',
+  archived: 'Архив',
 };
 
-const ELIGIBLE_STATUSES = new Set<FindingStatus>(['discovered', 'monitoring']);
 const ACTIVE_PLAN_STATUSES = new Set<TreatmentPlanStatus>(['draft', 'approved', 'in_progress']);
 
 export function CreatePlanFromFindingsModal({
@@ -91,11 +92,15 @@ export function CreatePlanFromFindingsModal({
     if (!isOpen) return [];
 
     return findings.filter(finding => {
-      const linkedPlanTitle = linkedPlanByFindingId.get(finding.id);
-      const visibleStatus = ELIGIBLE_STATUSES.has(finding.status) || Boolean(linkedPlanTitle);
-      const archivedStatus = finding.status === 'completed' || finding.status === 'declined_by_patient';
+      if (isArchivedFindingStatus(finding.status) || isInactiveFindingStatus(finding.status)) {
+        return false;
+      }
 
-      return finding.includeInTreatmentPlan && visibleStatus && !archivedStatus;
+      const linkedPlanTitle = linkedPlanByFindingId.get(finding.id);
+      const eligibleForNewPlan = isFindingEligibleForTreatmentPlan(finding);
+      const linkedActiveFinding = Boolean(linkedPlanTitle) && finding.includeInTreatmentPlan && isActiveFindingStatus(finding.status);
+
+      return eligibleForNewPlan || linkedActiveFinding;
     });
   }, [findings, linkedPlanByFindingId, isOpen]);
 
@@ -137,7 +142,7 @@ export function CreatePlanFromFindingsModal({
                 <ul className="list-disc pl-5 space-y-1">
                   <li>У пациента еще нет добавленных проблем.</li>
                   <li>В настройках существующих проблем не стоит галочка «Включить в план лечения».</li>
-                  <li>Проблемы уже переведены в статус «Завершено» или «Отказ».</li>
+                  <li>Проблемы уже завершены, архивированы или пациент отказался от лечения.</li>
                   <li>Все доступные проблемы уже включены в другие активные планы лечения.</li>
                 </ul>
               </div>

--- a/src/data/aggregators/ClinicalSummaryAggregator.test.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.test.ts
@@ -10,6 +10,7 @@ import type { DentalChart, TreatmentPlan, DentalFinding, Appointment, ChiefCompl
 
 describe('ClinicalSummaryAggregator', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     localStorage.clear();
   });
 
@@ -21,7 +22,7 @@ describe('ClinicalSummaryAggregator', () => {
     expect(summary.nextVisit).toBeUndefined();
   });
 
-  it('calculates dental summary from seeded chart/findings/plans/complaint', async () => {
+  it('calculates dental summary from seeded chart/findings/plans/complaint while excluding archived findings from active counters', async () => {
     // Seed chart
     const chart: DentalChart = {
       id: 'c1',
@@ -31,15 +32,15 @@ describe('ClinicalSummaryAggregator', () => {
       teeth: Array.from({ length: 32 }, (_, i) => ({
         toothNumber: i + 1,
         condition: i === 0 ? 'caries' : i === 1 ? 'pulpitis' : i === 2 ? 'missing' : 'healthy',
-        updatedAt: 'now'
-      } as ToothRecord))
+        updatedAt: 'now',
+      } as ToothRecord)),
     };
     localStorage.setItem('df_dental_charts', JSON.stringify({ 'patient_1': chart }));
 
     // Seed plans
     const plans: TreatmentPlan[] = [
       { id: '1', patientId: 'patient_1', title: 'Draft Plan', status: 'draft', stages: [], totalPrice: 1000, createdAt: '', updatedAt: '' },
-      { id: '2', patientId: 'patient_1', title: 'Completed Plan', status: 'completed', stages: [], totalPrice: 2000, createdAt: '', updatedAt: '' }
+      { id: '2', patientId: 'patient_1', title: 'Completed Plan', status: 'completed', stages: [], totalPrice: 2000, createdAt: '', updatedAt: '' },
     ];
     localStorage.setItem('df_treatment_plans', JSON.stringify(plans));
 
@@ -52,7 +53,8 @@ describe('ClinicalSummaryAggregator', () => {
       { id: '1', patientId: 'patient_1', toothNumber: 11, category: 'caries', title: 'Urgent', severity: 'urgent', status: 'discovered', description: 'a', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' },
       { id: '2', patientId: 'patient_1', toothNumber: 12, category: 'caries', title: 'High Completed', severity: 'high', status: 'completed', description: 'b', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' },
       { id: '3', patientId: 'patient_1', toothNumber: 13, category: 'caries', title: 'Med Rec', severity: 'medium', status: 'discovered', description: 'c', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' },
-      { id: '4', patientId: 'patient_1', toothNumber: 14, category: 'caries', title: 'Low Obs', severity: 'low', status: 'monitoring', description: 'd', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' }
+      { id: '4', patientId: 'patient_1', toothNumber: 14, category: 'caries', title: 'Low Obs', severity: 'low', status: 'monitoring', description: 'd', isChiefComplaintRelated: false, includeInTreatmentPlan: false, createdAt: '', updatedAt: '' },
+      { id: '5', patientId: 'patient_1', toothNumber: 15, category: 'caries', title: 'Archived urgent', severity: 'urgent', status: 'archived', description: 'e', isChiefComplaintRelated: false, includeInTreatmentPlan: true, createdAt: '', updatedAt: '' },
     ];
     localStorage.setItem('df_dental_findings', JSON.stringify(findings));
 
@@ -63,15 +65,15 @@ describe('ClinicalSummaryAggregator', () => {
     expect(summary.dentalSummary.activePlans).toBe(1); // draft
     expect(summary.dentalSummary.totalAmount).toBe(3000); // 1000 + 2000
     expect(summary.dentalSummary.chiefComplaintText).toBe('Toothache');
-    expect(summary.dentalSummary.highUrgentFindings).toBe(1); // urgent discovered (high completed is ignored)
-    expect(summary.dentalSummary.notIncludedFindings).toBe(2); // discovered
+    expect(summary.dentalSummary.highUrgentFindings).toBe(1); // urgent discovered only; completed/archived ignored
+    expect(summary.dentalSummary.notIncludedFindings).toBe(2); // discovered only
     expect(summary.dentalSummary.monitoringFindings).toBe(1); // monitoring
   });
 
   it('calculates lastVisit and nextVisit while ignoring cancelled/blocked', async () => {
     // Avoid default chart creation in this test
     localStorage.setItem('df_dental_charts', JSON.stringify({
-      'patient_1': { patientId: 'patient_1', teeth: [] }
+      'patient_1': { patientId: 'patient_1', teeth: [] },
     }));
 
     const pastDate = new Date(Date.now() - 86400000).toISOString(); // Yesterday
@@ -96,10 +98,10 @@ describe('ClinicalSummaryAggregator', () => {
   it('does not mutate unrelated storage', async () => {
     // Prevent default chart creation to keep storage exact
     localStorage.setItem('df_dental_charts', JSON.stringify({ 'patient_1': { patientId: 'patient_1', teeth: [] } }));
-    
+
     const findingsData = JSON.stringify([{ id: 'f1', mock: true }]);
     const plansData = JSON.stringify([{ id: 'p1', mock: true }]);
-    
+
     localStorage.setItem('df_dental_findings', findingsData);
     localStorage.setItem('df_treatment_plans', plansData);
 
@@ -121,19 +123,19 @@ describe('ClinicalSummaryAggregator', () => {
       vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository').mockReturnValue({
         listFindingsByPatient: vi.fn().mockRejectedValue(new Error('Supabase network error')),
       } as unknown as ReturnType<typeof FindingsRepositoryModule.createFindingsRepository>);
-      
+
       vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository').mockReturnValue({
         getDentalChart: vi.fn().mockResolvedValue({ teeth: [] }),
       } as unknown as ReturnType<typeof DentalChartRepositoryModule.createDentalChartRepository>);
-      
+
       vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository').mockReturnValue({
         listTreatmentPlansByPatient: vi.fn().mockResolvedValue([]),
       } as unknown as ReturnType<typeof TreatmentPlansRepositoryModule.createTreatmentPlansRepository>);
-      
+
       vi.spyOn(ChiefComplaintRepositoryModule, 'createChiefComplaintRepository').mockReturnValue({
         getChiefComplaint: vi.fn().mockResolvedValue(null),
       } as unknown as ReturnType<typeof ChiefComplaintRepositoryModule.createChiefComplaintRepository>);
-      
+
       vi.spyOn(AppointmentRepositoryModule, 'createAppointmentRepository').mockReturnValue({
         listAppointments: vi.fn().mockResolvedValue([]),
       } as unknown as ReturnType<typeof AppointmentRepositoryModule.createAppointmentRepository>);

--- a/src/data/aggregators/ClinicalSummaryAggregator.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.ts
@@ -3,7 +3,7 @@ import { createTreatmentPlansRepository } from '../repositories/TreatmentPlansRe
 import { createChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
 import { createFindingsRepository } from '../repositories/FindingsRepository';
 import { createAppointmentRepository } from '../repositories/AppointmentRepository';
-import { ACTIVE_FINDING_STATUSES } from '../../domain/findingStatus';
+import { isActiveFindingStatus } from '../../domain/findingStatus';
 
 export interface PatientDentalSummary {
   needsTreatment: number;
@@ -76,9 +76,10 @@ export async function getPatientMedicalSummary(patientId: string, config: Clinic
   const totalAmount = plans.reduce((sum, p) => sum + p.totalPrice, 0);
 
   const chiefComplaintText = complaint?.text || '';
-  const highUrgentFindings = findings.filter(f => (f.severity === 'high' || f.severity === 'urgent') && ACTIVE_FINDING_STATUSES.includes(f.status)).length;
-  const notIncludedFindings = findings.filter(f => f.status === 'discovered').length;
-  const monitoringFindings = findings.filter(f => f.status === 'monitoring').length;
+  const activeFindings = findings.filter(f => isActiveFindingStatus(f.status));
+  const highUrgentFindings = activeFindings.filter(f => f.severity === 'high' || f.severity === 'urgent').length;
+  const notIncludedFindings = activeFindings.filter(f => f.status === 'discovered').length;
+  const monitoringFindings = activeFindings.filter(f => f.status === 'monitoring').length;
 
   let lastVisit: Date | undefined;
   let nextVisit: Date | undefined;

--- a/src/domain/findingStatus.ts
+++ b/src/domain/findingStatus.ts
@@ -1,4 +1,4 @@
-import type { FindingStatus } from '../types';
+import type { DentalFinding, FindingStatus } from '../types';
 
 export const FINDING_STATUSES: readonly FindingStatus[] = [
   'discovered',
@@ -14,6 +14,17 @@ export const ACTIVE_FINDING_STATUSES: readonly FindingStatus[] = [
   'discovered',
   'planned',
   'in_treatment',
+  'monitoring',
+];
+
+export const INACTIVE_FINDING_STATUSES: readonly FindingStatus[] = [
+  'completed',
+  'declined_by_patient',
+  'archived',
+];
+
+export const TREATMENT_PLAN_ELIGIBLE_FINDING_STATUSES: readonly FindingStatus[] = [
+  'discovered',
   'monitoring',
 ];
 
@@ -43,6 +54,28 @@ export function normalizeFindingStatus(status: string | undefined | null): Findi
 export function isActiveFindingStatus(status: FindingStatus | string | undefined | null): boolean {
   const normalized = normalizeFindingStatus(status);
   return (ACTIVE_FINDING_STATUSES as readonly FindingStatus[]).includes(normalized);
+}
+
+export function isInactiveFindingStatus(status: FindingStatus | string | undefined | null): boolean {
+  const normalized = normalizeFindingStatus(status);
+  return (INACTIVE_FINDING_STATUSES as readonly FindingStatus[]).includes(normalized);
+}
+
+export function isArchivedFindingStatus(status: FindingStatus | string | undefined | null): boolean {
+  return normalizeFindingStatus(status) === 'archived';
+}
+
+export function isFindingEligibleForTreatmentPlan(
+  finding: Pick<DentalFinding, 'includeInTreatmentPlan' | 'status' | 'plannedWorkRecordIds'>,
+): boolean {
+  const normalizedStatus = normalizeFindingStatus(finding.status);
+  const alreadyLinkedToPlan = Boolean(finding.plannedWorkRecordIds?.length);
+
+  return (
+    finding.includeInTreatmentPlan === true &&
+    (TREATMENT_PLAN_ELIGIBLE_FINDING_STATUSES as readonly FindingStatus[]).includes(normalizedStatus) &&
+    !alreadyLinkedToPlan
+  );
 }
 
 export const FINDING_STATUS_LABELS: Record<FindingStatus, string> = {


### PR DESCRIPTION
## Summary

Implements `FINDINGS-ARCHIVE-UI-CLEANUP-001`.

- Replaces fake delete wording with archive wording for findings.
- Hides archived findings from active findings sections by default.
- Adds an explicit archive toggle/section for archived records.
- Excludes archived findings from create-plan candidates, including archived findings linked to active plans.
- Keeps completed/declined in inactive/history UI.
- Makes clinical summary active counters use explicit active finding status filtering.

## Scope

Changed allowed files only:

- `src/domain/findingStatus.ts`
- `src/components/dental/FindingsRisksTab.tsx`
- `src/components/dental/FindingsRisksTab.test.tsx`
- `src/components/treatment/CreatePlanFromFindingsModal.tsx`
- `src/components/treatment/CreatePlanFromFindingsModal.test.tsx`
- `src/data/aggregators/ClinicalSummaryAggregator.ts`
- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`
- `_ai_work/REPORTS/FINDINGS-ARCHIVE-UI-CLEANUP-001_archived_findings_ui_cleanup.md`

## Cloud / DB safety

- No DB migration.
- No cloud apply.
- No RLS changes.
- No hard delete.
- No dictionary/template changes.

## Checks

Pending GitHub Actions CI.

## Current verdict

PARTIAL until CI is green and browser smoke is completed or explicitly documented as blocked.