### PR TITLE
ENCOUNTER-VISIT-MODEL-001A: add visit encounter and completed service schema

### DIFF
--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md
@@ -22,9 +22,9 @@ https://github.com/NckNA/codex-test/pull/311
 
 ## 4. PR head reviewed before final report update
 
-`288bee64133507fe5f5ea1f88c548871aef10905`
+`bbc2d26e5885c6ec858548e823c4c30ed3e17d02`
 
-This is the PR head reviewed before the final report update. It includes the migration and validation report commits verified by CI #551.
+This is the PR head reviewed before the final report update. It includes the migration and validation report commits verified by CI #552.
 
 ## 5. Report update commit
 
@@ -533,9 +533,9 @@ All commands exited successfully.
 Fresh CI after report push:
 
 - Workflow: `CI`
-- Run id: `27806672669`
-- CI number: `551`
-- Tested commit: `288bee64133507fe5f5ea1f88c548871aef10905`
+- Run id: `27806751316`
+- CI number: `552`
+- Tested commit: `bbc2d26e5885c6ec858548e823c4c30ed3e17d02`
 - Status: completed
 - Conclusion: success
 - Required checks: ESLint, tests, build passed.

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md
@@ -22,9 +22,9 @@ https://github.com/NckNA/codex-test/pull/311
 
 ## 4. PR head reviewed before final report update
 
-`cca428c57be6227556b3ec1ecf890bf5fd08c256`
+`288bee64133507fe5f5ea1f88c548871aef10905`
 
-This is the migration-only PR head reviewed before adding this report.
+This is the PR head reviewed before the final report update. It includes the migration and validation report commits verified by CI #551.
 
 ## 5. Report update commit
 
@@ -530,7 +530,15 @@ All commands exited successfully.
 
 ### GitHub Actions CI
 
