### PR TITLE
ADMIN-AUDIT-VIEWER-001: add admin audit and activity viewer

### DIFF
--- a/_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md
+++ b/_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md
@@ -16,9 +16,9 @@ https://github.com/NckNA/codex-test/pull/308
 
 ## 4. PR head reviewed before final report update
 
-`079924fa13406815f7dada6bb34b0286f0195fec`
+`36dce18ad80c9dff64e58ff5dee4caa1a0350cd8`
 
-This is the PR head reviewed before the final report update. It includes the implementation commit and the initial report commit verified by CI #539.
+This is the PR head reviewed before the final report update. It includes the implementation commit and the final verified report state from CI #540.
 
 ## 5. Report update commit
 
@@ -343,9 +343,9 @@ Both test and build commands exited successfully.
 Fresh CI after report push:
 
 - Workflow: `CI`
-- Run id: `27762651778`
-- CI number: `539`
-- Tested commit: `079924fa13406815f7dada6bb34b0286f0195fec`
+- Run id: `27762876292`
+- CI number: `540`
+- Tested commit: `36dce18ad80c9dff64e58ff5dee4caa1a0350cd8`
 - Status: completed
 - Conclusion: success
 - Required checks: ESLint, tests, build passed.

--- a/_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md
+++ b/_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md
@@ -1,0 +1,351 @@
+# ADMIN-AUDIT-VIEWER-001 — Admin audit/activity viewer report
+
+## 1. Summary
+
+Implemented a read-only clinic admin audit/activity viewer for the active tenant.
+
+The viewer exposes safe product-facing `activity_events` and compliance-oriented `audit_events` through the existing read-only `AuditActivityRepository`. It does not create, update, delete, or write audit/activity records. It does not use service-role access, raw SQL, localStorage fallback, migrations, or cloud changes.
+
+## 2. Branch
+
+`feature/admin-audit-viewer-001`
+
+## 3. PR URL
+
+https://github.com/NckNA/codex-test/pull/308
+
+## 4. PR head reviewed before final report update
+
+`7ca54fcb261f8784101063385d791e75bcdec333`
+
+This is the implementation head reviewed before creating this report.
+
+## 5. Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed files summary
+
+Implementation files:
+
+- `src/pages/AdminAuditPage.tsx`
+- `src/components/admin/AdminAuditViewer.tsx`
+- `src/data/hooks/useAuditActivityEvents.ts`
+- `src/App.tsx`
+- `src/components/layout/Sidebar.tsx`
+
+Tests:
+
+- `src/components/admin/AdminAuditViewer.test.tsx`
+- `src/data/hooks/useAuditActivityEvents.test.tsx`
+
+Report:
+
+- `_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md`
+
+No migrations, Supabase config, seed data, patient timeline files, repository write methods, or cloud-related files were changed.
+
+## 7. Current UI/routing recon
+
+### Route pattern
+
+`src/App.tsx` registers routes under the main `Layout` route. Pages are imported directly and mounted with `<Route path="..." element={<Page />} />`.
+
+The new route follows that convention:
+
+- `/admin/audit` → `AdminAuditPage`
+
+### Navigation pattern
+
+`src/components/layout/Sidebar.tsx` owns the sidebar item list and renders `NavLink` items. Before this task, the sidebar list was static and did not hide role-specific links.
+
+This task adds one role-aware admin item:
+
+- label: `Журнал действий`
+- path: `/admin/audit`
+- visible only when `activeTenant.role` is `clinic_owner` or `clinic_admin`
+
+### Role guard pattern
+
+Existing role information comes from `useTenant().activeTenant.role`. Existing pages use role checks locally, for example clinical dictionary management checks `clinic_owner` / `clinic_admin` before allowing management actions.
+
+This task adds a small shared helper in `useAuditActivityEvents.ts`:
+
+- `canViewAdminAudit(role)`
+
+Allowed roles:
+
+- `clinic_owner`
+- `clinic_admin`
+
+Blocked roles:
+
+- `doctor`
+- `registrar`
+- `receptionist`
+- `cashier`
+- no tenant
+- platform-like roles by default
+
+### No-tenant behavior
+
+The app already has a global no-tenant gate for Supabase-authenticated users without clinic membership. The new page also has a page-level safe no-tenant gate to avoid repository queries if the route is reached directly without an active tenant.
+
+### Loading/error/empty state pattern
+
+Existing pages use simple Tailwind cards, inline loading text/spinners, error cards, and empty states. The new viewer follows that pattern:
+
+- loading: `Загрузка журнала...`
+- error: `Не удалось загрузить журнал.` plus repository error message
+- empty: `Событий по выбранным фильтрам нет.`
+
+## 8. Implementation summary
+
+### Page/route
+
+Added `src/pages/AdminAuditPage.tsx`.
+
+Behavior:
+
+- no tenant: show `Клиника не назначена`, no query
+- unauthorized role: show `Доступ запрещён`, no query
+- `clinic_owner` / `clinic_admin`: render `AdminAuditViewer`
+
+### Viewer component
+
+Added `src/components/admin/AdminAuditViewer.tsx`.
+
+It renders a read-only admin tool with two tabs:
+
+1. `Активность`
+   - source: `AuditActivityRepository.listActivityEvents`
+   - purpose: product-facing tenant activity
+
+2. `Аудит`
+   - source: `AuditActivityRepository.listAuditEvents`
+   - purpose: compliance/security audit records
+
+The viewer renders safe summary fields only. It does not dump raw metadata or before/after/diff JSON.
+
+### Hook
+
+Added `src/data/hooks/useAuditActivityEvents.ts`.
+
+Behavior:
+
+- accepts tenant id, role, active tab, filters, and backend availability
+- creates the existing read-only `AuditActivityRepository` only when enabled
+- calls `listActivityEvents` for the activity tab
+- calls `listAuditEvents` for the audit tab
+- does not query when tenant id is missing
+- does not query when role is not `clinic_owner` / `clinic_admin`
+- does not query when backend is unavailable
+- surfaces repository errors through the existing `useAsyncQuery` error path
+- has no local/fake fallback
+
+### Navigation item
+
+Updated `src/components/layout/Sidebar.tsx`.
+
+The sidebar now appends `Журнал действий` only for `clinic_owner` / `clinic_admin`.
+
+### Tabs and filters
+
+Common filters:
+
+- category
+- severity
+- date from
+- date to
+- limit
+- pagination offset via `Назад` / `Далее`
+
+Activity-specific filters:
+
+- visibility
+- include archived
+
+Audit-specific filters:
+
+- target type
+- patient id
+- actor user id
+
+Default limit is the repository default: `50`.
+
+## 9. Access control
+
+| User state / role | Viewer access | Repository query |
+|---|---:|---:|
+| `clinic_owner` | allowed | yes |
+| `clinic_admin` | allowed | yes |
+| `doctor` | denied | no |
+| `registrar` | denied | no |
+| `receptionist` | denied | no |
+| `cashier` | denied | no |
+| no tenant | denied / clinic gate | no |
+| platform-like roles | denied by default | no |
+
+RLS remains the real data security boundary. The frontend guard is an access/UX gate and prevents unnecessary repository calls before authorization is established.
+
+## 10. Data behavior
+
+### Activity events loading
+
+Activity tab calls:
+
+```ts
+listActivityEvents({ tenantId, categories, visibility, occurredFrom, occurredTo, includeArchived, limit, offset })
+```
+
+Shown fields:
+
+- occurred date
+- category
+- type
+- title
+- description
+- visibility
+- severity
+- actor user id
+- patient id
+- source type / source id
+- source status
+- archive marker
+
+### Audit events loading
+
+Audit tab calls:
+
+```ts
+listAuditEvents({ tenantId, categories, severities, targetType, patientId, actorUserId, createdFrom, createdTo, limit, offset })
+```
+
+Shown fields:
+
+- created date
+- category
+- action
+- severity
+- target type / target id
+- actor display/user id
+- actor role / tenant role
+- patient id
+- redaction level
+- reason
+
+### Tenant id handling
+
+Tenant id always comes from `activeTenant.tenantId`. There is no UI control for changing tenant id.
+
+### Pagination
+
+The viewer uses limit plus offset controls:
+
+- `Назад`
+- `Далее`
+
+The next button is enabled when the current page contains at least the requested limit.
+
+## 11. Safety boundary
+
+Preserved boundaries:
+
+- read-only UI
+- no create/update/delete audit/activity methods
+- no RPC helper calls from UI
+- no service-role access from client code
+- no raw SQL from frontend
+- no localStorage fallback
+- no Supabase cloud changes
+- no migrations
+- no RLS/grants changes
+- no raw before/after/diff display by default
+- no direct metadata JSON dump in tables/lists
+- no patient timeline changes
+- no visits/encounters/completed services/payments/stock/documents implementation
+
+The admin audit viewer is separate from patient timeline. Raw `audit_events` are not exposed in patient timeline.
+
+## 12. Tests
+
+Updated/added test files:
+
+- `src/components/admin/AdminAuditViewer.test.tsx`
+- `src/data/hooks/useAuditActivityEvents.test.tsx`
+
+Covered scenarios:
+
+1. `clinic_owner` can view admin audit page.
+2. `clinic_admin` can view admin audit page.
+3. `doctor` is denied and repository hook is not called.
+4. `registrar` is denied and repository hook is not called.
+5. `receptionist` is denied and repository hook is not called.
+6. `cashier` is denied and repository hook is not called.
+7. no-tenant state shows a safe gate and does not query.
+8. Activity tab renders safe activity fields.
+9. Audit tab renders safe audit fields.
+10. Loading state renders.
+11. Error state renders.
+12. Empty state renders.
+13. Activity filters are passed to the hook.
+14. Audit category and pagination state are passed to the hook.
+15. Hook passes audit filters to `listAuditEvents`, including category, severity, date range, target type, patient id, actor id, limit and offset.
+16. Hook passes activity filters to `listActivityEvents`, including category, visibility, date range, include archived, limit and offset.
+17. Hook does not query without tenant id.
+18. Hook does not query for unauthorized roles.
+19. Hook does not query when backend is unavailable.
+20. Repository errors are surfaced.
+21. Sidebar nav item appears for `clinic_owner` / `clinic_admin` only.
+22. Sidebar nav item is hidden for `doctor`, `registrar`, `receptionist`, `cashier`, and no-tenant.
+23. `beforeData`, `afterData`, `diffData` are not rendered in list/table.
+24. `metadata` JSON is not rendered directly.
+25. No audit/activity write method is introduced by the hook contract.
+
+Full routing was validated at page/component level rather than browser smoke. Browser smoke is intentionally out of scope for this task.
+
+## 13. What was intentionally NOT changed
+
+- no migrations
+- no Supabase cloud
+- no local Supabase
+- no browser smoke
+- no audit write paths
+- no service-role client usage
+- no patient timeline changes
+- no visits/encounters
+- no completed services
+- no payments implementation
+- no stock implementation
+- no documents implementation
+- no repository write methods
+- no RLS/grants changes
+- no seed changes
+
+## 14. Checks
+
+Local checks on implementation head `7ca54fcb261f8784101063385d791e75bcdec333`:
+
+- `git status --short`: clean before report creation
+- `npm run lint`: PASS
+- `npm run test -- --run`: PASS, 47 files / 414 tests
+- `npm run build`: PASS
+
+Warnings observed:
+
+- existing React `act(...)` warnings in unrelated older tests
+- existing Vite chunk-size warning
+
+Both test and build commands exited successfully.
+
+### GitHub Actions CI
+
+Pending after report push.
+
+## 15. Final verdict
+
+`ADMIN AUDIT VIEWER IMPLEMENTED AND VERIFIED`
+
+## 16. Recommended next task
+
+`ADMIN-AUDIT-VIEWER-SMOKE-001`

