### PR TITLE
AUDIT-ACTIVITY-REPOSITORY-001B: add read-only audit/activity repository

### DIFF
--- a/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
@@ -22,9 +22,9 @@ https://github.com/NckNA/codex-test/pull/304
 
 ## PR head reviewed before final report update
 
-`e4ee992eca67d580106bb57b4fff172e37590cec`
+`5335d99fbdfe6783333a79f52ba5112ab1e22fc6`
 
-This is the PR head before the report metadata update that added the PR URL and reviewed head.
+This is the PR head validated before this final report metadata update.
 
 ## Report update commit
 
@@ -76,6 +76,8 @@ Added in `src/data/repositories/AuditActivityRepository.ts`:
 - `normalizeAuditActivityOffset`
 
 The repository exposes camelCase domain records and hides Supabase snake_case rows behind mapper functions.
+
+The factory supports the Supabase backend only. A local backend request throws a clear unsupported error instead of creating fake local audit history.
 
 ## Read-only boundary
 
@@ -192,6 +194,7 @@ Covered scenarios:
 18. Before/after/diff JSON is preserved.
 19. Limit and offset are normalized safely.
 20. The public repository object does not expose create/update/delete methods.
+21. Local backend creation is rejected instead of creating fake audit history.
 
 Tests use a mocked Supabase query chain only.
 
@@ -214,19 +217,21 @@ Tests use a mocked Supabase query chain only.
 
 Local terminal checks were not run in this environment.
 
-GitHub Actions CI is pending after PR creation.
+GitHub Actions CI before this final report metadata update:
 
-Expected checks:
-
-- `npm run lint`
-- `npm run test -- --run`
-- `npm run build`
+- workflow: `CI`
+- run id: `27745822816`
+- run number / CI: `#515`
+- status: `completed`
+- conclusion: `success`
+- tested commit: `5335d99fbdfe6783333a79f52ba5112ab1e22fc6`
+- ESLint: success
+- tests: success
+- build: success
 
 ## Final verdict
 
-`PARTIAL`
-
-Reason: implementation and unit tests were added, but GitHub Actions CI has not run yet at this report metadata update.
+`AUDIT ACTIVITY REPOSITORY IMPLEMENTED AND VERIFIED`
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
@@ -18,11 +18,13 @@ The repository does not create, update, delete, archive, or insert audit/activit
 
 ## PR URL
 
-Pending until PR creation.
+https://github.com/NckNA/codex-test/pull/304
 
 ## PR head reviewed before final report update
 
-Pending until final report update.
+`e4ee992eca67d580106bb57b4fff172e37590cec`
+
+This is the PR head before the report metadata update that added the PR URL and reviewed head.
 
 ## Report update commit
 
@@ -224,7 +226,7 @@ Expected checks:
 
 `PARTIAL`
 
-Reason: implementation and unit tests were added, but GitHub Actions CI has not run yet at initial report creation time.
+Reason: implementation and unit tests were added, but GitHub Actions CI has not run yet at this report metadata update.
 
 ## Recommended next task
 

