### PR TITLE
ROLE-LABEL-UX-001: fix role labels in multitenant UI

### DIFF
--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -6,7 +6,7 @@ Implemented centralized role display mapping and replaced the layout header's ha
 
 - Branch name: `feature/role-label-ux-001`
 - PR URL: https://github.com/NckNA/codex-test/pull/290
-- PR head reviewed before final report update: `fae3749e3757d1b67264b4c57e49a6c781061f4b`
+- PR head reviewed before final report update: `cfa730142c5a4fc9b7ec9af52d6a0c048097e660`
 - Report update commit: N/A because the final report update commit cannot reference itself before creation.
 
 ---
@@ -16,6 +16,7 @@ Implemented centralized role display mapping and replaced the layout header's ha
 - `src/domain/roleLabels.ts`
 - `src/domain/roleLabels.test.ts`
 - `src/components/layout/Header.tsx`
+- `src/components/layout/Header.test.tsx`
 - `src/contexts/TenantContext.tsx`
 - `src/contexts/TenantContext.test.tsx`
 - `src/App.test.tsx`
@@ -69,6 +70,7 @@ Files changed because they directly participate in role label display or tests:
 
 - `src/domain/roleLabels.ts`
 - `src/components/layout/Header.tsx`
+- `src/components/layout/Header.test.tsx`
 - `src/contexts/TenantContext.tsx`
 - `src/domain/roleLabels.test.ts`
 - `src/contexts/TenantContext.test.tsx`
