### PR TITLE
PATIENT-TIMELINE-AGGREGATOR-001: add computed patient timeline aggregator

### DIFF
--- a/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
+++ b/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
@@ -2,29 +2,27 @@
 
 ## Summary
 
-Implemented the first patient timeline foundation: a UI-neutral domain event model plus a computed `buildPatientTimeline` aggregator.
+Implemented a UI-neutral patient timeline event model and a pure computed aggregator.
 
-The aggregator is intentionally pure. It accepts already loaded source objects and does not query Supabase, read localStorage, call browser APIs, or require local/cloud databases.
+The aggregator accepts already loaded source objects. It does not query Supabase, read localStorage, use browser APIs, or require local/cloud databases.
 
-## Branch name
+## Branch
 
 `feature/patient-timeline-aggregator-001`
 
-## PR URL
+## PR
 
-Pending PR creation.
+https://github.com/NckNA/codex-test/pull/297
 
 ## PR head reviewed before final report update
 
-Pending PR creation.
+`2ddbcf916e84ba3834411ed3ff18c4942624ad97`
 
 ## Report update commit
 
 N/A because the final report update commit cannot reference itself before creation.
 
-## Changed files summary
-
-Initial implementation scope:
+## Changed files
 
 - `src/data/aggregators/PatientTimelineAggregator.ts`
 - `src/data/aggregators/PatientTimelineAggregator.test.ts`
@@ -32,42 +30,17 @@ Initial implementation scope:
 
 ## Current state recon
 
-Inspected current project types and data-layer files:
+Inspected current patient-related data shapes:
 
-- `src/types/index.ts`
-- `src/data/aggregators/ClinicalSummaryAggregator.ts`
-- `src/domain/findingStatus.ts`
-- `src/data/repositories/PatientFilesRepository.ts`
-- `src/contexts/TenantContext.tsx`
+- `Patient`: id, status, createdAt.
+- `ChiefComplaint`: patientId, text, relatedTeeth, createdAt, updatedAt.
+- `DentalFinding`: patientId, optional toothNumber, status, createdAt, updatedAt.
+- `TreatmentPlan`: patientId, status, createdAt, updatedAt, stages, totalPrice.
+- `Appointment`: optional patientId, doctorId, service, start/end, status, createdAt.
+- `PatientFileRecord`: tenantId, patientId, storage metadata, archive fields, uploadedBy, archivedBy, createdAt, updatedAt.
+- `DentalChart`: patientId, createdAt, updatedAt, but no reliable per-change event history.
 
-Existing shapes found:
-
-- `Patient` has `id`, profile fields, `status`, and `createdAt`.
-- `ChiefComplaint` has `patientId`, `text`, `relatedTeeth`, `createdAt`, and `updatedAt`.
-- `DentalFinding` has `patientId`, optional `toothNumber`, `status`, `createdAt`, and `updatedAt`.
-- `TreatmentPlan` has `patientId`, `status`, `createdAt`, `updatedAt`, stages, and total price.
-- `Appointment` has optional `patientId`, start/end time, status, doctor id, service, and created timestamp.
-- `PatientFileRecord` has tenant/patient ids, storage metadata, archive fields, upload/archive actors, and created/updated timestamps.
-- `DentalChart` has patient id and chart timestamps, but no reliable per-change history or actor attribution.
-
-## Sources supported in this PR
-
-Supported now:
-
-- patient profile creation event, when patient object is provided;
-- chief complaint creation event, when complaint object is provided;
-- finding events;
-- treatment plan creation events;
-- appointment scheduled events;
-- patient file upload/archive events.
-
-Deferred:
-
-- dental chart per-tooth change events, because current chart data lacks reliable per-change actor/type history;
-- treatment stage events, because current stage type does not have reliable timestamps;
-- payments, stock, documents, audit events, and encounters, because those modules are future work or not stable timeline sources yet.
-
-## Implementation summary
+## Implementation
 
 Added `PatientTimelineAggregator.ts` with:
 
@@ -81,21 +54,42 @@ Added `PatientTimelineAggregator.ts` with:
 - `filterPatientTimelineEvents`;
 - `canRoleSeePatientTimelineEvent`.
 
-## Timeline event rules
+## Sources covered
+
+Supported:
+
+- patient creation event;
+- chief complaint event;
+- finding events;
+- treatment plan events;
+- appointment events;
+- patient file events.
+
+Deferred:
+
+- dental chart per-change events;
+- treatment stage events;
+- payments;
+- stock;
+- documents;
+- audit/activity;
+- encounter/visit model.
+
+## Rules
 
 Event id strategy:
 
 - `${sourceType}:${sourceId}:${type}`.
 
-`occurredAt` strategy:
+Timestamps:
 
-- source timestamp only;
-- no fake `now` events;
-- invalid or missing source timestamps are omitted.
+- source timestamps only;
+- invalid/missing timestamps are omitted;
+- no generated `now` events.
 
 Sorting:
 
-1. `occurredAt` descending;
+1. occurredAt descending;
 2. category order;
 3. source type;
 4. source id;
@@ -103,97 +97,68 @@ Sorting:
 
 Archived handling:
 
-- archived findings are excluded by default;
-- archived patient files are excluded by default;
+- archived findings/files are excluded by default;
 - archived findings/files are included only with `includeArchived: true`.
 
-Source links:
+Role visibility helper:
 
-- finding ids, tooth ids, treatment plan ids, appointment ids, file ids, and file clinical metadata are preserved where present.
+- owner/admin: all event visibility buckets;
+- doctor: clinical and admin;
+- registrar/receptionist: admin only;
+- cashier: financial and admin;
+- platform roles: no patient event access in this helper.
 
-Role visibility:
-
-- owner/admin can see all event visibility buckets;
-- doctor can see clinical and admin events;
-- registrar/receptionist can see admin events only;
-- cashier can see financial and admin events;
-- platform roles are conservative and do not receive patient event access in this helper.
-
-## No-tenant and data boundary
+## Boundary
 
 The aggregator requires:
 
 - `tenantId`;
 - `patientId`.
 
