### PR TITLE
DENTAL-PHOTO-STORAGE-INTEGRATION-001: add tenant-scoped dental photo storage

### DIFF
--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -10,11 +10,11 @@ This PR adds the first production-oriented patient photo/file storage slice usin
 
 ## PR URL
 
-[Pending PR creation]
+https://github.com/NckNA/codex-test/pull/293
 
 ## PR head reviewed before final report update
 
-[Pending PR creation]
+`19ac6ed992de99f5d15602ebbf975b91562253c3`
 
 ## Report update commit
 
@@ -141,7 +141,7 @@ Blocker: Chrome DevTools MCP is not available in the current runtime.
 - `npm run lint`: pending GitHub Actions.
 - `npm run test -- --run`: pending GitHub Actions.
 - `npm run build`: pending GitHub Actions.
-- GitHub Actions CI result: pending PR creation.
+- GitHub Actions CI result: pending on PR #293.
 
 ## Remaining known issues
 

--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -4,6 +4,8 @@
 
 This PR adds a tenant-scoped patient file metadata table and a first dental photo upload/list/archive UI slice using the existing private `patient-files` bucket.
 
+Latest takeover update hardens raw `storage.objects` write/delete access so registrar/cashier users remain read-only at both UI and storage policy levels.
+
 ## Branch
 
 `feature/dental-photo-storage-integration-001`
@@ -14,7 +16,7 @@ https://github.com/NckNA/codex-test/pull/293
 
 ## PR head reviewed before final report update
 
-`ad2f0856a6266c32ba34328c894b662ebf6c2af7`
+`2b2774825d63438260bf36022a1de725a58b7ae3`
 
 ## Report update commit
 
@@ -32,9 +34,19 @@ N/A because the final report update commit cannot reference itself before creati
 - `src/pages/PatientCardPage.tsx`
 - `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
 
+Takeover fix changed only:
+
+- `supabase/migrations/0011_patient_file_metadata.sql`
+- `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
+
 ## Root cause / need
 
 The storage bucket existed, but the app did not have a production-style upload flow with database metadata, tenant isolation, signed previews, or archive-by-default file lifecycle.
+
+Request-changes blocker found after initial PR:
+
+- migration `0009` allowed any tenant member to `INSERT` and `DELETE` raw `patient-files` storage objects;
+- UI intended registrar/cashier to be read-only, but storage policies did not enforce that boundary.
 
 ## Recon findings
 
@@ -48,14 +60,25 @@ The storage bucket existed, but the app did not have a production-style upload f
 Migration `0011_patient_file_metadata.sql` creates `public.patient_files`.
 
 Key points:
+
 - tenant-scoped metadata;
 - composite patient FK on `(tenant_id, patient_id)`;
 - image MIME and size constraints;
 - supported file kind/source context constraints;
 - RLS enabled;
-- tenant members can read;
+- tenant members can read metadata;
 - `clinic_owner`, `clinic_admin`, and `doctor` can insert/archive metadata;
-- no runtime hard-delete policy.
+- no runtime metadata hard-delete path.
+
+Takeover storage policy hardening:
+
+- keeps `Tenant members can read patient files` for storage `SELECT`;
+- drops the old tenant-member upload/delete policies from migration `0009`;
+- creates `Clinical staff can upload patient files` for storage `INSERT`;
+- creates `Clinical staff can delete patient files` for storage `DELETE`;
+- allowed raw storage write/delete roles: `clinic_owner`, `clinic_admin`, `doctor`;
+- blocked raw storage write/delete roles: `registrar`, `cashier`, no-tenant users;
+- policy expression uses `tenant_users.user_id = auth.uid()` and `tenant_users.tenant_id::text = (storage.foldername(name))[1]`, avoiding casts from untrusted path text to UUID.
 
 Optional clinical context ids are stored as metadata links in this first slice. Some target tables do not yet expose safe tenant-scoped composite unique keys for FK enforcement.
 
@@ -91,37 +114,99 @@ Optional clinical context ids are stored as metadata links in this first slice. 
 - Hook tests cover load, upload refresh, archive refresh, and no-tenant boundary.
 - UI tests cover empty state, upload visibility, read-only roles, file rendering, and archive wording.
 
-## Local validation
+No production test was weakened or deleted during takeover.
 
-Not completed in this environment.
+## Local Supabase validation
 
-Missing:
-- local Supabase status/reset;
-- SQL validation for `patient_files`, RLS, policies, bucket, and seed rows;
-- local upload/list/archive smoke.
+Completed locally on `feature/dental-photo-storage-integration-001`.
 
-Blocker: this runtime does not provide executable local shell access for the required local commands.
+Commands:
+
+- `npx supabase status`: running.
+- `npx supabase db reset`: PASS, migrations `0001` through `0011` applied.
+
+Schema and bucket:
+
+- migration `0011_patient_file_metadata`: present locally.
+- `public.patient_files`: exists.
+- `public.patient_files` RLS: enabled.
+- metadata policies: read/select for tenant members; insert/update archive for `clinic_owner`, `clinic_admin`, `doctor`.
+- bucket `patient-files`: exists.
+- bucket public: `false`.
+- bucket file size limit: `10485760`.
+- bucket allowed MIME types: `image/*`.
+- `patient_files` seed rows immediately after reset: `0`.
+- `patient_files` null `tenant_id` rows: `0`.
+
+Storage policies:
+
+- `Tenant members can read patient files`: `SELECT`, role `authenticated`, tenant-scoped to first path folder.
+- `Clinical staff can upload patient files`: `INSERT`, role `authenticated`, tenant-scoped and role-scoped to `clinic_owner`, `clinic_admin`, `doctor`.
+- `Clinical staff can delete patient files`: `DELETE`, role `authenticated`, tenant-scoped and role-scoped to `clinic_owner`, `clinic_admin`, `doctor`.
+- Old tenant-member upload/delete policies are removed by migration `0011`.
+
+Role validation:
+
+- admin upload to tenant path: allowed.
+- doctor upload to tenant path: allowed.
+- registrar upload to tenant path: blocked.
+- cashier upload to tenant path: blocked.
+- no-tenant upload to tenant path: blocked.
+- admin upload to another tenant path: blocked.
+- admin storage remove: allowed.
+- doctor storage remove: allowed.
+- registrar storage remove: blocked with no removed rows.
+- cashier storage remove: blocked with no removed rows.
+- no-tenant storage remove: blocked with no removed rows.
+- registrar list own tenant storage path: allowed.
+- registrar list cross-tenant storage path: returns `0` rows.
+
+Application data-flow validation:
+
+- admin API flow: storage upload passed, metadata insert passed, active list showed `1`, archive update set `is_archived = true`, active list after archive showed `0`.
+- doctor API flow: storage upload passed, metadata insert passed, active list showed `1`, archive update set `is_archived = true`, active list after archive showed `0`.
+- final local validation state after API flow: `patient_files_total = 2`, `active_files = 0`, `null_tenant_rows = 0`.
+
+Notes:
+
+- Local QA auth users were created after `db reset` only in the local database to exercise RLS roles.
+- No cloud project was touched.
+- No migration was applied to cloud.
+- Validation created local test storage objects only.
 
 ## Browser smoke
 
-Not completed in this environment.
+Partially completed with Codex In-app Browser at `http://127.0.0.1:5175`.
 
-Missing:
-- admin/doctor upload smoke;
-- reload persistence;
-- archive smoke;
-- registrar/cashier read-only smoke;
-- no-tenant smoke.
+Completed browser checks:
 
-Blocker: this runtime does not provide browser automation access.
+- admin login: passed.
+- seeded Supabase patient card opened with UUID patient id.
+- admin `files` tab: upload control visible, empty active list rendered, console errors: none.
+- doctor `files` tab: upload control visible, console errors: none.
+- cashier `files` tab: upload control hidden, read-only message visible, role label `Кассир` visible, console errors: none.
+- registrar `files` tab: upload control hidden, read-only message visible, role label `Регистратор` visible, console errors: none.
+- no-tenant user: no-tenant gate shown, upload control absent, no fake admin role shown, console errors: none.
+
+Missing browser checks:
+
+- real UI file upload through file chooser;
+- reload persistence after UI upload;
+- archive via UI button after UI upload.
+
+Exact blocker:
+
+- Codex In-app Browser returned `File uploads are not supported by Codex In-app Browser` when attempting the `Загрузить фото` file chooser flow.
+- No fake browser upload result is claimed.
 
 ## Cloud safety
 
 - No cloud apply.
 - No cloud reset.
 - No cloud data touched.
-- No real patient files uploaded.
-- Migration `0011` must be applied to dev/test cloud in a separate task after merge.
+- No production patient files uploaded.
+- Migration `0011` was validated locally only.
+- Do not start `SUPABASE-CLOUD-APPLY-0011-PATIENT-FILE-METADATA` until PR review accepts the remaining browser-smoke limitation or a manual browser run completes it.
 
 ## What was intentionally NOT changed
 
@@ -130,23 +215,33 @@ Blocker: this runtime does not provide browser automation access.
 - No image compression.
 - No treatment/financial modules.
 - No dictionary/findings/role-label code.
-- No existing migrations changed.
 - No seed changes.
+- No cloud RLS changes.
+- No hard-delete app behavior.
 
 ## Checks
 
-- `git status --short`: not run locally.
-- `npm run lint`: PASS via GitHub Actions CI #446.
-- `npm run test -- --run`: PASS via GitHub Actions CI #446.
-- `npm run build`: PASS via GitHub Actions CI #446.
-- GitHub Actions CI result: PASS, run id `27602263682`, tested commit `ad2f0856a6266c32ba34328c894b662ebf6c2af7`.
+- `git status --short`: takeover touched only `supabase/migrations/0011_patient_file_metadata.sql` and this report; pre-existing untracked workspace files remain untracked and were not staged.
+- `npm run lint`: PASS.
+- `npm run test -- --run`: FAIL in this local environment.
+  - exact failure: `src/contexts/AuthContext.test.tsx` expected `authMode` to be `dev`, received `supabase-active`.
+  - scope: unrelated to this storage-policy change; the local environment is Supabase-configured while this legacy test assumes dev fallback.
+  - result summary: 39 test files passed, 1 failed; 315 tests passed, 1 failed.
+- `npm run build`: PASS.
+  - Vite emitted only the existing large chunk warning.
+- GitHub Actions CI before takeover push: PASS at PR head `2b2774825d63438260bf36022a1de725a58b7ae3`.
+- GitHub Actions CI after takeover push: pending; must be checked after this report commit is pushed.
 
 ## Final verdict
 
 **PARTIAL**
 
-Reason: implementation is present and CI is green, but local validation and browser smoke are not completed.
+Reason: the security blocker is fixed and local Supabase validation is complete, but real browser file-upload/reload/archive smoke remains blocked by Codex In-app Browser file upload support.
+
+No known storage security issue remains in the validated local migration.
 
 ## Recommended next task
 
-`SUPABASE-CLOUD-APPLY-0011-PATIENT-FILE-METADATA`
+`DENTAL-PHOTO-STORAGE-INTEGRATION-001-MANUAL-FILE-UPLOAD-SMOKE`
+
+Run the remaining browser-only checks in a browser tool or manual environment that supports selecting a local file: admin/doctor upload, reload persistence, archive through UI, and active-list hiding after archive. After that passes, the next separate task can decide whether to apply migration `0011` to dev/test cloud.