--- a/_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md
+++ b/_ai_work/REPORTS/ADMIN-AUDIT-VIEWER-001_admin_audit_viewer.md
@@ -16,9 +16,9 @@ https://github.com/NckNA/codex-test/pull/308
 
 ## 4. PR head reviewed before final report update
 
-`7ca54fcb261f8784101063385d791e75bcdec333`
+`079924fa13406815f7dada6bb34b0286f0195fec`
 
-This is the implementation head reviewed before creating this report.
+This is the PR head reviewed before the final report update. It includes the implementation commit and the initial report commit verified by CI #539.
 
 ## 5. Report update commit
 
@@ -340,7 +340,15 @@ Both test and build commands exited successfully.
 
 ### GitHub Actions CI
 
-Pending after report push.
+Fresh CI after report push:
+
+- Workflow: `CI`
+- Run id: `27762651778`
+- CI number: `539`
+- Tested commit: `079924fa13406815f7dada6bb34b0286f0195fec`
+- Status: completed
+- Conclusion: success
+- Required checks: ESLint, tests, build passed.
 
 ## 15. Final verdict
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { BonusPage } from './pages/BonusPage';
 import { MailingPage } from './pages/MailingPage';
 import { SmsPage } from './pages/SmsPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { AdminAuditPage } from './pages/AdminAuditPage';
 import { PatientCardPage } from './pages/PatientCardPage';
 import { ClinicalDictionariesProvider } from './data/hooks/useDictionaries';
 