-Missing `tenantId` throws:
+It throws clear errors when either is missing.
 
-`Active clinic is required for patient timeline.`
-
-Missing `patientId` throws:
-
-`Patient is required for patient timeline.`
-
-The aggregator does not:
-
-- call Supabase;
-- read localStorage;
-- use browser APIs;
-- know about auth mode;
-- require local Supabase;
-- require cloud Supabase.
+It does not perform data loading. Future hook/UI code must load source data and pass it in.
 
 ## Tests
 
-Added:
+Added `src/data/aggregators/PatientTimelineAggregator.test.ts`.
 
-- `src/data/aggregators/PatientTimelineAggregator.test.ts`
+Covered:
 
-Covered cases:
+- findings;
+- treatment plans;
+- appointments;
+- appointment is not treatment completion;
+- patient files;
+- patient and complaint events;
+- timestamp sorting;
+- deterministic tie-break;
+- archived default exclusion;
+- includeArchived behavior;
+- missing tenant/patient errors;
+- invalid timestamp omission;
+- category/visibility/archive filtering;
+- patientId scoping;
+- pure unit behavior;
+- role visibility helper.
 
-- builds finding events;
-- builds treatment plan events;
-- builds appointment events;
-- appointment is not treated as completed treatment;
-- builds patient file events;
-- preserves tooth/finding/plan/file source links;
-- can include patient and complaint events;
-- sorts descending by source timestamp;
-- deterministic tie-break for equal timestamps;
-- archived findings excluded by default;
-- archived findings included with `includeArchived: true`;
-- archived patient files excluded by default;
-- archived patient files included with `includeArchived: true`;
-- missing tenant error;
-- missing patient error;
-- invalid timestamps are omitted;
-- filters by category, visibility, and archived flag;
-- patientId scoping for appointments/files;
-- pure unit behavior without Supabase/localStorage/browser;
-- conservative role visibility helper.
+## Not changed
 
-## What was intentionally NOT changed
-
-- no UI;
-- no PatientCardPage `История` tab;
+- no UI tab;
 - no hook;
-- no browser smoke;
 - no migrations;
 - no cloud;
-- no local Supabase;
+- no browser smoke;
+- no local database;
 - no audit table;
-- no encounter/visit model;
+- no visit/encounter model;
 - no payment/stock/documents implementation;
 - no dependencies.
 
 ## Checks
 
-Pending after PR creation:
+Pending after report metadata update:
 
-- `git status --short`;
-- `npm run lint`;
-- `npm run test -- --run`;
-- `npm run build`;
 - GitHub Actions CI.
 
 ## Final verdict

--- a/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
+++ b/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
@@ -2,9 +2,11 @@
 
 ## Summary
 
-Implemented a UI-neutral patient timeline event model and a pure computed aggregator.
+Implemented a UI-neutral patient timeline event model and pure computed aggregator.
 
 The aggregator accepts already loaded source objects. It does not query Supabase, read localStorage, use browser APIs, or require local/cloud databases.
+
+Review follow-up fixed patient scoping for every supported source object. Wrong-patient objects are ignored before timeline events are emitted.
 
 ## Branch
 
@@ -16,7 +18,7 @@ https://github.com/NckNA/codex-test/pull/297
 
 ## PR head reviewed before final report update
 
-`ddc30fc003dfdf2cf03ba6b34aa97476a7ec388e`
+`e79213fdaf7e5a48945320181ce145c901ffe768`
 
 ## Report update commit
 
@@ -75,7 +77,22 @@ Deferred:
 - audit/activity;
 - encounter/visit model.
 
-## Rules
+## Patient scoping
+
+All supported source objects are defensively scoped to `input.patientId` before event creation.
+
+Wrong-patient source objects are ignored for:
+
+- patient;
+- chief complaint;
+- findings;
+- treatment plans;
+- appointments;
+- patient files.
+
+Appointments and patient files already had patient filters. This update added the missing patient filters for patient, chief complaint, findings, and treatment plans.
+
+## Timeline rules
 
 Event id strategy:
 
@@ -121,7 +138,7 @@ It does not perform data loading. Future hook/UI code must load source data and 
 
 ## Tests
 
-Added `src/data/aggregators/PatientTimelineAggregator.test.ts`.
+Added and updated `src/data/aggregators/PatientTimelineAggregator.test.ts`.
 
 Covered:
 
@@ -138,7 +155,7 @@ Covered:
 - missing tenant/patient errors;
 - invalid timestamp omission;
 - category/visibility/archive filtering;
-- patientId scoping;
+- patientId scoping across patient, complaint, findings, treatment plans, appointments, and files;
 - pure unit behavior;
 - role visibility helper.
 
@@ -157,10 +174,10 @@ Covered:
 
 ## Checks
 
-GitHub Actions CI on reviewed head `ddc30fc003dfdf2cf03ba6b34aa97476a7ec388e`:
+GitHub Actions CI on reviewed head `e79213fdaf7e5a48945320181ce145c901ffe768`:
 
-- run `27630136211`;
-- CI `#472`;
+- run `27630859056`;
+- CI `#475`;
 - ESLint: success;
 - tests: success;
 - build: success.

--- a/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
+++ b/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
@@ -16,7 +16,7 @@ https://github.com/NckNA/codex-test/pull/297
 
 ## PR head reviewed before final report update
 
-`2ddbcf916e84ba3834411ed3ff18c4942624ad97`
+`ddc30fc003dfdf2cf03ba6b34aa97476a7ec388e`
 
 ## Report update commit
 
@@ -157,13 +157,17 @@ Covered:
 
 ## Checks
 
-Pending after report metadata update:
+GitHub Actions CI on reviewed head `ddc30fc003dfdf2cf03ba6b34aa97476a7ec388e`:
 
-- GitHub Actions CI.
+- run `27630136211`;
+- CI `#472`;
+- ESLint: success;
+- tests: success;
+- build: success.
 
 ## Final verdict
 