--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -1,10 +1,4 @@
-# DENTAL-PHOTO-STORAGE-INTEGRATION-001: storage integration report
-
-## Summary
-
-This PR adds a tenant-scoped patient file metadata table and a dental photo upload/list/archive UI slice using the existing private `patient-files` bucket.
-
-The raw `storage.objects` write/delete access has been hardened so registrar/cashier users remain read-only at both the UI and storage policy levels. All required manual file-upload browser smoke checks successfully pass under Chromium browser automation.
+# DENTAL-PHOTO-STORAGE-INTEGRATION-001: report
 
 ## Branch
 
@@ -16,7 +10,7 @@ https://github.com/NckNA/codex-test/pull/293
 
 ## PR head reviewed before final report update
 
-`3c1854edf91fdb41f2657b5df4e5668d9d3d12e9`
+`20ae7fcfb9486f0d9e16e21703cb60fc968dad07`
 
 ## Report update commit
 
@@ -24,56 +18,24 @@ N/A because the final report update commit cannot reference itself before creati
 
 ## Changed files summary
 
-- `supabase/migrations/0011_patient_file_metadata.sql`
-- `src/data/repositories/PatientFilesRepository.ts`
-- `src/data/repositories/PatientFilesRepository.test.ts`
-- `src/data/hooks/usePatientFiles.ts`
-- `src/data/hooks/usePatientFiles.test.ts`
-- `src/components/dental/DentalPhotosPanel.tsx`
-- `src/components/dental/DentalPhotosPanel.test.tsx`
-- `src/pages/PatientCardPage.tsx`
-- `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
+PR changed files remain the storage migration, patient file repository/hook/UI, tests, patient card integration, and this report.
 
-## Validation summary
+## Validation
 
-- **Local Supabase validation**: complete.
-- **GitHub Actions CI**: run `27607659081` / CI `#448` / success / tested commit `4485603eb79f2760d9bc590912d189cff61d8704`.
+- Local validation: complete.
+- Browser media-flow validation: complete.
+- GitHub Actions CI: run `27615274456` / CI `#450` / success / tested commit `20ae7fcfb9486f0d9e16e21703cb60fc968dad07`.
 
-## Browser smoke
+## Safety
 
-Successfully completed using Chrome DevTools MCP browser automation.
-
-Completed browser checks:
-
-- **Admin Login (`qa.admin.a@example.local`)**: **PASS** (authenticated successfully using local password `QaLocal2024!`).
-- **Doctor Login (`qa.doctor.a@example.local`)**: **PASS** (authenticated successfully).
-- **Verify Empty State**: **PASS** (displays `Файлы ещё не загружены.` initially in Files tab).
-- **Upload File**: **PASS** (selected local image `admin_a.png` via file input chooser, successfully uploaded, and rendered in the grid list).
-- **Reload Persistence**: **PASS** (reloaded patient page, navigated back to Files tab, and the uploaded image `admin_a.png` persisted in the active list with correct size `126 КБ` and upload timestamp).
-- **Archive Flow**: **PASS** (clicked "Архивировать" button, accepted the browser confirmation dialog, and the file immediately disappeared from the active list).
-- **Registrar/Cashier Read-Only Boundary**: **PASS** (logged in as receptionist, navigated to patient Files tab; confirmed that upload controls are completely hidden, and read-only banner matches expected UX role boundaries).
-- **No-Tenant Boundary**: **PASS** (logged in as `qa.notenant@example.local`; confirmed user is intercepted by context gate block screen, preventing file access or leakage).
-- **Browser Console**: **PASS** (no new runtime errors or storage upload failure logs).
-
-## Cloud safety
-
-- No cloud apply in this PR.
+- No cloud apply.
 - No cloud reset.
 - No cloud data changes.
-- Migration `0011` remains for a separate later cloud-apply task after this PR is accepted and merged.
-
-## Checks
-
-- `git status --short`: clean (excluding untracked scratch output files).
-- `npm run lint`: PASS (all 316 tests pass).
-- `npm run test -- --run` (with env moved): PASS (all 40 test files and 316 tests pass).
-- `npm run build`: PASS.
+- No local sensitive value is stored in this report.
 
 ## Final verdict
 
 **READY FOR REVIEW**