--- a/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
@@ -1,0 +1,231 @@
+# AUDIT-ACTIVITY-REPOSITORY-001B Repository Report
+
+## Summary
+
+This PR adds a read-only TypeScript repository layer for the audit/activity schema from `AUDIT-ACTIVITY-LOG-001A`.
+
+It adds domain types, query options, mapper functions, a read-only repository interface, and a Supabase implementation for:
+
+- tenant audit events;
+- tenant activity events;
+- patient activity events.
+
+The repository does not create, update, delete, archive, or insert audit/activity events. Write paths remain a future `AUDIT-ACTIVITY-RPC-001C` task, because letting arbitrary client code write compliance history would be software malpractice with prettier syntax.
+
+## Branch name
+
+`feature/audit-activity-repository-001b`
+
+## PR URL
+
+Pending until PR creation.
+
+## PR head reviewed before final report update
+
+Pending until final report update.
+
+## Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## Changed files summary
+
+Expected changed files:
+
+1. `src/data/repositories/AuditActivityRepository.ts`
+2. `src/data/repositories/AuditActivityRepository.test.ts`
+3. `_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md`
+
+No migrations, UI, cloud config, seed data, generated types, browser smoke, RPC, or timeline integration were changed.
+
+## Current repository pattern recon
+
+Existing repositories use tenant-scoped Supabase queries and throw Supabase errors instead of silently swallowing them.
+
+Observed patterns:
+
+- `FindingsRepository` uses `tenant_id` and `patient_id` filters for Supabase reads and writes.
+- `AppointmentRepository` filters appointments by `tenant_id`, and patient appointment reads also filter `patient_id`.
+- `PatientFilesRepository` requires an active clinic for Supabase file access and throws when Supabase is not configured.
+- Several older clinical repositories still have localStorage fallbacks for demo/local operation.
+
+For audit/activity this PR intentionally does not add localStorage fallback. Fake local audit history would look authoritative while being disposable. That is worse than having no audit history.
+
+## Implementation summary
+
+Added in `src/data/repositories/AuditActivityRepository.ts`:
+
+- `AuditEventCategory`
+- `AuditEventSeverity`
+- `AuditEventRedactionLevel`
+- `AuditEvent`
+- `ActivityEventCategory`
+- `ActivityEventVisibility`
+- `ActivityEvent`
+- `ListAuditEventsOptions`
+- `ListActivityEventsOptions`
+- `ListPatientActivityEventsOptions`
+- `AuditActivityRepository`
+- `SupabaseAuditActivityRepository`
+- `createAuditActivityRepository`
+- `mapAuditEventRow`
+- `mapActivityEventRow`
+- `normalizeAuditActivityLimit`
+- `normalizeAuditActivityOffset`
+
+The repository exposes camelCase domain records and hides Supabase snake_case rows behind mapper functions.
+
+## Read-only boundary
+
+The public repository interface only exposes:
+
+- `listAuditEvents`
+- `listActivityEvents`
+- `listPatientActivityEvents`
+
+It does not expose:
+
+- `createAuditEvent`
+- `createActivityEvent`
+- `updateAuditEvent`
+- `deleteAuditEvent`
+- `archiveAuditEvent`
+- raw insert/update/delete helpers.
+
+The implementation uses the normal Supabase browser client only. It does not call service-role APIs and does not include any secret-bearing path.
+
+## Query behavior
+
+### Audit events
+
+`listAuditEvents`:
+
+- requires `tenantId`;
+- queries `audit_events`;
+- filters defensively by `tenant_id`;
+- supports category, severity, target, patient, actor, and date filters;
+- sorts by `created_at` descending;
+- applies bounded pagination.
+
+### Activity events
+
+`listActivityEvents`:
+
+- requires `tenantId`;
+- queries `activity_events`;
+- filters defensively by `tenant_id`;
+- supports patient, category, visibility, source, and date filters;
+- excludes archived records by default;
+- includes archived records only when `includeArchived=true`;
+- sorts by `occurred_at` descending, then `created_at` descending;
+- applies bounded pagination.
+
+### Patient activity
+
+`listPatientActivityEvents`:
+
+- requires `tenantId`;
+- requires `patientId`;
+- delegates to `listActivityEvents` with both tenant and patient filters.
+
+Default limit is `50`. Maximum limit is `200`. Offset defaults to `0`.
+
+## RLS relationship
+
+The repository is not an authorization system by itself.
+
+It adds defensive tenant filters before every tenant-scoped query, while database RLS remains the source of authorization.
+
+The migration keeps raw audit reads limited to clinic owner/admin by tenant and restricts activity reads by role/visibility. This repository relies on those policies and does not add write access.
+
+## Mappers
+
+`mapAuditEventRow` maps:
+
+- `tenant_id` to `tenantId`;
+- `actor_user_id` to `actorUserId`;
+- `target_type` to `targetType`;
+- `before_data`, `after_data`, `diff_data` to JSON object records or null;
+- `redaction_level` to `redactionLevel`;
+- `created_at` to `createdAt`.
+
+`mapActivityEventRow` maps:
+
+- `tenant_id` to `tenantId`;
+- `patient_id` to `patientId`;
+- `audit_event_id` to `auditEventId`;
+- `source_type` and `source_id` to source fields;
+- `source_status` to `sourceStatus`;
+- `occurred_at` to `occurredAt`;
+- `is_archived` to `isArchived`;
+- `created_at` to `createdAt`.
+
+Metadata defaults to `{}` when missing or not an object.
+
+## Tests
+
+Test file:
+
+`src/data/repositories/AuditActivityRepository.test.ts`
+
+Covered scenarios:
+
+1. `listAuditEvents` requires tenantId.
+2. `listActivityEvents` requires tenantId.
+3. `listPatientActivityEvents` requires tenantId and patientId.
+4. `listAuditEvents` queries `audit_events`.
+5. `listAuditEvents` applies tenant, category, severity, target, patient, actor, and date filters.
+6. `listAuditEvents` sorts by `created_at` descending.
+7. `listAuditEvents` applies bounded range pagination.
+8. `listActivityEvents` queries `activity_events`.
+9. `listActivityEvents` applies tenant and patient filters.
+10. `listActivityEvents` excludes archived by default.
+11. `listActivityEvents` includes archived when requested.
+12. `listActivityEvents` applies visibility, category, source, and date filters.
+13. `listActivityEvents` sorts by `occurred_at` and `created_at` descending.
+14. `listPatientActivityEvents` filters tenant and patient.
+15. Supabase errors are surfaced.
+16. Mappers convert snake_case rows to camelCase records.
+17. Metadata defaults to `{}`.
+18. Before/after/diff JSON is preserved.
+19. Limit and offset are normalized safely.
+20. The public repository object does not expose create/update/delete methods.
+
+Tests use a mocked Supabase query chain only.
+
+## What was intentionally NOT changed
+
+- No migrations.
+- No Supabase cloud.
+- No local Supabase.
+- No browser smoke.
+- No UI.
+- No timeline integration.
+- No RPC/write path.
+- No encounter/visit implementation.
+- No payments, stock, or documents implementation.
+- No service role access.
+- No localStorage fallback.
+- No secrets or environment files.
+
+## Checks
+
+Local terminal checks were not run in this environment.
+
+GitHub Actions CI is pending after PR creation.
+
+Expected checks:
+
+- `npm run lint`
+- `npm run test -- --run`
+- `npm run build`
+
+## Final verdict
+
+`PARTIAL`
+
+Reason: implementation and unit tests were added, but GitHub Actions CI has not run yet at initial report creation time.
+
+## Recommended next task
+
+`AUDIT-ACTIVITY-RPC-001C`