-PARTIAL pending CI validation.
+TIMELINE AGGREGATOR IMPLEMENTED AND VERIFIED
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
+++ b/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
@@ -1,0 +1,205 @@
+# PATIENT-TIMELINE-AGGREGATOR-001 timeline aggregator
+
+## Summary
+
+Implemented the first patient timeline foundation: a UI-neutral domain event model plus a computed `buildPatientTimeline` aggregator.
+
+The aggregator is intentionally pure. It accepts already loaded source objects and does not query Supabase, read localStorage, call browser APIs, or require local/cloud databases.
+
+## Branch name
+
+`feature/patient-timeline-aggregator-001`
+
+## PR URL
+
+Pending PR creation.
+
+## PR head reviewed before final report update
+
+Pending PR creation.
+
+## Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## Changed files summary
+
+Initial implementation scope:
+
+- `src/data/aggregators/PatientTimelineAggregator.ts`
+- `src/data/aggregators/PatientTimelineAggregator.test.ts`
+- `_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md`
+
+## Current state recon
+
+Inspected current project types and data-layer files:
+
+- `src/types/index.ts`
+- `src/data/aggregators/ClinicalSummaryAggregator.ts`
+- `src/domain/findingStatus.ts`
+- `src/data/repositories/PatientFilesRepository.ts`
+- `src/contexts/TenantContext.tsx`
+
+Existing shapes found:
+
+- `Patient` has `id`, profile fields, `status`, and `createdAt`.
+- `ChiefComplaint` has `patientId`, `text`, `relatedTeeth`, `createdAt`, and `updatedAt`.
+- `DentalFinding` has `patientId`, optional `toothNumber`, `status`, `createdAt`, and `updatedAt`.
+- `TreatmentPlan` has `patientId`, `status`, `createdAt`, `updatedAt`, stages, and total price.
+- `Appointment` has optional `patientId`, start/end time, status, doctor id, service, and created timestamp.
+- `PatientFileRecord` has tenant/patient ids, storage metadata, archive fields, upload/archive actors, and created/updated timestamps.
+- `DentalChart` has patient id and chart timestamps, but no reliable per-change history or actor attribution.
+
+## Sources supported in this PR
+
+Supported now:
+
+- patient profile creation event, when patient object is provided;
+- chief complaint creation event, when complaint object is provided;
+- finding events;
+- treatment plan creation events;
+- appointment scheduled events;
+- patient file upload/archive events.
+
+Deferred:
+
+- dental chart per-tooth change events, because current chart data lacks reliable per-change actor/type history;
+- treatment stage events, because current stage type does not have reliable timestamps;
+- payments, stock, documents, audit events, and encounters, because those modules are future work or not stable timeline sources yet.
+
+## Implementation summary
+
+Added `PatientTimelineAggregator.ts` with:
+
+- `PatientTimelineEventCategory`;
+- `PatientTimelineEventVisibility`;
+- `PatientTimelineSourceType`;
+- `PatientTimelineEvent`;
+- `BuildPatientTimelineInput`;
+- `buildPatientTimeline`;
+- `sortPatientTimelineEvents`;
+- `filterPatientTimelineEvents`;
+- `canRoleSeePatientTimelineEvent`.
+
+## Timeline event rules
+
+Event id strategy:
+
+- `${sourceType}:${sourceId}:${type}`.
+
+`occurredAt` strategy:
+
+- source timestamp only;
+- no fake `now` events;
+- invalid or missing source timestamps are omitted.
+
+Sorting:
+
+1. `occurredAt` descending;
+2. category order;
+3. source type;
+4. source id;
+5. event id.
+
+Archived handling:
+
+- archived findings are excluded by default;
+- archived patient files are excluded by default;
+- archived findings/files are included only with `includeArchived: true`.
+
+Source links:
+
+- finding ids, tooth ids, treatment plan ids, appointment ids, file ids, and file clinical metadata are preserved where present.
+
+Role visibility:
+
+- owner/admin can see all event visibility buckets;
+- doctor can see clinical and admin events;
+- registrar/receptionist can see admin events only;
+- cashier can see financial and admin events;
+- platform roles are conservative and do not receive patient event access in this helper.
+
+## No-tenant and data boundary
+
+The aggregator requires:
+
+- `tenantId`;
+- `patientId`.
+
+Missing `tenantId` throws:
+
+`Active clinic is required for patient timeline.`
+
+Missing `patientId` throws:
+
+`Patient is required for patient timeline.`
+
+The aggregator does not:
+
+- call Supabase;
+- read localStorage;
+- use browser APIs;
+- know about auth mode;
+- require local Supabase;
+- require cloud Supabase.
+
+## Tests
+
+Added:
+
+- `src/data/aggregators/PatientTimelineAggregator.test.ts`
+
+Covered cases:
+
+- builds finding events;
+- builds treatment plan events;
+- builds appointment events;
+- appointment is not treated as completed treatment;
+- builds patient file events;
+- preserves tooth/finding/plan/file source links;
+- can include patient and complaint events;
+- sorts descending by source timestamp;
+- deterministic tie-break for equal timestamps;
+- archived findings excluded by default;
+- archived findings included with `includeArchived: true`;
+- archived patient files excluded by default;
+- archived patient files included with `includeArchived: true`;
+- missing tenant error;
+- missing patient error;
+- invalid timestamps are omitted;
+- filters by category, visibility, and archived flag;
+- patientId scoping for appointments/files;
+- pure unit behavior without Supabase/localStorage/browser;
+- conservative role visibility helper.
+
+## What was intentionally NOT changed
+
+- no UI;
+- no PatientCardPage `История` tab;
+- no hook;
+- no browser smoke;
+- no migrations;
+- no cloud;
+- no local Supabase;
+- no audit table;
+- no encounter/visit model;
+- no payment/stock/documents implementation;
+- no dependencies.
+
+## Checks
+
+Pending after PR creation:
+
+- `git status --short`;
+- `npm run lint`;
+- `npm run test -- --run`;
+- `npm run build`;
+- GitHub Actions CI.
+
+## Final verdict
+
+PARTIAL pending CI validation.
+
+## Recommended next task
+
+`PATIENT-TIMELINE-UI-001`