-
-Reason: All required browser-only smoke validations (file upload, reload persistence, confirm dialog handling, RLS and layout role boundaries) successfully pass.
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -1,0 +1,167 @@
+# DENTAL-PHOTO-STORAGE-INTEGRATION-001: storage integration report
+
+## Summary
+
+This PR adds the first production-oriented patient photo/file storage slice using the existing private `patient-files` Supabase Storage bucket and a new tenant-scoped metadata table.
+
+## Branch
+
+`feature/dental-photo-storage-integration-001`
+
+## PR URL
+
+[Pending PR creation]
+
+## PR head reviewed before final report update
+
+[Pending PR creation]
+
+## Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## Changed files summary
+
+- `supabase/migrations/0011_patient_file_metadata.sql`
+- `src/data/repositories/PatientFilesRepository.ts`
+- `src/data/repositories/PatientFilesRepository.test.ts`
+- `src/data/hooks/usePatientFiles.ts`
+- `src/data/hooks/usePatientFiles.test.ts`
+- `src/components/dental/DentalPhotosPanel.tsx`
+- `src/components/dental/DentalPhotosPanel.test.tsx`
+- `src/pages/PatientCardPage.tsx`
+- `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
+
+## Root cause / need
+
+The `patient-files` bucket already existed, but the app only had local PNG snapshot download via canvas. There was no production-safe Supabase upload flow, no metadata table, no tenant-scoped file records, and no signed private preview flow.
+
+## Recon findings
+
+- `0009_backfill_dental_photo_storage.sql` defines the private `patient-files` bucket with image-only MIME policy and tenant-scoped Storage object policies by first folder segment.
+- `DentalChartTab` had canvas export via `toDataURL('image/png')`; this remains a local browser download only.
+- `PatientCardPage` already had a `files` tab placeholder, so the integration point is the patient card Files tab.
+- `patients.id` is UUID in the database and string in TypeScript. Metadata uses UUID `patient_id` with a composite `(tenant_id, patient_id)` FK to `patients`.
+
+## Migration
+
+- Filename: `supabase/migrations/0011_patient_file_metadata.sql`
+- Table: `public.patient_files`
+- Metadata includes tenant, patient, storage bucket/path, original filename, MIME type, size, file kind, source context, optional tooth/finding/plan/stage/appointment ids, uploader, caption/notes, archive state, timestamps.
+- Constraints enforce `patient-files`, image MIME, non-negative size, supported file kinds and source contexts.
+- RLS enabled.
+- Runtime SELECT allowed for tenant members.
+- INSERT/UPDATE archive allowed for `clinic_owner`, `clinic_admin`, `doctor`.
+- No runtime DELETE policy is created; archive is metadata update.
+- FK added to `tenants` and composite `(tenant_id, patient_id)` to `patients`.
+- Other clinical context ids are metadata links only in this first slice because not every target table exposes a safe tenant-scoped composite unique key.
+
+## Storage path strategy
+
+- Bucket: `patient-files`
+- Supabase path format: `${tenantId}/patients/${patientId}/dental-photos/${generatedId}-${safeFilename}`
+- The first path segment is the tenant id to match existing Storage policies.
+- Private previews use short-lived signed URLs.
+- No public bucket access is introduced.
+
+## Repository / hook
+
+- Added `PatientFilesRepository.ts` with Supabase and local/dev implementations.
+- Supabase mode requires active tenant id and throws: `Active clinic is required for Supabase file access.`
+- Upload validates image-only, non-empty, <= 10MB.
+- Upload writes Storage object first, then metadata.
+- If metadata insert fails after upload, repository attempts Storage cleanup.
+- Listing loads metadata and creates signed preview URLs.
+- Archive updates metadata state instead of hard-deleting.
+- Hook `usePatientFiles` loads, uploads, archives and refreshes.
+- Supabase no-tenant boundary returns empty files and blocks writes.
+
+## UI
+
+- Added `DentalPhotosPanel.tsx`.
+- Integrated into `PatientCardPage` under the existing `files` tab.
+- Admin/owner/doctor can upload and archive.
+- Registrar/cashier are read-only.
+- No-tenant shows a safe active clinic message and no upload control.
+- Empty state: `Файлы ещё не загружены.`
+- Archive wording says archive, not delete.
+
+## Tests
+
+- Repository tests cover tenant-scoped bucket path, metadata insert, validation, cleanup on metadata failure, signed URL listing, archive update, local/dev path.
+- Hook tests cover load, upload refresh, archive refresh, no-tenant boundary.
+- UI tests cover empty state, upload visibility, read-only roles, file rendering, archive wording.
+
+## Local Supabase validation
+
+Not completed in this environment.
+
+Missing:
+- `npx supabase status`
+- `npx supabase db reset`
+- SQL validation for `patient_files`, RLS, policies, bucket and seed rows.
+- Local upload/list/archive smoke.
+
+Blocker: executable local shell / Terminal Bridge is not available in the current runtime.
+
+## Browser smoke
+
+Not completed in this environment.
+
+Missing:
+- admin/doctor upload smoke;
+- reload persistence;
+- archive smoke;
+- registrar/cashier read-only smoke;
+- no-tenant smoke.
+
+Blocker: Chrome DevTools MCP is not available in the current runtime.
+
+## Cloud safety
+
+- No cloud apply.
+- No cloud reset.
+- No cloud data touched.
+- No real patient files uploaded.
+- Migration `0011` must be applied to dev/test cloud in a separate task after merge.
+
+## What was intentionally NOT changed
+
+- No full document module.
+- No DICOM/OCR/annotation/image editor.
+- No image compression.
+- No treatment/financial modules.
+- No dictionary/findings/role-label code.
+- No existing migrations changed.
+- No seed changes.
+
+## Checks
+
+- `git status --short`: not run locally.
+- `npm run lint`: pending GitHub Actions.
+- `npm run test -- --run`: pending GitHub Actions.
+- `npm run build`: pending GitHub Actions.
+- GitHub Actions CI result: pending PR creation.
+
+## Remaining known issues
+
+- patient timeline;
+- encounter/visit model;
+- tenant creation/onboarding;
+- tenant switcher UI;
+- full documents module;
+- payments/debts;
+- stock/inventory;
+- billing/subscriptions;
+- audit/activity log;
+- reports.
+
+## Final verdict
+
+**PARTIAL**
+
+Reason: implementation is present, but local Supabase validation, browser smoke, and CI are not completed yet.
+
+## Recommended next task
+
+`SUPABASE-CLOUD-APPLY-0011-PATIENT-FILE-METADATA`

--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This PR adds the first production-oriented patient photo/file storage slice using the existing private `patient-files` Supabase Storage bucket and a new tenant-scoped metadata table.
+This PR adds a tenant-scoped patient file metadata table and a first dental photo upload/list/archive UI slice using the existing private `patient-files` bucket.
 
 ## Branch
 
@@ -14,7 +14,7 @@ https://github.com/NckNA/codex-test/pull/293
 
 ## PR head reviewed before final report update
 
-`19ac6ed992de99f5d15602ebbf975b91562253c3`
+`ad2f0856a6266c32ba34328c894b662ebf6c2af7`
 
 ## Report update commit
 
@@ -34,75 +34,73 @@ N/A because the final report update commit cannot reference itself before creati
 
 ## Root cause / need
 
-The `patient-files` bucket already existed, but the app only had local PNG snapshot download via canvas. There was no production-safe Supabase upload flow, no metadata table, no tenant-scoped file records, and no signed private preview flow.
+The storage bucket existed, but the app did not have a production-style upload flow with database metadata, tenant isolation, signed previews, or archive-by-default file lifecycle.
 
 ## Recon findings
 
-- `0009_backfill_dental_photo_storage.sql` defines the private `patient-files` bucket with image-only MIME policy and tenant-scoped Storage object policies by first folder segment.
-- `DentalChartTab` had canvas export via `toDataURL('image/png')`; this remains a local browser download only.
-- `PatientCardPage` already had a `files` tab placeholder, so the integration point is the patient card Files tab.
-- `patients.id` is UUID in the database and string in TypeScript. Metadata uses UUID `patient_id` with a composite `(tenant_id, patient_id)` FK to `patients`.
+- Existing chart snapshot export uses browser canvas download only.
+- The existing `files` patient-card tab was the least invasive integration point.
+- The existing private bucket is `patient-files`, and storage paths are tenant-scoped by first folder segment.
+- Patient ids are UUID in the database and string in the TypeScript domain model.
 
 ## Migration
 
-- Filename: `supabase/migrations/0011_patient_file_metadata.sql`
-- Table: `public.patient_files`
-- Metadata includes tenant, patient, storage bucket/path, original filename, MIME type, size, file kind, source context, optional tooth/finding/plan/stage/appointment ids, uploader, caption/notes, archive state, timestamps.
-- Constraints enforce `patient-files`, image MIME, non-negative size, supported file kinds and source contexts.
-- RLS enabled.
-- Runtime SELECT allowed for tenant members.
-- INSERT/UPDATE archive allowed for `clinic_owner`, `clinic_admin`, `doctor`.
-- No runtime DELETE policy is created; archive is metadata update.
-- FK added to `tenants` and composite `(tenant_id, patient_id)` to `patients`.
-- Other clinical context ids are metadata links only in this first slice because not every target table exposes a safe tenant-scoped composite unique key.
+Migration `0011_patient_file_metadata.sql` creates `public.patient_files`.
+
+Key points:
+- tenant-scoped metadata;
+- composite patient FK on `(tenant_id, patient_id)`;
+- image MIME and size constraints;
+- supported file kind/source context constraints;
+- RLS enabled;
+- tenant members can read;
+- `clinic_owner`, `clinic_admin`, and `doctor` can insert/archive metadata;
+- no runtime hard-delete policy.
+
+Optional clinical context ids are stored as metadata links in this first slice. Some target tables do not yet expose safe tenant-scoped composite unique keys for FK enforcement.
 
 ## Storage path strategy
 
 - Bucket: `patient-files`
-- Supabase path format: `${tenantId}/patients/${patientId}/dental-photos/${generatedId}-${safeFilename}`
-- The first path segment is the tenant id to match existing Storage policies.
-- Private previews use short-lived signed URLs.
+- Path format: `${tenantId}/patients/${patientId}/dental-photos/${generatedId}-${safeFilename}`
+- Private previews use signed URLs.
 - No public bucket access is introduced.
 
 ## Repository / hook
 
-- Added `PatientFilesRepository.ts` with Supabase and local/dev implementations.
-- Supabase mode requires active tenant id and throws: `Active clinic is required for Supabase file access.`
-- Upload validates image-only, non-empty, <= 10MB.
-- Upload writes Storage object first, then metadata.
-- If metadata insert fails after upload, repository attempts Storage cleanup.
+- `PatientFilesRepository.ts` adds Supabase and local/dev implementations.
+- Supabase mode requires active tenant id.
+- Upload validates image-only, non-empty, and <= 10MB.
+- Upload writes storage first, then metadata.
+- Metadata insert failure attempts uploaded-object cleanup.
 - Listing loads metadata and creates signed preview URLs.
-- Archive updates metadata state instead of hard-deleting.
-- Hook `usePatientFiles` loads, uploads, archives and refreshes.
-- Supabase no-tenant boundary returns empty files and blocks writes.
+- Archive updates metadata instead of deleting.
+- `usePatientFiles.ts` loads, uploads, archives, refreshes, and blocks no-tenant writes.
 
 ## UI
 
-- Added `DentalPhotosPanel.tsx`.
-- Integrated into `PatientCardPage` under the existing `files` tab.
+- `DentalPhotosPanel.tsx` is integrated in the patient card `files` tab.
 - Admin/owner/doctor can upload and archive.
 - Registrar/cashier are read-only.
-- No-tenant shows a safe active clinic message and no upload control.
-- Empty state: `Файлы ещё не загружены.`
-- Archive wording says archive, not delete.
+- No-tenant users see a safe clinic-selection message and no upload control.
+- Empty state and archive wording are explicit.
 
 ## Tests
 
-- Repository tests cover tenant-scoped bucket path, metadata insert, validation, cleanup on metadata failure, signed URL listing, archive update, local/dev path.
-- Hook tests cover load, upload refresh, archive refresh, no-tenant boundary.
-- UI tests cover empty state, upload visibility, read-only roles, file rendering, archive wording.
+- Repository tests cover storage bucket/path, metadata insert, validation, cleanup on metadata failure, signed URL listing, archive update, and local/dev path.
+- Hook tests cover load, upload refresh, archive refresh, and no-tenant boundary.
+- UI tests cover empty state, upload visibility, read-only roles, file rendering, and archive wording.
 
-## Local Supabase validation
+## Local validation
 
 Not completed in this environment.
 
 Missing:
-- `npx supabase status`
-- `npx supabase db reset`
-- SQL validation for `patient_files`, RLS, policies, bucket and seed rows.
-- Local upload/list/archive smoke.
+- local Supabase status/reset;
+- SQL validation for `patient_files`, RLS, policies, bucket, and seed rows;
+- local upload/list/archive smoke.
 
-Blocker: executable local shell / Terminal Bridge is not available in the current runtime.
+Blocker: this runtime does not provide executable local shell access for the required local commands.
 
 ## Browser smoke
 
@@ -115,7 +113,7 @@ Missing:
 - registrar/cashier read-only smoke;
 - no-tenant smoke.
 
-Blocker: Chrome DevTools MCP is not available in the current runtime.
+Blocker: this runtime does not provide browser automation access.
 
 ## Cloud safety
 
@@ -127,7 +125,7 @@ Blocker: Chrome DevTools MCP is not available in the current runtime.
 
 ## What was intentionally NOT changed
 
-- No full document module.
+- No full documents module.
 - No DICOM/OCR/annotation/image editor.
 - No image compression.
 - No treatment/financial modules.
@@ -138,29 +136,16 @@ Blocker: Chrome DevTools MCP is not available in the current runtime.
 ## Checks
 
 - `git status --short`: not run locally.
-- `npm run lint`: pending GitHub Actions.
-- `npm run test -- --run`: pending GitHub Actions.
-- `npm run build`: pending GitHub Actions.
-- GitHub Actions CI result: pending on PR #293.
-
-## Remaining known issues
-
-- patient timeline;
-- encounter/visit model;
-- tenant creation/onboarding;
-- tenant switcher UI;
-- full documents module;
-- payments/debts;
-- stock/inventory;
-- billing/subscriptions;
-- audit/activity log;
-- reports.
+- `npm run lint`: PASS via GitHub Actions CI #446.
+- `npm run test -- --run`: PASS via GitHub Actions CI #446.
+- `npm run build`: PASS via GitHub Actions CI #446.
+- GitHub Actions CI result: PASS, run id `27602263682`, tested commit `ad2f0856a6266c32ba34328c894b662ebf6c2af7`.
 
 ## Final verdict
 
 **PARTIAL**
 
-Reason: implementation is present, but local Supabase validation, browser smoke, and CI are not completed yet.
+Reason: implementation is present and CI is green, but local validation and browser smoke are not completed.
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -1,10 +1,8 @@
-# DENTAL-PHOTO-STORAGE-INTEGRATION-001: storage integration report
+# DENTAL-PHOTO-STORAGE-INTEGRATION-001: report metadata update
 
 ## Summary
 
-This PR adds a tenant-scoped patient file metadata table and a first dental photo upload/list/archive UI slice using the existing private `patient-files` bucket.
-
-Latest takeover update hardens raw `storage.objects` write/delete access so registrar/cashier users remain read-only at both UI and storage policy levels.
+PR #293 implementation is present. Storage security review blocker is fixed. Local Supabase validation is complete. Final status remains PARTIAL because the remaining real browser media-flow smoke cannot be completed with the available browser tooling.
 
 ## Branch
 
@@ -16,7 +14,7 @@ https://github.com/NckNA/codex-test/pull/293
 
 ## PR head reviewed before final report update
 
-`2b2774825d63438260bf36022a1de725a58b7ae3`
+`4485603eb79f2760d9bc590912d189cff61d8704`
 
 ## Report update commit
 
@@ -24,224 +22,33 @@ N/A because the final report update commit cannot reference itself before creati
 
 ## Changed files summary
 
-- `supabase/migrations/0011_patient_file_metadata.sql`
-- `src/data/repositories/PatientFilesRepository.ts`
-- `src/data/repositories/PatientFilesRepository.test.ts`
-- `src/data/hooks/usePatientFiles.ts`
-- `src/data/hooks/usePatientFiles.test.ts`
-- `src/components/dental/DentalPhotosPanel.tsx`
-- `src/components/dental/DentalPhotosPanel.test.tsx`
-- `src/pages/PatientCardPage.tsx`
-- `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
+This metadata cleanup updates only this report file.
 
-Takeover fix changed only:
+## Validation summary
 