--- a/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
@@ -7,7 +7,7 @@ This PR adds a read-only TypeScript repository layer for the audit/activity sche
 It adds domain types, query options, mapper functions, a read-only repository interface, and a Supabase implementation for:
 
 - tenant audit events;
-- tenant activity events;
+-- tenant activity events;
 - patient activity events.
 
 The repository does not create, update, delete, archive, or insert audit/activity events. Write paths remain a future `AUDIT-ACTIVITY-RPC-001C` task, because letting arbitrary client code write compliance history would be software malpractice with prettier syntax.
@@ -22,7 +22,7 @@ https://github.com/NckNA/codex-test/pull/304
 
 ## PR head reviewed before final report update
 
-`5335d99fbdfe6783333a79f52ba5112ab1e22fc6`
+`5176f954284dc9bf4ee4fca3ff4ba147f07d7547`
 
 This is the PR head validated before this final report metadata update.
 
@@ -220,11 +220,11 @@ Local terminal checks were not run in this environment.
 GitHub Actions CI before this final report metadata update:
 
 - workflow: `CI`
-- run id: `27745822816`
-- run number / CI: `#515`
+- run id: `27745915253`
+- run number / CI: `#516`
 - status: `completed`
 - conclusion: `success`
-- tested commit: `5335d99fbdfe6783333a79f52ba5112ab1e22fc6`
+- tested commit: `5176f954284dc9bf4ee4fca3ff4ba147f07d7547`
 - ESLint: success
 - tests: success
 - build: success

--- a/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/AUDIT-ACTIVITY-REPOSITORY-001B_repository.md
@@ -7,7 +7,7 @@ This PR adds a read-only TypeScript repository layer for the audit/activity sche
 It adds domain types, query options, mapper functions, a read-only repository interface, and a Supabase implementation for:
 
 - tenant audit events;
--- tenant activity events;
+- tenant activity events;
 - patient activity events.
 
 The repository does not create, update, delete, archive, or insert audit/activity events. Write paths remain a future `AUDIT-ACTIVITY-RPC-001C` task, because letting arbitrary client code write compliance history would be software malpractice with prettier syntax.

--- a/src/data/repositories/AuditActivityRepository.test.ts
+++ b/src/data/repositories/AuditActivityRepository.test.ts
@@ -22,47 +22,52 @@ type QueryCall = {
   args: unknown[];
 };
 
-type QueryChain = {
-  select: ReturnType<typeof vi.fn>;
-  eq: ReturnType<typeof vi.fn>;
-  in: ReturnType<typeof vi.fn>;
-  gte: ReturnType<typeof vi.fn>;
-  lte: ReturnType<typeof vi.fn>;
-  order: ReturnType<typeof vi.fn>;
-  range: ReturnType<typeof vi.fn>;
-};
-
-function createQuery(result: QueryResult) {
-  const calls: QueryCall[] = [];
-  let chain: QueryChain;
-  const record = (method: string, args: unknown[]) => {
-    calls.push({ method, args });
-    return chain;
-  };
-
-  chain = {
-    select: vi.fn((...args: unknown[]) => record('select', args)),
-    eq: vi.fn((...args: unknown[]) => record('eq', args)),
-    in: vi.fn((...args: unknown[]) => record('in', args)),
-    gte: vi.fn((...args: unknown[]) => record('gte', args)),
-    lte: vi.fn((...args: unknown[]) => record('lte', args)),
-    order: vi.fn((...args: unknown[]) => record('order', args)),
-    range: vi.fn(async (...args: unknown[]) => {
-      calls.push({ method: 'range', args });
-      return result;
-    }),
-  };
-
-  return { chain, calls };
-}
-
 function createRepository(result: QueryResult) {
-  const query = createQuery(result);
+  const calls: QueryCall[] = [];
+  const chain = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    gte: vi.fn(),
+    lte: vi.fn(),
+    order: vi.fn(),
+    range: vi.fn(),
+  };
+
+  chain.select.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'select', args });
+    return chain;
+  });
+  chain.eq.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'eq', args });
+    return chain;
+  });
+  chain.in.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'in', args });
+    return chain;
+  });
+  chain.gte.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'gte', args });
+    return chain;
+  });
+  chain.lte.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'lte', args });
+    return chain;
+  });
+  chain.order.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'order', args });
+    return chain;
+  });
+  chain.range.mockImplementation(async (...args: unknown[]) => {
+    calls.push({ method: 'range', args });
+    return result;
+  });
+
   const client = {
-    from: vi.fn(() => query.chain),
+    from: vi.fn(() => chain),
   };
   const repository = new SupabaseAuditActivityRepository(client as unknown as SupabaseClient);
-  return { repository, client, calls: query.calls };
+  return { repository, client, calls };
 }
 
 const tenantId = '11111111-1111-1111-1111-111111111111';
@@ -266,5 +271,9 @@ describe('AuditActivityRepository', () => {
     expect('createActivityEvent' in repository).toBe(false);
     expect('updateAuditEvent' in repository).toBe(false);
     expect('deleteAuditEvent' in repository).toBe(false);
+  });
+
+  it('rejects local backend instead of creating fake audit history', () => {
+    expect(() => createAuditActivityRepository({ backend: 'local' })).toThrow('does not support localStorage fallback');
   });
 });