--- a/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
+++ b/_ai_work/REPORTS/PATIENT-TIMELINE-AGGREGATOR-001_timeline_aggregator.md
@@ -18,7 +18,7 @@ https://github.com/NckNA/codex-test/pull/297
 
 ## PR head reviewed before final report update
 
-`e79213fdaf7e5a48945320181ce145c901ffe768`
+`e2387c0cc7a229e843d04ff7c090ffad3b7fd16b`
 
 ## Report update commit
 
@@ -174,10 +174,11 @@ Covered:
 
 ## Checks
 
-GitHub Actions CI on reviewed head `e79213fdaf7e5a48945320181ce145c901ffe768`:
+GitHub Actions CI on reviewed head `e2387c0cc7a229e843d04ff7c090ffad3b7fd16b`:
 
-- run `27630859056`;
-- CI `#475`;
+- run `27630972480`;
+- CI `#476`;
+- tested commit `e2387c0cc7a229e843d04ff7c090ffad3b7fd16b`;
 - ESLint: success;
 - tests: success;
 - build: success.

--- a/src/data/aggregators/PatientTimelineAggregator.test.ts
+++ b/src/data/aggregators/PatientTimelineAggregator.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import type { Appointment, ChiefComplaint, DentalFinding, Patient, TreatmentPlan } from '../../types';
+import type { TimelinePatientFile, PatientTimelineEvent } from './PatientTimelineAggregator';
+import {
+  ACTIVE_CLINIC_REQUIRED_FOR_TIMELINE,
+  PATIENT_REQUIRED_FOR_TIMELINE,
+  buildPatientTimeline,
+  canRoleSeePatientTimelineEvent,
+  filterPatientTimelineEvents,
+  sortPatientTimelineEvents,
+} from './PatientTimelineAggregator';
+
+const tenantId = 'tenant-a';
+const patientId = 'patient-a';
+
+function finding(overrides: Partial<DentalFinding> = {}): DentalFinding {
+  return {
+    id: 'finding-a',
+    patientId,
+    toothNumber: 11,
+    title: 'Кариес 11',
+    category: 'caries',
+    severity: 'medium',
+    description: 'Описание находки',
+    isChiefComplaintRelated: false,
+    includeInTreatmentPlan: true,
+    status: 'discovered',
+    createdAt: '2026-01-02T10:00:00.000Z',
+    updatedAt: '2026-01-02T11:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function plan(overrides: Partial<TreatmentPlan> = {}): TreatmentPlan {
+  return {
+    id: 'plan-a',
+    patientId,
+    title: 'План лечения',
+    status: 'draft',
+    stages: [],
+    totalPrice: 120000,
+    createdAt: '2026-01-03T10:00:00.000Z',
+    updatedAt: '2026-01-03T11:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function appointment(overrides: Partial<Appointment> = {}): Appointment {
+  return {
+    id: 'appointment-a',
+    patientId,
+    doctorId: 'doctor-a',
+    cabinet: '1',
+    service: 'Консультация',
+    start: '2026-01-04T10:00:00.000Z',
+    end: '2026-01-04T10:30:00.000Z',
+    status: 'confirmed',
+    createdAt: '2026-01-01T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function patientFile(overrides: Partial<TimelinePatientFile> = {}): TimelinePatientFile {
+  return {
+    id: 'file-a',
+    tenantId,
+    patientId,
+    storageBucket: 'patient-files',
+    storagePath: `${tenantId}/patients/${patientId}/dental-photos/file-a-photo.jpg`,
+    originalFilename: 'photo.jpg',
+    mimeType: 'image/jpeg',
+    sizeBytes: 1024,
+    fileKind: 'dental_photo',
+    sourceContext: 'dental_chart',
+    isArchived: false,
+    createdAt: '2026-01-05T10:00:00.000Z',
+    updatedAt: '2026-01-05T10:00:00.000Z',
+    toothId: '11',
+    findingId: 'finding-a',
+    treatmentPlanId: 'plan-a',
+    uploadedBy: 'doctor-a',
+    ...overrides,
+  };
+}
+
+describe('PatientTimelineAggregator', () => {
+  it('builds timeline events from findings', () => {
+    const events = buildPatientTimeline({ tenantId, patientId, findings: [finding()] });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      category: 'finding',
+      sourceType: 'finding',
+      sourceId: 'finding-a',
+      findingId: 'finding-a',
+      toothId: '11',
+      visibility: 'clinical',
+      sourceStatus: 'discovered',
+      isArchived: false,
+    });
+  });
+
+  it('builds timeline events from treatment plans without inventing stage events', () => {
+    const events = buildPatientTimeline({ tenantId, patientId, treatmentPlans: [plan()] });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      category: 'treatment_plan',
+      sourceType: 'treatment_plan',
+      treatmentPlanId: 'plan-a',
+      visibility: 'clinical',
+      sourceStatus: 'draft',
+      metadata: { totalPrice: 120000, stageCount: 0 },
+    });
+  });
+
+  it('builds appointment events without treating appointments as completed treatment', () => {
+    const events = buildPatientTimeline({ tenantId, patientId, appointments: [appointment({ status: 'completed' })] });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      category: 'appointment',
+      sourceType: 'appointment',
+      appointmentId: 'appointment-a',
+      type: 'appointment_scheduled',
+      sourceStatus: 'completed',
+      visibility: 'admin',
+    });
+    expect(events[0].category).not.toBe('treatment_plan');
+  });
+
+  it('builds patient file events and preserves metadata source links', () => {
+    const events = buildPatientTimeline({ tenantId, patientId, patientFiles: [patientFile()] });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      category: 'file',
+      sourceType: 'patient_file',
+      fileId: 'file-a',
+      toothId: '11',
+      findingId: 'finding-a',
+      treatmentPlanId: 'plan-a',
+      actorUserId: 'doctor-a',
+      visibility: 'clinical',
+      isArchived: false,
+    });
+  });
+
+  it('can include patient and chief complaint events when source data is passed in', () => {
+    const patient: Patient = {
+      id: patientId,
+      fullName: 'Test Patient',
+      phone: '+70000000000',
+      source: 'phone',
+      status: 'active',
+      createdAt: '2026-01-01T09:00:00.000Z',
+    };
+    const complaint: ChiefComplaint = {
+      id: 'complaint-a',
+      patientId,
+      text: 'Болит зуб',
+      relatedTeeth: [11],
+      createdAt: '2026-01-01T10:00:00.000Z',
+      updatedAt: '2026-01-01T10:00:00.000Z',
+    };
+
+    const events = buildPatientTimeline({ tenantId, patientId, patient, chiefComplaint: complaint });
+
+    expect(events.map((event) => event.category)).toEqual(['complaint', 'patient']);
+    expect(events[0].sourceType).toBe('complaint');
+    expect(events[1].sourceType).toBe('patient');
+  });
+
+  it('sorts events by occurredAt descending', () => {
+    const events = buildPatientTimeline({
+      tenantId,
+      patientId,
+      findings: [finding()],
+      treatmentPlans: [plan()],
+      appointments: [appointment()],
+      patientFiles: [patientFile()],
+    });
+
+    expect(events.map((event) => event.sourceType)).toEqual([
+      'patient_file',
+      'appointment',
+      'treatment_plan',
+      'finding',
+    ]);
+  });
+
+  it('uses a deterministic tie-break for equal timestamps', () => {
+    const sameTime = '2026-01-06T10:00:00.000Z';
+    const events: PatientTimelineEvent[] = [
+      {
+        id: 'z',
+        tenantId,
+        patientId,
+        occurredAt: sameTime,
+        category: 'file',
+        type: 'b',
+        title: 'File',
+        sourceType: 'patient_file',
+        sourceId: 'z',
+        visibility: 'clinical',
+      },
+      {
+        id: 'a',
+        tenantId,
+        patientId,
+        occurredAt: sameTime,
+        category: 'finding',
+        type: 'a',
+        title: 'Finding',
+        sourceType: 'finding',
+        sourceId: 'a',
+        visibility: 'clinical',
+      },
+    ];
+
+    expect(sortPatientTimelineEvents(events).map((event) => event.id)).toEqual(['a', 'z']);
+  });
+
+  it('excludes archived findings by default and includes them when requested', () => {
+    const archived = finding({ id: 'finding-archived', status: 'archived' });
+
+    expect(buildPatientTimeline({ tenantId, patientId, findings: [archived] })).toHaveLength(0);
+
+    const events = buildPatientTimeline({ tenantId, patientId, findings: [archived], includeArchived: true });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ isArchived: true, type: 'finding_archived' });
+  });
+
+  it('excludes archived patient files by default and includes them when requested', () => {
+    const archived = patientFile({
+      id: 'file-archived',
+      isArchived: true,
+      archivedAt: '2026-01-07T10:00:00.000Z',
+      archivedBy: 'doctor-a',
+    });
+
+    expect(buildPatientTimeline({ tenantId, patientId, patientFiles: [archived] })).toHaveLength(0);
+
+    const events = buildPatientTimeline({ tenantId, patientId, patientFiles: [archived], includeArchived: true });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ isArchived: true, type: 'patient_file_archived', actorUserId: 'doctor-a' });
+  });
+
+  it('throws clear errors for missing tenantId or patientId', () => {
+    expect(() => buildPatientTimeline({ tenantId: '', patientId })).toThrow(ACTIVE_CLINIC_REQUIRED_FOR_TIMELINE);
+    expect(() => buildPatientTimeline({ tenantId, patientId: '' })).toThrow(PATIENT_REQUIRED_FOR_TIMELINE);
+  });
+
+  it('omits source events with invalid timestamps instead of inventing now-based events', () => {
+    const events = buildPatientTimeline({
+      tenantId,
+      patientId,
+      findings: [finding({ createdAt: '' })],
+      treatmentPlans: [plan({ createdAt: 'not-a-date' })],
+      patientFiles: [patientFile({ createdAt: 'bad-date' })],
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('filters built events by category, visibility, and archived flag', () => {
+    const events = buildPatientTimeline({
+      tenantId,
+      patientId,
+      findings: [finding(), finding({ id: 'archived-finding', status: 'archived' })],
+      appointments: [appointment()],
+      includeArchived: true,
+    });
+
+    expect(filterPatientTimelineEvents(events, { categories: ['finding'] })).toHaveLength(2);
+    expect(filterPatientTimelineEvents(events, { visibility: ['admin'] })).toHaveLength(1);
+    expect(filterPatientTimelineEvents(events, { includeArchived: false })).toHaveLength(2);
+  });
+
+  it('keeps patientId scoped for appointments and files', () => {
+    const events = buildPatientTimeline({
+      tenantId,
+      patientId,
+      appointments: [appointment({ id: 'other-appointment', patientId: 'other-patient' })],
+      patientFiles: [patientFile({ id: 'other-file', patientId: 'other-patient' })],
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not require Supabase, localStorage, browser, or local database', () => {
+    const events = buildPatientTimeline({ tenantId, patientId, findings: [finding()] });
+
+    expect(events[0].sourceType).toBe('finding');
+  });
+
+  it('implements conservative role visibility rules', () => {
+    const clinicalEvent = buildPatientTimeline({ tenantId, patientId, findings: [finding()] })[0];
+    const adminEvent = buildPatientTimeline({ tenantId, patientId, appointments: [appointment()] })[0];
+    const financialEvent: PatientTimelineEvent = {
+      id: 'payment:p1:created',
+      tenantId,
+      patientId,
+      occurredAt: '2026-01-08T10:00:00.000Z',
+      category: 'payment',
+      type: 'payment_created',
+      title: 'Оплата',
+      sourceType: 'payment',
+      sourceId: 'p1',
+      visibility: 'financial',
+    };
+
+    expect(canRoleSeePatientTimelineEvent('clinic_admin', financialEvent)).toBe(true);
+    expect(canRoleSeePatientTimelineEvent('doctor', clinicalEvent)).toBe(true);
+    expect(canRoleSeePatientTimelineEvent('doctor', adminEvent)).toBe(true);
+    expect(canRoleSeePatientTimelineEvent('doctor', financialEvent)).toBe(false);
+    expect(canRoleSeePatientTimelineEvent('registrar', clinicalEvent)).toBe(false);
+    expect(canRoleSeePatientTimelineEvent('registrar', adminEvent)).toBe(true);
+    expect(canRoleSeePatientTimelineEvent('cashier', financialEvent)).toBe(true);
+    expect(canRoleSeePatientTimelineEvent('platform_admin', clinicalEvent)).toBe(false);
+    expect(canRoleSeePatientTimelineEvent(null, clinicalEvent)).toBe(false);
+  });
+});

--- a/src/data/aggregators/PatientTimelineAggregator.test.ts
+++ b/src/data/aggregators/PatientTimelineAggregator.test.ts
@@ -150,7 +150,7 @@ describe('PatientTimelineAggregator', () => {
     const patient: Patient = {
       id: patientId,
       fullName: 'Test Patient',
-      phone: '+70000000000',
+      phone: 'test-phone',
       source: 'phone',
       status: 'active',
       createdAt: '2026-01-01T09:00:00.000Z',
@@ -277,10 +277,31 @@ describe('PatientTimelineAggregator', () => {
     expect(filterPatientTimelineEvents(events, { includeArchived: false })).toHaveLength(2);
   });
 
-  it('keeps patientId scoped for appointments and files', () => {
+  it('keeps patientId scoped for all supported source objects', () => {
+    const otherPatient: Patient = {
+      id: 'other-patient',
+      fullName: 'Other Patient',
+      phone: 'test-phone',
+      source: 'phone',
+      status: 'active',
+      createdAt: '2026-01-01T09:00:00.000Z',
+    };
+    const otherComplaint: ChiefComplaint = {
+      id: 'complaint-other',
+      patientId: 'other-patient',
+      text: 'Other complaint',
+      relatedTeeth: [12],
+      createdAt: '2026-01-01T10:00:00.000Z',
+      updatedAt: '2026-01-01T10:00:00.000Z',
+    };
+
     const events = buildPatientTimeline({
       tenantId,
       patientId,
+      patient: otherPatient,
+      chiefComplaint: otherComplaint,
+      findings: [finding({ id: 'other-finding', patientId: 'other-patient' })],
+      treatmentPlans: [plan({ id: 'other-plan', patientId: 'other-patient' })],
       appointments: [appointment({ id: 'other-appointment', patientId: 'other-patient' })],
       patientFiles: [patientFile({ id: 'other-file', patientId: 'other-patient' })],
     });

--- a/src/data/aggregators/PatientTimelineAggregator.ts
+++ b/src/data/aggregators/PatientTimelineAggregator.ts
@@ -154,6 +154,7 @@ export function filterPatientTimelineEvents(
 function buildPatientEvent(input: BuildPatientTimelineInput): PatientTimelineEvent | null {
   const patient = input.patient;
   if (!patient) return null;
+  if (patient.id !== input.patientId) return null;
 
   return createEvent({
     id: eventId('patient', patient.id, 'created'),
@@ -175,6 +176,7 @@ function buildPatientEvent(input: BuildPatientTimelineInput): PatientTimelineEve
 function buildChiefComplaintEvent(input: BuildPatientTimelineInput): PatientTimelineEvent | null {
   const complaint = input.chiefComplaint;
   if (!complaint) return null;
+  if (complaint.patientId !== input.patientId) return null;
 
   return createEvent({
     id: eventId('complaint', complaint.id, 'created'),
@@ -194,6 +196,8 @@ function buildChiefComplaintEvent(input: BuildPatientTimelineInput): PatientTime
 
 function buildFindingEvents(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
   return (input.findings ?? []).flatMap((finding) => {
+    if (finding.patientId !== input.patientId) return [];
+
     const isArchived = isArchivedFindingStatus(finding.status);
     if (isArchived && !input.includeArchived) return [];
 
@@ -228,6 +232,8 @@ function buildFindingEvents(input: BuildPatientTimelineInput): PatientTimelineEv
 
 function buildTreatmentPlanEvents(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
   return (input.treatmentPlans ?? []).flatMap((plan) => {
+    if (plan.patientId !== input.patientId) return [];
+
     const event = createEvent({
       id: eventId('treatment_plan', plan.id, 'created'),
       tenantId: input.tenantId,

--- a/src/data/aggregators/PatientTimelineAggregator.ts
+++ b/src/data/aggregators/PatientTimelineAggregator.ts
@@ -1,0 +1,356 @@
+import type {
+  Appointment,
+  ChiefComplaint,
+  DentalChart,
+  DentalFinding,
+  Patient,
+  TreatmentPlan,
+} from '../../types';
+import { isArchivedFindingStatus } from '../../domain/findingStatus';
+import type { PatientFileRecord } from '../repositories/PatientFilesRepository';
+
+export type PatientTimelineEventCategory =
+  | 'patient'
+  | 'complaint'
+  | 'dental_chart'
+  | 'finding'
+  | 'treatment_plan'
+  | 'appointment'
+  | 'file'
+  | 'payment'
+  | 'stock'
+  | 'audit';
+
+export type PatientTimelineEventVisibility = 'clinical' | 'admin' | 'financial' | 'system';
+
+export type PatientTimelineSourceType =
+  | 'patient'
+  | 'complaint'
+  | 'dental_chart'
+  | 'finding'
+  | 'treatment_plan'
+  | 'treatment_stage'
+  | 'appointment'
+  | 'patient_file'
+  | 'payment'
+  | 'stock_movement'
+  | 'audit_event';
+
+export interface PatientTimelineEvent {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  occurredAt: string;
+  category: PatientTimelineEventCategory;
+  type: string;
+  title: string;
+  sourceType: PatientTimelineSourceType;
+  sourceId: string;
+  visibility: PatientTimelineEventVisibility;
+  description?: string;
+  sourceStatus?: string;
+  toothId?: string | null;
+  findingId?: string | null;
+  treatmentPlanId?: string | null;
+  treatmentStageId?: string | null;
+  appointmentId?: string | null;
+  fileId?: string | null;
+  actorUserId?: string | null;
+  actorLabel?: string | null;
+  isArchived?: boolean;
+  linkTarget?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PatientTimelineFilterOptions {
+  categories?: PatientTimelineEventCategory[];
+  visibility?: PatientTimelineEventVisibility[];
+  includeArchived?: boolean;
+}
+
+export type TimelinePatientFile = PatientFileRecord & {
+  findingId?: string | null;
+  treatmentPlanId?: string | null;
+  treatmentStageId?: string | null;
+  appointmentId?: string | null;
+};
+
+export interface BuildPatientTimelineInput {
+  tenantId: string;
+  patientId: string;
+  patient?: Patient | null;
+  chiefComplaint?: ChiefComplaint | null;
+  findings?: DentalFinding[];
+  treatmentPlans?: TreatmentPlan[];
+  appointments?: Appointment[];
+  patientFiles?: TimelinePatientFile[];
+  dentalChart?: DentalChart | null;
+  includeArchived?: boolean;
+}
+
+const CATEGORY_ORDER: Record<PatientTimelineEventCategory, number> = {
+  patient: 10,
+  complaint: 20,
+  dental_chart: 30,
+  finding: 40,
+  treatment_plan: 50,
+  appointment: 60,
+  file: 70,
+  payment: 80,
+  stock: 90,
+  audit: 100,
+};
+
+export const ACTIVE_CLINIC_REQUIRED_FOR_TIMELINE = 'Active clinic is required for patient timeline.';
+export const PATIENT_REQUIRED_FOR_TIMELINE = 'Patient is required for patient timeline.';
+
+function isValidIsoLikeDate(value: string | undefined | null): value is string {
+  return Boolean(value && !Number.isNaN(new Date(value).getTime()));
+}
+
+function eventId(sourceType: PatientTimelineSourceType, sourceId: string, type: string) {
+  return `${sourceType}:${sourceId}:${type}`;
+}
+
+function createEvent(input: Omit<PatientTimelineEvent, 'occurredAt'> & { occurredAt?: string | null }): PatientTimelineEvent | null {
+  if (!isValidIsoLikeDate(input.occurredAt)) return null;
+  return { ...input, occurredAt: input.occurredAt };
+}
+
+function pushEvent(events: PatientTimelineEvent[], event: PatientTimelineEvent | null) {
+  if (event) events.push(event);
+}
+
+export function sortPatientTimelineEvents(events: PatientTimelineEvent[]): PatientTimelineEvent[] {
+  return [...events].sort((a, b) => {
+    const byDate = new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime();
+    if (byDate !== 0) return byDate;
+
+    const byCategory = CATEGORY_ORDER[a.category] - CATEGORY_ORDER[b.category];
+    if (byCategory !== 0) return byCategory;
+
+    const bySourceType = a.sourceType.localeCompare(b.sourceType);
+    if (bySourceType !== 0) return bySourceType;
+
+    const bySourceId = a.sourceId.localeCompare(b.sourceId);
+    if (bySourceId !== 0) return bySourceId;
+
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function filterPatientTimelineEvents(
+  events: PatientTimelineEvent[],
+  options: PatientTimelineFilterOptions = {},
+): PatientTimelineEvent[] {
+  return events.filter((event) => {
+    if (options.categories?.length && !options.categories.includes(event.category)) return false;
+    if (options.visibility?.length && !options.visibility.includes(event.visibility)) return false;
+    if (options.includeArchived === false && event.isArchived) return false;
+    return true;
+  });
+}
+
+function buildPatientEvent(input: BuildPatientTimelineInput): PatientTimelineEvent | null {
+  const patient = input.patient;
+  if (!patient) return null;
+
+  return createEvent({
+    id: eventId('patient', patient.id, 'created'),
+    tenantId: input.tenantId,
+    patientId: input.patientId,
+    occurredAt: patient.createdAt,
+    category: 'patient',
+    type: 'patient_created',
+    title: 'Пациент добавлен',
+    description: patient.fullName,
+    sourceType: 'patient',
+    sourceId: patient.id,
+    visibility: 'admin',
+    sourceStatus: patient.status,
+    linkTarget: 'patient_card',
+  });
+}
+
+function buildChiefComplaintEvent(input: BuildPatientTimelineInput): PatientTimelineEvent | null {
+  const complaint = input.chiefComplaint;
+  if (!complaint) return null;
+
+  return createEvent({
+    id: eventId('complaint', complaint.id, 'created'),
+    tenantId: input.tenantId,
+    patientId: input.patientId,
+    occurredAt: complaint.createdAt,
+    category: 'complaint',
+    type: 'chief_complaint_added',
+    title: 'Добавлена жалоба пациента',
+    description: complaint.text,
+    sourceType: 'complaint',
+    sourceId: complaint.id,
+    visibility: 'clinical',
+    metadata: { relatedTeeth: complaint.relatedTeeth },
+  });
+}
+
+function buildFindingEvents(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
+  return (input.findings ?? []).flatMap((finding) => {
+    const isArchived = isArchivedFindingStatus(finding.status);
+    if (isArchived && !input.includeArchived) return [];
+
+    const event = createEvent({
+      id: eventId('finding', finding.id, 'created'),
+      tenantId: input.tenantId,
+      patientId: input.patientId,
+      occurredAt: finding.createdAt,
+      category: 'finding',
+      type: isArchived ? 'finding_archived' : 'finding_discovered',
+      title: isArchived ? 'Находка в архиве' : 'Выявлена находка',
+      description: finding.title,
+      sourceType: 'finding',
+      sourceId: finding.id,
+      sourceStatus: finding.status,
+      toothId: finding.toothNumber ? String(finding.toothNumber) : null,
+      findingId: finding.id,
+      visibility: 'clinical',
+      isArchived,
+      linkTarget: 'findings',
+      metadata: {
+        category: finding.category,
+        severity: finding.severity,
+        clinicalZone: finding.clinicalZone ?? null,
+        includeInTreatmentPlan: finding.includeInTreatmentPlan,
+      },
+    });
+
+    return event ? [event] : [];
+  });
+}
+
+function buildTreatmentPlanEvents(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
+  return (input.treatmentPlans ?? []).flatMap((plan) => {
+    const event = createEvent({
+      id: eventId('treatment_plan', plan.id, 'created'),
+      tenantId: input.tenantId,
+      patientId: input.patientId,
+      occurredAt: plan.createdAt,
+      category: 'treatment_plan',
+      type: 'treatment_plan_created',
+      title: 'Создан план лечения',
+      description: plan.title,
+      sourceType: 'treatment_plan',
+      sourceId: plan.id,
+      sourceStatus: plan.status,
+      treatmentPlanId: plan.id,
+      visibility: 'clinical',
+      linkTarget: 'treatment_plans',
+      metadata: {
+        totalPrice: plan.totalPrice,
+        stageCount: plan.stages.length,
+      },
+    });
+
+    return event ? [event] : [];
+  });
+}
+
+function buildAppointmentEvents(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
+  return (input.appointments ?? []).flatMap((appointment) => {
+    if (appointment.patientId !== input.patientId) return [];
+
+    const event = createEvent({
+      id: eventId('appointment', appointment.id, 'scheduled'),
+      tenantId: input.tenantId,
+      patientId: input.patientId,
+      occurredAt: appointment.start,
+      category: 'appointment',
+      type: 'appointment_scheduled',
+      title: 'Запланирован приём',
+      description: appointment.service,
+      sourceType: 'appointment',
+      sourceId: appointment.id,
+      sourceStatus: appointment.status,
+      appointmentId: appointment.id,
+      actorUserId: appointment.doctorId,
+      visibility: 'admin',
+      linkTarget: 'appointments',
+      metadata: {
+        cabinet: appointment.cabinet,
+        end: appointment.end,
+        paymentType: appointment.paymentType ?? null,
+      },
+    });
+
+    return event ? [event] : [];
+  });
+}
+
+function buildPatientFileEvents(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
+  return (input.patientFiles ?? []).flatMap((file) => {
+    if (file.patientId !== input.patientId) return [];
+    if (file.isArchived && !input.includeArchived) return [];
+
+    const event = createEvent({
+      id: eventId('patient_file', file.id, file.isArchived ? 'archived' : 'uploaded'),
+      tenantId: input.tenantId,
+      patientId: input.patientId,
+      occurredAt: file.isArchived ? file.archivedAt ?? file.updatedAt : file.createdAt,
+      category: 'file',
+      type: file.isArchived ? 'patient_file_archived' : 'patient_file_uploaded',
+      title: file.isArchived ? 'Файл в архиве' : 'Загружен файл пациента',
+      description: file.originalFilename,
+      sourceType: 'patient_file',
+      sourceId: file.id,
+      sourceStatus: file.fileKind,
+      toothId: file.toothId ?? null,
+      findingId: file.findingId ?? null,
+      treatmentPlanId: file.treatmentPlanId ?? null,
+      treatmentStageId: file.treatmentStageId ?? null,
+      appointmentId: file.appointmentId ?? null,
+      fileId: file.id,
+      actorUserId: file.isArchived ? file.archivedBy ?? null : file.uploadedBy ?? null,
+      visibility: 'clinical',
+      isArchived: file.isArchived,
+      linkTarget: 'patient_files',
+      metadata: {
+        fileKind: file.fileKind,
+        sourceContext: file.sourceContext,
+        mimeType: file.mimeType,
+        sizeBytes: file.sizeBytes,
+      },
+    });
+
+    return event ? [event] : [];
+  });
+}
+
+export function buildPatientTimeline(input: BuildPatientTimelineInput): PatientTimelineEvent[] {
+  if (!input.tenantId) throw new Error(ACTIVE_CLINIC_REQUIRED_FOR_TIMELINE);
+  if (!input.patientId) throw new Error(PATIENT_REQUIRED_FOR_TIMELINE);
+
+  const events: PatientTimelineEvent[] = [];
+
+  pushEvent(events, buildPatientEvent(input));
+  pushEvent(events, buildChiefComplaintEvent(input));
+  events.push(...buildFindingEvents(input));
+  events.push(...buildTreatmentPlanEvents(input));
+  events.push(...buildAppointmentEvents(input));
+  events.push(...buildPatientFileEvents(input));
+
+  // Dental chart changes are intentionally not emitted yet because the current chart model has
+  // tooth-level updatedAt values but no reliable per-change actor/type history.
+  void input.dentalChart;
+
+  return sortPatientTimelineEvents(events);
+}
+
+export function canRoleSeePatientTimelineEvent(role: string | null | undefined, event: PatientTimelineEvent): boolean {
+  if (!role) return false;
+
+  if (role === 'clinic_owner' || role === 'clinic_admin') return true;
+  if (role === 'doctor') return event.visibility === 'clinical' || event.visibility === 'admin';
+  if (role === 'registrar' || role === 'receptionist') return event.visibility === 'admin';
+  if (role === 'cashier') return event.visibility === 'financial' || event.visibility === 'admin';
+
+  // Platform roles require explicit audited patient access in a future task.
+  return false;
+}


### PR DESCRIPTION
Report/code implementation for PATIENT-TIMELINE-AGGREGATOR-001.

Scope:
- add pure patient timeline event model and aggregator
- add pure unit tests
- add task report

No migrations, no cloud, no UI tab, no browser smoke.