@@ -145,7 +147,7 @@ No-tenant users remain blocked by the existing `Клиника не назнач
 
 ### Multi-tenant behavior
 
-When `activeTenant.role` changes, the header label changes with it. This is covered by `App.test.tsx`.
+When `activeTenant.role` changes, the header label changes with it. This is covered by `Header.test.tsx`, `TenantContext.test.tsx`, and `App.test.tsx`.
 
 ### Platform context
 
@@ -165,6 +167,17 @@ Covers:
 - unknown fallback;
 - doctor/receptionist/registrar/no-tenant never mapping to generic admin;
 - clinic/platform context separation.
+
+### `src/components/layout/Header.test.tsx`
+
+Covers:
+
+- dev fallback header label;
+- Supabase header label;
+- clinic_admin / clinic_owner / doctor / receptionist / registrar / cashier labels;
+- platform role not shown as clinic role;
+- missing role fallback;
+- header label updates when active tenant role changes.
 
 ### `src/contexts/TenantContext.test.tsx`
 
@@ -202,7 +215,7 @@ Blocked in this environment: Chrome DevTools MCP is not available, so I could no
 
 Not faked.
 
-Required manual smoke after CI if browser tooling is available:
+Required manual smoke if browser tooling is available:
 
 1. Admin Clinic A: visible role label should be `Администратор клиники`, not generic `Администратор`.
 2. Doctor Clinic A: visible role label should be `Врач`; dictionary page should remain read-only.
@@ -229,10 +242,10 @@ Required manual smoke after CI if browser tooling is available:
 ## Checks
 
 - `git status --short`: not run locally; GitHub PR file list must be used as source of truth.
-- `npm run lint`: pending GitHub Actions CI.
-- `npm run test -- --run`: pending GitHub Actions CI.
-- `npm run build`: pending GitHub Actions CI.
-- `GitHub Actions CI result`: pending.
+- `npm run lint`: PASS via GitHub Actions CI #429.
+- `npm run test -- --run`: PASS via GitHub Actions CI #429.
+- `npm run build`: PASS via GitHub Actions CI #429.
+- `GitHub Actions CI result`: PASS, run id `27573586816`, run number `429`, tested commit `cfa730142c5a4fc9b7ec9af52d6a0c048097e660`.
 
 ---
 
@@ -254,7 +267,7 @@ Required manual smoke after CI if browser tooling is available:
 
 **PARTIAL**
 
-Reason: implementation is complete, but GitHub Actions CI and browser smoke are not completed yet.
+Reason: implementation is complete and CI is green, but browser smoke is blocked because Chrome DevTools MCP is not available in this environment.
 
 ---
 

--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -1,15 +1,13 @@
-# ROLE-LABEL-UX-001: fix clinic/platform role labels in UI
+# ROLE-LABEL-UX-001: role label UX report
 
 ## Summary
 
-Implemented centralized role display mapping and replaced the layout header's hardcoded role label with the active clinic tenant membership role.
+This report was sanitized to remove local credential material from the Git-tracked report.
 
-- Branch name: `feature/role-label-ux-001`
-- PR URL: https://github.com/NckNA/codex-test/pull/290
-- PR head reviewed before final report update: `f6cd38fd06c1f0d1ee922bbbd0eab5dcce8e4a6b`
+- Branch: `feature/role-label-ux-001`
+- PR: https://github.com/NckNA/codex-test/pull/290
+- PR head reviewed before final report update: `0dfcddc22d667684855f55a384e16a7fa01fe352`
 - Report update commit: N/A because the final report update commit cannot reference itself before creation.
-
----
 
 ## Changed Files Summary
 
@@ -22,289 +20,26 @@ Implemented centralized role display mapping and replaced the layout header's ha
 - `src/App.test.tsx`
 - `_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md`
 
----
+## Result
 
-## Root Cause
+Role labels are centralized and rendered from active clinic tenant membership instead of a hardcoded admin label.
 
-The layout header rendered a hardcoded role label:
+## Smoke Summary
 
-```tsx
-<div className="text-xs text-slate-500">Администратор</div>
-```
+Local browser role-label smoke was completed for clinic admin, doctor, no-tenant, multi-tenant default tenant, registrar, and cashier role-label scenarios.
 
-That meant doctors, registrars/receptionists, cashiers, no-tenant users, and multi-tenant users could receive a misleading admin label in clinic context. The bug was display-only, but it undermined multitenant UX clarity.
-
-The architecture rule from `_ai_work/SOURCES/02_ROLES_AND_PERMISSIONS.md` is that access and role display must be derived from tenant membership in the active tenant context, not from one global user role.
-
----
-
-## Recon Results
-
-Searched for:
-
-- `Администратор`
-- `Врач`
-- `Регистратор`
-- `Кассир`
-- `Владелец`
-- `role`
-- `activeTenant.role`
-- `user.role`
-- `clinic_admin`
-- `doctor`
-- `receptionist`
-- `cashier`
-- `clinic_owner`
-- `platform_admin`
-- `platform_owner`
-
-Findings:
-
-- `src/components/layout/Header.tsx` rendered the wrong hardcoded label `Администратор`.
-- `src/contexts/TenantContext.tsx` already exposes `activeTenant.role` loaded from `tenant_users.role` in Supabase mode.
-- `src/contexts/TenantContext.tsx` dev fallback used legacy `admin`, which did not match the clinic role model.
-- `src/App.tsx` no-tenant gate blocks layout rendering before the header, so no-tenant users should not receive a fake header role.
-- `src/pages/MedicalPage.tsx` contains permission labels and dictionary permission UI, but that role-based permission behavior is intentionally left unchanged.
-
-Files changed because they directly participate in role label display or tests:
-
-- `src/domain/roleLabels.ts`
-- `src/components/layout/Header.tsx`
-- `src/components/layout/Header.test.tsx`
-- `src/contexts/TenantContext.tsx`
-- `src/domain/roleLabels.test.ts`
-- `src/contexts/TenantContext.test.tsx`
-- `src/App.test.tsx`
-
----
-
-## Role Label Mapping
-
-Centralized helper added in `src/domain/roleLabels.ts`.
-
-Clinic labels:
-
-- `clinic_owner` -> `Владелец клиники`
-- `clinic_admin` -> `Администратор клиники`
-- `doctor` -> `Врач`
-- `receptionist` -> `Регистратор`
-- `registrar` -> `Регистратор` for current DB enum compatibility
-- `cashier` -> `Кассир`
-
-Platform labels:
-
-- `platform_owner` -> `Владелец платформы`
-- `platform_admin` -> `Администратор платформы`
-- `platform_support` -> `Поддержка платформы`
-- `support` -> `Поддержка платформы` for current DB enum compatibility
-
-Fallbacks:
-
-- null / undefined / empty -> `Роль не назначена`
-- unknown value -> `Неизвестная роль`
-
-Rules locked by tests:
-
-- doctor never maps to generic `Администратор`.
-- receptionist/registrar never maps to generic `Администратор`.
-- no-tenant/null never maps to generic `Администратор`.
-- clinic and platform contexts stay separate.
-
----
-
-## UI Changes
-
-### `Header.tsx`
-
-Changed role label source from hardcoded `Администратор` to:
-
-```tsx
-const { activeTenant } = useTenant();
-const roleLabel = getClinicRoleLabel(activeTenant?.role);
-```
-
-The current visible role label is now derived from `activeTenant.role` in the clinic layout context.
-
-Examples:
-
-- `clinic_admin` -> `Администратор клиники`
-- `clinic_owner` -> `Владелец клиники`
-- `doctor` -> `Врач`
-- `receptionist` / `registrar` -> `Регистратор`
-- `cashier` -> `Кассир`
-
-### `TenantContext.tsx`
-
-Updated dev fallback role from legacy `admin` to canonical clinic role `clinic_admin`.
-
-No Supabase tenant loading logic was changed.
-No permission checks were changed.
-No RLS/database/cloud changes were made.
-
-### No-tenant behavior
-
-No-tenant users remain blocked by the existing `Клиника не назначена` gate in `App.tsx`, so the header does not render a fake clinic role.
-
-### Multi-tenant behavior
-
-When `activeTenant.role` changes, the header label changes with it. This is covered by `Header.test.tsx`, `TenantContext.test.tsx`, and `App.test.tsx`.
-
-### Platform context
-
-Platform labels are available through the helper, but no platform UI was wired in this task because the current layout is clinic-context UI.
-
----
-
-## Tests
-
-### `src/domain/roleLabels.test.ts`
-
-Covers:
-
-- clinic owner/admin/doctor/receptionist/registrar/cashier labels;
-- platform owner/admin/support labels;
-- null/undefined/empty fallback;
-- unknown fallback;
-- doctor/receptionist/registrar/no-tenant never mapping to generic admin;
-- clinic/platform context separation.
-
-### `src/components/layout/Header.test.tsx`
-
-Covers:
-
-- dev fallback header label;
-- Supabase header label;
-- clinic_admin / clinic_owner / doctor / receptionist / registrar / cashier labels;
-- platform role not shown as clinic role;
-- missing role fallback;
-- header label updates when active tenant role changes.
-
-### `src/contexts/TenantContext.test.tsx`
-
-Updated:
-
-- dev fallback role is now `clinic_admin`;
-- multi-tenant active role changes from `clinic_admin` to `doctor` when active tenant changes.
-
-### `src/App.test.tsx`
-
-Added/updated UI coverage:
-
-- admin tenant shows `Администратор клиники`;
-- owner tenant shows `Владелец клиники`;
-- doctor tenant shows `Врач`;
-- receptionist/registrar tenant shows `Регистратор`;
-- cashier tenant shows `Кассир`;
-- no-tenant user does not render a fake admin role;
-- platform admin is not shown as clinic admin in the header;
-- active tenant role changes update the visible header label.
-
-### Permission regression
-
-Dictionary permission logic was intentionally not changed. Existing dictionary permission tests remain the guard for:
-
-- doctor read-only behavior;
-- clinic_admin edit access;
-- no-tenant gate behavior.
-
----
-
-## Browser Smoke
-
-Successfully completed with real in-app browser tooling against local Vite on `http://localhost:5173/`.
-
-Local QA fixture inventory:
-
-- `qa.admin.a@example.local`: exists, `clinic_admin` in Demo Clinic A.
-- `qa.doctor.a@example.local`: exists, `doctor` in Demo Clinic A.
-- `qa.admin.b@example.local`: exists, `clinic_admin` in Demo Clinic B.
-- `qa.notenant@example.local`: exists, no tenant membership.
-- `qa.multitenant@example.local`: exists, `clinic_admin` in Demo Clinic A and `doctor` in Demo Clinic B.
-- `qa.receptionist.a@example.local`: exists, `registrar` (mapped role) in Demo Clinic A.
-- `qa.cashier.a@example.local`: exists, `cashier` in Demo Clinic A.
-
-Validated scenarios:
-
-1. **Admin Clinic A** (`qa.admin.a@example.local`)
-   - Login: **PASS** (authenticated successfully using local password `QaLocal2024!`).
-   - Role Label: **PASS** (correctly renders `Администратор клиники`).
-   - Saved screenshot: [admin_a.png](file:///C:/Users/User/.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/admin_a.png).
-
-2. **Doctor Clinic A** (`qa.doctor.a@example.local`)
-   - Login: **PASS** (authenticated successfully).
-   - Role Label: **PASS** (correctly renders `Врач`).
-
-3. **Admin Clinic B** (`qa.admin.b@example.local`)
-   - Login: **PASS** (authenticated successfully).
-   - Role Label: **PASS** (correctly renders `Администратор клиники` in Clinic B).
-
-4. **No-Tenant User** (`qa.notenant@example.local`)
-   - Login: **PASS** (authenticated successfully).
-   - Behavior: **PASS** (successfully intercepted by the "Клиника не назначена" context gate screen; no app crashes occurred).
-
-5. **Multi-Tenant User** (`qa.multitenant@example.local`)
-   - Login: **PASS** (authenticated successfully).
-   - Role Label: **PASS** (correctly renders `Администратор клиники` for the default/first active tenant Demo Clinic A).
-
-6. **Receptionist / registrar** (`qa.receptionist.a@example.local`)
-   - Login: **PASS** (authenticated successfully).
-   - Role Label: **PASS** (correctly renders `Регистратор`).
-
-7. **Cashier** (`qa.cashier.a@example.local`)
-   - Login: **PASS** (authenticated successfully).
-   - Role Label: **PASS** (correctly renders `Кассир`).
-
-Console errors:
-- None. No unexpected console errors were logged during successful authentications or while rendering the role labels.
-
----
-
-## What Was Intentionally NOT Changed
-
-- No DB migration.
-- No cloud apply.
-- No RLS changes.
-- No permission logic change.
-- No tenant loading rewrite.
-- No dictionary code changes.
-- No findings/treatment changes.
-- No source document edits.
-- No dependencies.
-- No next feature started.
-
----
+No local credential value is stored in this report.
 
 ## Checks
 
-- `git status --short` before report edit: clean.
 - `npm run lint`: PASS.
-- `npm run test -- --run` with local `.env.local` moved: PASS, 37 test files and 300 tests.
+- `npm run test -- --run`: PASS.
 - `npm run build`: PASS.
-- `GitHub Actions CI result before this report update`: PASS, run id `27577889344` (CI #438), head `2de7245a6bd604a3a8761c0c539d78e277b818ad`.
-
----
-
-## Remaining Known Issues
-
-- Dental photo upload/storage integration.
-- Tenant creation/onboarding flow.
-- Documents module.
-- Payments module.
-- Stock module.
-- Billing/subscription access control UX.
-- Reporting.
-- Integrations.
-- `integration_tokens` advisor info if still present.
-
----
+- `GitHub Actions CI result before this report update`: PASS, run id `27598340906` (CI #440), head `0dfcddc22d667684855f55a384e16a7fa01fe352`.
 
 ## Final Verdict
 
 **READY FOR REVIEW**
-
-Reason: Implementation is complete, all 7 local QA fixtures are fully verified via local browser smoke testing, and the visible role labels are correctly matching their mapped tenant roles in the header.
-
----
 
 ## Recommended Next Task
 

--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -6,7 +6,7 @@ Implemented centralized role display mapping and replaced the layout header's ha
 
 - Branch name: `feature/role-label-ux-001`
 - PR URL: https://github.com/NckNA/codex-test/pull/290
-- PR head reviewed before final report update: `cfa730142c5a4fc9b7ec9af52d6a0c048097e660`
+- PR head reviewed before final report update: `909dbf309e59fcc991a96be17349a7c4a716cccf`
 - Report update commit: N/A because the final report update commit cannot reference itself before creation.
 
 ---
@@ -211,16 +211,58 @@ Dictionary permission logic was intentionally not changed. Existing dictionary p
 
 ## Browser Smoke
 
-Blocked in this environment: Chrome DevTools MCP is not available, so I could not perform real browser login/navigation smoke.
+Partially attempted with real in-app browser tooling against local Vite on `http://127.0.0.1:5177`.
 
-Not faked.
+Tooling status:
 
-Required manual smoke if browser tooling is available:
+- Browser tooling is available.
+- A stale crashed browser tab from a previous native confirm flow was bypassed by opening a fresh in-app browser tab.
+- Local Supabase was running.
+- The app opened the Supabase login screen successfully.
 
-1. Admin Clinic A: visible role label should be `Администратор клиники`, not generic `Администратор`.
-2. Doctor Clinic A: visible role label should be `Врач`; dictionary page should remain read-only.
-3. No-tenant user: no fake admin role; no-tenant gate remains.
-4. Multi-tenant fixture: switching active tenant should update visible role label.
+Local QA fixture inventory:
+
+- `qa.admin.a@example.local`: exists, `clinic_admin` in Demo Clinic A.
+- `qa.doctor.a@example.local`: exists, `doctor` in Demo Clinic A.
+- `qa.notenant@example.local`: exists, no tenant membership.
+- `qa.multitenant@example.local`: exists, `clinic_admin` in Demo Clinic A and `doctor` in Demo Clinic B.
+- receptionist/registrar fixture: not present in local `tenant_users`.
+- cashier fixture: not present in local `tenant_users`.
+
+Attempted scenarios:
+
+1. Admin Clinic A
+   - Login attempted with the local QA admin fixture.
+   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
+   - Role label could not be observed after login.
+
+2. Doctor Clinic A
+   - Login attempted with the local QA doctor fixture.
+   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
+   - Role label and dictionary read-only UI could not be observed after login.
+
+3. Receptionist / registrar
+   - Result: BLOCKED because no receptionist/registrar auth fixture exists in the current local database.
+
+4. Cashier
+   - Result: BLOCKED because no cashier auth fixture exists in the current local database.
+
+5. No-tenant
+   - Login attempted with the local no-tenant fixture.
+   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
+   - No-tenant gate could not be observed after login.
+
+6. Multi-tenant
+   - Login attempted with the local multi-tenant fixture.
+   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
+   - Additional blocker: no active-tenant switcher UI exists in the current app (`setActiveTenant` is not called from rendered UI), so switching Clinic A -> Clinic B cannot be completed in browser even when login works.
+
+Console errors:
+
+- The only observed browser console errors were the expected failed-login `AuthApiError: Invalid login credentials` entries from the blocked fixture login attempts.
+- No post-login role-label console state could be verified because authentication did not complete.
+
+Not faked. No production role-label bug was found in this smoke attempt, and no code was changed.
 
 ---
 
@@ -241,11 +283,13 @@ Required manual smoke if browser tooling is available:
 
 ## Checks
 
-- `git status --short`: not run locally; GitHub PR file list must be used as source of truth.
-- `npm run lint`: PASS via GitHub Actions CI #429.
-- `npm run test -- --run`: PASS via GitHub Actions CI #429.
-- `npm run build`: PASS via GitHub Actions CI #429.
-- `GitHub Actions CI result`: PASS, run id `27573586816`, run number `429`, tested commit `cfa730142c5a4fc9b7ec9af52d6a0c048097e660`.
+- `git status --short` before report edit: only pre-existing untracked `_ai_work/scratch/`, `outputs/`, `pr.txt`, `seed_output.sql`, and `temp.md`.
+- `npm run lint`: PASS.
+- `npm run test -- --run` with local `.env.local`: FAIL in unrelated `AuthContext (Dev Fallback)` because local Supabase configuration selects `supabase-active` instead of `dev`.
+- `npm run test -- --run` in CI-equivalent env-neutral mode: PASS, 37 test files and 300 tests.
+- `npm run build`: PASS. Vite emitted the existing large-chunk warning.
+- `GitHub Actions CI result before this report update`: PASS, run id `27573732129`, tested commit `909dbf309e59fcc991a96be17349a7c4a716cccf`.
+- `GitHub Actions CI result after this report update`: PENDING until this report-only commit is pushed.
 
 ---
 
@@ -267,7 +311,7 @@ Required manual smoke if browser tooling is available:
 
 **PARTIAL**
 
-Reason: implementation is complete and CI is green, but browser smoke is blocked because Chrome DevTools MCP is not available in this environment.
+Reason: implementation is complete and current PR CI is green, but browser smoke remains blocked by local QA fixture credentials and missing local role fixtures for receptionist/registrar and cashier. Multi-tenant role-switch smoke is additionally blocked by the absence of an active-tenant switcher UI.
 
 ---
 

--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -1,0 +1,263 @@
+# ROLE-LABEL-UX-001: fix clinic/platform role labels in UI
+
+## Summary
+
+Implemented centralized role display mapping and replaced the layout header's hardcoded role label with the active clinic tenant membership role.
+
+- Branch name: `feature/role-label-ux-001`
+- PR URL: [Pending PR creation]
+- PR head reviewed before final report update: [Pending PR creation]
+- Report update commit: N/A because the final report update commit cannot reference itself before creation.
+
+---
+
+## Changed Files Summary
+
+- `src/domain/roleLabels.ts`
+- `src/domain/roleLabels.test.ts`
+- `src/components/layout/Header.tsx`
+- `src/contexts/TenantContext.tsx`
+- `src/contexts/TenantContext.test.tsx`
+- `src/App.test.tsx`
+- `_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md`
+
+---
+
+## Root Cause
+
+The layout header rendered a hardcoded role label:
+
+```tsx
+<div className="text-xs text-slate-500">Администратор</div>
+```
+
+That meant doctors, registrars/receptionists, cashiers, no-tenant users, and multi-tenant users could receive a misleading admin label in clinic context. The bug was display-only, but it undermined multitenant UX clarity.
+
+The architecture rule from `_ai_work/SOURCES/02_ROLES_AND_PERMISSIONS.md` is that access and role display must be derived from tenant membership in the active tenant context, not from one global user role.
+
+---
+
+## Recon Results
+
+Searched for:
+
+- `Администратор`
+- `Врач`
+- `Регистратор`
+- `Кассир`
+- `Владелец`
+- `role`
+- `activeTenant.role`
+- `user.role`
+- `clinic_admin`
+- `doctor`
+- `receptionist`
+- `cashier`
+- `clinic_owner`
+- `platform_admin`
+- `platform_owner`
+
+Findings:
+
+- `src/components/layout/Header.tsx` rendered the wrong hardcoded label `Администратор`.
+- `src/contexts/TenantContext.tsx` already exposes `activeTenant.role` loaded from `tenant_users.role` in Supabase mode.
+- `src/contexts/TenantContext.tsx` dev fallback used legacy `admin`, which did not match the clinic role model.
+- `src/App.tsx` no-tenant gate blocks layout rendering before the header, so no-tenant users should not receive a fake header role.
+- `src/pages/MedicalPage.tsx` contains permission labels and dictionary permission UI, but that role-based permission behavior is intentionally left unchanged.
+
+Files changed because they directly participate in role label display or tests:
+
+- `src/domain/roleLabels.ts`
+- `src/components/layout/Header.tsx`
+- `src/contexts/TenantContext.tsx`
+- `src/domain/roleLabels.test.ts`
+- `src/contexts/TenantContext.test.tsx`
+- `src/App.test.tsx`
+
+---
+
+## Role Label Mapping
+
+Centralized helper added in `src/domain/roleLabels.ts`.
+
+Clinic labels:
+
+- `clinic_owner` -> `Владелец клиники`
+- `clinic_admin` -> `Администратор клиники`
+- `doctor` -> `Врач`
+- `receptionist` -> `Регистратор`
+- `registrar` -> `Регистратор` for current DB enum compatibility
+- `cashier` -> `Кассир`
+
+Platform labels:
+
+- `platform_owner` -> `Владелец платформы`
+- `platform_admin` -> `Администратор платформы`
+- `platform_support` -> `Поддержка платформы`
+- `support` -> `Поддержка платформы` for current DB enum compatibility
+
+Fallbacks:
+
+- null / undefined / empty -> `Роль не назначена`
+- unknown value -> `Неизвестная роль`
+
+Rules locked by tests:
+
+- doctor never maps to generic `Администратор`.
+- receptionist/registrar never maps to generic `Администратор`.
+- no-tenant/null never maps to generic `Администратор`.
+- clinic and platform contexts stay separate.
+
+---
+
+## UI Changes
+
+### `Header.tsx`
+
+Changed role label source from hardcoded `Администратор` to:
+
+```tsx
+const { activeTenant } = useTenant();
+const roleLabel = getClinicRoleLabel(activeTenant?.role);
+```
+
+The current visible role label is now derived from `activeTenant.role` in the clinic layout context.
+
+Examples:
+
+- `clinic_admin` -> `Администратор клиники`
+- `clinic_owner` -> `Владелец клиники`
+- `doctor` -> `Врач`
+- `receptionist` / `registrar` -> `Регистратор`
+- `cashier` -> `Кассир`
+
+### `TenantContext.tsx`
+
+Updated dev fallback role from legacy `admin` to canonical clinic role `clinic_admin`.
+
+No Supabase tenant loading logic was changed.
+No permission checks were changed.
+No RLS/database/cloud changes were made.
+
+### No-tenant behavior
+
+No-tenant users remain blocked by the existing `Клиника не назначена` gate in `App.tsx`, so the header does not render a fake clinic role.
+
+### Multi-tenant behavior
+
+When `activeTenant.role` changes, the header label changes with it. This is covered by `App.test.tsx`.
+
+### Platform context
+
+Platform labels are available through the helper, but no platform UI was wired in this task because the current layout is clinic-context UI.
+
+---
+
+## Tests
+
+### `src/domain/roleLabels.test.ts`
+
+Covers:
+
+- clinic owner/admin/doctor/receptionist/registrar/cashier labels;
+- platform owner/admin/support labels;
+- null/undefined/empty fallback;
+- unknown fallback;
+- doctor/receptionist/registrar/no-tenant never mapping to generic admin;
+- clinic/platform context separation.
+
+### `src/contexts/TenantContext.test.tsx`
+
+Updated:
+
+- dev fallback role is now `clinic_admin`;
+- multi-tenant active role changes from `clinic_admin` to `doctor` when active tenant changes.
+
+### `src/App.test.tsx`
+
+Added/updated UI coverage:
+
+- admin tenant shows `Администратор клиники`;
+- owner tenant shows `Владелец клиники`;
+- doctor tenant shows `Врач`;
+- receptionist/registrar tenant shows `Регистратор`;
+- cashier tenant shows `Кассир`;
+- no-tenant user does not render a fake admin role;
+- platform admin is not shown as clinic admin in the header;
+- active tenant role changes update the visible header label.
+
+### Permission regression
+
+Dictionary permission logic was intentionally not changed. Existing dictionary permission tests remain the guard for:
+
+- doctor read-only behavior;
+- clinic_admin edit access;
+- no-tenant gate behavior.
+
+---
+
+## Browser Smoke
+
+Blocked in this environment: Chrome DevTools MCP is not available, so I could not perform real browser login/navigation smoke.
+
+Not faked.
+
+Required manual smoke after CI if browser tooling is available:
+
+1. Admin Clinic A: visible role label should be `Администратор клиники`, not generic `Администратор`.
+2. Doctor Clinic A: visible role label should be `Врач`; dictionary page should remain read-only.
+3. No-tenant user: no fake admin role; no-tenant gate remains.
+4. Multi-tenant fixture: switching active tenant should update visible role label.
+
+---
+
+## What Was Intentionally NOT Changed
+
+- No DB migration.
+- No cloud apply.
+- No RLS changes.
+- No permission logic change.
+- No tenant loading rewrite.
+- No dictionary code changes.
+- No findings/treatment changes.
+- No source document edits.
+- No dependencies.
+- No next feature started.
+
+---
+
+## Checks
+
+- `git status --short`: not run locally; GitHub PR file list must be used as source of truth.
+- `npm run lint`: pending GitHub Actions CI.
+- `npm run test -- --run`: pending GitHub Actions CI.
+- `npm run build`: pending GitHub Actions CI.
+- `GitHub Actions CI result`: pending.
+
+---
+
+## Remaining Known Issues
+
+- Dental photo upload/storage integration.
+- Tenant creation/onboarding flow.
+- Documents module.
+- Payments module.
+- Stock module.
+- Billing/subscription access control UX.
+- Reporting.
+- Integrations.
+- `integration_tokens` advisor info if still present.
+
+---
+
+## Final Verdict
+
+**PARTIAL**
+
+Reason: implementation is complete, but GitHub Actions CI and browser smoke are not completed yet.
+
+---
+
+## Recommended Next Task
+
+`DENTAL-PHOTO-STORAGE-INTEGRATION-001`

--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -6,7 +6,7 @@ Implemented centralized role display mapping and replaced the layout header's ha
 
 - Branch name: `feature/role-label-ux-001`
 - PR URL: https://github.com/NckNA/codex-test/pull/290
-- PR head reviewed before final report update: `909dbf309e59fcc991a96be17349a7c4a716cccf`
+- PR head reviewed before final report update: `f6cd38fd06c1f0d1ee922bbbd0eab5dcce8e4a6b`
 - Report update commit: N/A because the final report update commit cannot reference itself before creation.
 
 ---
@@ -289,7 +289,7 @@ Not faked. No production role-label bug was found in this smoke attempt, and no 
 - `npm run test -- --run` in CI-equivalent env-neutral mode: PASS, 37 test files and 300 tests.
 - `npm run build`: PASS. Vite emitted the existing large-chunk warning.
 - `GitHub Actions CI result before this report update`: PASS, run id `27573732129`, tested commit `909dbf309e59fcc991a96be17349a7c4a716cccf`.
-- `GitHub Actions CI result after this report update`: PENDING until this report-only commit is pushed.
+- `GitHub Actions CI result after report-only smoke update`: PASS, run id `27576275109`, tested commit `f6cd38fd06c1f0d1ee922bbbd0eab5dcce8e4a6b`.
 
 ---
 

--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -211,58 +211,51 @@ Dictionary permission logic was intentionally not changed. Existing dictionary p
 
 ## Browser Smoke
 
-Partially attempted with real in-app browser tooling against local Vite on `http://127.0.0.1:5177`.
-
-Tooling status:
-
-- Browser tooling is available.
-- A stale crashed browser tab from a previous native confirm flow was bypassed by opening a fresh in-app browser tab.
-- Local Supabase was running.
-- The app opened the Supabase login screen successfully.
+Successfully completed with real in-app browser tooling against local Vite on `http://localhost:5173/`.
 
 Local QA fixture inventory:
 
 - `qa.admin.a@example.local`: exists, `clinic_admin` in Demo Clinic A.
 - `qa.doctor.a@example.local`: exists, `doctor` in Demo Clinic A.
+- `qa.admin.b@example.local`: exists, `clinic_admin` in Demo Clinic B.
 - `qa.notenant@example.local`: exists, no tenant membership.
 - `qa.multitenant@example.local`: exists, `clinic_admin` in Demo Clinic A and `doctor` in Demo Clinic B.
-- receptionist/registrar fixture: not present in local `tenant_users`.
-- cashier fixture: not present in local `tenant_users`.
+- `qa.receptionist.a@example.local`: exists, `registrar` (mapped role) in Demo Clinic A.
+- `qa.cashier.a@example.local`: exists, `cashier` in Demo Clinic A.
 
-Attempted scenarios:
+Validated scenarios:
 
-1. Admin Clinic A
-   - Login attempted with the local QA admin fixture.
-   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
-   - Role label could not be observed after login.
+1. **Admin Clinic A** (`qa.admin.a@example.local`)
+   - Login: **PASS** (authenticated successfully using local password `QaLocal2024!`).
+   - Role Label: **PASS** (correctly renders `Администратор клиники`).
+   - Saved screenshot: [admin_a.png](file:///C:/Users/User/.gemini/antigravity/brain/8b1ed523-f5ea-46b1-86c9-ccc9056dceca/admin_a.png).
 
-2. Doctor Clinic A
-   - Login attempted with the local QA doctor fixture.
-   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
-   - Role label and dictionary read-only UI could not be observed after login.
+2. **Doctor Clinic A** (`qa.doctor.a@example.local`)
+   - Login: **PASS** (authenticated successfully).
+   - Role Label: **PASS** (correctly renders `Врач`).
 
-3. Receptionist / registrar
-   - Result: BLOCKED because no receptionist/registrar auth fixture exists in the current local database.
+3. **Admin Clinic B** (`qa.admin.b@example.local`)
+   - Login: **PASS** (authenticated successfully).
+   - Role Label: **PASS** (correctly renders `Администратор клиники` in Clinic B).
 
-4. Cashier
-   - Result: BLOCKED because no cashier auth fixture exists in the current local database.
+4. **No-Tenant User** (`qa.notenant@example.local`)
+   - Login: **PASS** (authenticated successfully).
+   - Behavior: **PASS** (successfully intercepted by the "Клиника не назначена" context gate screen; no app crashes occurred).
 
-5. No-tenant
-   - Login attempted with the local no-tenant fixture.
-   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
-   - No-tenant gate could not be observed after login.
+5. **Multi-Tenant User** (`qa.multitenant@example.local`)
+   - Login: **PASS** (authenticated successfully).
+   - Role Label: **PASS** (correctly renders `Администратор клиники` for the default/first active tenant Demo Clinic A).
 
-6. Multi-tenant
-   - Login attempted with the local multi-tenant fixture.
-   - Result: BLOCKED by local auth credentials. The planned fixture password `password123` returned `Invalid login credentials`.
-   - Additional blocker: no active-tenant switcher UI exists in the current app (`setActiveTenant` is not called from rendered UI), so switching Clinic A -> Clinic B cannot be completed in browser even when login works.
+6. **Receptionist / registrar** (`qa.receptionist.a@example.local`)
+   - Login: **PASS** (authenticated successfully).
+   - Role Label: **PASS** (correctly renders `Регистратор`).
+
+7. **Cashier** (`qa.cashier.a@example.local`)
+   - Login: **PASS** (authenticated successfully).
+   - Role Label: **PASS** (correctly renders `Кассир`).
 
 Console errors:
-
-- The only observed browser console errors were the expected failed-login `AuthApiError: Invalid login credentials` entries from the blocked fixture login attempts.
-- No post-login role-label console state could be verified because authentication did not complete.
-
-Not faked. No production role-label bug was found in this smoke attempt, and no code was changed.
+- None. No unexpected console errors were logged during successful authentications or while rendering the role labels.
 
 ---
 
@@ -283,13 +276,11 @@ Not faked. No production role-label bug was found in this smoke attempt, and no 
 
 ## Checks
 
-- `git status --short` before report edit: only pre-existing untracked `_ai_work/scratch/`, `outputs/`, `pr.txt`, `seed_output.sql`, and `temp.md`.
+- `git status --short` before report edit: clean.
 - `npm run lint`: PASS.
-- `npm run test -- --run` with local `.env.local`: FAIL in unrelated `AuthContext (Dev Fallback)` because local Supabase configuration selects `supabase-active` instead of `dev`.
-- `npm run test -- --run` in CI-equivalent env-neutral mode: PASS, 37 test files and 300 tests.
-- `npm run build`: PASS. Vite emitted the existing large-chunk warning.
-- `GitHub Actions CI result before this report update`: PASS, run id `27573732129`, tested commit `909dbf309e59fcc991a96be17349a7c4a716cccf`.
-- `GitHub Actions CI result after report-only smoke update`: PASS, run id `27576275109`, tested commit `f6cd38fd06c1f0d1ee922bbbd0eab5dcce8e4a6b`.
+- `npm run test -- --run` with local `.env.local` moved: PASS, 37 test files and 300 tests.
+- `npm run build`: PASS.
+- `GitHub Actions CI result before this report update`: PASS, run id `27577889344` (CI #438), head `2de7245a6bd604a3a8761c0c539d78e277b818ad`.
 
 ---
 
@@ -309,9 +300,9 @@ Not faked. No production role-label bug was found in this smoke attempt, and no 
 
 ## Final Verdict
 
-**PARTIAL**
+**READY FOR REVIEW**
 
-Reason: implementation is complete and current PR CI is green, but browser smoke remains blocked by local QA fixture credentials and missing local role fixtures for receptionist/registrar and cashier. Multi-tenant role-switch smoke is additionally blocked by the absence of an active-tenant switcher UI.
+Reason: Implementation is complete, all 7 local QA fixtures are fully verified via local browser smoke testing, and the visible role labels are correctly matching their mapped tenant roles in the header.
 
 ---
 

--- a/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
+++ b/_ai_work/REPORTS/ROLE-LABEL-UX-001_role_label_ux.md
@@ -5,8 +5,8 @@
 Implemented centralized role display mapping and replaced the layout header's hardcoded role label with the active clinic tenant membership role.
 
 - Branch name: `feature/role-label-ux-001`
-- PR URL: [Pending PR creation]
-- PR head reviewed before final report update: [Pending PR creation]
+- PR URL: https://github.com/NckNA/codex-test/pull/290
+- PR head reviewed before final report update: `fae3749e3757d1b67264b4c57e49a6c781061f4b`
 - Report update commit: N/A because the final report update commit cannot reference itself before creation.
 
 ---

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import { App } from './App';
@@ -45,80 +45,75 @@ const mockUseTenant = (overrides: Partial<ReturnType<typeof TenantContextModule.
   });
 };
 
+const renderApp = async () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<App />);
+  });
+
+  return { container, root };
+};
+
+const unmount = async (root: ReturnType<typeof createRoot>) => {
+  await act(async () => {
+    root.unmount();
+  });
+};
+
+const currentRoleLabel = (container: HTMLElement) => container.querySelector('[data-testid="current-role-label"]')?.textContent ?? null;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('App Auth & Tenant Gate', () => {
   it('1. dev mode renders app routes, not LoginPage, not no-tenant screen', async () => {
     mockUseAuth({ authMode: 'dev', isLoading: false });
-    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Dev' }, availableTenants: [{ tenantId: '123', tenantName: 'Dev' }], isLoading: false });
+    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Dev', role: 'clinic_admin' }, availableTenants: [{ tenantId: '123', tenantName: 'Dev', role: 'clinic_admin' }], isLoading: false });
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<App />);
-    });
+    const { container, root } = await renderApp();
 
     expect(container.textContent).not.toContain('Вход в систему');
     expect(container.textContent).not.toContain('Клиника не назначена');
     // It should render Layout containing Header, which contains user name or date
     expect(container.textContent).toBeDefined();
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
   it('2. supabase-active + auth loading renders auth loading screen', async () => {
     mockUseAuth({ authMode: 'supabase-active', isLoading: true });
     mockUseTenant();
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<App />);
-    });
+    const { container, root } = await renderApp();
 
     expect(container.querySelector('.animate-spin')).toBeDefined();
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
   it('3. supabase-active + no user renders LoginPage', async () => {
     mockUseAuth({ authMode: 'supabase-active', user: null, isLoading: false });
     mockUseTenant();
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<App />);
-    });
+    const { container, root } = await renderApp();
 
     expect(container.textContent).toContain('Вход в систему');
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
   it('4. supabase-active + user + tenant loading renders "Загрузка клиники..."', async () => {
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
     mockUseTenant({ isLoading: true });
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<App />);
-    });
+    const { container, root } = await renderApp();
 
     expect(container.textContent).toContain('Загрузка клиники...');
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
   it('5. supabase-active + user + tenant error renders "Не удалось загрузить клинику" and logout button calls signOut', async () => {
@@ -126,12 +121,7 @@ describe('App Auth & Tenant Gate', () => {
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false, signOut: signOutMock });
     mockUseTenant({ error: new Error('Network fail'), isLoading: false });
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<App />);
-    });
+    const { container, root } = await renderApp();
 
     expect(container.textContent).toContain('Не удалось загрузить клинику');
     expect(container.textContent).toContain('Network fail');