@@ -111,6 +112,7 @@ function AppContent() {
           <Route path="mailing" element={<MailingPage />} />
           <Route path="sms" element={<SmsPage />} />
           <Route path="settings" element={<SettingsPage />} />
+          <Route path="admin/audit" element={<AdminAuditPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/admin/AdminAuditViewer.test.tsx
+++ b/src/components/admin/AdminAuditViewer.test.tsx
@@ -1,0 +1,352 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act, type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminAuditViewer } from './AdminAuditViewer';
+import { AdminAuditPage } from '../../pages/AdminAuditPage';
+import { Sidebar } from '../layout/Sidebar';
+import * as AuthContextModule from '../../contexts/AuthContext';
+import * as TenantContextModule from '../../contexts/TenantContext';
+import {
+  canViewAdminAudit,
+  useAuditActivityEvents,
+  type UseAuditActivityEventsResult,
+} from '../../data/hooks/useAuditActivityEvents';
+import type { ActivityEvent, AuditEvent } from '../../data/repositories/AuditActivityRepository';
+
+vi.mock('../../data/hooks/useAuditActivityEvents', async () => {
+  const actual = await vi.importActual<typeof import('../../data/hooks/useAuditActivityEvents')>('../../data/hooks/useAuditActivityEvents');
+  return {
+    ...actual,
+    useAuditActivityEvents: vi.fn(),
+  };
+});
+
+const mockedUseAuditActivityEvents = vi.mocked(useAuditActivityEvents);
+
+function defaultHookResult(overrides: Partial<UseAuditActivityEventsResult> = {}): UseAuditActivityEventsResult {
+  return {
+    activityEvents: [],
+    auditEvents: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refresh: vi.fn(async () => undefined),
+    isEnabled: true,
+    ...overrides,
+  };
+}
+
+const activityEvent: ActivityEvent = {
+  id: 'activity-1',
+  tenantId: 'tenant-1',
+  patientId: 'patient-1',
+  auditEventId: 'audit-hidden-id',
+  actorUserId: 'actor-1',
+  category: 'patient',
+  type: 'patient.updated',
+  title: 'Пациент обновлён',
+  description: 'Изменены безопасные поля карточки',
+  sourceType: 'patient',
+  sourceId: 'patient-1',
+  sourceStatus: 'active',
+  visibility: 'admin',
+  severity: 'info',
+  occurredAt: '2026-06-18T09:00:00.000Z',
+  metadata: { shouldNotRender: 'metadata-secret-value' },
+  isArchived: false,
+  createdAt: '2026-06-18T09:00:01.000Z',
+};
+
+const auditEvent: AuditEvent = {
+  id: 'audit-1',
+  tenantId: 'tenant-1',
+  actorUserId: 'actor-2',
+  actorRole: 'authenticated',
+  actorTenantRole: 'clinic_admin',
+  actorDisplayName: 'Admin User',
+  action: 'patient.update',
+  category: 'patient',
+  severity: 'warning',
+  targetType: 'patient',
+  targetId: 'patient-1',
+  patientId: 'patient-1',
+  beforeData: { shouldNotRender: 'before-secret-value' },
+  afterData: { shouldNotRender: 'after-secret-value' },
+  diffData: { shouldNotRender: 'diff-secret-value' },
+  redactionLevel: 'standard',
+  reason: 'Проверка доступа',
+  metadata: { shouldNotRender: 'audit-metadata-secret-value' },
+  createdAt: '2026-06-18T10:00:00.000Z',
+  appointmentId: null,
+  visitId: null,
+  encounterId: null,
+  treatmentPlanId: null,
+  treatmentStageId: null,
+  findingId: null,
+  fileId: null,
+  paymentId: null,
+  stockMovementId: null,
+  requestId: null,
+  sessionId: null,
+  ipAddress: null,
+  userAgent: null,
+};
+
+const mockUseAuth = (overrides: Partial<ReturnType<typeof AuthContextModule.useAuth>> = {}) => {
+  vi.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
+    user: { id: 'user-1', email: 'admin@example.com' },
+    isLoading: false,
+    error: null,
+    authMode: 'supabase-active',
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides,
+  });
+};
+
+const mockUseTenant = (role: string | null, tenantId = 'tenant-1') => {
+  vi.spyOn(TenantContextModule, 'useTenant').mockReturnValue({
+    activeTenant: tenantId ? { tenantId, tenantName: 'Clinic', role: role ?? undefined } : null,
+    availableTenants: tenantId ? [{ tenantId, tenantName: 'Clinic', role: role ?? undefined }] : [],
+    setActiveTenant: vi.fn(),
+    isLoading: false,
+    error: null,
+  });
+};
+
+async function renderNode(node: ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return { container, root };
+}
+
+async function unmount(root: ReturnType<typeof createRoot>, container: HTMLElement) {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mockedUseAuditActivityEvents.mockReset();
+  document.body.innerHTML = '';
+});
+
+describe('admin audit access helpers', () => {
+  it.each(['clinic_owner', 'clinic_admin'])('allows %s', (role) => {
+    expect(canViewAdminAudit(role)).toBe(true);
+  });
+
+  it.each(['doctor', 'registrar', 'receptionist', 'cashier', null, undefined, 'platform_admin'])('blocks %s', (role) => {
+    expect(canViewAdminAudit(role)).toBe(false);
+  });
+});
+
+describe('AdminAuditPage access guard', () => {
+  it.each(['clinic_owner', 'clinic_admin'])('renders viewer for %s', async (role) => {
+    mockUseAuth();
+    mockUseTenant(role);
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult({ activityEvents: [activityEvent] }));
+
+    const { container, root } = await renderNode(<AdminAuditPage />);
+
+    expect(container.textContent).toContain('Журнал действий');
+    expect(mockedUseAuditActivityEvents).toHaveBeenCalled();
+
+    await unmount(root, container);
+  });
+
+  it.each(['doctor', 'registrar', 'receptionist', 'cashier'])('blocks %s and does not query repository hook', async (role) => {
+    mockUseAuth();
+    mockUseTenant(role);
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult());
+
+    const { container, root } = await renderNode(<AdminAuditPage />);
+
+    expect(container.textContent).toContain('Доступ запрещён');
+    expect(mockedUseAuditActivityEvents).not.toHaveBeenCalled();
+
+    await unmount(root, container);
+  });
+
+  it('blocks no-tenant state and does not query repository hook', async () => {
+    mockUseAuth();
+    mockUseTenant(null, '');
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult());
+
+    const { container, root } = await renderNode(<AdminAuditPage />);
+
+    expect(container.textContent).toContain('Клиника не назначена');
+    expect(mockedUseAuditActivityEvents).not.toHaveBeenCalled();
+
+    await unmount(root, container);
+  });
+});
+
+describe('AdminAuditViewer rendering and filters', () => {
+  it('renders activity safe fields without dumping metadata JSON or opaque audit id', async () => {
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult({ activityEvents: [activityEvent] }));
+
+    const { container, root } = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+
+    expect(container.textContent).toContain('Пациент обновлён');
+    expect(container.textContent).toContain('Изменены безопасные поля карточки');
+    expect(container.textContent).toContain('patient.updated');
+    expect(container.textContent).not.toContain('metadata-secret-value');
+    expect(container.textContent).not.toContain('audit-hidden-id');
+
+    await unmount(root, container);
+  });
+
+  it('renders audit safe fields without dumping before/after/diff/metadata JSON', async () => {
+    mockedUseAuditActivityEvents
+      .mockReturnValueOnce(defaultHookResult({ activityEvents: [activityEvent] }))
+      .mockReturnValue(defaultHookResult({ auditEvents: [auditEvent] }));
+
+    const { container, root } = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+    const auditTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Аудит');
+
+    await act(async () => {
+      auditTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('patient.update');
+    expect(container.textContent).toContain('Admin User');
+    expect(container.textContent).toContain('Проверка доступа');
+    expect(container.textContent).not.toContain('before-secret-value');
+    expect(container.textContent).not.toContain('after-secret-value');
+    expect(container.textContent).not.toContain('diff-secret-value');
+    expect(container.textContent).not.toContain('audit-metadata-secret-value');
+
+    await unmount(root, container);
+  });
+
+  it('renders loading, empty, and error states', async () => {
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult({ isLoading: true }));
+    const loading = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+    expect(loading.container.textContent).toContain('Загрузка журнала');
+    await unmount(loading.root, loading.container);
+
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult());
+    const empty = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+    expect(empty.container.textContent).toContain('Событий по выбранным фильтрам нет');
+    await unmount(empty.root, empty.container);
+
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult({ error: new Error('RLS failed'), isError: true }));
+    const error = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+    expect(error.container.textContent).toContain('Не удалось загрузить журнал');
+    expect(error.container.textContent).toContain('RLS failed');
+    await unmount(error.root, error.container);
+  });
+
+  it('passes activity filters to hook', async () => {
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult({ activityEvents: [activityEvent] }));
+    const { container, root } = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+
+    const selects = Array.from(container.querySelectorAll('select'));
+    await act(async () => {
+      selects[0].value = 'patient';
+      selects[0].dispatchEvent(new Event('change', { bubbles: true }));
+      selects[1].value = 'warning';
+      selects[1].dispatchEvent(new Event('change', { bubbles: true }));
+      selects[2].value = 'clinical';
+      selects[2].dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const latestCall = mockedUseAuditActivityEvents.mock.calls.at(-1)?.[0];
+    expect(latestCall).toMatchObject({
+      tenantId: 'tenant-1',
+      role: 'clinic_admin',
+      activeTab: 'activity',
+      filters: expect.objectContaining({ category: 'patient', severity: 'warning', visibility: 'clinical' }),
+    });
+
+    await unmount(root, container);
+  });
+
+  it('passes audit filters to hook and paginates', async () => {
+    mockedUseAuditActivityEvents
+      .mockReturnValueOnce(defaultHookResult({ activityEvents: [activityEvent] }))
+      .mockReturnValue(defaultHookResult({ auditEvents: Array.from({ length: 50 }, (_, index) => ({ ...auditEvent, id: `audit-${index}` })) }));
+
+    const { container, root } = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" />);
+    const auditTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Аудит');
+
+    await act(async () => {
+      auditTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const selects = Array.from(container.querySelectorAll('select'));
+    const targetTypeInput = container.querySelector('input[placeholder="patient, file..."]') as HTMLInputElement;
+    const patientIdInput = container.querySelector('input[placeholder="UUID пациента"]') as HTMLInputElement;
+    const actorUserIdInput = container.querySelector('input[placeholder="UUID пользователя"]') as HTMLInputElement;
+    await act(async () => {
+      selects[0].value = 'patient';
+      selects[0].dispatchEvent(new Event('change', { bubbles: true }));
+      targetTypeInput.value = 'patient';
+      targetTypeInput.dispatchEvent(new Event('input', { bubbles: true }));
+      targetTypeInput.dispatchEvent(new Event('change', { bubbles: true }));
+      patientIdInput.value = 'patient-1';
+      patientIdInput.dispatchEvent(new Event('input', { bubbles: true }));
+      patientIdInput.dispatchEvent(new Event('change', { bubbles: true }));
+      actorUserIdInput.value = 'actor-2';
+      actorUserIdInput.dispatchEvent(new Event('input', { bubbles: true }));
+      actorUserIdInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const nextButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Далее');
+    await act(async () => {
+      nextButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const latestCall = mockedUseAuditActivityEvents.mock.calls.at(-1)?.[0];
+    expect(latestCall).toMatchObject({
+      activeTab: 'audit',
+      filters: expect.objectContaining({
+        category: 'patient',
+        limit: 50,
+        offset: 50,
+      }),
+    });
+
+    await unmount(root, container);
+  });
+
+  it('does not render an unavailable backend as data table', async () => {
+    mockedUseAuditActivityEvents.mockReturnValue(defaultHookResult({ isEnabled: false }));
+
+    const { container, root } = await renderNode(<AdminAuditViewer tenantId="tenant-1" role="clinic_admin" backendAvailable={false} />);
+
+    expect(container.textContent).toContain('Журнал недоступен');
+
+    await unmount(root, container);
+  });
+});
+
+describe('Sidebar admin audit navigation', () => {
+  it.each(['clinic_owner', 'clinic_admin'])('shows nav item for %s', async (role) => {
+    mockUseTenant(role);
+    const { container, root } = await renderNode(<MemoryRouter><Sidebar /></MemoryRouter>);
+
+    expect(container.textContent).toContain('Журнал действий');
+
+    await unmount(root, container);
+  });
+
+  it.each(['doctor', 'registrar', 'receptionist', 'cashier', null])('hides nav item for %s', async (role) => {
+    mockUseTenant(role);
+    const { container, root } = await renderNode(<MemoryRouter><Sidebar /></MemoryRouter>);
+
+    expect(container.textContent).not.toContain('Журнал действий');
+
+    await unmount(root, container);
+  });
+});

--- a/src/components/admin/AdminAuditViewer.tsx
+++ b/src/components/admin/AdminAuditViewer.tsx
@@ -1,0 +1,431 @@
+import { useMemo, useState } from 'react';
+import { AlertTriangle, Clock3, FileSearch, RefreshCw, ShieldCheck } from 'lucide-react';
+import {
+  DEFAULT_AUDIT_ACTIVITY_LIMIT,
+  type ActivityEvent,
+  type ActivityEventCategory,
+  type ActivityEventVisibility,
+  type AuditEvent,
+  type AuditEventCategory,
+  type AuditEventSeverity,
+} from '../../data/repositories/AuditActivityRepository';
+import {
+  type AuditActivityViewerFilters,
+  type AuditActivityViewerTab,
+  useAuditActivityEvents,
+} from '../../data/hooks/useAuditActivityEvents';
+
+interface AdminAuditViewerProps {
+  tenantId: string;
+  role: string;
+  backendAvailable?: boolean;
+}
+
+const ACTIVITY_CATEGORY_LABELS: Record<ActivityEventCategory, string> = {
+  patient: 'Пациент',
+  complaint: 'Жалоба',
+  dental_chart: 'Зубная карта',
+  finding: 'Находка',
+  treatment_plan: 'План лечения',
+  appointment: 'Приём',
+  visit: 'Визит',
+  encounter: 'Осмотр',
+  completed_service: 'Выполненная услуга',
+  file: 'Файл',
+  document: 'Документ',
+  payment: 'Оплата',
+  stock: 'Склад',
+  audit: 'Аудит',
+  system: 'Система',
+};
+
+const AUDIT_CATEGORY_LABELS: Record<AuditEventCategory, string> = {
+  auth: 'Авторизация',
+  tenant: 'Клиника',
+  role_membership: 'Роли',
+  patient: 'Пациент',
+  appointment: 'Приём',
+  visit: 'Визит',
+  encounter: 'Осмотр',
+  finding: 'Находка',
+  treatment_plan: 'План лечения',
+  completed_service: 'Выполненная услуга',
+  file: 'Файл',
+  document: 'Документ',
+  payment: 'Оплата',
+  stock: 'Склад',
+  dictionary: 'Справочник',
+  billing_subscription: 'Подписка',
+  system: 'Система',
+  support_access: 'Доступ поддержки',
+};
+
+const SEVERITY_LABELS: Record<AuditEventSeverity, string> = {
+  debug: 'Debug',
+  info: 'Info',
+  warning: 'Warning',
+  critical: 'Critical',
+};
+
+const VISIBILITY_LABELS: Record<ActivityEventVisibility, string> = {
+  clinical: 'Клиническая',
+  admin: 'Административная',
+  financial: 'Финансовая',
+  system: 'Системная',
+};
+
+const ACTIVITY_CATEGORY_OPTIONS = Object.keys(ACTIVITY_CATEGORY_LABELS) as ActivityEventCategory[];
+const AUDIT_CATEGORY_OPTIONS = Object.keys(AUDIT_CATEGORY_LABELS) as AuditEventCategory[];
+const SEVERITY_OPTIONS = Object.keys(SEVERITY_LABELS) as AuditEventSeverity[];
+const VISIBILITY_OPTIONS = Object.keys(VISIBILITY_LABELS) as ActivityEventVisibility[];
+const LIMIT_OPTIONS = [25, DEFAULT_AUDIT_ACTIVITY_LIMIT, 100, 200];
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return 'Дата не указана';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Дата не указана';
+  return new Intl.DateTimeFormat('ru-RU', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}
+
+function optionalValue(value: string | null | undefined) {
+  return value?.trim() ? value : '—';
+}
+
+function updateTextFilter(value: string): string | undefined {
+  return value.trim() ? value : undefined;
+}
+
+export function AdminAuditViewer({ tenantId, role, backendAvailable = true }: AdminAuditViewerProps) {
+  const [activeTab, setActiveTab] = useState<AuditActivityViewerTab>('activity');
+  const [category, setCategory] = useState<string>('all');
+  const [severity, setSeverity] = useState<AuditEventSeverity | 'all'>('all');
+  const [dateFrom, setDateFrom] = useState<string>('');
+  const [dateTo, setDateTo] = useState<string>('');
+  const [visibility, setVisibility] = useState<ActivityEventVisibility | 'all'>('all');
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [targetType, setTargetType] = useState('');
+  const [patientId, setPatientId] = useState('');
+  const [actorUserId, setActorUserId] = useState('');
+  const [limit, setLimit] = useState(DEFAULT_AUDIT_ACTIVITY_LIMIT);
+  const [offset, setOffset] = useState(0);
+
+  const filters = useMemo<AuditActivityViewerFilters>(() => ({
+    category: category === 'all' ? undefined : category,
+    severity,
+    dateFrom: dateFrom || undefined,
+    dateTo: dateTo || undefined,
+    visibility,
+    includeArchived,
+    targetType: updateTextFilter(targetType),
+    patientId: updateTextFilter(patientId),
+    actorUserId: updateTextFilter(actorUserId),
+    limit,
+    offset,
+  }), [actorUserId, category, dateFrom, dateTo, includeArchived, limit, offset, patientId, severity, targetType, visibility]);
+
+  const { activityEvents, auditEvents, isLoading, error, refresh, isEnabled } = useAuditActivityEvents({
+    tenantId,
+    role,
+    activeTab,
+    filters,
+    backendAvailable,
+  });
+
+  const rowsCount = activeTab === 'activity' ? activityEvents.length : auditEvents.length;
+  const canGoBack = offset > 0;
+  const canGoNext = rowsCount >= limit;
+
+  const changeTab = (tab: AuditActivityViewerTab) => {
+    setActiveTab(tab);
+    setCategory('all');
+    setOffset(0);
+  };
+
+  const resetOffset = () => setOffset(0);
+
+  if (!isEnabled) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <h2 className="font-semibold">Журнал недоступен</h2>
+            <p className="mt-1 text-sm">Для просмотра нужен активный Supabase backend и роль администратора клиники.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-4" data-testid="admin-audit-viewer">
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-900">
+              <ShieldCheck className="h-6 w-6 text-blue-600" /> Журнал действий
+            </h1>
+            <p className="mt-1 text-sm text-slate-500">Аудит и активность клиники. Только чтение.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => { void refresh(); }}
+            className="inline-flex items-center gap-2 rounded border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50"
+          >
+            <RefreshCw className="h-4 w-4" /> Обновить
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex border-b border-slate-200">
+          <button
+            type="button"
+            onClick={() => changeTab('activity')}
+            className={`px-4 py-3 text-sm font-medium ${activeTab === 'activity' ? 'border-b-2 border-blue-600 text-blue-700' : 'text-slate-500 hover:text-slate-800'}`}
+          >
+            Активность
+          </button>
+          <button
+            type="button"
+            onClick={() => changeTab('audit')}
+            className={`px-4 py-3 text-sm font-medium ${activeTab === 'audit' ? 'border-b-2 border-blue-600 text-blue-700' : 'text-slate-500 hover:text-slate-800'}`}
+          >
+            Аудит
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 border-b border-slate-100 p-4 md:grid-cols-2 xl:grid-cols-4">
+          <label className="text-xs font-medium text-slate-600">
+            Категория
+            <select
+              value={category}
+              onChange={(event) => { setCategory(event.target.value); resetOffset(); }}
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+            >
+              <option value="all">Все</option>
+              {(activeTab === 'activity' ? ACTIVITY_CATEGORY_OPTIONS : AUDIT_CATEGORY_OPTIONS).map((value) => (
+                <option key={value} value={value}>
+                  {activeTab === 'activity'
+                    ? ACTIVITY_CATEGORY_LABELS[value as ActivityEventCategory]
+                    : AUDIT_CATEGORY_LABELS[value as AuditEventCategory]}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-xs font-medium text-slate-600">
+            Важность
+            <select
+              value={severity}
+              onChange={(event) => { setSeverity(event.target.value as AuditEventSeverity | 'all'); resetOffset(); }}
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+            >
+              <option value="all">Все</option>
+              {SEVERITY_OPTIONS.map((value) => <option key={value} value={value}>{SEVERITY_LABELS[value]}</option>)}
+            </select>
+          </label>
+
+          <label className="text-xs font-medium text-slate-600">
+            С даты
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(event) => { setDateFrom(event.target.value); resetOffset(); }}
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+            />
+          </label>
+
+          <label className="text-xs font-medium text-slate-600">
+            По дату
+            <input
+              type="date"
+              value={dateTo}
+              onChange={(event) => { setDateTo(event.target.value); resetOffset(); }}
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+            />
+          </label>
+
+          {activeTab === 'activity' ? (
+            <>
+              <label className="text-xs font-medium text-slate-600">
+                Видимость
+                <select
+                  value={visibility}
+                  onChange={(event) => { setVisibility(event.target.value as ActivityEventVisibility | 'all'); resetOffset(); }}
+                  className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+                >
+                  <option value="all">Все</option>
+                  {VISIBILITY_OPTIONS.map((value) => <option key={value} value={value}>{VISIBILITY_LABELS[value]}</option>)}
+                </select>
+              </label>
+              <label className="mt-6 flex items-center gap-2 text-sm font-medium text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={includeArchived}
+                  onChange={(event) => { setIncludeArchived(event.target.checked); resetOffset(); }}
+                  className="rounded border-slate-300"
+                />
+                Показать архивные
+              </label>
+            </>
+          ) : (
+            <>
+              <label className="text-xs font-medium text-slate-600">
+                Target type
+                <input
+                  value={targetType}
+                  onChange={(event) => { setTargetType(event.target.value); resetOffset(); }}
+                  className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+                  placeholder="patient, file..."
+                />
+              </label>
+              <label className="text-xs font-medium text-slate-600">
+                Patient ID
+                <input
+                  value={patientId}
+                  onChange={(event) => { setPatientId(event.target.value); resetOffset(); }}
+                  className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+                  placeholder="UUID пациента"
+                />
+              </label>
+              <label className="text-xs font-medium text-slate-600">
+                Actor user ID
+                <input
+                  value={actorUserId}
+                  onChange={(event) => { setActorUserId(event.target.value); resetOffset(); }}
+                  className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+                  placeholder="UUID пользователя"
+                />
+              </label>
+            </>
+          )}
+
+          <label className="text-xs font-medium text-slate-600">
+            Лимит
+            <select
+              value={limit}
+              onChange={(event) => { setLimit(Number(event.target.value)); resetOffset(); }}
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+            >
+              {LIMIT_OPTIONS.map((value) => <option key={value} value={value}>{value}</option>)}
+            </select>
+          </label>
+        </div>
+
+        {error ? (
+          <div className="p-8 text-center text-red-600">
+            <AlertTriangle className="mx-auto mb-3 h-10 w-10 text-red-300" />
+            <p className="font-medium">Не удалось загрузить журнал.</p>
+            <p className="mt-2 text-xs text-red-500">{error.message}</p>
+          </div>
+        ) : isLoading ? (
+          <div className="p-8 text-center text-slate-500">
+            <Clock3 className="mx-auto mb-3 h-10 w-10 animate-pulse text-slate-300" />
+            <p>Загрузка журнала...</p>
+          </div>
+        ) : activeTab === 'activity' ? (
+          <ActivityList events={activityEvents} />
+        ) : (
+          <AuditList events={auditEvents} />
+        )}
+
+        <div className="flex items-center justify-between border-t border-slate-100 p-4 text-sm text-slate-600">
+          <span>Показано: {rowsCount}. Смещение: {offset}.</span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={!canGoBack}
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+              className="rounded border border-slate-200 px-3 py-1.5 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Назад
+            </button>
+            <button
+              type="button"
+              disabled={!canGoNext}
+              onClick={() => setOffset(offset + limit)}
+              className="rounded border border-slate-200 px-3 py-1.5 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Далее
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="p-8 text-center text-slate-500">
+      <FileSearch className="mx-auto mb-3 h-10 w-10 text-slate-300" />
+      <p>Событий по выбранным фильтрам нет.</p>
+    </div>
+  );
+}
+
+function ActivityList({ events }: { events: ActivityEvent[] }) {
+  if (events.length === 0) return <EmptyState />;
+
+  return (
+    <div className="divide-y divide-slate-100">
+      {events.map((event) => (
+        <article key={event.id} className="p-4" data-testid="activity-event-row">
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap gap-2 text-xs font-medium">
+                <span className="rounded-full bg-blue-50 px-2 py-0.5 text-blue-700">{ACTIVITY_CATEGORY_LABELS[event.category]}</span>
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-slate-700">{event.type}</span>
+                <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-emerald-700">{VISIBILITY_LABELS[event.visibility]}</span>
+                <span className="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700">{SEVERITY_LABELS[event.severity]}</span>
+                {event.isArchived && <span className="rounded-full bg-slate-200 px-2 py-0.5 text-slate-700">Архив</span>}
+              </div>
+              <h2 className="mt-2 font-semibold text-slate-900">{event.title}</h2>
+              {event.description && <p className="mt-1 text-sm text-slate-600">{event.description}</p>}
+            </div>
+            <time className="shrink-0 text-sm text-slate-500">{formatDateTime(event.occurredAt)}</time>
+          </div>
+          <dl className="mt-3 grid grid-cols-1 gap-2 text-xs text-slate-500 md:grid-cols-3">
+            <div><dt className="font-medium text-slate-600">Actor</dt><dd>{optionalValue(event.actorUserId)}</dd></div>
+            <div><dt className="font-medium text-slate-600">Patient</dt><dd>{optionalValue(event.patientId)}</dd></div>
+            <div><dt className="font-medium text-slate-600">Source</dt><dd>{event.sourceType} / {event.sourceId}</dd></div>
+            <div><dt className="font-medium text-slate-600">Status</dt><dd>{optionalValue(event.sourceStatus)}</dd></div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function AuditList({ events }: { events: AuditEvent[] }) {
+  if (events.length === 0) return <EmptyState />;
+
+  return (
+    <div className="divide-y divide-slate-100">
+      {events.map((event) => (
+        <article key={event.id} className="p-4" data-testid="audit-event-row">
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap gap-2 text-xs font-medium">
+                <span className="rounded-full bg-purple-50 px-2 py-0.5 text-purple-700">{AUDIT_CATEGORY_LABELS[event.category]}</span>
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-slate-700">{event.action}</span>
+                <span className="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700">{SEVERITY_LABELS[event.severity]}</span>
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-slate-700">{event.redactionLevel}</span>
+              </div>
+              <h2 className="mt-2 font-semibold text-slate-900">{event.targetType}: {event.targetId}</h2>
+              {event.reason && <p className="mt-1 text-sm text-slate-600">Причина: {event.reason}</p>}
+            </div>
+            <time className="shrink-0 text-sm text-slate-500">{formatDateTime(event.createdAt)}</time>
+          </div>
+          <dl className="mt-3 grid grid-cols-1 gap-2 text-xs text-slate-500 md:grid-cols-3">
+            <div><dt className="font-medium text-slate-600">Actor</dt><dd>{optionalValue(event.actorDisplayName ?? event.actorUserId)}</dd></div>
+            <div><dt className="font-medium text-slate-600">Role</dt><dd>{optionalValue(event.actorTenantRole ?? event.actorRole)}</dd></div>
+            <div><dt className="font-medium text-slate-600">Patient</dt><dd>{optionalValue(event.patientId)}</dd></div>
+            <div><dt className="font-medium text-slate-600">Target</dt><dd>{event.targetType} / {event.targetId}</dd></div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,8 +15,11 @@ import {
   Gift,
   Mail,
   MessageSquare,
-  Settings
+  Settings,
+  ShieldCheck,
 } from 'lucide-react';
+import { useTenant } from '../../contexts/TenantContext';
+import { canViewAdminAudit } from '../../data/hooks/useAuditActivityEvents';
 
 const navItems = [
   { to: '/', icon: CalendarDays, label: 'Расписание' },
@@ -36,7 +39,16 @@ const navItems = [
   { to: '/settings', icon: Settings, label: 'Настройки' },
 ];
 
+const adminNavItems = [
+  { to: '/admin/audit', icon: ShieldCheck, label: 'Журнал действий' },
+];
+
 export function Sidebar() {
+  const { activeTenant } = useTenant();
+  const visibleItems = canViewAdminAudit(activeTenant?.role)
+    ? [...navItems, ...adminNavItems]
+    : navItems;
+
   return (
     <aside className="w-64 bg-slate-900 text-slate-300 flex flex-col h-full overflow-y-auto shrink-0 border-r border-slate-800">
       <div className="p-4 border-b border-slate-800/50 sticky top-0 bg-slate-900 z-10">
@@ -49,7 +61,7 @@ export function Sidebar() {
       </div>
       <nav className="flex-1 py-4">
         <ul className="space-y-1 px-2">
-          {navItems.map((item) => (
+          {visibleItems.map((item) => (
             <li key={item.to}>
               <NavLink
                 to={item.to}

--- a/src/data/hooks/useAuditActivityEvents.test.tsx
+++ b/src/data/hooks/useAuditActivityEvents.test.tsx
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act, useEffect, type ReactNode } from 'react';
+import {
+  useAuditActivityEvents,
+  type AuditActivityViewerFilters,
+  type AuditActivityViewerTab,
+  type UseAuditActivityEventsResult,
+} from './useAuditActivityEvents';
+import {
+  createAuditActivityRepository,
+  type ActivityEvent,
+  type AuditActivityRepository,
+  type AuditEvent,
+} from '../repositories/AuditActivityRepository';
+
+vi.mock('../repositories/AuditActivityRepository', async () => {
+  const actual = await vi.importActual<typeof import('../repositories/AuditActivityRepository')>('../repositories/AuditActivityRepository');
+  return {
+    ...actual,
+    createAuditActivityRepository: vi.fn(),
+  };
+});
+
+const mockedCreateRepository = vi.mocked(createAuditActivityRepository);
+const listActivityEvents = vi.fn<AuditActivityRepository['listActivityEvents']>();
+const listAuditEvents = vi.fn<AuditActivityRepository['listAuditEvents']>();
+const listPatientActivityEvents = vi.fn<AuditActivityRepository['listPatientActivityEvents']>();
+
+const activityEvent: ActivityEvent = {
+  id: 'activity-1',
+  tenantId: 'tenant-1',
+  patientId: 'patient-1',
+  auditEventId: 'audit-1',
+  actorUserId: 'actor-1',
+  category: 'patient',
+  type: 'patient.updated',
+  title: 'Patient updated',
+  description: 'Safe summary',
+  sourceType: 'patient',
+  sourceId: 'patient-1',
+  sourceStatus: 'active',
+  visibility: 'admin',
+  severity: 'info',
+  occurredAt: '2026-06-18T09:00:00.000Z',
+  metadata: {},
+  isArchived: false,
+  createdAt: '2026-06-18T09:00:01.000Z',
+};
+
+const auditEvent: AuditEvent = {
+  id: 'audit-1',
+  tenantId: 'tenant-1',
+  actorUserId: 'actor-1',
+  actorRole: 'authenticated',
+  actorTenantRole: 'clinic_admin',
+  actorDisplayName: 'Admin',
+  action: 'patient.update',
+  category: 'patient',
+  severity: 'info',
+  targetType: 'patient',
+  targetId: 'patient-1',
+  patientId: 'patient-1',
+  redactionLevel: 'standard',
+  reason: null,
+  metadata: {},
+  createdAt: '2026-06-18T09:00:00.000Z',
+};
+
+interface HookProbeProps {
+  tenantId?: string | null;
+  role?: string | null;
+  activeTab: AuditActivityViewerTab;
+  filters?: AuditActivityViewerFilters;
+  backendAvailable?: boolean;
+  onUpdate: (result: UseAuditActivityEventsResult) => void;
+}
+
+function HookProbe({ tenantId, role, activeTab, filters, backendAvailable = true, onUpdate }: HookProbeProps) {
+  const result = useAuditActivityEvents({ tenantId, role, activeTab, filters, backendAvailable });
+  useEffect(() => {
+    onUpdate(result);
+  }, [onUpdate, result]);
+  return <div>{result.activityEvents.length + result.auditEvents.length}</div>;
+}
+
+async function renderNode(node: ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(node);
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  return { container, root };
+}
+
+async function unmount(root: ReturnType<typeof createRoot>, container: HTMLElement) {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('useAuditActivityEvents', () => {
+  it('does not create repository without tenantId', async () => {
+    const updates: UseAuditActivityEventsResult[] = [];
+
+    const { root, container } = await renderNode(
+      <HookProbe tenantId={null} role="clinic_admin" activeTab="activity" onUpdate={(result) => updates.push(result)} />
+    );
+
+    expect(mockedCreateRepository).not.toHaveBeenCalled();
+    expect(updates.at(-1)?.isEnabled).toBe(false);
+    await unmount(root, container);
+  });
+
+  it.each(['doctor', 'registrar', 'receptionist', 'cashier'])('does not query for unauthorized role %s', async (role) => {
+    const { root, container } = await renderNode(
+      <HookProbe tenantId="tenant-1" role={role} activeTab="activity" onUpdate={vi.fn()} />
+    );
+
+    expect(mockedCreateRepository).not.toHaveBeenCalled();
+    expect(listActivityEvents).not.toHaveBeenCalled();
+    expect(listAuditEvents).not.toHaveBeenCalled();
+    await unmount(root, container);
+  });
+
+  it('does not query when backend is unavailable', async () => {
+    const { root, container } = await renderNode(
+      <HookProbe tenantId="tenant-1" role="clinic_admin" activeTab="activity" backendAvailable={false} onUpdate={vi.fn()} />
+    );
+
+    expect(mockedCreateRepository).not.toHaveBeenCalled();
+    await unmount(root, container);
+  });
+
+  it('calls listActivityEvents with active tenant and filters', async () => {
+    const updates: UseAuditActivityEventsResult[] = [];
+    listActivityEvents.mockResolvedValue([activityEvent]);
+    listAuditEvents.mockResolvedValue([]);
+    mockedCreateRepository.mockReturnValue({ listActivityEvents, listAuditEvents, listPatientActivityEvents });
+
+    const { root, container } = await renderNode(
+      <HookProbe
+        tenantId="tenant-1"
+        role="clinic_admin"
+        activeTab="activity"
+        filters={{
+          category: 'patient',
+          severity: 'warning',
+          visibility: 'admin',
+          includeArchived: true,
+          dateFrom: '2026-06-01',
+          dateTo: '2026-06-18',
+          limit: 25,
+          offset: 25,
+        }}
+        onUpdate={(result) => updates.push(result)}
+      />
+    );
+
+    expect(mockedCreateRepository).toHaveBeenCalledWith({ backend: 'supabase' });
+    expect(listActivityEvents).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      categories: ['patient'],
+      visibility: ['admin'],
+      occurredFrom: '2026-06-01T00:00:00.000Z',
+      occurredTo: '2026-06-18T23:59:59.999Z',
+      includeArchived: true,
+      limit: 25,
+      offset: 25,
+    });
+    expect(updates.at(-1)?.activityEvents).toEqual([activityEvent]);
+    expect(listAuditEvents).not.toHaveBeenCalled();
+    await unmount(root, container);
+  });
+
+  it('calls listAuditEvents with active tenant and filters', async () => {
+    const updates: UseAuditActivityEventsResult[] = [];
+    listActivityEvents.mockResolvedValue([]);
+    listAuditEvents.mockResolvedValue([auditEvent]);
+    mockedCreateRepository.mockReturnValue({ listActivityEvents, listAuditEvents, listPatientActivityEvents });
+
+    const { root, container } = await renderNode(
+      <HookProbe
+        tenantId="tenant-1"
+        role="clinic_owner"
+        activeTab="audit"
+        filters={{
+          category: 'patient',
+          severity: 'critical',
+          targetType: ' patient ',
+          patientId: ' patient-1 ',
+          actorUserId: ' actor-1 ',
+          dateFrom: '2026-06-01',
+          dateTo: '2026-06-18',
+          limit: 100,
+          offset: 0,
+        }}
+        onUpdate={(result) => updates.push(result)}
+      />
+    );
+
+    expect(listAuditEvents).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      categories: ['patient'],
+      severities: ['critical'],
+      targetType: 'patient',
+      patientId: 'patient-1',
+      actorUserId: 'actor-1',
+      createdFrom: '2026-06-01T00:00:00.000Z',
+      createdTo: '2026-06-18T23:59:59.999Z',
+      limit: 100,
+      offset: 0,
+    });
+    expect(updates.at(-1)?.auditEvents).toEqual([auditEvent]);
+    expect(listActivityEvents).not.toHaveBeenCalled();
+    await unmount(root, container);
+  });
+
+  it('surfaces repository errors', async () => {
+    const updates: UseAuditActivityEventsResult[] = [];
+    const failure = new Error('Repository failed');
+    listActivityEvents.mockRejectedValue(failure);
+    mockedCreateRepository.mockReturnValue({ listActivityEvents, listAuditEvents, listPatientActivityEvents });
+
+    const { root, container } = await renderNode(
+      <HookProbe tenantId="tenant-1" role="clinic_admin" activeTab="activity" onUpdate={(result) => updates.push(result)} />
+    );
+
+    expect(updates.at(-1)?.isError).toBe(true);
+    expect(updates.at(-1)?.error?.message).toBe('Repository failed');
+    await unmount(root, container);
+  });
+
+  it('never calls patient timeline activity helper or raw write methods', async () => {
+    listActivityEvents.mockResolvedValue([]);
+    listAuditEvents.mockResolvedValue([]);
+    mockedCreateRepository.mockReturnValue({ listActivityEvents, listAuditEvents, listPatientActivityEvents });
+
+    const { root, container } = await renderNode(
+      <HookProbe tenantId="tenant-1" role="clinic_admin" activeTab="activity" onUpdate={vi.fn()} />
+    );
+
+    expect(listPatientActivityEvents).not.toHaveBeenCalled();
+    expect(Object.keys(mockedCreateRepository.mock.results[0]?.value ?? {})).toEqual([
+      'listActivityEvents',
+      'listAuditEvents',
+      'listPatientActivityEvents',
+    ]);
+    await unmount(root, container);
+  });
+});

--- a/src/data/hooks/useAuditActivityEvents.ts
+++ b/src/data/hooks/useAuditActivityEvents.ts
@@ -1,0 +1,144 @@
+import { useCallback, useMemo } from 'react';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import { useAsyncQuery } from './useAsyncQuery';
+import {
+  createAuditActivityRepository,
+  DEFAULT_AUDIT_ACTIVITY_LIMIT,
+  type ActivityEvent,
+  type ActivityEventCategory,
+  type ActivityEventVisibility,
+  type AuditEvent,
+  type AuditEventCategory,
+  type AuditEventSeverity,
+} from '../repositories/AuditActivityRepository';
+
+export type AuditActivityViewerTab = 'activity' | 'audit';
+
+export const ADMIN_AUDIT_ALLOWED_ROLES = ['clinic_owner', 'clinic_admin'] as const;
+
+export function canViewAdminAudit(role: string | null | undefined): boolean {
+  return role === 'clinic_owner' || role === 'clinic_admin';
+}
+
+export interface AuditActivityViewerFilters {
+  category?: string;
+  severity?: AuditEventSeverity | 'all';
+  dateFrom?: string;
+  dateTo?: string;
+  visibility?: ActivityEventVisibility | 'all';
+  includeArchived?: boolean;
+  targetType?: string;
+  patientId?: string;
+  actorUserId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+const EMPTY_AUDIT_ACTIVITY_FILTERS: AuditActivityViewerFilters = {};
+
+interface UseAuditActivityEventsOptions {
+  tenantId?: string | null;
+  role?: string | null;
+  activeTab: AuditActivityViewerTab;
+  filters?: AuditActivityViewerFilters;
+  backendAvailable?: boolean;
+}
+
+export interface UseAuditActivityEventsResult {
+  activityEvents: ActivityEvent[];
+  auditEvents: AuditEvent[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+  isEnabled: boolean;
+}
+
+interface AuditActivityQueryResult {
+  activityEvents: ActivityEvent[];
+  auditEvents: AuditEvent[];
+}
+
+function normalizeTextFilter(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function dateStart(value?: string): string | undefined {
+  return value ? `${value}T00:00:00.000Z` : undefined;
+}
+
+function dateEnd(value?: string): string | undefined {
+  return value ? `${value}T23:59:59.999Z` : undefined;
+}
+
+function singleValueArray<T extends string>(value?: T | 'all' | string): T[] | undefined {
+  if (!value || value === 'all') return undefined;
+  return [value as T];
+}
+
+export function useAuditActivityEvents({
+  tenantId,
+  role,
+  activeTab,
+  filters = EMPTY_AUDIT_ACTIVITY_FILTERS,
+  backendAvailable = isSupabaseConfigured,
+}: UseAuditActivityEventsOptions): UseAuditActivityEventsResult {
+  const isEnabled = Boolean(backendAvailable && tenantId && canViewAdminAudit(role));
+  const limit = filters.limit ?? DEFAULT_AUDIT_ACTIVITY_LIMIT;
+  const offset = filters.offset ?? 0;
+
+  const queryFn = useCallback(async (): Promise<AuditActivityQueryResult> => {
+    if (!isEnabled || !tenantId) {
+      return { activityEvents: [], auditEvents: [] };
+    }
+
+    const repository = createAuditActivityRepository({ backend: 'supabase' });
+
+    if (activeTab === 'activity') {
+      const activityEvents = await repository.listActivityEvents({
+        tenantId,
+        categories: singleValueArray<ActivityEventCategory>(filters.category),
+        visibility: singleValueArray<ActivityEventVisibility>(filters.visibility),
+        occurredFrom: dateStart(filters.dateFrom),
+        occurredTo: dateEnd(filters.dateTo),
+        includeArchived: filters.includeArchived,
+        limit,
+        offset,
+      });
+      return { activityEvents, auditEvents: [] };
+    }
+
+    const auditEvents = await repository.listAuditEvents({
+      tenantId,
+      categories: singleValueArray<AuditEventCategory>(filters.category),
+      severities: singleValueArray<AuditEventSeverity>(filters.severity),
+      targetType: normalizeTextFilter(filters.targetType),
+      patientId: normalizeTextFilter(filters.patientId),
+      actorUserId: normalizeTextFilter(filters.actorUserId),
+      createdFrom: dateStart(filters.dateFrom),
+      createdTo: dateEnd(filters.dateTo),
+      limit,
+      offset,
+    });
+    return { activityEvents: [], auditEvents };
+  }, [activeTab, filters, isEnabled, limit, offset, tenantId]);
+
+  const initialData = useMemo<AuditActivityQueryResult>(() => ({ activityEvents: [], auditEvents: [] }), []);
+
+  const { data, isLoading, isError, error, refetch } = useAsyncQuery<AuditActivityQueryResult>({
+    queryFn,
+    initialData,
+    enabled: isEnabled,
+  });
+
+  return {
+    activityEvents: isEnabled ? data.activityEvents : [],
+    auditEvents: isEnabled ? data.auditEvents : [],
+    isLoading: isEnabled ? isLoading : false,
+    isError,
+    error,
+    refresh: refetch,
+    isEnabled,
+  };
+}

--- a/src/pages/AdminAuditPage.tsx
+++ b/src/pages/AdminAuditPage.tsx
@@ -1,0 +1,55 @@
+import { AlertTriangle, ShieldCheck } from 'lucide-react';
+import { AdminAuditViewer } from '../components/admin/AdminAuditViewer';
+import { useAuth } from '../contexts/AuthContext';
+import { useTenant } from '../contexts/TenantContext';
+import { isSupabaseConfigured } from '../lib/supabaseClient';
+import { canViewAdminAudit } from '../data/hooks/useAuditActivityEvents';
+
+export function AdminAuditPage() {
+  const { authMode } = useAuth();
+  const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const role = activeTenant?.role;
+
+  if (!tenantId) {
+    return (
+      <div className="mx-auto max-w-4xl p-4 md:p-8">
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <h1 className="font-semibold">Клиника не назначена</h1>
+              <p className="mt-1 text-sm">Журнал действий доступен только пользователям активной клиники.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!canViewAdminAudit(role)) {
+    return (
+      <div className="mx-auto max-w-4xl p-4 md:p-8">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-red-700">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <h1 className="font-semibold">Доступ запрещён</h1>
+              <p className="mt-1 text-sm">Журнал аудита доступен только владельцу или администратору клиники.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl p-4 md:p-8">
+      <AdminAuditViewer
+        tenantId={tenantId}
+        role={role ?? ''}
+        backendAvailable={authMode === 'supabase-active' && isSupabaseConfigured}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add read-only clinic admin/owner audit and activity viewer at /admin/audit
- Load audit/activity through existing AuditActivityRepository only
- Hide route/navigation from unauthorized tenant roles and no-tenant users
- Add tests for access, filters, safe rendering, hook behavior, and navigation
- Add validation report

## Safety
- no migrations
- no Supabase cloud
- no browser smoke
- no audit/activity write paths
- no service_role usage in UI
- no raw JSON/diff dump in viewer tables
- no patient timeline changes
- no encounter/visit work

## Checks
- Local: npm run lint PASS
- Local: npm run test -- --run PASS, 47 files / 414 tests
- Local: npm run build PASS
- GitHub Actions CI #540 PASS on 36dce18ad80c9dff64e58ff5dee4caa1a0350cd8

Final verdict: ADMIN AUDIT VIEWER IMPLEMENTED AND VERIFIED