-Pending after report push.
+Fresh CI after report push:
+
+- Workflow: `CI`
+- Run id: `27806672669`
+- CI number: `551`
+- Tested commit: `288bee64133507fe5f5ea1f88c548871aef10905`
+- Status: completed
+- Conclusion: success
+- Required checks: ESLint, tests, build passed.
 
 ## 18. Final verdict
 

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md
@@ -1,0 +1,541 @@
+# ENCOUNTER-VISIT-MODEL-001A — visit, encounter, completed service schema report
+
+## 1. Summary
+
+Implemented the schema-only foundation for actual patient attendance, clinical documentation sessions, and performed clinical/billable service facts.
+
+The migration adds three source-of-truth tables:
+
+- `public.patient_visits`
+- `public.clinical_encounters`
+- `public.completed_services`
+
+No app code, UI, repositories, hooks, seed/backfill, browser smoke, payment/stock/document work, timeline integration, or Supabase cloud changes were made.
+
+## 2. Branch name
+
+`feature/encounter-visit-model-001a`
+
+## 3. PR URL
+
+https://github.com/NckNA/codex-test/pull/311
+
+## 4. PR head reviewed before final report update
+
+`cca428c57be6227556b3ec1ecf890bf5fd08c256`
+
+This is the migration-only PR head reviewed before adding this report.
+
+## 5. Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed files summary
+
+Expected files:
+
+- `supabase/migrations/0014_create_encounter_visit_model.sql`
+- `_ai_work/REPORTS/ENCOUNTER-VISIT-MODEL-001A_schema.md`
+
+No app code changed.
+No UI changed.
+No repositories/hooks changed.
+No seed files changed.
+No generated types changed.
+
+## 7. Current schema recon
+
+### Existing core tables inspected
+
+Relevant existing schema from migrations:
+
+- `public.tenants`
+- `public.profiles`
+- `public.tenant_users`
+- `public.patients`
+- `public.appointments`
+- `public.findings`
+- `public.treatment_plans`
+- `public.treatment_stages`
+- `public.clinical_dictionary_items`
+- `public.audit_logs`
+- `public.audit_events`
+- `public.activity_events`
+
+### Existing ID type findings
+
+| Entity | ID type / shape |
+|---|---|
+| `tenants.id` | `uuid` |
+| `profiles.id` | `uuid`, references `auth.users(id)` |
+| `tenant_users.id` | `uuid` |
+| `tenant_users.user_id` | `uuid`, references `profiles(id)` |
+| `patients.id` | `uuid`, with `UNIQUE(tenant_id, id)` |
+| `appointments.id` | `uuid` |
+| `findings.id` | `uuid` |
+| `treatment_plans.id` | `uuid`, with `UNIQUE(tenant_id, id)` |
+| `treatment_stages.id` | `uuid` |
+| `clinical_dictionary_items.id` | `text`, composite PK `(tenant_id, id)` |
+| `audit_events.id` | `uuid` |
+| `activity_events.id` | `uuid` |
+
+Important design consequence: `clinical_dictionary_item_id` in `completed_services` is `text`, not `uuid`, and is scoped by `(tenant_id, clinical_dictionary_item_id)`.
+
+### Existing app_role enum
+
+Exact enum values from `app_role`:
+
+- `platform_owner`
+- `platform_admin`
+- `clinic_owner`
+- `clinic_admin`
+- `doctor`
+- `registrar`
+- `cashier`
+- `marketer`
+- `support`
+
+There is no `receptionist` enum value. The project uses `registrar` for that role boundary.
+
+### Existing RLS helper functions
+
+Available and reused:
+
+- `public.get_user_tenants()`
+- `public.has_tenant_role(target_tenant_id uuid, allowed_roles app_role[])`
+
+These helpers are suitable for tenant-scoped SELECT policies on the new tables.
+
+### Existing write patterns
+
+Current older domain tables still have broad tenant-member insert/update policies in early migrations.
+
+Recent sensitive work is moving toward controlled RPC/helper patterns:
+
+- treatment plan/stage sync uses a transactional RPC;
+- audit/activity writes use internal helpers granted only to trusted backend context;
+- audit/activity tables use conservative grants and no broad browser write path.
+
+For this task, the new clinical fact tables follow the newer conservative approach: no broad client INSERT/UPDATE/DELETE policies in 001A.
+
+## 8. Migration summary
+
+Migration file:
+
+`supabase/migrations/0014_create_encounter_visit_model.sql`
+
+Created tables:
+
+- `public.patient_visits`
+- `public.clinical_encounters`
+- `public.completed_services`
+
+Added helper:
+
+- `public.set_updated_at()` generic timestamp trigger helper
+
+Added triggers:
+
+- `patient_visits_set_updated_at`
+- `clinical_encounters_set_updated_at`
+- `completed_services_set_updated_at`
+
+Validation counts from local schema checks:
+
+- new tables found: `3`
+- new table columns found: `78` total across the three tables
+- constraints found: `57`
+- indexes found: `24`
+- comments found: `20`
+- RLS-enabled new tables: `3`
+- SELECT policies found: `3`
+- authenticated SELECT grants: `3`
+- authenticated extra grants: `0`
+
+## 9. Domain boundary
+
+### Appointment vs visit
+
+`appointments` remain booking intent / scheduled slot records.
+
+`patient_visits` represent actual attendance. A `patient_visits.appointment_id` is only a context link to the booking. Appointment status alone is not a clinical record and is not proof of treatment.
+
+`no_show` was intentionally not added to `patient_visits.status`; no-show remains an appointment outcome, not an actual visit.
+
+### Visit vs clinical encounter
+
+A visit is attendance.
+
+A clinical encounter is a documented doctor interaction/session, usually inside a visit. The two are related but not interchangeable.
+
+### Encounter vs completed service
+
+A clinical encounter documents clinical interaction.
+
+A completed service is a performed clinical/billable fact. It can reference an encounter, but it is its own source fact for performed-service reports.
+
+### Completed service vs treatment plan/stage
+
+Treatment plans and stages are intended future work.
+
+`completed_services` records performed facts. Plan/stage links are references only and do not prove completion by themselves.
+
+### Completed service vs payment
+
+`completed_services.unit_price` and `completed_services.total_amount` are service/billing snapshots only.
+
+Payment allocation/debt/balance is a future financial module and was not implemented here.
+
+### Source fact vs audit/activity
+
+Audit/activity events record action history and product activity projections.
+
+They are not the source of clinical facts. Future domain RPCs should write the clinical fact and audit/activity events in the same transaction.
+
+## 10. patient_visits design
+
+Purpose: actual patient attendance instance in a clinic.
+
+Key fields:
+
+- `tenant_id`
+- `patient_id`
+- optional `appointment_id`
+- `status`
+- `visit_type`
+- timestamps for arrival/check-in/start/completion/cancellation/archive
+- actor references for create/update/archive
+- administrative notes
+- safe `metadata` object
+
+Allowed statuses:
+
+- `checked_in`
+- `in_progress`
+- `completed`
+- `cancelled`
+- `archived`
+
+Allowed visit types:
+
+- `regular`
+- `emergency`
+- `consultation`
+- `follow_up`
+- `procedure`
+- `other`
+
+Selected constraints:
+
+- metadata must be a JSON object;
+- completed timestamp only with completed/archived state;
+- cancelled timestamp only with cancelled state;
+- archived timestamp only with archived state.
+
+## 11. clinical_encounters design
+
+Purpose: documented clinical interaction/session, usually inside a patient visit.
+
+Key fields:
+
+- `tenant_id`
+- `patient_id`
+- optional `visit_id`
+- optional `appointment_id`
+- `doctor_user_id`
+- `status`
+- `encounter_type`
+- clinical summary fields
+- correction reason
+- safe `metadata` object
+
+Allowed statuses:
+
+- `draft`
+- `in_progress`
+- `completed`
+- `locked`
+- `archived`
+
+Allowed encounter types:
+
+- `consultation`
+- `treatment`
+- `surgery`
+- `orthodontics`
+- `prosthetics`
+- `hygiene`
+- `emergency`
+- `follow_up`
+- `other`
+
+Selected constraints:
+
+- metadata must be a JSON object;
+- completed timestamp only with completed/locked/archived state;
+- locked timestamp only with locked/archived state;
+- archived timestamp only with archived state.
+
+## 12. completed_services design
+
+Purpose: performed clinical/billable service fact.
+
+Key fields:
+
+- `tenant_id`
+- `patient_id`
+- optional `visit_id`
+- optional `encounter_id`
+- optional context links to appointment/finding/treatment plan/treatment stage/dictionary item
+- service code/name
+- tooth fields
+- quantity
+- price/amount snapshot
+- currency
+- performed_by/performed_at
+- correction/void/archive fields
+- safe `metadata` object
+
+Allowed statuses:
+
+- `completed`
+- `corrected`
+- `voided`
+- `archived`
+
+Selected constraints:
+
+- metadata must be a JSON object;
+- quantity must be positive;
+- unit price and total amount must be non-negative when present;
+- currency must be non-empty;
+- service name must be non-empty;
+- corrected/voided status requires correction reason;
+- voided status requires voided timestamp;
+- archived status requires archived timestamp.
+
+## 13. RLS / role visibility
+
+RLS is enabled on all three tables.
+
+### `patient_visits`
+
+Allowed SELECT roles:
+
+- `clinic_owner`
+- `clinic_admin`
+- `doctor`
+- `registrar`
+
+Blocked in 001A:
+
+- `cashier`
+- no-tenant users
+- cross-tenant users
+- platform/support/marketing roles unless future product policy explicitly allows them
+
+Rationale: visits can contain patient attendance and notes, so cashier access is deferred until a billing/privacy policy defines limited read models.
+
+### `clinical_encounters`
+
+Allowed SELECT roles:
+
+- `clinic_owner`
+- `clinic_admin`
+- `doctor`
+
+Blocked:
+
+- `registrar`
+- `cashier`
+- no-tenant users
+- cross-tenant users
+
+Rationale: encounters are clinical documentation, not front desk or billing data.
+
+### `completed_services`
+
+Allowed SELECT roles:
+
+- `clinic_owner`
+- `clinic_admin`
+- `doctor`
+
+Blocked in 001A:
+
+- `registrar`
+- `cashier`
+- no-tenant users
+- cross-tenant users
+
+Rationale: completed services include clinical and billing-facing details. Cashier access is intentionally deferred until payment/debt policy defines a safe billing-facing view.
+
+## 14. Write path strategy
+
+No broad browser/client write policies were added for:
+
+- `patient_visits`
+- `clinical_encounters`
+- `completed_services`
+
+`authenticated` receives SELECT only, controlled by RLS.
+
+Future write tasks should add controlled domain RPCs/repositories. Those RPCs should:
+
+- validate tenant/patient ownership;
+- perform clinical mutation;
+- record audit/activity events with existing internal helpers;
+- require correction reasons for high-risk corrections/voids.
+
+## 15. Local validation
+
+### Local Supabase status
+
+Detected local Supabase:
+
+- API: `http://127.0.0.1:54321`
+- DB: `127.0.0.1:54322/postgres`
+- cloudAccess: `false`
+
+Optional services reported stopped:
+
+- `imgproxy`
+- `edge_runtime`
+- `pooler`
+
+These are not blockers for schema validation.
+
+### Local db reset
+
+`npx supabase db reset --yes`: PASS
+
+Migration `0014_create_encounter_visit_model.sql` applied successfully after migrations `0001` through `0013`.
+
+### Table existence and counts
+
+New tables exist:
+
+- `patient_visits`: yes
+- `clinical_encounters`: yes
+- `completed_services`: yes
+
+Counts after reset and cleanup:
+
+- `patient_visits = 0`
+- `clinical_encounters = 0`
+- `completed_services = 0`
+
+Existing table preservation check:
+
+- `appointments`: exists
+- `treatment_plans`: exists
+- `treatment_stages`: exists
+- `findings`: exists
+- `audit_events`: exists
+- `activity_events`: exists
+- `audit_logs`: exists
+
+No destructive changes to those tables were made by this migration.
+
+### RLS/policies/grants
+
+- RLS enabled on all three new tables: PASS
+- SELECT policies exist: PASS
+- authenticated has SELECT only: PASS
+- authenticated extra grants: `0`
+- anon has no direct grants: PASS
+- service_role privileged backend access granted: PASS
+
+### Constraints/indexes/comments
+
+- constraints found: `57`
+- indexes found: `24`
+- comments found: `20`
+
+### RLS simulation
+
+RLS was validated through local Supabase clients using seeded QA users and temporary local rows, then cleaned up.
+
+Results:
+
+| QA role | patient_visits | clinical_encounters | completed_services |
+|---|---:|---:|---:|
+| Clinic A admin | 1 | 1 | 1 |
+| Clinic A doctor | 1 | 1 | 1 |
+| Clinic A registrar | 1 | 0 | 0 |
+| Clinic A cashier | 0 | 0 | 0 |
+| no-tenant | 0 | 0 | 0 |
+| Clinic B admin | 0 | 0 | 0 |
+
+Direct authenticated insert into `patient_visits`: blocked.
+
+Cleanup returned counts to 0.
+
+### Invalid payload tests
+
+All expected invalid payloads were rejected:
+
+- invalid patient visit status;
+- invalid encounter status;
+- invalid completed service status;
+- patient visit metadata array instead of object;
+- completed service quantity `0`;
+- empty completed service name;
+- negative completed service amount.
+
+### Local advisors
+
+`npx supabase db lint --local`: completed with exit code 0.
+
+Warnings were reported only for existing `public.save_treatment_plan_with_stages` from migration `0006`:
+
+- assignment cast warning for `submitted_stage_ids` initialization;
+- loop variable shadowing warning;
+- unused variable warning.
+
+No new `0014`-specific advisor warning was reported.
+
+## 16. What was intentionally NOT changed
+
+- no app code;
+- no UI;
+- no repositories;
+- no hooks;
+- no patient timeline integration;
+- no Supabase cloud;
+- no browser smoke;
+- no payments;
+- no stock;
+- no documents;
+- no seed changes;
+- no backfill;
+- no persistent validation data.
+
+## 17. Checks
+
+Local checks:
+
+- `git status --short`: only expected migration/report files before report commit;
+- `npm run lint`: PASS;
+- `npm run test -- --run`: PASS, 47 files / 414 tests;
+- `npm run build`: PASS.
+
+Warnings observed:
+
+- existing React `act(...)` warnings in tests;
+- existing Vite chunk-size warning;
+- existing Supabase CLI version notice.
+
+All commands exited successfully.
+
+### GitHub Actions CI
+
+Pending after report push.
+
+## 18. Final verdict
+
+`ENCOUNTER VISIT MODEL SCHEMA IMPLEMENTED AND VERIFIED`
+
+## 19. Recommended next task
+
+`ENCOUNTER-VISIT-REPOSITORY-001B`