--- a/src/data/repositories/AuditActivityRepository.test.ts
+++ b/src/data/repositories/AuditActivityRepository.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  ACTIVE_CLINIC_REQUIRED_FOR_AUDIT_ACTIVITY_ERROR,
+  MAX_AUDIT_ACTIVITY_LIMIT,
+  SupabaseAuditActivityRepository,
+  createAuditActivityRepository,
+  mapActivityEventRow,
+  mapAuditEventRow,
+  normalizeAuditActivityLimit,
+  normalizeAuditActivityOffset,
+  type AuditActivityRepository,
+} from './AuditActivityRepository';
+
+type QueryResult = {
+  data: Record<string, unknown>[] | null;
+  error: Error | null;
+};
+
+type QueryCall = {
+  method: string;
+  args: unknown[];
+};
+
+type QueryChain = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  gte: ReturnType<typeof vi.fn>;
+  lte: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  range: ReturnType<typeof vi.fn>;
+};
+
+function createQuery(result: QueryResult) {
+  const calls: QueryCall[] = [];
+  let chain: QueryChain;
+  const record = (method: string, args: unknown[]) => {
+    calls.push({ method, args });
+    return chain;
+  };
+
+  chain = {
+    select: vi.fn((...args: unknown[]) => record('select', args)),
+    eq: vi.fn((...args: unknown[]) => record('eq', args)),
+    in: vi.fn((...args: unknown[]) => record('in', args)),
+    gte: vi.fn((...args: unknown[]) => record('gte', args)),
+    lte: vi.fn((...args: unknown[]) => record('lte', args)),
+    order: vi.fn((...args: unknown[]) => record('order', args)),
+    range: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'range', args });
+      return result;
+    }),
+  };
+
+  return { chain, calls };
+}
+
+function createRepository(result: QueryResult) {
+  const query = createQuery(result);
+  const client = {
+    from: vi.fn(() => query.chain),
+  };
+  const repository = new SupabaseAuditActivityRepository(client as unknown as SupabaseClient);
+  return { repository, client, calls: query.calls };
+}
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const patientId = '22222222-2222-2222-2222-222222222222';
+
+const auditRow = {
+  id: 'audit-1',
+  tenant_id: tenantId,
+  actor_user_id: 'user-1',
+  actor_role: 'authenticated',
+  actor_tenant_role: 'clinic_admin',
+  actor_display_name: 'Admin',
+  action: 'update',
+  category: 'patient',
+  severity: 'warning',
+  target_type: 'patient',
+  target_id: patientId,
+  patient_id: patientId,
+  appointment_id: 'appointment-1',
+  visit_id: '33333333-3333-3333-3333-333333333333',
+  encounter_id: '44444444-4444-4444-4444-444444444444',
+  treatment_plan_id: 'plan-1',
+  treatment_stage_id: 'stage-1',
+  finding_id: 'finding-1',
+  file_id: 'file-1',
+  payment_id: 'payment-1',
+  stock_movement_id: 'stock-1',
+  before_data: { old: 'value' },
+  after_data: { next: 'value' },
+  diff_data: { changed: true },
+  redaction_level: 'restricted',
+  reason: 'correction',
+  request_id: 'request-1',
+  session_id: 'session-1',
+  ip_address: '127.0.0.1',
+  user_agent: 'vitest',
+  metadata: { source: 'test' },
+  created_at: '2026-06-18T08:00:00Z',
+};
+
+const activityRow = {
+  id: 'activity-1',
+  tenant_id: tenantId,
+  patient_id: patientId,
+  audit_event_id: 'audit-1',
+  actor_user_id: 'user-1',
+  category: 'finding',
+  type: 'finding_updated',
+  title: 'Находка обновлена',
+  description: 'Описание',
+  source_type: 'finding',
+  source_id: 'finding-1',
+  source_status: 'monitoring',
+  visibility: 'clinical',
+  severity: 'info',
+  occurred_at: '2026-06-18T09:00:00Z',
+  metadata: { toothId: '16' },
+  is_archived: false,
+  created_at: '2026-06-18T09:01:00Z',
+};
+
+function expectCall(calls: QueryCall[], method: string, ...args: unknown[]) {
+  expect(calls).toContainEqual({ method, args });
+}
+
+describe('AuditActivityRepository', () => {
+  it('listAuditEvents requires tenantId', async () => {
+    const { repository } = createRepository({ data: [], error: null });
+    await expect(repository.listAuditEvents({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_AUDIT_ACTIVITY_ERROR);
+  });
+
+  it('listActivityEvents requires tenantId', async () => {
+    const { repository } = createRepository({ data: [], error: null });
+    await expect(repository.listActivityEvents({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_AUDIT_ACTIVITY_ERROR);
+  });
+
+  it('listPatientActivityEvents requires tenantId and patientId', async () => {
+    const { repository } = createRepository({ data: [], error: null });
+    await expect(repository.listPatientActivityEvents({ tenantId: '', patientId })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_AUDIT_ACTIVITY_ERROR);
+    await expect(repository.listPatientActivityEvents({ tenantId, patientId: '' })).rejects.toThrow('Patient is required for patient activity access.');
+  });
+
+  it('listAuditEvents queries audit_events with tenant and optional filters', async () => {
+    const { repository, client, calls } = createRepository({ data: [auditRow], error: null });
+
+    const events = await repository.listAuditEvents({
+      tenantId,
+      categories: ['patient', 'finding'],
+      severities: ['warning'],
+      targetType: 'patient',
+      targetId: patientId,
+      patientId,
+      actorUserId: 'user-1',
+      createdFrom: '2026-06-01T00:00:00Z',
+      createdTo: '2026-06-30T00:00:00Z',
+      limit: 500,
+      offset: 5,
+    });
+
+    expect(client.from).toHaveBeenCalledWith('audit_events');
+    expectCall(calls, 'select', '*');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'in', 'category', ['patient', 'finding']);
+    expectCall(calls, 'in', 'severity', ['warning']);
+    expectCall(calls, 'eq', 'target_type', 'patient');
+    expectCall(calls, 'eq', 'target_id', patientId);
+    expectCall(calls, 'eq', 'patient_id', patientId);
+    expectCall(calls, 'eq', 'actor_user_id', 'user-1');
+    expectCall(calls, 'gte', 'created_at', '2026-06-01T00:00:00Z');
+    expectCall(calls, 'lte', 'created_at', '2026-06-30T00:00:00Z');
+    expectCall(calls, 'order', 'created_at', { ascending: false });
+    expectCall(calls, 'range', 5, 204);
+    expect(events[0]).toMatchObject({ id: 'audit-1', tenantId, category: 'patient', beforeData: { old: 'value' } });
+  });
+
+  it('listActivityEvents queries activity_events with tenant, visibility, source, date, and archived filters', async () => {
+    const { repository, client, calls } = createRepository({ data: [activityRow], error: null });
+
+    const events = await repository.listActivityEvents({
+      tenantId,
+      patientId,
+      categories: ['finding'],
+      visibility: ['clinical', 'admin'],
+      sourceType: 'finding',
+      sourceId: 'finding-1',
+      occurredFrom: '2026-06-01T00:00:00Z',
+      occurredTo: '2026-06-30T00:00:00Z',
+      limit: 25,
+      offset: 10,
+    });
+
+    expect(client.from).toHaveBeenCalledWith('activity_events');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'patient_id', patientId);
+    expectCall(calls, 'eq', 'is_archived', false);
+    expectCall(calls, 'in', 'category', ['finding']);
+    expectCall(calls, 'in', 'visibility', ['clinical', 'admin']);
+    expectCall(calls, 'eq', 'source_type', 'finding');
+    expectCall(calls, 'eq', 'source_id', 'finding-1');
+    expectCall(calls, 'gte', 'occurred_at', '2026-06-01T00:00:00Z');
+    expectCall(calls, 'lte', 'occurred_at', '2026-06-30T00:00:00Z');
+    expectCall(calls, 'order', 'occurred_at', { ascending: false });
+    expectCall(calls, 'order', 'created_at', { ascending: false });
+    expectCall(calls, 'range', 10, 34);
+    expect(events[0]).toMatchObject({ id: 'activity-1', tenantId, patientId, metadata: { toothId: '16' } });
+  });
+
+  it('listActivityEvents includes archived records only when requested', async () => {
+    const active = createRepository({ data: [], error: null });
+    await active.repository.listActivityEvents({ tenantId });
+    expectCall(active.calls, 'eq', 'is_archived', false);
+
+    const archived = createRepository({ data: [], error: null });
+    await archived.repository.listActivityEvents({ tenantId, includeArchived: true });
+    expect(archived.calls).not.toContainEqual({ method: 'eq', args: ['is_archived', false] });
+  });
+
+  it('listPatientActivityEvents filters by tenant_id and patient_id', async () => {
+    const { repository, calls } = createRepository({ data: [activityRow], error: null });
+    await repository.listPatientActivityEvents({ tenantId, patientId, categories: ['finding'], visibility: ['clinical'], includeArchived: true });
+
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'patient_id', patientId);
+    expectCall(calls, 'in', 'category', ['finding']);
+    expectCall(calls, 'in', 'visibility', ['clinical']);
+    expect(calls).not.toContainEqual({ method: 'eq', args: ['is_archived', false] });
+  });
+
+  it('surfaces Supabase errors', async () => {
+    const error = new Error('RLS denied');
+    const { repository } = createRepository({ data: null, error });
+    await expect(repository.listAuditEvents({ tenantId })).rejects.toThrow('RLS denied');
+  });
+
+  it('mappers convert snake_case rows to camelCase and default metadata', () => {
+    const audit = mapAuditEventRow({ ...auditRow, metadata: null, before_data: { safe: true }, after_data: { safe: false }, diff_data: { field: ['a', 'b'] } });
+    expect(audit).toMatchObject({ actorUserId: 'user-1', actorTenantRole: 'clinic_admin', targetType: 'patient', redactionLevel: 'restricted', metadata: {} });
+    expect(audit.beforeData).toEqual({ safe: true });
+    expect(audit.afterData).toEqual({ safe: false });
+    expect(audit.diffData).toEqual({ field: ['a', 'b'] });
+
+    const activity = mapActivityEventRow({ ...activityRow, metadata: undefined, is_archived: true });
+    expect(activity).toMatchObject({ auditEventId: 'audit-1', sourceStatus: 'monitoring', isArchived: true, metadata: {} });
+  });
+
+  it('normalizes limit and offset safely', () => {
+    expect(normalizeAuditActivityLimit()).toBe(50);
+    expect(normalizeAuditActivityLimit(0)).toBe(1);
+    expect(normalizeAuditActivityLimit(999)).toBe(MAX_AUDIT_ACTIVITY_LIMIT);
+    expect(normalizeAuditActivityOffset()).toBe(0);
+    expect(normalizeAuditActivityOffset(-5)).toBe(0);
+    expect(normalizeAuditActivityOffset(2.9)).toBe(2);
+  });
+
+  it('factory creates only Supabase read repository and does not expose write methods', () => {
+    const client = { from: vi.fn() } as unknown as SupabaseClient;
+    const repository: AuditActivityRepository = createAuditActivityRepository({ backend: 'supabase', client });
+
+    expect(repository).toBeInstanceOf(SupabaseAuditActivityRepository);
+    expect('createAuditEvent' in repository).toBe(false);
+    expect('createActivityEvent' in repository).toBe(false);
+    expect('updateAuditEvent' in repository).toBe(false);
+    expect('deleteAuditEvent' in repository).toBe(false);
+  });
+});

--- a/src/data/repositories/AuditActivityRepository.ts
+++ b/src/data/repositories/AuditActivityRepository.ts
@@ -1,0 +1,400 @@
+import { supabase as defaultSupabase } from '../../lib/supabaseClient';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type AuditEventCategory =
+  | 'auth'
+  | 'tenant'
+  | 'role_membership'
+  | 'patient'
+  | 'appointment'
+  | 'visit'
+  | 'encounter'
+  | 'finding'
+  | 'treatment_plan'
+  | 'completed_service'
+  | 'file'
+  | 'document'
+  | 'payment'
+  | 'stock'
+  | 'dictionary'
+  | 'billing_subscription'
+  | 'system'
+  | 'support_access';
+
+export type AuditEventSeverity = 'debug' | 'info' | 'warning' | 'critical';
+export type AuditEventRedactionLevel = 'none' | 'standard' | 'restricted' | 'confidential';
+
+export interface AuditEvent {
+  id: string;
+  tenantId: string | null;
+  actorUserId: string | null;
+  actorRole: string | null;
+  actorTenantRole: string | null;
+  actorDisplayName: string | null;
+  action: string;
+  category: AuditEventCategory;
+  severity: AuditEventSeverity;
+  targetType: string;
+  targetId: string;
+  patientId?: string | null;
+  appointmentId?: string | null;
+  visitId?: string | null;
+  encounterId?: string | null;
+  treatmentPlanId?: string | null;
+  treatmentStageId?: string | null;
+  findingId?: string | null;
+  fileId?: string | null;
+  paymentId?: string | null;
+  stockMovementId?: string | null;
+  beforeData?: Record<string, unknown> | null;
+  afterData?: Record<string, unknown> | null;
+  diffData?: Record<string, unknown> | null;
+  redactionLevel: AuditEventRedactionLevel;
+  reason?: string | null;
+  requestId?: string | null;
+  sessionId?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+export type ActivityEventCategory =
+  | 'patient'
+  | 'complaint'
+  | 'dental_chart'
+  | 'finding'
+  | 'treatment_plan'
+  | 'appointment'
+  | 'visit'
+  | 'encounter'
+  | 'completed_service'
+  | 'file'
+  | 'document'
+  | 'payment'
+  | 'stock'
+  | 'audit'
+  | 'system';
+
+export type ActivityEventVisibility = 'clinical' | 'admin' | 'financial' | 'system';
+
+export interface ActivityEvent {
+  id: string;
+  tenantId: string;
+  patientId?: string | null;
+  auditEventId?: string | null;
+  actorUserId?: string | null;
+  category: ActivityEventCategory;
+  type: string;
+  title: string;
+  description?: string | null;
+  sourceType: string;
+  sourceId: string;
+  sourceStatus?: string | null;
+  visibility: ActivityEventVisibility;
+  severity: AuditEventSeverity;
+  occurredAt: string;
+  metadata: Record<string, unknown>;
+  isArchived: boolean;
+  createdAt: string;
+}
+
+export interface ListAuditEventsOptions {
+  tenantId: string;
+  categories?: AuditEventCategory[];
+  severities?: AuditEventSeverity[];
+  targetType?: string;
+  targetId?: string;
+  patientId?: string;
+  actorUserId?: string;
+  createdFrom?: string;
+  createdTo?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListActivityEventsOptions {
+  tenantId: string;
+  patientId?: string;
+  categories?: ActivityEventCategory[];
+  visibility?: ActivityEventVisibility[];
+  sourceType?: string;
+  sourceId?: string;
+  occurredFrom?: string;
+  occurredTo?: string;
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListPatientActivityEventsOptions {
+  tenantId: string;
+  patientId: string;
+  includeArchived?: boolean;
+  categories?: ActivityEventCategory[];
+  visibility?: ActivityEventVisibility[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface AuditActivityRepository {
+  listAuditEvents(options: ListAuditEventsOptions): Promise<AuditEvent[]>;
+  listActivityEvents(options: ListActivityEventsOptions): Promise<ActivityEvent[]>;
+  listPatientActivityEvents(options: ListPatientActivityEventsOptions): Promise<ActivityEvent[]>;
+}
+
+export type AuditActivityRepositoryBackend = 'supabase';
+
+export interface CreateAuditActivityRepositoryOptions {
+  backend: AuditActivityRepositoryBackend;
+  client?: SupabaseClient;
+}
+
+export const ACTIVE_CLINIC_REQUIRED_FOR_AUDIT_ACTIVITY_ERROR = 'Active clinic is required for audit/activity access.';
+export const PATIENT_REQUIRED_FOR_ACTIVITY_ERROR = 'Patient is required for patient activity access.';
+export const DEFAULT_AUDIT_ACTIVITY_LIMIT = 50;
+export const MAX_AUDIT_ACTIVITY_LIMIT = 200;
+
+type JsonObject = Record<string, unknown>;
+
+type AuditEventRow = {
+  id: unknown;
+  tenant_id: unknown;
+  actor_user_id?: unknown;
+  actor_role?: unknown;
+  actor_tenant_role?: unknown;
+  actor_display_name?: unknown;
+  action: unknown;
+  category: unknown;
+  severity?: unknown;
+  target_type: unknown;
+  target_id: unknown;
+  patient_id?: unknown;
+  appointment_id?: unknown;
+  visit_id?: unknown;
+  encounter_id?: unknown;
+  treatment_plan_id?: unknown;
+  treatment_stage_id?: unknown;
+  finding_id?: unknown;
+  file_id?: unknown;
+  payment_id?: unknown;
+  stock_movement_id?: unknown;
+  before_data?: unknown;
+  after_data?: unknown;
+  diff_data?: unknown;
+  redaction_level?: unknown;
+  reason?: unknown;
+  request_id?: unknown;
+  session_id?: unknown;
+  ip_address?: unknown;
+  user_agent?: unknown;
+  metadata?: unknown;
+  created_at: unknown;
+};
+
+type ActivityEventRow = {
+  id: unknown;
+  tenant_id: unknown;
+  patient_id?: unknown;
+  audit_event_id?: unknown;
+  actor_user_id?: unknown;
+  category: unknown;
+  type: unknown;
+  title: unknown;
+  description?: unknown;
+  source_type: unknown;
+  source_id: unknown;
+  source_status?: unknown;
+  visibility: unknown;
+  severity?: unknown;
+  occurred_at: unknown;
+  metadata?: unknown;
+  is_archived?: unknown;
+  created_at: unknown;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+function jsonObjectOrNull(value: unknown): JsonObject | null {
+  if (value === null || value === undefined) return null;
+  return isRecord(value) ? value : {};
+}
+
+function metadataObject(value: unknown): JsonObject {
+  return isRecord(value) ? value : {};
+}
+
+function requireTenantId(tenantId: string | null | undefined): string {
+  if (!tenantId || tenantId.trim().length === 0) throw new Error(ACTIVE_CLINIC_REQUIRED_FOR_AUDIT_ACTIVITY_ERROR);
+  return tenantId;
+}
+
+function requirePatientId(patientId: string | null | undefined): string {
+  if (!patientId || patientId.trim().length === 0) throw new Error(PATIENT_REQUIRED_FOR_ACTIVITY_ERROR);
+  return patientId;
+}
+
+export function normalizeAuditActivityLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_AUDIT_ACTIVITY_LIMIT;
+  return Math.max(1, Math.min(MAX_AUDIT_ACTIVITY_LIMIT, Math.floor(limit)));
+}
+
+export function normalizeAuditActivityOffset(offset?: number): number {
+  if (offset === undefined || !Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.floor(offset));
+}
+
+export function mapAuditEventRow(row: AuditEventRow | Record<string, unknown>): AuditEvent {
+  return {
+    id: String(row.id),
+    tenantId: nullableString(row.tenant_id),
+    actorUserId: nullableString(row.actor_user_id),
+    actorRole: nullableString(row.actor_role),
+    actorTenantRole: nullableString(row.actor_tenant_role),
+    actorDisplayName: nullableString(row.actor_display_name),
+    action: String(row.action),
+    category: String(row.category) as AuditEventCategory,
+    severity: String(row.severity ?? 'info') as AuditEventSeverity,
+    targetType: String(row.target_type),
+    targetId: String(row.target_id),
+    patientId: nullableString(row.patient_id),
+    appointmentId: nullableString(row.appointment_id),
+    visitId: nullableString(row.visit_id),
+    encounterId: nullableString(row.encounter_id),
+    treatmentPlanId: nullableString(row.treatment_plan_id),
+    treatmentStageId: nullableString(row.treatment_stage_id),
+    findingId: nullableString(row.finding_id),
+    fileId: nullableString(row.file_id),
+    paymentId: nullableString(row.payment_id),
+    stockMovementId: nullableString(row.stock_movement_id),
+    beforeData: jsonObjectOrNull(row.before_data),
+    afterData: jsonObjectOrNull(row.after_data),
+    diffData: jsonObjectOrNull(row.diff_data),
+    redactionLevel: String(row.redaction_level ?? 'standard') as AuditEventRedactionLevel,
+    reason: nullableString(row.reason),
+    requestId: nullableString(row.request_id),
+    sessionId: nullableString(row.session_id),
+    ipAddress: nullableString(row.ip_address),
+    userAgent: nullableString(row.user_agent),
+    metadata: metadataObject(row.metadata),
+    createdAt: String(row.created_at),
+  };
+}
+
+export function mapActivityEventRow(row: ActivityEventRow | Record<string, unknown>): ActivityEvent {
+  return {
+    id: String(row.id),
+    tenantId: String(row.tenant_id),
+    patientId: nullableString(row.patient_id),
+    auditEventId: nullableString(row.audit_event_id),
+    actorUserId: nullableString(row.actor_user_id),
+    category: String(row.category) as ActivityEventCategory,
+    type: String(row.type),
+    title: String(row.title),
+    description: nullableString(row.description),
+    sourceType: String(row.source_type),
+    sourceId: String(row.source_id),
+    sourceStatus: nullableString(row.source_status),
+    visibility: String(row.visibility) as ActivityEventVisibility,
+    severity: String(row.severity ?? 'info') as AuditEventSeverity,
+    occurredAt: String(row.occurred_at),
+    metadata: metadataObject(row.metadata),
+    isArchived: Boolean(row.is_archived),
+    createdAt: String(row.created_at),
+  };
+}
+
+export class SupabaseAuditActivityRepository implements AuditActivityRepository {
+  private readonly client: SupabaseClient;
+
+  constructor(client: SupabaseClient) {
+    this.client = client;
+  }
+
+  async listAuditEvents(options: ListAuditEventsOptions): Promise<AuditEvent[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeAuditActivityLimit(options.limit);
+    const offset = normalizeAuditActivityOffset(options.offset);
+
+    let query = this.client
+      .from('audit_events')
+      .select('*')
+      .eq('tenant_id', tenantId);
+
+    if (options.categories?.length) query = query.in('category', options.categories);
+    if (options.severities?.length) query = query.in('severity', options.severities);
+    if (options.targetType) query = query.eq('target_type', options.targetType);
+    if (options.targetId) query = query.eq('target_id', options.targetId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.actorUserId) query = query.eq('actor_user_id', options.actorUserId);
+    if (options.createdFrom) query = query.gte('created_at', options.createdFrom);
+    if (options.createdTo) query = query.lte('created_at', options.createdTo);
+
+    const { data, error } = await query
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapAuditEventRow);
+  }
+
+  async listActivityEvents(options: ListActivityEventsOptions): Promise<ActivityEvent[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeAuditActivityLimit(options.limit);
+    const offset = normalizeAuditActivityOffset(options.offset);
+
+    let query = this.client
+      .from('activity_events')
+      .select('*')
+      .eq('tenant_id', tenantId);
+
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (!options.includeArchived) query = query.eq('is_archived', false);
+    if (options.categories?.length) query = query.in('category', options.categories);
+    if (options.visibility?.length) query = query.in('visibility', options.visibility);
+    if (options.sourceType) query = query.eq('source_type', options.sourceType);
+    if (options.sourceId) query = query.eq('source_id', options.sourceId);
+    if (options.occurredFrom) query = query.gte('occurred_at', options.occurredFrom);
+    if (options.occurredTo) query = query.lte('occurred_at', options.occurredTo);
+
+    const { data, error } = await query
+      .order('occurred_at', { ascending: false })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapActivityEventRow);
+  }
+
+  async listPatientActivityEvents(options: ListPatientActivityEventsOptions): Promise<ActivityEvent[]> {
+    return this.listActivityEvents({
+      tenantId: requireTenantId(options.tenantId),
+      patientId: requirePatientId(options.patientId),
+      categories: options.categories,
+      visibility: options.visibility,
+      includeArchived: options.includeArchived,
+      limit: options.limit,
+      offset: options.offset,
+    });
+  }
+}
+
+export function createAuditActivityRepository(options: CreateAuditActivityRepositoryOptions): AuditActivityRepository {
+  if (options.backend !== 'supabase') {
+    throw new Error('Audit/activity repository only supports Supabase backend.');
+  }
+
+  const client = options.client ?? defaultSupabase;
+  if (!client) {
+    throw new Error('Supabase client is not configured for audit/activity access.');
+  }
+
+  return new SupabaseAuditActivityRepository(client as SupabaseClient);
+}

--- a/src/data/repositories/AuditActivityRepository.ts
+++ b/src/data/repositories/AuditActivityRepository.ts
@@ -143,7 +143,7 @@ export interface AuditActivityRepository {
   listPatientActivityEvents(options: ListPatientActivityEventsOptions): Promise<ActivityEvent[]>;
 }
 
-export type AuditActivityRepositoryBackend = 'supabase';
+export type AuditActivityRepositoryBackend = 'supabase' | 'local';
 
 export interface CreateAuditActivityRepositoryOptions {
   backend: AuditActivityRepositoryBackend;
@@ -387,8 +387,8 @@ export class SupabaseAuditActivityRepository implements AuditActivityRepository 
 }
 
 export function createAuditActivityRepository(options: CreateAuditActivityRepositoryOptions): AuditActivityRepository {
-  if (options.backend !== 'supabase') {
-    throw new Error('Audit/activity repository only supports Supabase backend.');
+  if (options.backend === 'local') {
+    throw new Error('Audit/activity repository does not support localStorage fallback.');
   }
 
   const client = options.client ?? defaultSupabase;


### PR DESCRIPTION
## Summary

Adds a read-only TypeScript/data-layer repository foundation for `audit_events` and `activity_events` from `AUDIT-ACTIVITY-LOG-001A`.

## Scope

- Adds `AuditActivityRepository` domain types, query options, mappers, and Supabase implementation.
- Adds pure mocked Supabase unit tests.
- Adds task report.

## Boundaries

- No migrations.
- No UI.
- No Supabase cloud.
- No browser smoke.
- No write methods or RPC implementation.
- No localStorage fallback.

## Checks

GitHub Actions CI completed successfully:

- run: `27745915253`
- CI: `#516`
- tested commit: `5176f954284dc9bf4ee4fca3ff4ba147f07d7547`
- ESLint: success
- tests: success
- build: success