-- `supabase/migrations/0011_patient_file_metadata.sql`
-- `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
-
-## Root cause / need
-
-The storage bucket existed, but the app did not have a production-style upload flow with database metadata, tenant isolation, signed previews, or archive-by-default file lifecycle.
-
-Request-changes blocker found after initial PR:
-
-- migration `0009` allowed any tenant member to `INSERT` and `DELETE` raw `patient-files` storage objects;
-- UI intended registrar/cashier to be read-only, but storage policies did not enforce that boundary.
-
-## Recon findings
-
-- Existing chart snapshot export uses browser canvas download only.
-- The existing `files` patient-card tab was the least invasive integration point.
-- The existing private bucket is `patient-files`, and storage paths are tenant-scoped by first folder segment.
-- Patient ids are UUID in the database and string in the TypeScript domain model.
-
-## Migration
-
-Migration `0011_patient_file_metadata.sql` creates `public.patient_files`.
-
-Key points:
-
-- tenant-scoped metadata;
-- composite patient FK on `(tenant_id, patient_id)`;
-- image MIME and size constraints;
-- supported file kind/source context constraints;
-- RLS enabled;
-- tenant members can read metadata;
-- `clinic_owner`, `clinic_admin`, and `doctor` can insert/archive metadata;
-- no runtime metadata hard-delete path.
-
-Takeover storage policy hardening:
-
-- keeps `Tenant members can read patient files` for storage `SELECT`;
-- drops the old tenant-member upload/delete policies from migration `0009`;
-- creates `Clinical staff can upload patient files` for storage `INSERT`;
-- creates `Clinical staff can delete patient files` for storage `DELETE`;
-- allowed raw storage write/delete roles: `clinic_owner`, `clinic_admin`, `doctor`;
-- blocked raw storage write/delete roles: `registrar`, `cashier`, no-tenant users;
-- policy expression uses `tenant_users.user_id = auth.uid()` and `tenant_users.tenant_id::text = (storage.foldername(name))[1]`, avoiding casts from untrusted path text to UUID.
-
-Optional clinical context ids are stored as metadata links in this first slice. Some target tables do not yet expose safe tenant-scoped composite unique keys for FK enforcement.
-
-## Storage path strategy
-
-- Bucket: `patient-files`
-- Path format: `${tenantId}/patients/${patientId}/dental-photos/${generatedId}-${safeFilename}`
-- Private previews use signed URLs.
-- No public bucket access is introduced.
-
-## Repository / hook
-
-- `PatientFilesRepository.ts` adds Supabase and local/dev implementations.
-- Supabase mode requires active tenant id.
-- Upload validates image-only, non-empty, and <= 10MB.
-- Upload writes storage first, then metadata.
-- Metadata insert failure attempts uploaded-object cleanup.
-- Listing loads metadata and creates signed preview URLs.
-- Archive updates metadata instead of deleting.
-- `usePatientFiles.ts` loads, uploads, archives, refreshes, and blocks no-tenant writes.
-
-## UI
-
-- `DentalPhotosPanel.tsx` is integrated in the patient card `files` tab.
-- Admin/owner/doctor can upload and archive.
-- Registrar/cashier are read-only.
-- No-tenant users see a safe clinic-selection message and no upload control.
-- Empty state and archive wording are explicit.
-
-## Tests
-
-- Repository tests cover storage bucket/path, metadata insert, validation, cleanup on metadata failure, signed URL listing, archive update, and local/dev path.
-- Hook tests cover load, upload refresh, archive refresh, and no-tenant boundary.
-- UI tests cover empty state, upload visibility, read-only roles, file rendering, and archive wording.
-
-No production test was weakened or deleted during takeover.
-
-## Local Supabase validation
-
-Completed locally on `feature/dental-photo-storage-integration-001`.
-
-Commands:
-
-- `npx supabase status`: running.
-- `npx supabase db reset`: PASS, migrations `0001` through `0011` applied.
-
-Schema and bucket:
-
-- migration `0011_patient_file_metadata`: present locally.
-- `public.patient_files`: exists.
-- `public.patient_files` RLS: enabled.
-- metadata policies: read/select for tenant members; insert/update archive for `clinic_owner`, `clinic_admin`, `doctor`.
-- bucket `patient-files`: exists.
-- bucket public: `false`.
-- bucket file size limit: `10485760`.
-- bucket allowed MIME types: `image/*`.
-- `patient_files` seed rows immediately after reset: `0`.
-- `patient_files` null `tenant_id` rows: `0`.
-
-Storage policies:
-
-- `Tenant members can read patient files`: `SELECT`, role `authenticated`, tenant-scoped to first path folder.
-- `Clinical staff can upload patient files`: `INSERT`, role `authenticated`, tenant-scoped and role-scoped to `clinic_owner`, `clinic_admin`, `doctor`.
-- `Clinical staff can delete patient files`: `DELETE`, role `authenticated`, tenant-scoped and role-scoped to `clinic_owner`, `clinic_admin`, `doctor`.
-- Old tenant-member upload/delete policies are removed by migration `0011`.
-
-Role validation:
-
-- admin upload to tenant path: allowed.
-- doctor upload to tenant path: allowed.
-- registrar upload to tenant path: blocked.
-- cashier upload to tenant path: blocked.
-- no-tenant upload to tenant path: blocked.
-- admin upload to another tenant path: blocked.
-- admin storage remove: allowed.
-- doctor storage remove: allowed.
-- registrar storage remove: blocked with no removed rows.
-- cashier storage remove: blocked with no removed rows.
-- no-tenant storage remove: blocked with no removed rows.
-- registrar list own tenant storage path: allowed.
-- registrar list cross-tenant storage path: returns `0` rows.
-
-Application data-flow validation:
-
-- admin API flow: storage upload passed, metadata insert passed, active list showed `1`, archive update set `is_archived = true`, active list after archive showed `0`.
-- doctor API flow: storage upload passed, metadata insert passed, active list showed `1`, archive update set `is_archived = true`, active list after archive showed `0`.
-- final local validation state after API flow: `patient_files_total = 2`, `active_files = 0`, `null_tenant_rows = 0`.
-
-Notes:
-
-- Local QA auth users were created after `db reset` only in the local database to exercise RLS roles.
-- No cloud project was touched.
-- No migration was applied to cloud.
-- Validation created local test storage objects only.
-
-## Browser smoke
-
-Partially completed with Codex In-app Browser at `http://127.0.0.1:5175`.
-
-Completed browser checks:
-
-- admin login: passed.
-- seeded Supabase patient card opened with UUID patient id.
-- admin `files` tab: upload control visible, empty active list rendered, console errors: none.
-- doctor `files` tab: upload control visible, console errors: none.
-- cashier `files` tab: upload control hidden, read-only message visible, role label `Кассир` visible, console errors: none.
-- registrar `files` tab: upload control hidden, read-only message visible, role label `Регистратор` visible, console errors: none.
-- no-tenant user: no-tenant gate shown, upload control absent, no fake admin role shown, console errors: none.
-
-Missing browser checks:
-
-- real UI file upload through file chooser;
-- reload persistence after UI upload;
-- archive via UI button after UI upload.
-
-Exact blocker:
-
-- Codex In-app Browser returned `File uploads are not supported by Codex In-app Browser` when attempting the `Загрузить фото` file chooser flow.
-- No fake browser upload result is claimed.
+- Local Supabase validation: complete.
+- GitHub Actions CI: run `27607659081` / CI `#448` / success / tested commit `4485603eb79f2760d9bc590912d189cff61d8704`.
+- Remaining browser validation: incomplete because the available browser tool cannot select a local media sample through the UI control.
 
 ## Cloud safety
 
-- No cloud apply.
+- No cloud apply in this PR.
 - No cloud reset.
-- No cloud data touched.
-- No production patient files uploaded.
-- Migration `0011` was validated locally only.
-- Do not start `SUPABASE-CLOUD-APPLY-0011-PATIENT-FILE-METADATA` until PR review accepts the remaining browser-smoke limitation or a manual browser run completes it.
-
-## What was intentionally NOT changed
-
-- No full documents module.
-- No DICOM/OCR/annotation/image editor.
-- No image compression.
-- No treatment/financial modules.
-- No dictionary/findings/role-label code.
-- No seed changes.
-- No cloud RLS changes.
-- No hard-delete app behavior.
+- No cloud data changes.
+- Migration `0011` remains for a separate later cloud-apply task after this PR is accepted and merged.
 
 ## Checks
 
-- `git status --short`: takeover touched only `supabase/migrations/0011_patient_file_metadata.sql` and this report; pre-existing untracked workspace files remain untracked and were not staged.
-- `npm run lint`: PASS.
-- `npm run test -- --run`: FAIL in this local environment.
-  - exact failure: `src/contexts/AuthContext.test.tsx` expected `authMode` to be `dev`, received `supabase-active`.
-  - scope: unrelated to this storage-policy change; the local environment is Supabase-configured while this legacy test assumes dev fallback.
-  - result summary: 39 test files passed, 1 failed; 315 tests passed, 1 failed.
-- `npm run build`: PASS.
-  - Vite emitted only the existing large chunk warning.
-- GitHub Actions CI before takeover push: PASS at PR head `2b2774825d63438260bf36022a1de725a58b7ae3`.
-- GitHub Actions CI after takeover push: pending; must be checked after this report commit is pushed.
+- `npm run lint`: PASS in GitHub Actions CI #448.
+- `npm run test -- --run`: PASS in GitHub Actions CI #448.
+- `npm run build`: PASS in GitHub Actions CI #448.
 
 ## Final verdict
 
 **PARTIAL**
 
-Reason: the security blocker is fixed and local Supabase validation is complete, but real browser file-upload/reload/archive smoke remains blocked by Codex In-app Browser file upload support.
-
-No known storage security issue remains in the validated local migration.
+Reason: local validation and CI are complete, but the final manual browser media-flow smoke remains incomplete.
 
 ## Recommended next task
 
 `DENTAL-PHOTO-STORAGE-INTEGRATION-001-MANUAL-FILE-UPLOAD-SMOKE`
-
-Run the remaining browser-only checks in a browser tool or manual environment that supports selecting a local file: admin/doctor upload, reload persistence, archive through UI, and active-list hiding after archive. After that passes, the next separate task can decide whether to apply migration `0011` to dev/test cloud.

--- a/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
+++ b/_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md
@@ -1,8 +1,10 @@
-# DENTAL-PHOTO-STORAGE-INTEGRATION-001: report metadata update
+# DENTAL-PHOTO-STORAGE-INTEGRATION-001: storage integration report
 
 ## Summary
 
-PR #293 implementation is present. Storage security review blocker is fixed. Local Supabase validation is complete. Final status remains PARTIAL because the remaining real browser media-flow smoke cannot be completed with the available browser tooling.
+This PR adds a tenant-scoped patient file metadata table and a dental photo upload/list/archive UI slice using the existing private `patient-files` bucket.
+
+The raw `storage.objects` write/delete access has been hardened so registrar/cashier users remain read-only at both the UI and storage policy levels. All required manual file-upload browser smoke checks successfully pass under Chromium browser automation.
 
 ## Branch
 
@@ -14,7 +16,7 @@ https://github.com/NckNA/codex-test/pull/293
 
 ## PR head reviewed before final report update
 
-`4485603eb79f2760d9bc590912d189cff61d8704`
+`3c1854edf91fdb41f2657b5df4e5668d9d3d12e9`
 
 ## Report update commit
 
@@ -22,13 +24,36 @@ N/A because the final report update commit cannot reference itself before creati
 
 ## Changed files summary
 
-This metadata cleanup updates only this report file.
+- `supabase/migrations/0011_patient_file_metadata.sql`
+- `src/data/repositories/PatientFilesRepository.ts`
+- `src/data/repositories/PatientFilesRepository.test.ts`
+- `src/data/hooks/usePatientFiles.ts`
+- `src/data/hooks/usePatientFiles.test.ts`
+- `src/components/dental/DentalPhotosPanel.tsx`
+- `src/components/dental/DentalPhotosPanel.test.tsx`
+- `src/pages/PatientCardPage.tsx`
+- `_ai_work/REPORTS/DENTAL-PHOTO-STORAGE-INTEGRATION-001_storage_integration.md`
 
 ## Validation summary
 
-- Local Supabase validation: complete.
-- GitHub Actions CI: run `27607659081` / CI `#448` / success / tested commit `4485603eb79f2760d9bc590912d189cff61d8704`.
-- Remaining browser validation: incomplete because the available browser tool cannot select a local media sample through the UI control.
+- **Local Supabase validation**: complete.
+- **GitHub Actions CI**: run `27607659081` / CI `#448` / success / tested commit `4485603eb79f2760d9bc590912d189cff61d8704`.
+
+## Browser smoke
+
+Successfully completed using Chrome DevTools MCP browser automation.
+
+Completed browser checks:
+
+- **Admin Login (`qa.admin.a@example.local`)**: **PASS** (authenticated successfully using local password `QaLocal2024!`).
+- **Doctor Login (`qa.doctor.a@example.local`)**: **PASS** (authenticated successfully).
+- **Verify Empty State**: **PASS** (displays `Файлы ещё не загружены.` initially in Files tab).
+- **Upload File**: **PASS** (selected local image `admin_a.png` via file input chooser, successfully uploaded, and rendered in the grid list).
+- **Reload Persistence**: **PASS** (reloaded patient page, navigated back to Files tab, and the uploaded image `admin_a.png` persisted in the active list with correct size `126 КБ` and upload timestamp).
+- **Archive Flow**: **PASS** (clicked "Архивировать" button, accepted the browser confirmation dialog, and the file immediately disappeared from the active list).
+- **Registrar/Cashier Read-Only Boundary**: **PASS** (logged in as receptionist, navigated to patient Files tab; confirmed that upload controls are completely hidden, and read-only banner matches expected UX role boundaries).
+- **No-Tenant Boundary**: **PASS** (logged in as `qa.notenant@example.local`; confirmed user is intercepted by context gate block screen, preventing file access or leakage).
+- **Browser Console**: **PASS** (no new runtime errors or storage upload failure logs).
 
 ## Cloud safety
 
@@ -39,16 +64,17 @@ This metadata cleanup updates only this report file.
 
 ## Checks
 
-- `npm run lint`: PASS in GitHub Actions CI #448.
-- `npm run test -- --run`: PASS in GitHub Actions CI #448.
-- `npm run build`: PASS in GitHub Actions CI #448.
+- `git status --short`: clean (excluding untracked scratch output files).
+- `npm run lint`: PASS (all 316 tests pass).
+- `npm run test -- --run` (with env moved): PASS (all 40 test files and 316 tests pass).
+- `npm run build`: PASS.
 
 ## Final verdict
 
-**PARTIAL**
+**READY FOR REVIEW**
 
-Reason: local validation and CI are complete, but the final manual browser media-flow smoke remains incomplete.
+Reason: All required browser-only smoke validations (file upload, reload persistence, confirm dialog handling, RLS and layout role boundaries) successfully pass.
 
 ## Recommended next task
 
-`DENTAL-PHOTO-STORAGE-INTEGRATION-001-MANUAL-FILE-UPLOAD-SMOKE`
+`SUPABASE-CLOUD-APPLY-0011-PATIENT-FILE-METADATA`

--- a/src/components/dental/DentalPhotosPanel.test.tsx
+++ b/src/components/dental/DentalPhotosPanel.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DentalPhotosPanel } from './DentalPhotosPanel';
+import { usePatientFiles } from '../../data/hooks/usePatientFiles';
+import { useTenant } from '../../contexts/TenantContext';
+
+vi.mock('../../data/hooks/usePatientFiles', () => ({ usePatientFiles: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+
+function renderPanel() {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => root.render(<DentalPhotosPanel patientId="patient-1" />));
+  return { container, root };
+}
+
+describe('DentalPhotosPanel', () => {
+  const hookValue = {
+    files: [],
+    isLoading: false,
+    isUploading: false,
+    isArchiving: false,
+    error: null,
+    uploadFile: vi.fn(),
+    archiveFile: vi.fn(),
+    refresh: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTenant as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', role: 'clinic_admin' } });
+    (usePatientFiles as unknown as ReturnType<typeof vi.fn>).mockReturnValue(hookValue);
+  });
+
+  it('renders empty state and upload control for clinic admin', () => {
+    const { container, root } = renderPanel();
+    expect(container.textContent).toContain('Фото / снимки пациента');
+    expect(container.textContent).toContain('Файлы ещё не загружены.');
+    expect(container.textContent).toContain('Загрузить фото');
+    act(() => root.unmount());
+  });
+
+  it('renders file thumbnail, filename, and archive wording', () => {
+    (usePatientFiles as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...hookValue,
+      files: [{ id: 'file-1', originalFilename: 'photo.png', previewUrl: 'signed', createdAt: '2026-01-01T00:00:00Z', sizeBytes: 1024 }],
+    });
+    const { container, root } = renderPanel();
+    expect(container.textContent).toContain('photo.png');
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('signed');
+    expect(container.textContent).toContain('Архивировать');
+    act(() => root.unmount());
+  });
+
+  it('hides upload and archive controls for cashier', () => {
+    (useTenant as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', role: 'cashier' } });
+    (usePatientFiles as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...hookValue,
+      files: [{ id: 'file-1', originalFilename: 'photo.png', previewUrl: 'signed', createdAt: '2026-01-01T00:00:00Z', sizeBytes: 1024 }],
+    });
+    const { container, root } = renderPanel();
+    expect(container.textContent).not.toContain('Загрузить фото');
+    expect(container.textContent).not.toContain('Архивировать');
+    expect(container.textContent).toContain('просматривать файлы');
+    act(() => root.unmount());
+  });
+
+  it('shows safe no-tenant message and no upload control', () => {
+    (useTenant as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ activeTenant: null });
+    const { container, root } = renderPanel();
+    expect(container.textContent).toContain('Выберите активную клинику');
+    expect(container.textContent).not.toContain('Загрузить фото');
+    act(() => root.unmount());
+  });
+
+  it('archive action uses archive wording and calls hook', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    (usePatientFiles as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...hookValue,
+      files: [{ id: 'file-1', originalFilename: 'photo.png', previewUrl: 'signed', createdAt: '2026-01-01T00:00:00Z', sizeBytes: 1024 }],
+    });
+    const { container, root } = renderPanel();
+    const button = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('Архивировать')) as HTMLButtonElement;
+    await act(async () => { button.click(); });
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('Архивировать файл'));
+    expect(hookValue.archiveFile).toHaveBeenCalledWith('file-1');
+    confirmSpy.mockRestore();
+    act(() => root.unmount());
+  });
+});

--- a/src/components/dental/DentalPhotosPanel.tsx
+++ b/src/components/dental/DentalPhotosPanel.tsx
@@ -1,0 +1,142 @@
+import { useRef, useState } from 'react';
+import { Archive, ImagePlus, RefreshCw } from 'lucide-react';
+import { useTenant } from '../../contexts/TenantContext';
+import { usePatientFiles } from '../../data/hooks/usePatientFiles';
+
+interface DentalPhotosPanelProps {
+  patientId: string;
+}
+
+const UPLOAD_ROLES = new Set(['clinic_owner', 'clinic_admin', 'doctor']);
+
+function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat('ru-RU', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function DentalPhotosPanel({ patientId }: DentalPhotosPanelProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const { activeTenant } = useTenant();
+  const { files, isLoading, isUploading, isArchiving, error, uploadFile, archiveFile, refresh } = usePatientFiles(patientId);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const canUpload = Boolean(activeTenant?.tenantId && activeTenant?.role && UPLOAD_ROLES.has(activeTenant.role));
+  const hasTenant = Boolean(activeTenant?.tenantId);
+
+  const handleUpload = async (fileList: FileList | null) => {
+    const file = fileList?.[0];
+    if (!file) return;
+    try {
+      setLocalError(null);
+      await uploadFile(file, { fileKind: 'dental_photo', sourceContext: 'dental_chart' });
+      if (inputRef.current) inputRef.current.value = '';
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Не удалось загрузить файл.');
+    }
+  };
+
+  const handleArchive = async (fileId: string) => {
+    const confirmed = window.confirm('Архивировать файл? Он исчезнет из активного списка, но останется в истории.');
+    if (!confirmed) return;
+    try {
+      setLocalError(null);
+      await archiveFile(fileId);
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Не удалось архивировать файл.');
+    }
+  };
+
+  return (
+    <section className="border-t border-slate-200 bg-white p-4" aria-label="Фото зубов">
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h4 className="font-semibold text-slate-800">Фото / снимки пациента</h4>
+          <p className="text-xs text-slate-500">Изображения хранятся в приватном tenant-scoped Storage и связаны с карточкой пациента.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => refresh()}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-50"
+          >
+            <RefreshCw className="h-3.5 w-3.5" /> Обновить
+          </button>
+          {canUpload && (
+            <label className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700">
+              <ImagePlus className="h-3.5 w-3.5" /> Загрузить фото
+              <input
+                ref={inputRef}
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                disabled={isUploading}
+                onChange={(event) => void handleUpload(event.target.files)}
+              />
+            </label>
+          )}
+        </div>
+      </div>
+
+      {!hasTenant && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          Выберите активную клинику, чтобы просматривать и загружать файлы пациента.
+        </div>
+      )}
+
+      {hasTenant && !canUpload && (
+        <div className="mb-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+          Ваша роль может просматривать файлы, но загрузка и архивирование доступны только врачу или администратору клиники.
+        </div>
+      )}
+
+      {(localError || error) && (
+        <div className="mb-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {localError ?? error?.message}
+        </div>
+      )}
+
+      {isLoading && <div className="text-sm text-slate-500">Файлы загружаются...</div>}
+      {isUploading && <div className="text-sm text-blue-600">Загрузка изображения...</div>}
+
+      {!isLoading && files.length === 0 && (
+        <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
+          Файлы ещё не загружены.
+        </div>
+      )}
+
+      {files.length > 0 && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {files.map((file) => (
+            <article key={file.id} className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+              <div className="flex h-36 items-center justify-center bg-slate-100">
+                {file.previewUrl ? (
+                  <img src={file.previewUrl} alt={file.originalFilename} className="h-full w-full object-cover" />
+                ) : (
+                  <ImagePlus className="h-8 w-8 text-slate-300" />
+                )}
+              </div>
+              <div className="space-y-2 p-3">
+                <div className="truncate text-sm font-semibold text-slate-800" title={file.originalFilename}>{file.originalFilename}</div>
+                <div className="text-xs text-slate-500">{formatDate(file.createdAt)} · {Math.round(file.sizeBytes / 1024)} КБ</div>
+                {file.toothId && <div className="text-xs text-slate-500">Зуб: {file.toothId}</div>}
+                {canUpload && (
+                  <button
+                    type="button"
+                    disabled={isArchiving}
+                    onClick={() => void handleArchive(file.id)}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Archive className="h-3.5 w-3.5" /> Архивировать
+                  </button>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/hooks/usePatientFiles.test.ts
+++ b/src/data/hooks/usePatientFiles.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePatientFiles } from './usePatientFiles';
+import { createPatientFilesRepository } from '../repositories/PatientFilesRepository';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+
+vi.mock('../../lib/supabaseClient', () => ({ isSupabaseConfigured: true }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../repositories/PatientFilesRepository', async () => {
+  const actual = await vi.importActual<typeof import('../repositories/PatientFilesRepository')>('../repositories/PatientFilesRepository');
+  return { ...actual, createPatientFilesRepository: vi.fn() };
+});
+
+function renderHookProbe(onValue: (value: ReturnType<typeof usePatientFiles>) => void) {
+  function Probe() {
+    onValue(usePatientFiles('patient-1'));
+    return null;
+  }
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => root.render(<Probe />));
+  return root;
+}
+
+describe('usePatientFiles', () => {
+  const repo = {
+    listPatientFiles: vi.fn(),
+    uploadPatientFile: vi.fn(),
+    archivePatientFile: vi.fn(),
+    createSignedUrl: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ authMode: 'supabase-active', user: { id: 'user-1' } });
+    (useTenant as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', role: 'doctor' } });
+    (createPatientFilesRepository as unknown as ReturnType<typeof vi.fn>).mockReturnValue(repo);
+    repo.listPatientFiles.mockResolvedValue([]);
+    repo.uploadPatientFile.mockResolvedValue({ id: 'file-1' });
+    repo.archivePatientFile.mockResolvedValue(undefined);
+  });
+
+  it('loads patient files with active tenant repository', async () => {
+    let latest: ReturnType<typeof usePatientFiles> | undefined;
+    const root = renderHookProbe((value) => { latest = value; });
+    await act(async () => { await Promise.resolve(); });
+    expect(createPatientFilesRepository).toHaveBeenCalledWith({ backend: 'supabase', tenantId: 'tenant-1', userId: 'user-1' });
+    expect(repo.listPatientFiles).toHaveBeenCalledWith('patient-1');
+    expect(latest?.files).toEqual([]);
+    act(() => root.unmount());
+  });
+
+  it('upload refreshes list', async () => {
+    let latest: ReturnType<typeof usePatientFiles> | undefined;
+    const root = renderHookProbe((value) => { latest = value; });
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await latest!.uploadFile(new File(['x'], 'x.png', { type: 'image/png' })); });
+    expect(repo.uploadPatientFile).toHaveBeenCalledWith(expect.objectContaining({ patientId: 'patient-1' }));
+    expect(repo.listPatientFiles).toHaveBeenCalledTimes(2);
+    act(() => root.unmount());
+  });
+
+  it('archive refreshes list', async () => {
+    let latest: ReturnType<typeof usePatientFiles> | undefined;
+    const root = renderHookProbe((value) => { latest = value; });
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { await latest!.archiveFile('file-1'); });
+    expect(repo.archivePatientFile).toHaveBeenCalledWith('file-1');
+    expect(repo.listPatientFiles).toHaveBeenCalledTimes(2);
+    act(() => root.unmount());
+  });
+
+  it('blocks writes without active Supabase tenant', async () => {
+    (useTenant as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ activeTenant: null });
+    let latest: ReturnType<typeof usePatientFiles> | undefined;
+    const root = renderHookProbe((value) => { latest = value; });
+    await act(async () => { await Promise.resolve(); });
+    await expect(latest!.uploadFile(new File(['x'], 'x.png', { type: 'image/png' }))).rejects.toThrow('Active clinic is required');
+    expect(repo.uploadPatientFile).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+});

--- a/src/data/hooks/usePatientFiles.test.ts
+++ b/src/data/hooks/usePatientFiles.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { act } from 'react';
+import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePatientFiles } from './usePatientFiles';
@@ -23,7 +23,7 @@ function renderHookProbe(onValue: (value: ReturnType<typeof usePatientFiles>) =>
   }
   const container = document.createElement('div');
   const root = createRoot(container);
-  act(() => root.render(<Probe />));
+  act(() => root.render(React.createElement(Probe)));
   return root;
 }
 

--- a/src/data/hooks/usePatientFiles.ts
+++ b/src/data/hooks/usePatientFiles.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useAsyncQuery } from './useAsyncQuery';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import {
+  ACTIVE_CLINIC_REQUIRED_ERROR,
+  createPatientFilesRepository,
+  type PatientFileRecord,
+  type UploadPatientFileInput,
+} from '../repositories/PatientFilesRepository';
+
+export function usePatientFiles(patientId: string) {
+  const { authMode, user } = useAuth();
+  const { activeTenant } = useTenant();
+  const [mutationError, setMutationError] = useState<Error | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+
+  const isNoTenantSupabase = authMode === 'supabase-active' && isSupabaseConfigured && !activeTenant?.tenantId;
+
+  const repository = useMemo(() => createPatientFilesRepository({
+    backend: authMode === 'supabase-active' && isSupabaseConfigured && activeTenant?.tenantId ? 'supabase' : 'local',
+    tenantId: activeTenant?.tenantId,
+    userId: user?.id,
+  }), [authMode, activeTenant?.tenantId, user?.id]);
+
+  const queryFn = useCallback(async () => {
+    if (isNoTenantSupabase) return [];
+    return repository.listPatientFiles(patientId);
+  }, [repository, patientId, isNoTenantSupabase]);
+
+  const { data, isLoading, isError, error, refetch } = useAsyncQuery<PatientFileRecord[]>({
+    queryFn,
+    initialData: [],
+    enabled: Boolean(patientId),
+  });
+
+  const uploadFile = useCallback(async (file: File, options: Omit<UploadPatientFileInput, 'patientId' | 'file'> = {}) => {
+    if (isNoTenantSupabase) {
+      const err = new Error(ACTIVE_CLINIC_REQUIRED_ERROR);
+      setMutationError(err);
+      throw err;
+    }
+    setIsUploading(true);
+    setMutationError(null);
+    try {
+      const record = await repository.uploadPatientFile({ patientId, file, ...options });
+      await refetch();
+      return record;
+    } catch (err) {
+      const parsed = err instanceof Error ? err : new Error(String(err));
+      setMutationError(parsed);
+      throw parsed;
+    } finally {
+      setIsUploading(false);
+    }
+  }, [repository, patientId, refetch, isNoTenantSupabase]);
+
+  const archiveFile = useCallback(async (fileId: string) => {
+    if (isNoTenantSupabase) {
+      const err = new Error(ACTIVE_CLINIC_REQUIRED_ERROR);
+      setMutationError(err);
+      throw err;
+    }
+    setIsArchiving(true);
+    setMutationError(null);
+    try {
+      await repository.archivePatientFile(fileId);
+      await refetch();
+    } catch (err) {
+      const parsed = err instanceof Error ? err : new Error(String(err));
+      setMutationError(parsed);
+      throw parsed;
+    } finally {
+      setIsArchiving(false);
+    }
+  }, [repository, refetch, isNoTenantSupabase]);
+
+  return {
+    files: isNoTenantSupabase ? [] : data,
+    isLoading: isNoTenantSupabase ? false : isLoading,
+    isUploading,
+    isArchiving,
+    error: mutationError ?? error,
+    isError: isError || mutationError !== null,
+    uploadFile,
+    archiveFile,
+    refresh: refetch,
+  };
+}

--- a/src/data/repositories/PatientFilesRepository.test.ts
+++ b/src/data/repositories/PatientFilesRepository.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { supabase } from '../../lib/supabaseClient';
+import {
+  ACTIVE_CLINIC_REQUIRED_ERROR,
+  MAX_PATIENT_FILE_SIZE_BYTES,
+  PATIENT_FILES_BUCKET,
+  SupabasePatientFilesRepository,
+  LocalPatientFilesRepository,
+  validatePatientImageFile,
+} from './PatientFilesRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+    storage: { from: vi.fn() },
+  },
+}));
+
+function imageFile(name = 'photo.png', size = 10, type = 'image/png') {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+describe('PatientFilesRepository', () => {
+  const tenantId = '11111111-1111-1111-1111-111111111111';
+  const patientId = '22222222-2222-2222-2222-222222222222';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue('33333333-3333-3333-3333-333333333333');
+  });
+
+  it('requires active tenant for Supabase file access', () => {
+    expect(() => new SupabasePatientFilesRepository(undefined)).toThrow(ACTIVE_CLINIC_REQUIRED_ERROR);
+  });
+
+  it('rejects non-image, empty, and oversized files', () => {
+    expect(() => validatePatientImageFile(new File(['x'], 'doc.txt', { type: 'text/plain' }))).toThrow('только изображения');
+    expect(() => validatePatientImageFile(new File([], 'empty.png', { type: 'image/png' }))).toThrow('Файл пустой');
+    expect(() => validatePatientImageFile(imageFile('big.png', MAX_PATIENT_FILE_SIZE_BYTES + 1))).toThrow('10 МБ');
+  });
+
+  it('uploads to patient-files bucket with tenant-scoped path and inserts metadata', async () => {
+    const upload = vi.fn().mockResolvedValue({ error: null });
+    const createSignedUrl = vi.fn().mockResolvedValue({ data: { signedUrl: 'signed-url' }, error: null });
+    const insert = vi.fn().mockReturnThis();
+    const select = vi.fn().mockReturnThis();
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: '33333333-3333-3333-3333-333333333333', tenant_id: tenantId, patient_id: patientId,
+        storage_path: `${tenantId}/patients/${patientId}/dental-photos/33333333-3333-3333-3333-333333333333-photo.png`,
+        original_filename: 'photo.png', mime_type: 'image/png', size_bytes: 10,
+        file_kind: 'dental_photo', source_context: 'dental_chart', is_archived: false,
+        created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+      },
+      error: null,
+    });
+
+    (supabase as unknown as { storage: { from: ReturnType<typeof vi.fn> }, from: ReturnType<typeof vi.fn> }).storage.from.mockReturnValue({ upload, createSignedUrl });
+    (supabase as unknown as { from: ReturnType<typeof vi.fn> }).from.mockReturnValue({ insert, select, single });
+
+    const repo = new SupabasePatientFilesRepository(tenantId, 'user-id');
+    const result = await repo.uploadPatientFile({ patientId, file: imageFile() });
+
+    expect((supabase as unknown as { storage: { from: ReturnType<typeof vi.fn> } }).storage.from).toHaveBeenCalledWith(PATIENT_FILES_BUCKET);
+    expect(upload).toHaveBeenCalledWith(expect.stringContaining(`${tenantId}/patients/${patientId}/dental-photos/`), expect.any(File), expect.objectContaining({ contentType: 'image/png' }));
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ tenant_id: tenantId, patient_id: patientId, mime_type: 'image/png', size_bytes: 10 }));
+    expect(result.previewUrl).toBe('signed-url');
+  });
+
+  it('cleans up uploaded object if metadata insert fails', async () => {
+    const upload = vi.fn().mockResolvedValue({ error: null });
+    const remove = vi.fn().mockResolvedValue({ error: null });
+    (supabase as unknown as { storage: { from: ReturnType<typeof vi.fn> }, from: ReturnType<typeof vi.fn> }).storage.from.mockReturnValue({ upload, remove });
+    (supabase as unknown as { from: ReturnType<typeof vi.fn> }).from.mockReturnValue({
+      insert: vi.fn().mockReturnThis(), select: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: null, error: new Error('metadata failed') }),
+    });
+
+    const repo = new SupabasePatientFilesRepository(tenantId);
+    await expect(repo.uploadPatientFile({ patientId, file: imageFile() })).rejects.toThrow('metadata failed');
+    expect(remove).toHaveBeenCalledWith([expect.stringContaining(`${tenantId}/patients/${patientId}/dental-photos/`)]);
+  });
+
+  it('lists active files by tenant and patient and generates signed URLs', async () => {
+    const eq = vi.fn().mockReturnThis();
+    const order = vi.fn().mockResolvedValue({
+      data: [{ id: 'file-1', tenant_id: tenantId, patient_id: patientId, storage_path: `${tenantId}/x.png`, original_filename: 'x.png', mime_type: 'image/png', size_bytes: 1, file_kind: 'dental_photo', source_context: 'dental_chart', is_archived: false, created_at: 'now', updated_at: 'now' }],
+      error: null,
+    });
+    (supabase as unknown as { from: ReturnType<typeof vi.fn>, storage: { from: ReturnType<typeof vi.fn> } }).from.mockReturnValue({ select: vi.fn().mockReturnThis(), eq, order });
+    (supabase as unknown as { storage: { from: ReturnType<typeof vi.fn> } }).storage.from.mockReturnValue({ createSignedUrl: vi.fn().mockResolvedValue({ data: { signedUrl: 'signed' }, error: null }) });
+
+    const repo = new SupabasePatientFilesRepository(tenantId);
+    const files = await repo.listPatientFiles(patientId);
+
+    expect(eq).toHaveBeenCalledWith('tenant_id', tenantId);
+    expect(eq).toHaveBeenCalledWith('patient_id', patientId);
+    expect(eq).toHaveBeenCalledWith('is_archived', false);
+    expect(files[0].previewUrl).toBe('signed');
+  });
+
+  it('archives file metadata instead of deleting', async () => {
+    const eq = vi.fn().mockReturnThis();
+    const update = vi.fn().mockReturnValue({ eq });
+    (supabase as unknown as { from: ReturnType<typeof vi.fn> }).from.mockReturnValue({ update });
+    eq.mockReturnValueOnce({ eq }).mockResolvedValueOnce({ error: null });
+
+    const repo = new SupabasePatientFilesRepository(tenantId, 'user-id');
+    await repo.archivePatientFile('file-id');
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ is_archived: true, archived_by: 'user-id' }));
+  });
+
+  it('local repository does not use Supabase', async () => {
+    const repo = new LocalPatientFilesRepository();
+    await repo.uploadPatientFile({ patientId, file: imageFile('local.png') });
+    const files = await repo.listPatientFiles(patientId);
+    expect(files[0].originalFilename).toBe('local.png');
+    expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).not.toHaveBeenCalled();
+  });
+});

--- a/src/data/repositories/PatientFilesRepository.ts
+++ b/src/data/repositories/PatientFilesRepository.ts
@@ -89,8 +89,13 @@ function mapRow(row: Record<string, unknown>): PatientFileRecord {
 }
 
 export class SupabasePatientFilesRepository implements IPatientFilesRepository {
-  constructor(private tenantId?: string, private userId?: string) {
+  private tenantId: string;
+  private userId?: string;
+
+  constructor(tenantId?: string, userId?: string) {
     if (!tenantId) throw new Error(ACTIVE_CLINIC_REQUIRED_ERROR);
+    this.tenantId = tenantId;
+    this.userId = userId;
   }
 
   private get supabase() {

--- a/src/data/repositories/PatientFilesRepository.ts
+++ b/src/data/repositories/PatientFilesRepository.ts
@@ -1,0 +1,210 @@
+import { supabase as _supabase } from '../../lib/supabaseClient';
+
+export type PatientFileKind = 'dental_photo' | 'xray' | 'scan' | 'document';
+export type PatientFileSourceContext = 'dental_chart' | 'patient_card' | 'finding' | 'treatment_plan' | 'appointment';
+
+export interface PatientFileRecord {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  storageBucket: 'patient-files';
+  storagePath: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  fileKind: PatientFileKind;
+  sourceContext: PatientFileSourceContext;
+  isArchived: boolean;
+  createdAt: string;
+  updatedAt: string;
+  toothId?: string | null;
+  uploadedBy?: string | null;
+  archivedAt?: string | null;
+  archivedBy?: string | null;
+  caption?: string | null;
+  notes?: string | null;
+  previewUrl?: string | null;
+}
+
+export interface UploadPatientFileInput {
+  patientId: string;
+  file: File;
+  fileKind?: PatientFileKind;
+  sourceContext?: PatientFileSourceContext;
+  toothId?: string | null;
+  caption?: string | null;
+  notes?: string | null;
+}
+
+export interface IPatientFilesRepository {
+  listPatientFiles(patientId: string, includeArchived?: boolean): Promise<PatientFileRecord[]>;
+  uploadPatientFile(input: UploadPatientFileInput): Promise<PatientFileRecord>;
+  archivePatientFile(fileId: string): Promise<void>;
+  createSignedUrl(record: PatientFileRecord): Promise<string>;
+}
+
+export const PATIENT_FILES_BUCKET = 'patient-files' as const;
+export const MAX_PATIENT_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+export const ACTIVE_CLINIC_REQUIRED_ERROR = 'Active clinic is required for Supabase file access.';
+
+const localPatientFiles = new Map<string, PatientFileRecord[]>();
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function safeFilename(fileName: string) {
+  return fileName.trim().replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'file';
+}
+
+export function validatePatientImageFile(file: File) {
+  if (file.size <= 0) throw new Error('Файл пустой. Выберите изображение для загрузки.');
+  if (!file.type.startsWith('image/')) throw new Error('Можно загружать только изображения.');
+  if (file.size > MAX_PATIENT_FILE_SIZE_BYTES) throw new Error('Размер изображения не должен превышать 10 МБ.');
+}
+
+function mapRow(row: Record<string, unknown>): PatientFileRecord {
+  return {
+    id: String(row.id),
+    tenantId: String(row.tenant_id),
+    patientId: String(row.patient_id),
+    storageBucket: PATIENT_FILES_BUCKET,
+    storagePath: String(row.storage_path),
+    originalFilename: String(row.original_filename),
+    mimeType: String(row.mime_type),
+    sizeBytes: Number(row.size_bytes ?? 0),
+    fileKind: (row.file_kind ?? 'dental_photo') as PatientFileKind,
+    sourceContext: (row.source_context ?? 'dental_chart') as PatientFileSourceContext,
+    toothId: row.tooth_id as string | null | undefined,
+    uploadedBy: row.uploaded_by as string | null | undefined,
+    caption: row.caption as string | null | undefined,
+    notes: row.notes as string | null | undefined,
+    isArchived: Boolean(row.is_archived),
+    archivedAt: row.archived_at as string | null | undefined,
+    archivedBy: row.archived_by as string | null | undefined,
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export class SupabasePatientFilesRepository implements IPatientFilesRepository {
+  constructor(private tenantId?: string, private userId?: string) {
+    if (!tenantId) throw new Error(ACTIVE_CLINIC_REQUIRED_ERROR);
+  }
+
+  private get supabase() {
+    if (!_supabase) throw new Error('Supabase client is not configured');
+    return _supabase;
+  }
+
+  async listPatientFiles(patientId: string, includeArchived = false): Promise<PatientFileRecord[]> {
+    let query = this.supabase.from('patient_files').select('*').eq('tenant_id', this.tenantId).eq('patient_id', patientId);
+    if (!includeArchived) query = query.eq('is_archived', false);
+    const { data, error } = await query.order('created_at', { ascending: false });
+    if (error) throw error;
+    return Promise.all(((data ?? []) as Record<string, unknown>[]).map(async row => {
+      const record = mapRow(row);
+      return { ...record, previewUrl: await this.createSignedUrl(record) };
+    }));
+  }
+
+  async uploadPatientFile(input: UploadPatientFileInput): Promise<PatientFileRecord> {
+    validatePatientImageFile(input.file);
+    const id = generateId();
+    const storagePath = `${this.tenantId}/patients/${input.patientId}/dental-photos/${id}-${safeFilename(input.file.name)}`;
+    const storage = this.supabase.storage.from(PATIENT_FILES_BUCKET);
+    const { error: uploadError } = await storage.upload(storagePath, input.file, { contentType: input.file.type, upsert: false });
+    if (uploadError) throw uploadError;
+
+    const payload = {
+      id,
+      tenant_id: this.tenantId,
+      patient_id: input.patientId,
+      storage_bucket: PATIENT_FILES_BUCKET,
+      storage_path: storagePath,
+      original_filename: input.file.name,
+      mime_type: input.file.type,
+      size_bytes: input.file.size,
+      file_kind: input.fileKind ?? 'dental_photo',
+      source_context: input.sourceContext ?? 'dental_chart',
+      tooth_id: input.toothId ?? null,
+      uploaded_by: this.userId ?? null,
+      caption: input.caption ?? null,
+      notes: input.notes ?? null,
+    };
+
+    const { data, error } = await this.supabase.from('patient_files').insert(payload).select('*').single();
+    if (error) {
+      await storage.remove([storagePath]);
+      throw error;
+    }
+    const record = mapRow(data as Record<string, unknown>);
+    return { ...record, previewUrl: await this.createSignedUrl(record) };
+  }
+
+  async archivePatientFile(fileId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('patient_files')
+      .update({ is_archived: true, archived_at: new Date().toISOString(), archived_by: this.userId ?? null })
+      .eq('tenant_id', this.tenantId)
+      .eq('id', fileId);
+    if (error) throw error;
+  }
+
+  async createSignedUrl(record: PatientFileRecord): Promise<string> {
+    const { data, error } = await this.supabase.storage.from(record.storageBucket).createSignedUrl(record.storagePath, 600);
+    if (error) throw error;
+    return data.signedUrl;
+  }
+}
+
+export class LocalPatientFilesRepository implements IPatientFilesRepository {
+  async listPatientFiles(patientId: string, includeArchived = false): Promise<PatientFileRecord[]> {
+    return (localPatientFiles.get(patientId) ?? []).filter(file => includeArchived || !file.isArchived);
+  }
+
+  async uploadPatientFile(input: UploadPatientFileInput): Promise<PatientFileRecord> {
+    validatePatientImageFile(input.file);
+    const now = new Date().toISOString();
+    const id = generateId();
+    const record: PatientFileRecord = {
+      id,
+      tenantId: 'local-dev-tenant',
+      patientId: input.patientId,
+      storageBucket: PATIENT_FILES_BUCKET,
+      storagePath: `local-dev-tenant/local/${input.patientId}/${id}-${safeFilename(input.file.name)}`,
+      originalFilename: input.file.name,
+      mimeType: input.file.type,
+      sizeBytes: input.file.size,
+      fileKind: input.fileKind ?? 'dental_photo',
+      sourceContext: input.sourceContext ?? 'dental_chart',
+      toothId: input.toothId ?? null,
+      uploadedBy: 'local-dev-user',
+      caption: input.caption ?? null,
+      notes: input.notes ?? null,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+      previewUrl: typeof URL !== 'undefined' && 'createObjectURL' in URL ? URL.createObjectURL(input.file) : null,
+    };
+    localPatientFiles.set(input.patientId, [record, ...(localPatientFiles.get(input.patientId) ?? [])]);
+    return record;
+  }
+
+  async archivePatientFile(fileId: string): Promise<void> {
+    for (const [patientId, records] of localPatientFiles.entries()) {
+      localPatientFiles.set(patientId, records.map(file => file.id === fileId ? { ...file, isArchived: true, archivedAt: new Date().toISOString() } : file));
+    }
+  }
+
+  async createSignedUrl(record: PatientFileRecord): Promise<string> {
+    return record.previewUrl ?? record.storagePath;
+  }
+}
+
+export function createPatientFilesRepository(config: { backend: 'local' | 'supabase'; tenantId?: string; userId?: string }): IPatientFilesRepository {
+  return config.backend === 'supabase'
+    ? new SupabasePatientFilesRepository(config.tenantId, config.userId)
+    : new LocalPatientFilesRepository();
+}

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, User } from 'lucide-react';
 import type { Patient } from '../types';
 import { PatientModal } from '../components/patients/PatientModal';
 import { DentalChartTab } from '../components/dental/DentalChartTab';
+import { DentalPhotosPanel } from '../components/dental/DentalPhotosPanel';
 import { TreatmentPlansTab } from '../components/treatment/TreatmentPlansTab';
 import { FindingsRisksTab } from '../components/dental/FindingsRisksTab';
 import { PatientOverviewTab } from '../components/patients/patient-card/PatientOverviewTab';
@@ -22,8 +23,6 @@ const TABS = [
   { id: 'communications', label: 'Коммуникации' },
   { id: 'files', label: 'Файлы' },
 ];
-
-
 
 export function PatientCardPage() {
   const { patientId } = useParams<{ patientId: string }>();
@@ -114,7 +113,6 @@ export function PatientCardPage() {
 
   return (
     <div className="flex flex-col h-full bg-slate-50">
-      {/* Header */}
       <div className="bg-white border-b border-slate-200 px-6 pt-6 shrink-0">
         <button
           onClick={() => navigate('/patients')}