--- a/supabase/migrations/0014_create_encounter_visit_model.sql
+++ b/supabase/migrations/0014_create_encounter_visit_model.sql
@@ -1,0 +1,306 @@
+-- 0014_create_encounter_visit_model.sql
+-- Schema-only foundation for actual visits, documented clinical encounters,
+-- and performed clinical/billable services.
+--
+-- Domain boundary:
+-- - appointment = scheduled slot / booking intent;
+-- - patient_visit = actual patient attendance instance;
+-- - clinical_encounter = documented clinical session / doctor interaction;
+-- - completed_service = performed clinical/billable fact;
+-- - treatment plan/stage = intended work, not proof of completion;
+-- - payment = separate financial fact, not proof of treatment;
+-- - audit/activity = immutable/action history, not source clinical fact.
+
+CREATE TABLE IF NOT EXISTS public.patient_visits (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'checked_in',
+  visit_type text NOT NULL DEFAULT 'regular',
+  arrived_at timestamptz NOT NULL DEFAULT now(),
+  checked_in_at timestamptz,
+  started_at timestamptz,
+  completed_at timestamptz,
+  cancelled_at timestamptz,
+  archived_at timestamptz,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  archived_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  notes text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT patient_visits_patient_fk
+    FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT patient_visits_status_check
+    CHECK (status IN ('checked_in', 'in_progress', 'completed', 'cancelled', 'archived')),
+  CONSTRAINT patient_visits_visit_type_check
+    CHECK (visit_type IN ('regular', 'emergency', 'consultation', 'follow_up', 'procedure', 'other')),
+  CONSTRAINT patient_visits_metadata_object_check
+    CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT patient_visits_completed_at_status_check
+    CHECK (completed_at IS NULL OR status IN ('completed', 'archived')),
+  CONSTRAINT patient_visits_cancelled_at_status_check
+    CHECK (cancelled_at IS NULL OR status = 'cancelled'),
+  CONSTRAINT patient_visits_archived_at_status_check
+    CHECK (archived_at IS NULL OR status = 'archived')
+);
+
+CREATE TABLE IF NOT EXISTS public.clinical_encounters (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  visit_id uuid REFERENCES public.patient_visits(id) ON DELETE SET NULL,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL,
+  doctor_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'draft',
+  encounter_type text NOT NULL DEFAULT 'consultation',
+  started_at timestamptz,
+  completed_at timestamptz,
+  locked_at timestamptz,
+  archived_at timestamptz,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  locked_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  archived_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  chief_complaint_snapshot text,
+  clinical_summary text,
+  correction_reason text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT clinical_encounters_patient_fk
+    FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT clinical_encounters_status_check
+    CHECK (status IN ('draft', 'in_progress', 'completed', 'locked', 'archived')),
+  CONSTRAINT clinical_encounters_type_check
+    CHECK (encounter_type IN ('consultation', 'treatment', 'surgery', 'orthodontics', 'prosthetics', 'hygiene', 'emergency', 'follow_up', 'other')),
+  CONSTRAINT clinical_encounters_metadata_object_check
+    CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT clinical_encounters_completed_at_status_check
+    CHECK (completed_at IS NULL OR status IN ('completed', 'locked', 'archived')),
+  CONSTRAINT clinical_encounters_locked_at_status_check
+    CHECK (locked_at IS NULL OR status IN ('locked', 'archived')),
+  CONSTRAINT clinical_encounters_archived_at_status_check
+    CHECK (archived_at IS NULL OR status = 'archived')
+);
+
+CREATE TABLE IF NOT EXISTS public.completed_services (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  visit_id uuid REFERENCES public.patient_visits(id) ON DELETE SET NULL,
+  encounter_id uuid REFERENCES public.clinical_encounters(id) ON DELETE SET NULL,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL,
+  finding_id uuid REFERENCES public.findings(id) ON DELETE SET NULL,
+  treatment_plan_id uuid,
+  treatment_stage_id uuid REFERENCES public.treatment_stages(id) ON DELETE SET NULL,
+  clinical_dictionary_item_id text,
+  service_code text,
+  service_name text NOT NULL,
+  tooth_number text,
+  tooth_surface text,
+  quantity numeric(12,2) NOT NULL DEFAULT 1,
+  unit_price numeric(14,2),
+  total_amount numeric(14,2),
+  currency text NOT NULL DEFAULT 'KZT',
+  performed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  performed_at timestamptz NOT NULL DEFAULT now(),
+  status text NOT NULL DEFAULT 'completed',
+  correction_of_id uuid REFERENCES public.completed_services(id) ON DELETE SET NULL,
+  correction_reason text,
+  voided_at timestamptz,
+  voided_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  archived_at timestamptz,
+  archived_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT completed_services_patient_fk
+    FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT completed_services_treatment_plan_fk
+    FOREIGN KEY (tenant_id, treatment_plan_id) REFERENCES public.treatment_plans(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT completed_services_dictionary_fk
+    FOREIGN KEY (tenant_id, clinical_dictionary_item_id) REFERENCES public.clinical_dictionary_items(tenant_id, id) ON DELETE SET NULL,
+  CONSTRAINT completed_services_status_check
+    CHECK (status IN ('completed', 'corrected', 'voided', 'archived')),
+  CONSTRAINT completed_services_metadata_object_check
+    CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT completed_services_quantity_positive_check
+    CHECK (quantity > 0),
+  CONSTRAINT completed_services_unit_price_nonnegative_check
+    CHECK (unit_price IS NULL OR unit_price >= 0),
+  CONSTRAINT completed_services_total_amount_nonnegative_check
+    CHECK (total_amount IS NULL OR total_amount >= 0),
+  CONSTRAINT completed_services_currency_non_empty_check
+    CHECK (length(btrim(currency)) > 0),
+  CONSTRAINT completed_services_service_name_non_empty_check
+    CHECK (length(btrim(service_name)) > 0),
+  CONSTRAINT completed_services_correction_reason_check
+    CHECK (status NOT IN ('corrected', 'voided') OR length(btrim(COALESCE(correction_reason, ''))) > 0),
+  CONSTRAINT completed_services_voided_at_check
+    CHECK (status <> 'voided' OR voided_at IS NOT NULL),
+  CONSTRAINT completed_services_archived_at_check
+    CHECK (status <> 'archived' OR archived_at IS NOT NULL),
+  CONSTRAINT completed_services_voided_at_status_check
+    CHECK (voided_at IS NULL OR status = 'voided'),
+  CONSTRAINT completed_services_archived_at_status_check
+    CHECK (archived_at IS NULL OR status = 'archived')
+);
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS patient_visits_set_updated_at ON public.patient_visits;
+CREATE TRIGGER patient_visits_set_updated_at
+BEFORE UPDATE ON public.patient_visits
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS clinical_encounters_set_updated_at ON public.clinical_encounters;
+CREATE TRIGGER clinical_encounters_set_updated_at
+BEFORE UPDATE ON public.clinical_encounters
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+DROP TRIGGER IF EXISTS completed_services_set_updated_at ON public.completed_services;
+CREATE TRIGGER completed_services_set_updated_at
+BEFORE UPDATE ON public.completed_services
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX IF NOT EXISTS idx_patient_visits_tenant_arrived_at
+  ON public.patient_visits (tenant_id, arrived_at DESC);
+CREATE INDEX IF NOT EXISTS idx_patient_visits_tenant_patient_arrived_at
+  ON public.patient_visits (tenant_id, patient_id, arrived_at DESC);
+CREATE INDEX IF NOT EXISTS idx_patient_visits_tenant_status
+  ON public.patient_visits (tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_patient_visits_appointment_id
+  ON public.patient_visits (appointment_id);
+CREATE INDEX IF NOT EXISTS idx_patient_visits_created_by
+  ON public.patient_visits (created_by);
+
+CREATE INDEX IF NOT EXISTS idx_clinical_encounters_tenant_created_at
+  ON public.clinical_encounters (tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_clinical_encounters_tenant_patient_created_at
+  ON public.clinical_encounters (tenant_id, patient_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_clinical_encounters_tenant_visit
+  ON public.clinical_encounters (tenant_id, visit_id);
+CREATE INDEX IF NOT EXISTS idx_clinical_encounters_tenant_doctor_created_at
+  ON public.clinical_encounters (tenant_id, doctor_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_clinical_encounters_tenant_status
+  ON public.clinical_encounters (tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_clinical_encounters_appointment_id
+  ON public.clinical_encounters (appointment_id);
+
+CREATE INDEX IF NOT EXISTS idx_completed_services_tenant_performed_at
+  ON public.completed_services (tenant_id, performed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_completed_services_tenant_patient_performed_at
+  ON public.completed_services (tenant_id, patient_id, performed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_completed_services_tenant_encounter
+  ON public.completed_services (tenant_id, encounter_id);
+CREATE INDEX IF NOT EXISTS idx_completed_services_tenant_visit
+  ON public.completed_services (tenant_id, visit_id);
+CREATE INDEX IF NOT EXISTS idx_completed_services_tenant_performed_by_performed_at
+  ON public.completed_services (tenant_id, performed_by, performed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_completed_services_tenant_status
+  ON public.completed_services (tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_completed_services_treatment_plan_id
+  ON public.completed_services (treatment_plan_id);
+CREATE INDEX IF NOT EXISTS idx_completed_services_treatment_stage_id
+  ON public.completed_services (treatment_stage_id);
+CREATE INDEX IF NOT EXISTS idx_completed_services_finding_id
+  ON public.completed_services (finding_id);
+CREATE INDEX IF NOT EXISTS idx_completed_services_dictionary_item_id
+  ON public.completed_services (tenant_id, clinical_dictionary_item_id);
+
+COMMENT ON TABLE public.patient_visits IS 'Actual patient attendance instance in a clinic. This is not appointment intent and is not proof of completed treatment.';
+COMMENT ON COLUMN public.patient_visits.appointment_id IS 'Optional link to booking context only. Appointment status alone is not proof of completed treatment.';
+COMMENT ON COLUMN public.patient_visits.status IS 'Visit lifecycle for actual attendance. no_show remains an appointment outcome, not a visit status.';
+COMMENT ON COLUMN public.patient_visits.notes IS 'Administrative visit notes only. Clinical documentation belongs in clinical_encounters.';
+
+COMMENT ON TABLE public.clinical_encounters IS 'Documented clinical interaction/session, usually inside a patient visit. Not an appointment and not payment.';
+COMMENT ON COLUMN public.clinical_encounters.visit_id IS 'Optional link to actual attendance. Encounter documentation may exist inside a visit but is not the visit itself.';
+COMMENT ON COLUMN public.clinical_encounters.appointment_id IS 'Optional link to booking context only. Appointment status is not clinical documentation.';
+COMMENT ON COLUMN public.clinical_encounters.clinical_summary IS 'Clinical session summary. Raw clinical notes UI and correction workflow are future tasks.';
+COMMENT ON COLUMN public.clinical_encounters.correction_reason IS 'Future correction flows must use controlled domain RPCs with audit/activity events.';
+
+COMMENT ON TABLE public.completed_services IS 'Performed clinical/billable service fact. This is not a treatment plan, not appointment completion, and not payment.';
+COMMENT ON COLUMN public.completed_services.appointment_id IS 'Optional booking context only. Appointment completion is not proof of performed service.';
+COMMENT ON COLUMN public.completed_services.treatment_plan_id IS 'Optional reference to intended plan. A treatment plan is not proof that service was performed.';
+COMMENT ON COLUMN public.completed_services.treatment_stage_id IS 'Optional reference to intended treatment stage. Stage status alone is not the source of performed service facts.';
+COMMENT ON COLUMN public.completed_services.finding_id IS 'Optional source finding link. Finding status alone is not proof of performed service.';
+COMMENT ON COLUMN public.completed_services.clinical_dictionary_item_id IS 'Optional tenant dictionary item reference. clinical_dictionary_items.id is text and scoped by tenant_id.';
+COMMENT ON COLUMN public.completed_services.unit_price IS 'Service/billing snapshot only. This is not payment.';
+COMMENT ON COLUMN public.completed_services.total_amount IS 'Performed service amount snapshot only. Payment/debt allocation is a future financial module.';
+COMMENT ON COLUMN public.completed_services.correction_of_id IS 'Links correction rows to the original performed service fact. Future correction writes must be audited through domain RPCs.';
+COMMENT ON COLUMN public.completed_services.correction_reason IS 'Required for corrected/voided service facts when those statuses are used.';
+COMMENT ON COLUMN public.completed_services.metadata IS 'Safe structured metadata only. Do not store secrets, raw file contents, or broad PHI dumps.';
+COMMENT ON FUNCTION public.set_updated_at() IS 'Generic updated_at trigger helper for schema-only tables that follow the project timestamp convention.';
+
+ALTER TABLE public.patient_visits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.clinical_encounters ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.completed_services ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Clinic staff can read tenant visits" ON public.patient_visits;
+CREATE POLICY "Clinic staff can read tenant visits"
+ON public.patient_visits
+FOR SELECT
+TO authenticated
+USING (
+  public.has_tenant_role(
+    tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role, 'registrar'::public.app_role]
+  )
+);
+
+DROP POLICY IF EXISTS "Clinical staff can read tenant encounters" ON public.clinical_encounters;
+CREATE POLICY "Clinical staff can read tenant encounters"
+ON public.clinical_encounters
+FOR SELECT
+TO authenticated
+USING (
+  public.has_tenant_role(
+    tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  )
+);
+
+DROP POLICY IF EXISTS "Clinical staff can read tenant completed services" ON public.completed_services;
+CREATE POLICY "Clinical staff can read tenant completed services"
+ON public.completed_services
+FOR SELECT
+TO authenticated
+USING (
+  public.has_tenant_role(
+    tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  )
+);
+
+REVOKE ALL ON TABLE public.patient_visits FROM PUBLIC;
+REVOKE ALL ON TABLE public.clinical_encounters FROM PUBLIC;
+REVOKE ALL ON TABLE public.completed_services FROM PUBLIC;
+REVOKE ALL ON TABLE public.patient_visits FROM anon;
+REVOKE ALL ON TABLE public.clinical_encounters FROM anon;
+REVOKE ALL ON TABLE public.completed_services FROM anon;
+REVOKE ALL ON TABLE public.patient_visits FROM authenticated;
+REVOKE ALL ON TABLE public.clinical_encounters FROM authenticated;
+REVOKE ALL ON TABLE public.completed_services FROM authenticated;
+GRANT SELECT ON TABLE public.patient_visits TO authenticated;
+GRANT SELECT ON TABLE public.clinical_encounters TO authenticated;
+GRANT SELECT ON TABLE public.completed_services TO authenticated;
+GRANT ALL ON TABLE public.patient_visits TO service_role;
+GRANT ALL ON TABLE public.clinical_encounters TO service_role;
+GRANT ALL ON TABLE public.completed_services TO service_role;


### PR DESCRIPTION
Schema-only foundation for visits, clinical encounters, and completed services.\n\nVerified locally:\n- local Supabase detected, cloud not touched\n- db reset applied migrations through 0014\n- patient_visits, clinical_encounters, completed_services exist\n- RLS enabled, policies present, authenticated SELECT-only grants\n- RLS simulated with QA roles\n- invalid payloads rejected\n- cleanup counts returned to 0\n- lint, tests, build passed\n\nFinal CI: run 27806751316 / CI #552 / success / tested commit bbc2d26e5885c6ec858548e823c4c30ed3e17d02\n\nNo app code, UI, repositories, hooks, seed/backfill, browser smoke, or cloud changes.