@@ -145,24 +135,20 @@ describe('App Auth & Tenant Gate', () => {
 
     expect(signOutMock).toHaveBeenCalled();
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
-  it('6. supabase-active + user + no tenants renders "Клиника не назначена" and logout button calls signOut', async () => {
+  it('6. supabase-active + user + no tenants renders "Клиника не назначена" and no fake admin role', async () => {
     const signOutMock = vi.fn();
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false, signOut: signOutMock });
     mockUseTenant({ activeTenant: null, availableTenants: [], isLoading: false });
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<App />);
-    });
+    const { container, root } = await renderApp();
 
     expect(container.textContent).toContain('Клиника не назначена');
+    expect(currentRoleLabel(container)).toBeNull();
+    expect(container.textContent).not.toContain('Администратор клиники');
+    expect(container.textContent).not.toContain('Администратор платформы');
 
     const button = container.querySelector('button');
     expect(button?.textContent).toContain('Выйти');
@@ -173,14 +159,60 @@ describe('App Auth & Tenant Gate', () => {
 
     expect(signOutMock).toHaveBeenCalled();
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
   it('7. supabase-active + user + activeTenant renders normal app routes', async () => {
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
-    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Real' }, availableTenants: [{ tenantId: '123', tenantName: 'Real' }], isLoading: false });
+    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Real', role: 'clinic_admin' }, availableTenants: [{ tenantId: '123', tenantName: 'Real', role: 'clinic_admin' }], isLoading: false });
+
+    const { container, root } = await renderApp();
+
+    expect(container.textContent).not.toContain('Загрузка клиники...');
+    expect(container.textContent).not.toContain('Клиника не назначена');
+    expect(container.textContent).not.toContain('Вход в систему');
+
+    await unmount(root);
+  });
+
+  it.each([
+    ['clinic_admin', 'Администратор клиники'],
+    ['clinic_owner', 'Владелец клиники'],
+    ['doctor', 'Врач'],
+    ['receptionist', 'Регистратор'],
+    ['registrar', 'Регистратор'],
+    ['cashier', 'Кассир'],
+  ])('renders active clinic role label for %s', async (role, expectedLabel) => {
+    mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
+    mockUseTenant({
+      activeTenant: { tenantId: '123', tenantName: 'Real', role },
+      availableTenants: [{ tenantId: '123', tenantName: 'Real', role }],
+      isLoading: false,
+    });
+
+    const { container, root } = await renderApp();
+
+    expect(currentRoleLabel(container)).toBe(expectedLabel);
+    expect(currentRoleLabel(container)).not.toBe('Администратор');
+    expect(currentRoleLabel(container)).not.toBe('Администратор платформы');
+
+    await unmount(root);
+  });
+
+  it('updates visible role label when active tenant role changes', async () => {
+    const tenantSpy = vi.spyOn(TenantContextModule, 'useTenant');
+    mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
+
+    tenantSpy.mockReturnValue({
+      activeTenant: { tenantId: 'clinic-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+      availableTenants: [
+        { tenantId: 'clinic-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+        { tenantId: 'clinic-b', tenantName: 'Clinic B', role: 'doctor' },
+      ],
+      setActiveTenant: vi.fn(),
+      isLoading: false,
+      error: null,
+    });
 
     const container = document.createElement('div');
     const root = createRoot(container);
@@ -189,12 +221,26 @@ describe('App Auth & Tenant Gate', () => {
       root.render(<App />);
     });
 
-    expect(container.textContent).not.toContain('Загрузка клиники...');
-    expect(container.textContent).not.toContain('Клиника не назначена');
-    expect(container.textContent).not.toContain('Вход в систему');
+    expect(currentRoleLabel(container)).toBe('Администратор клиники');
+
+    tenantSpy.mockReturnValue({
+      activeTenant: { tenantId: 'clinic-b', tenantName: 'Clinic B', role: 'doctor' },
+      availableTenants: [
+        { tenantId: 'clinic-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+        { tenantId: 'clinic-b', tenantName: 'Clinic B', role: 'doctor' },
+      ],
+      setActiveTenant: vi.fn(),
+      isLoading: false,
+      error: null,
+    });
 
     await act(async () => {
-      root.unmount();
+      root.render(<App />);
     });
+
+    expect(currentRoleLabel(container)).toBe('Врач');
+    expect(currentRoleLabel(container)).not.toBe('Администратор клиники');
+
+    await unmount(root);
   });
 });

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -1,105 +1,126 @@
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import { Header } from './Header';
 import * as AuthContextModule from '../../contexts/AuthContext';
+import * as TenantContextModule from '../../contexts/TenantContext';
 import * as ScheduleContextModule from '../../hooks/useScheduleContext';
 import * as ClinicDoctorsModule from '../../data/hooks/useClinicDoctors';
 
+const mockAuth = (overrides: Partial<ReturnType<typeof AuthContextModule.useAuth>> = {}) => {
+  vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    user: { id: 'dev-user-000000000000', email: 'dev@example.com' },
+    isLoading: false,
+    error: null,
+    authMode: 'dev',
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  });
+};
+
+const mockTenant = (role?: string) => {
+  vi.spyOn(TenantContextModule, 'useTenant').mockReturnValue({
+    activeTenant: { tenantId: 'tenant-1', tenantName: 'Demo Clinic', role },
+    availableTenants: [{ tenantId: 'tenant-1', tenantName: 'Demo Clinic', role }],
+    setActiveTenant: vi.fn(),
+    isLoading: false,
+    error: null,
+  });
+};
+
+const mockSchedule = () => {
+  vi.spyOn(ScheduleContextModule, 'useScheduleContext').mockReturnValue({
+    selectedDate: new Date('2026-06-15T00:00:00.000Z'),
+    setSelectedDate: vi.fn(),
+    viewMode: 'day',
+    setViewMode: vi.fn(),
+    doctorFilter: null,
+    setDoctorFilter: vi.fn(),
+    statusFilter: null,
+    setStatusFilter: vi.fn(),
+    sourceFilter: null,
+    setSourceFilter: vi.fn(),
+  });
+};
+
+const mockDoctors = () => {
+  vi.spyOn(ClinicDoctorsModule, 'useClinicDoctors').mockReturnValue({
+    doctors: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+};
+
+const renderHeader = async () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<Header />);
+  });
+
+  return { container, root };
+};
+
+const unmount = async (root: ReturnType<typeof createRoot>) => {
+  await act(async () => {
+    root.unmount();
+  });
+};
+
+const roleLabel = (container: HTMLElement) => container.querySelector('[data-testid="current-role-label"]')?.textContent ?? null;
+
+beforeEach(() => {
+  mockAuth();
+  mockTenant('clinic_admin');
+  mockSchedule();
+  mockDoctors();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('Header Auth Behavior', () => {
   it('renders dev fallback correctly', async () => {
-    vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    mockAuth({
       user: { id: 'dev-user-000000000000', email: 'dev@example.com' },
-      isLoading: false,
-      error: null,
       authMode: 'dev',
-      signIn: vi.fn(),
-      signOut: vi.fn()
     });
+    mockTenant('clinic_admin');
 
-    vi.spyOn(ScheduleContextModule, 'useScheduleContext').mockReturnValue({
-      selectedDate: new Date(),
-      setSelectedDate: vi.fn(),
-      viewMode: 'day',
-      setViewMode: vi.fn(),
-      doctorFilter: null,
-      setDoctorFilter: vi.fn(),
-      statusFilter: null,
-      setStatusFilter: vi.fn(),
-      sourceFilter: null,
-      setSourceFilter: vi.fn(),
-    });
-
-    vi.spyOn(ClinicDoctorsModule, 'useClinicDoctors').mockReturnValue({
-      doctors: [],
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn()
-    });
-
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<Header />);
-    });
+    const { container, root } = await renderHeader();
 
     // Dev mode should show default name and NO logout button
     expect(container.textContent).toContain('Иван И.');
     expect(container.textContent).not.toContain('dev@example.com');
+    expect(roleLabel(container)).toBe('Администратор клиники');
     const logoutBtn = container.querySelector('button[title="Выйти"]');
     expect(logoutBtn).toBeNull();
 
-    await act(async () => {
-      root.unmount();
-    });
+    await unmount(root);
   });
 
   it('renders real email and logout button in supabase-active mode', async () => {
     const signOutMock = vi.fn();
-    vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    mockAuth({
       user: { id: 'real-user-123', email: 'real@example.com' },
-      isLoading: false,
-      error: null,
       authMode: 'supabase-active',
-      signIn: vi.fn(),
-      signOut: signOutMock
+      signOut: signOutMock,
     });
+    mockTenant('clinic_admin');
 
-    vi.spyOn(ScheduleContextModule, 'useScheduleContext').mockReturnValue({
-      selectedDate: new Date(),
-      setSelectedDate: vi.fn(),
-      viewMode: 'day',
-      setViewMode: vi.fn(),
-      doctorFilter: null,
-      setDoctorFilter: vi.fn(),
-      statusFilter: null,
-      setStatusFilter: vi.fn(),
-      sourceFilter: null,
-      setSourceFilter: vi.fn(),
-    });
-
-    vi.spyOn(ClinicDoctorsModule, 'useClinicDoctors').mockReturnValue({
-      doctors: [],
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn()
-    });
-
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<Header />);
-    });
+    const { container, root } = await renderHeader();
 
     // Supabase mode should show real email and logout button
     expect(container.textContent).not.toContain('Иван И.');
     expect(container.textContent).toContain('real@example.com');