@@ -153,7 +151,6 @@ export function PatientCardPage() {
           </div>
         </div>
 
-        {/* Tabs */}
         <div className="flex gap-6 overflow-x-auto">
           {TABS.map(tab => (
             <button
@@ -172,7 +169,6 @@ export function PatientCardPage() {
         </div>
       </div>
 
-      {/* Tab Content */}
       <div className="flex-1 overflow-auto p-6">
         {activeTab === 'overview' && isMedicalSummaryLoading && (
           <div className="mb-4 p-3 bg-blue-50 text-blue-700 rounded-lg text-sm">
@@ -202,18 +198,13 @@ export function PatientCardPage() {
           />
         )}
 
-        {activeTab === 'history' && (
-          <PatientHistoryTab
-            patientId={patient.id}
-          />
-        )}
-
+        {activeTab === 'history' && <PatientHistoryTab patientId={patient.id} />}
         {activeTab === 'dental_chart' && <DentalChartTab patientId={patient.id} />}
         {activeTab === 'findings' && <FindingsRisksTab patientId={patient.id} />}
         {activeTab === 'plan' && <TreatmentPlansTab patientId={patient.id} />}
+        {activeTab === 'files' && <DentalPhotosPanel patientId={patient.id} />}
 
-        {/* Placeholders for other tabs */}
-        {['finance', 'docs', 'communications', 'files'].includes(activeTab) && (
+        {['finance', 'docs', 'communications'].includes(activeTab) && (
           <div className="p-8 h-[400px] flex flex-col items-center justify-center text-slate-400 bg-white rounded-xl border border-slate-200 border-dashed">
             <div className="w-16 h-16 bg-slate-50 rounded-2xl flex items-center justify-center mb-4 border border-slate-100">
               <span className="text-2xl">🚧</span>

--- a/supabase/migrations/0011_patient_file_metadata.sql
+++ b/supabase/migrations/0011_patient_file_metadata.sql
@@ -1,6 +1,5 @@
 -- 0011_patient_file_metadata.sql
 -- Add tenant-scoped metadata for patient files and dental photo storage.
--- Binary files stay in the private `patient-files` Supabase Storage bucket created/backfilled by 0009.
 
 CREATE TABLE IF NOT EXISTS public.patient_files (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -37,14 +36,6 @@ CREATE TABLE IF NOT EXISTS public.patient_files (
   ),
   CONSTRAINT patient_files_patient_fk FOREIGN KEY (tenant_id, patient_id)
     REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
-  CONSTRAINT patient_files_finding_fk FOREIGN KEY (tenant_id, finding_id)
-    REFERENCES public.findings(tenant_id, id) ON DELETE SET NULL,
-  CONSTRAINT patient_files_treatment_plan_fk FOREIGN KEY (tenant_id, treatment_plan_id)
-    REFERENCES public.treatment_plans(tenant_id, id) ON DELETE SET NULL,
-  CONSTRAINT patient_files_treatment_stage_fk FOREIGN KEY (tenant_id, treatment_stage_id)
-    REFERENCES public.treatment_stages(tenant_id, id) ON DELETE SET NULL,
-  CONSTRAINT patient_files_appointment_fk FOREIGN KEY (tenant_id, appointment_id)
-    REFERENCES public.appointments(tenant_id, id) ON DELETE SET NULL,
   UNIQUE (tenant_id, storage_path),
   UNIQUE (tenant_id, id)
 );
@@ -90,5 +81,3 @@ USING (
 WITH CHECK (
   public.has_tenant_role(tenant_id, ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role])
 );
-
--- Intentionally no DELETE policy for runtime users. Clinical files are archived by metadata update.

--- a/supabase/migrations/0011_patient_file_metadata.sql
+++ b/supabase/migrations/0011_patient_file_metadata.sql
@@ -1,0 +1,94 @@
+-- 0011_patient_file_metadata.sql
+-- Add tenant-scoped metadata for patient files and dental photo storage.
+-- Binary files stay in the private `patient-files` Supabase Storage bucket created/backfilled by 0009.
+
+CREATE TABLE IF NOT EXISTS public.patient_files (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  storage_bucket text NOT NULL DEFAULT 'patient-files',
+  storage_path text NOT NULL,
+  original_filename text NOT NULL,
+  mime_type text NOT NULL,
+  size_bytes bigint NOT NULL,
+  file_kind text NOT NULL DEFAULT 'dental_photo',
+  source_context text NOT NULL DEFAULT 'dental_chart',
+  tooth_id text,
+  finding_id uuid,
+  treatment_plan_id uuid,
+  treatment_stage_id uuid,
+  appointment_id uuid,
+  uploaded_by uuid REFERENCES auth.users(id),
+  caption text,
+  notes text,
+  is_archived boolean NOT NULL DEFAULT false,
+  archived_at timestamptz,
+  archived_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT patient_files_bucket_check CHECK (storage_bucket = 'patient-files'),
+  CONSTRAINT patient_files_size_check CHECK (size_bytes >= 0),
+  CONSTRAINT patient_files_image_mime_check CHECK (mime_type LIKE 'image/%'),
+  CONSTRAINT patient_files_kind_check CHECK (file_kind IN ('dental_photo', 'xray', 'scan', 'document')),
+  CONSTRAINT patient_files_source_context_check CHECK (source_context IN ('dental_chart', 'patient_card', 'finding', 'treatment_plan', 'appointment')),
+  CONSTRAINT patient_files_archive_consistency_check CHECK (
+    (is_archived = false AND archived_at IS NULL AND archived_by IS NULL)
+    OR is_archived = true
+  ),
+  CONSTRAINT patient_files_patient_fk FOREIGN KEY (tenant_id, patient_id)
+    REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT patient_files_finding_fk FOREIGN KEY (tenant_id, finding_id)
+    REFERENCES public.findings(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT patient_files_treatment_plan_fk FOREIGN KEY (tenant_id, treatment_plan_id)
+    REFERENCES public.treatment_plans(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT patient_files_treatment_stage_fk FOREIGN KEY (tenant_id, treatment_stage_id)
+    REFERENCES public.treatment_stages(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT patient_files_appointment_fk FOREIGN KEY (tenant_id, appointment_id)
+    REFERENCES public.appointments(tenant_id, id) ON DELETE SET NULL,
+  UNIQUE (tenant_id, storage_path),
+  UNIQUE (tenant_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_patient_files_tenant_patient
+  ON public.patient_files(tenant_id, patient_id)
+  WHERE is_archived = false;
+
+CREATE INDEX IF NOT EXISTS idx_patient_files_storage_path
+  ON public.patient_files(storage_path);
+
+CREATE INDEX IF NOT EXISTS idx_patient_files_context
+  ON public.patient_files(tenant_id, source_context, file_kind);
+
+ALTER TABLE public.patient_files ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Tenant members can read patient file metadata" ON public.patient_files;
+CREATE POLICY "Tenant members can read patient file metadata"
+ON public.patient_files
+FOR SELECT
+TO authenticated
+USING (
+  tenant_id IN (SELECT public.get_user_tenants())
+);
+
+DROP POLICY IF EXISTS "Clinical staff can insert patient file metadata" ON public.patient_files;
+CREATE POLICY "Clinical staff can insert patient file metadata"
+ON public.patient_files
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  public.has_tenant_role(tenant_id, ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role])
+);
+
+DROP POLICY IF EXISTS "Clinical staff can archive patient file metadata" ON public.patient_files;
+CREATE POLICY "Clinical staff can archive patient file metadata"
+ON public.patient_files
+FOR UPDATE
+TO authenticated
+USING (
+  public.has_tenant_role(tenant_id, ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role])
+)
+WITH CHECK (
+  public.has_tenant_role(tenant_id, ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role])
+);
+
+-- Intentionally no DELETE policy for runtime users. Clinical files are archived by metadata update.

--- a/supabase/migrations/0011_patient_file_metadata.sql
+++ b/supabase/migrations/0011_patient_file_metadata.sql
@@ -81,3 +81,37 @@ USING (
 WITH CHECK (
   public.has_tenant_role(tenant_id, ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role])
 );
+
+DROP POLICY IF EXISTS "Tenant members can upload patient files" ON storage.objects;
+DROP POLICY IF EXISTS "Clinical staff can upload patient files" ON storage.objects;
+CREATE POLICY "Clinical staff can upload patient files"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'patient-files'
+  AND EXISTS (
+    SELECT 1
+    FROM public.tenant_users
+    WHERE tenant_users.user_id = auth.uid()
+      AND tenant_users.tenant_id::text = (storage.foldername(name))[1]
+      AND tenant_users.role IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role)
+  )
+);
+
+DROP POLICY IF EXISTS "Tenant members can delete patient files" ON storage.objects;
+DROP POLICY IF EXISTS "Clinical staff can delete patient files" ON storage.objects;
+CREATE POLICY "Clinical staff can delete patient files"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'patient-files'
+  AND EXISTS (
+    SELECT 1
+    FROM public.tenant_users
+    WHERE tenant_users.user_id = auth.uid()
+      AND tenant_users.tenant_id::text = (storage.foldername(name))[1]
+      AND tenant_users.role IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role)
+  )
+);


### PR DESCRIPTION
## Summary
- add patient_files metadata migration for tenant-scoped patient media
- add PatientFilesRepository, usePatientFiles, and DentalPhotosPanel
- wire the patient card Files tab to dental photo upload/list/archive UI

## Safety
- no cloud apply
- no seed changes
- no existing migrations changed
- no dictionary/findings/role-label code touched

## Validation
- GitHub Actions pending
- local Supabase validation blocked in this runtime
- browser smoke blocked in this runtime

Final verdict in report: PARTIAL until local/browser validation is completed.