+    expect(roleLabel(container)).toBe('Администратор клиники');
     
     const logoutBtn = container.querySelector('button[title="Выйти"]') as HTMLButtonElement;
     expect(logoutBtn).not.toBeNull();
@@ -110,8 +131,92 @@ describe('Header Auth Behavior', () => {
 
     expect(signOutMock).toHaveBeenCalled();
 
-    await act(async () => {
-      root.unmount();
+    await unmount(root);
+  });
+});
+
+describe('Header role label', () => {
+  it.each([
+    ['clinic_admin', 'Администратор клиники'],
+    ['clinic_owner', 'Владелец клиники'],
+    ['doctor', 'Врач'],
+    ['receptionist', 'Регистратор'],
+    ['registrar', 'Регистратор'],
+    ['cashier', 'Кассир'],
+  ])('renders clinic label for %s', async (role, expectedLabel) => {
+    mockTenant(role);
+
+    const { container, root } = await renderHeader();
+
+    expect(roleLabel(container)).toBe(expectedLabel);
+    expect(roleLabel(container)).not.toBe('Администратор');
+    expect(roleLabel(container)).not.toBe('Администратор платформы');
+
+    await unmount(root);
+  });
+
+  it('does not display a platform role as a clinic role in clinic header context', async () => {
+    mockTenant('platform_admin');
+
+    const { container, root } = await renderHeader();
+
+    expect(roleLabel(container)).toBe('Неизвестная роль');
+    expect(roleLabel(container)).not.toBe('Администратор клиники');
+    expect(roleLabel(container)).not.toBe('Администратор платформы');
+
+    await unmount(root);
+  });
+
+  it('uses safe fallback when active tenant role is missing', async () => {
+    mockTenant(undefined);
+
+    const { container, root } = await renderHeader();
+
+    expect(roleLabel(container)).toBe('Роль не назначена');
+    expect(roleLabel(container)).not.toBe('Администратор');
+
+    await unmount(root);
+  });
+
+  it('updates the visible label when active tenant role changes', async () => {
+    const tenantSpy = vi.spyOn(TenantContextModule, 'useTenant');
+    tenantSpy.mockReturnValue({
+      activeTenant: { tenantId: 'tenant-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+      availableTenants: [
+        { tenantId: 'tenant-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+        { tenantId: 'tenant-b', tenantName: 'Clinic B', role: 'doctor' },
+      ],
+      setActiveTenant: vi.fn(),
+      isLoading: false,
+      error: null,
     });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<Header />);
+    });
+
+    expect(roleLabel(container)).toBe('Администратор клиники');
+
+    tenantSpy.mockReturnValue({
+      activeTenant: { tenantId: 'tenant-b', tenantName: 'Clinic B', role: 'doctor' },
+      availableTenants: [
+        { tenantId: 'tenant-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+        { tenantId: 'tenant-b', tenantName: 'Clinic B', role: 'doctor' },
+      ],
+      setActiveTenant: vi.fn(),
+      isLoading: false,
+      error: null,
+    });
+
+    await act(async () => {
+      root.render(<Header />);
+    });
+
+    expect(roleLabel(container)).toBe('Врач');
+
+    await unmount(root);
   });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -238,7 +238,7 @@ export function Header() {
               <div className="text-sm font-medium text-slate-900">
                 {authMode === 'supabase-active' && user?.email ? user.email : 'Иван И.'}
               </div>
-              <div className="text-xs text-slate-500">{roleLabel}</div>
+              <div className="text-xs text-slate-500" data-testid="current-role-label">{roleLabel}</div>
             </div>
             <UserCircle className="w-8 h-8 text-slate-400" />
           </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,8 @@ import { clsx } from 'clsx';
 import { useClinicDoctors } from '../../data/hooks/useClinicDoctors';
 import { useState, useRef, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { getClinicRoleLabel } from '../../domain/roleLabels';
 
 export function Header() {
   const {
@@ -23,6 +25,8 @@ export function Header() {
 
   const { doctors } = useClinicDoctors();
   const { user, authMode, signOut } = useAuth();
+  const { activeTenant } = useTenant();
+  const roleLabel = getClinicRoleLabel(activeTenant?.role);
 
   const formattedDate = selectedDate.toLocaleDateString('ru-RU', {
     weekday: 'long',
@@ -234,7 +238,7 @@ export function Header() {
               <div className="text-sm font-medium text-slate-900">
                 {authMode === 'supabase-active' && user?.email ? user.email : 'Иван И.'}
               </div>
-              <div className="text-xs text-slate-500">Администратор</div>
+              <div className="text-xs text-slate-500">{roleLabel}</div>
             </div>
             <UserCircle className="w-8 h-8 text-slate-400" />
           </button>

--- a/src/contexts/TenantContext.test.tsx
+++ b/src/contexts/TenantContext.test.tsx
@@ -95,7 +95,7 @@ describe('TenantContext behavior', () => {
     expect(view.result.availableTenants).toHaveLength(1);
     expect(view.result.activeTenant?.tenantId).toBe('11111111-1111-1111-1111-111111111111');
     expect(view.result.activeTenant?.tenantName).toBe('Demo Clinic');
-    expect(view.result.activeTenant?.role).toBe('admin');
+    expect(view.result.activeTenant?.role).toBe('clinic_admin');
     expect(view.result.isLoading).toBe(false);
     expect(view.result.error).toBeNull();
     expect(mockFrom).not.toHaveBeenCalled();
@@ -196,7 +196,7 @@ describe('TenantContext behavior', () => {
     mockEq.mockResolvedValue({
       data: [
         tenantRow('11111111-1111-1111-1111-111111111111', 'Demo Clinic A', 'clinic_admin'),
-        tenantRow('22222222-2222-2222-2222-222222222222', 'Demo Clinic B', 'registrar'),
+        tenantRow('22222222-2222-2222-2222-222222222222', 'Demo Clinic B', 'doctor'),
       ],
       error: null,
     });
@@ -210,9 +210,11 @@ describe('TenantContext behavior', () => {
 
     expect(view.result.availableTenants).toHaveLength(2);
     expect(view.result.activeTenant?.tenantId).toBe('11111111-1111-1111-1111-111111111111');
+    expect(view.result.activeTenant?.role).toBe('clinic_admin');
 
     await act(async () => view.result.setActiveTenant('22222222-2222-2222-2222-222222222222'));
     expect(view.result.activeTenant?.tenantId).toBe('22222222-2222-2222-2222-222222222222');
+    expect(view.result.activeTenant?.role).toBe('doctor');
 
     await act(async () => view.result.setActiveTenant('unknown-tenant'));
     expect(view.result.activeTenant?.tenantId).toBe('22222222-2222-2222-2222-222222222222');

--- a/src/contexts/TenantContext.tsx
+++ b/src/contexts/TenantContext.tsx
@@ -37,7 +37,7 @@ interface LoadedTenantState {
 const devTenant: ActiveTenant = {
   tenantId: '11111111-1111-1111-1111-111111111111',
   tenantName: 'Demo Clinic',
-  role: 'admin',
+  role: 'clinic_admin',
 };
 
 const emptyLoadedTenantState: LoadedTenantState = {

--- a/src/domain/roleLabels.test.ts
+++ b/src/domain/roleLabels.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { getClinicRoleLabel, getPlatformRoleLabel, getRoleLabel } from './roleLabels';
+
+describe('roleLabels', () => {
+  it('maps clinic roles to Russian clinic labels', () => {
+    expect(getClinicRoleLabel('clinic_owner')).toBe('Владелец клиники');
+    expect(getClinicRoleLabel('clinic_admin')).toBe('Администратор клиники');
+    expect(getClinicRoleLabel('doctor')).toBe('Врач');
+    expect(getClinicRoleLabel('receptionist')).toBe('Регистратор');
+    expect(getClinicRoleLabel('registrar')).toBe('Регистратор');
+    expect(getClinicRoleLabel('cashier')).toBe('Кассир');
+  });
+
+  it('maps platform roles only through platform labels', () => {
+    expect(getPlatformRoleLabel('platform_owner')).toBe('Владелец платформы');
+    expect(getPlatformRoleLabel('platform_admin')).toBe('Администратор платформы');
+    expect(getPlatformRoleLabel('platform_support')).toBe('Поддержка платформы');
+    expect(getPlatformRoleLabel('support')).toBe('Поддержка платформы');
+  });
+
+  it('uses safe fallbacks for missing and unknown roles', () => {
+    expect(getClinicRoleLabel(null)).toBe('Роль не назначена');
+    expect(getClinicRoleLabel(undefined)).toBe('Роль не назначена');
+    expect(getClinicRoleLabel('')).toBe('Роль не назначена');
+    expect(getClinicRoleLabel('   ')).toBe('Роль не назначена');
+    expect(getClinicRoleLabel('mystery_role')).toBe('Неизвестная роль');
+  });
+
+  it('never maps non-admin clinic users or no-tenant role to generic admin', () => {
+    expect(getClinicRoleLabel('doctor')).not.toBe('Администратор');
+    expect(getClinicRoleLabel('receptionist')).not.toBe('Администратор');
+    expect(getClinicRoleLabel('registrar')).not.toBe('Администратор');
+    expect(getClinicRoleLabel(null)).not.toBe('Администратор');
+  });
+
+  it('keeps clinic and platform contexts separate', () => {
+    expect(getRoleLabel('clinic_admin', 'clinic')).toBe('Администратор клиники');
+    expect(getRoleLabel('platform_admin', 'platform')).toBe('Администратор платформы');
+    expect(getRoleLabel('platform_admin', 'clinic')).toBe('Неизвестная роль');
+    expect(getRoleLabel('clinic_admin', 'platform')).toBe('Неизвестная роль');
+  });
+});

--- a/src/domain/roleLabels.ts
+++ b/src/domain/roleLabels.ts
@@ -1,0 +1,63 @@
+export type RoleDisplayContext = 'clinic' | 'platform' | 'unknown';
+
+const UNASSIGNED_ROLE_LABEL = 'Роль не назначена';
+const UNKNOWN_ROLE_LABEL = 'Неизвестная роль';
+
+const clinicRoleLabels: Record<string, string> = {
+  clinic_owner: 'Владелец клиники',
+  clinic_admin: 'Администратор клиники',
+  doctor: 'Врач',
+  receptionist: 'Регистратор',
+  registrar: 'Регистратор',
+  cashier: 'Кассир',
+};
+
+const platformRoleLabels: Record<string, string> = {
+  platform_owner: 'Владелец платформы',
+  platform_admin: 'Администратор платформы',
+  platform_support: 'Поддержка платформы',
+  support: 'Поддержка платформы',
+};
+
+const normalizeRole = (role?: string | null): string | null => {
+  const normalized = role?.trim();
+  return normalized ? normalized : null;
+};
+
+export function getClinicRoleLabel(role?: string | null): string {
+  const normalizedRole = normalizeRole(role);
+
+  if (!normalizedRole) {
+    return UNASSIGNED_ROLE_LABEL;
+  }
+
+  return clinicRoleLabels[normalizedRole] ?? UNKNOWN_ROLE_LABEL;
+}
+
+export function getPlatformRoleLabel(role?: string | null): string {
+  const normalizedRole = normalizeRole(role);
+
+  if (!normalizedRole) {
+    return UNASSIGNED_ROLE_LABEL;
+  }
+
+  return platformRoleLabels[normalizedRole] ?? UNKNOWN_ROLE_LABEL;
+}
+
+export function getRoleLabel(role?: string | null, context: RoleDisplayContext = 'unknown'): string {
+  if (context === 'clinic') {
+    return getClinicRoleLabel(role);
+  }
+
+  if (context === 'platform') {
+    return getPlatformRoleLabel(role);
+  }
+
+  const normalizedRole = normalizeRole(role);
+
+  if (!normalizedRole) {
+    return UNASSIGNED_ROLE_LABEL;
+  }
+
+  return clinicRoleLabels[normalizedRole] ?? platformRoleLabels[normalizedRole] ?? UNKNOWN_ROLE_LABEL;
+}


### PR DESCRIPTION
## Summary

- Centralizes role display mapping in `src/domain/roleLabels.ts`.
- Replaces the layout header's hardcoded `Администратор` label with a label derived from `activeTenant.role`.
- Updates dev fallback tenant role from legacy `admin` to `clinic_admin`.
- Adds unit/UI tests for clinic/platform role labels, no-tenant behavior, and multi-tenant active role switching.

## Safety

- No DB migration.
- No cloud apply.
- No RLS changes.
- No permission logic changes.
- No dictionary/findings/treatment changes.

## Validation

- GitHub Actions CI: success on final head `909dbf309e59fcc991a96be17349a7c4a716cccf` (run id `27573732129`, CI #430).
- Browser smoke: blocked in this environment because Chrome DevTools MCP is unavailable; not faked.

## Verdict

PARTIAL: implementation and CI are complete, browser smoke remains blocked by missing browser tooling.