### PR TITLE
ENCOUNTER-VISIT-REPOSITORY-001B: add read-only encounter visit repository

### DIFF
--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md
@@ -1,0 +1,304 @@
+# ENCOUNTER-VISIT-REPOSITORY-001B — Read-only encounter/visit repository
+
+## 1. Summary
+
+Implemented a typed read-only TypeScript repository layer for the schema introduced by `ENCOUNTER-VISIT-MODEL-001A`.
+
+The repository provides safe read access to:
+
+- `public.patient_visits`
+- `public.clinical_encounters`
+- `public.completed_services`
+
+It preserves the domain boundary:
+
+- appointment is booking intent, not visit;
+- visit is actual attendance, not clinical documentation;
+- clinical encounter is documented clinical session, not payment;
+- completed service is performed clinical/billable fact, not a treatment plan or payment;
+- audit/activity remains history, not the source clinical fact.
+
+This task is read-only. No write methods were added.
+
+## 2. Branch name
+
+`feature/encounter-visit-repository-001b`
+
+## 3. PR URL
+
+https://github.com/NckNA/codex-test/pull/312
+
+## 4. PR head reviewed before final report update
+
+`02059d7a9efc442cbaff296e1905ccfebabf360e`
+
+## 5. Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed files summary
+
+Expected files changed:
+
+- `src/data/repositories/EncounterVisitRepository.ts`
+- `src/data/repositories/EncounterVisitRepository.test.ts`
+- `_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md`
+
+No migrations, UI, hooks, timeline, seed, Supabase config, browser smoke, or cloud files were changed.
+
+## 7. Current repository pattern recon
+
+### Existing repository style
+
+The project has a mixed repository history:
+
+- older clinical repositories such as findings/treatment plans still include localStorage fallback paths for legacy prototype flows;
+- newer high-integrity data boundaries such as audit/activity use a stricter Supabase-only repository with camelCase domain objects, explicit mappers, defensive tenant checks, bounded pagination, and no fake local data fallback;
+- source-of-truth clinical workflow data should follow the audit/activity style, not the legacy localStorage style.
+
+### Tenant/no-tenant behavior
+
+The new repository follows the newer strict pattern:
+
+- every list/get method requires `tenantId`;
+- patient-scoped workflow reads require `patientId`;
+- missing active clinic throws: `Active clinic is required for encounter/visit access.`;
+- get-by-id methods require both `tenantId` and `id`.
+
+### Error handling
+
+The repository surfaces Supabase errors directly. It does not swallow RLS/data errors and does not hide partial workflow failures.
+
+### Factory/local fallback pattern
+
+A factory was added:
+
+- `createEncounterVisitRepository({ backend: 'supabase' })` returns `SupabaseEncounterVisitRepository`;
+- `backend: 'local'` throws `Encounter/visit repository requires Supabase backend.`;
+- no localStorage fallback is provided.
+
+That is intentional because visits, encounters, and completed services are clinical source-of-truth records.
+
+## 8. Implementation summary
+
+### Domain types
+
+Added typed domain models:
+
+- `PatientVisit`
+- `ClinicalEncounter`
+- `CompletedService`
+
+Added status/type unions:
+
+- `PatientVisitStatus`
+- `PatientVisitType`
+- `ClinicalEncounterStatus`
+- `ClinicalEncounterType`
+- `CompletedServiceStatus`
+
+JSON metadata is represented as `Record<string, unknown>`.
+
+### Query option types
+
+Added:
+
+- `ListPatientVisitsOptions`
+- `ListClinicalEncountersOptions`
+- `ListCompletedServicesOptions`
+- `GetByIdOptions`
+- `PatientScopedOptions`
+- `ListPatientClinicalWorkflowOptions`
+
+Limits are bounded:
+
+- default limit: `50`
+- max limit: `200`
+- default offset: `0`
+
+### Repository interface
+
+Added read-only interface `EncounterVisitRepository` with methods:
+
+- `listPatientVisits`
+- `getPatientVisitById`
+- `listClinicalEncounters`
+- `getClinicalEncounterById`
+- `listCompletedServices`
+- `getCompletedServiceById`
+- `listPatientClinicalWorkflow`
+
+No create/update/delete/void/correct/start/complete/lock methods were added.
+
+### Supabase implementation
+
+Added `SupabaseEncounterVisitRepository`.
+
+Behavior:
+
+- uses the normal Supabase client;
+- queries only the three schema tables;
+- always filters by `tenant_id`;
+- uses query builder filters, not raw SQL strings;
+- relies on database RLS for authorization;
+- still passes `tenantId` defensively;
+- surfaces Supabase errors;
+- has no fake/local fallback;
+- has no service-role client path.
+
+### Mappers
+
+Added:
+
+- `mapPatientVisitRow`
+- `mapClinicalEncounterRow`
+- `mapCompletedServiceRow`
+
+They convert snake_case database rows to camelCase domain objects, default invalid/non-object metadata to `{}`, preserve nullable fields, convert numeric service values to numbers, and reject missing required fields/invalid required numbers instead of silently coercing them.
+
+## 9. Domain boundary
+
+The repository keeps the clinical workflow model separated:
+
+- appointment references are only booking-context links;
+- visit records represent attendance;
+- encounter records represent clinical documentation sessions;
+- completed service records represent performed service facts;
+- treatment plan/stage references are optional planning links, not completion proof;
+- unit/total amounts are service/billing snapshots, not payment facts;
+- payment, stock, documents, audit/activity writes, and timeline integration remain future work.
+
+## 10. Query behavior
+
+### Tenant filters
+
+All methods filter by `tenant_id` and throw before querying if tenant id is missing.
+
+### Patient filters
+
+Patient-scoped methods filter by `patient_id`. `listPatientClinicalWorkflow` calls all three list methods using the same `tenantId` and `patientId`.
+
+### Status/type filters
+
+Supported filters:
+
+- visit statuses and visit types;
+- encounter statuses and encounter types;
+- service statuses;
+- doctor/performed-by filters;
+- appointment, visit, encounter, finding, plan, stage, and dictionary item filters where appropriate.
+
+### Archived/voided handling
+
+Defaults:
+
+- patient visits exclude `status = archived` unless `includeArchived = true`;
+- clinical encounters exclude `status = archived` unless `includeArchived = true`;
+- completed services exclude `status = archived` unless `includeArchived = true`;
+- completed services exclude `status = voided` unless `includeVoided = true`;
+- corrected services remain visible by default because they are still part of the correction chain and not hidden by the 001B read boundary.
+
+### Sorting
+
+- `patient_visits`: `arrived_at desc`, then `created_at desc`
+- `clinical_encounters`: `created_at desc`
+- `completed_services`: `performed_at desc`, then `created_at desc`
+
+### Pagination
+
+All list methods apply bounded `.range(offset, offset + limit - 1)` with normalized limit and offset.
+
+## 11. Safety boundary
+
+Confirmed by implementation and tests:
+
+- no write methods;
+- no insert/update/delete/upsert/rpc calls;
+- no localStorage fallback;
+- no service-role usage;
+- no audit/activity helper calls;
+- no UI changes;
+- no timeline integration;
+- no migrations;
+- RLS remains the source of authorization.
+
+## 12. Tests
+
+Test file:
+
+- `src/data/repositories/EncounterVisitRepository.test.ts`
+
+Covered scenarios:
+
+- list methods require `tenantId`;
+- get-by-id methods require `tenantId` and `id`;
+- patient workflow method requires `tenantId` and `patientId`;
+- patient visits query `patient_visits`;
+- visit tenant/patient/appointment/status/type/date filters;
+- visit archived default/include behavior;
+- visit get-by-id and null result;
+- clinical encounters query `clinical_encounters`;
+- encounter tenant/patient/visit/appointment/doctor/status/type/date filters;
+- encounter archived default/include behavior;
+- encounter get-by-id;
+- completed services query `completed_services`;
+- service tenant/patient/visit/encounter/appointment/finding/plan/stage/dictionary/performedBy/status/date filters;
+- service archived and voided default/include behavior;
+- service get-by-id;
+- workflow method calls all three lists with the same tenant/patient;
+- Supabase errors surface;
+- workflow does not hide partial errors;
+- mappers convert snake_case to camelCase;
+- numeric service fields map to numbers;
+- invalid required mapper values throw;
+- limit/offset normalization;
+- factory rejects local backend;
+- repository object exposes no write methods.
+
+Targeted test result:
+
+- `npm run test -- EncounterVisitRepository.test.ts --run`: PASS, 18 tests.
+
+## 13. What was intentionally NOT changed
+
+- no migrations;
+- no Supabase cloud;
+- no local Supabase requirement;
+- no browser smoke;
+- no UI;
+- no PatientCardPage changes;
+- no PatientTimelineAggregator changes;
+- no timeline integration;
+- no hooks;
+- no RPC/write path;
+- no payments;
+- no stock;
+- no documents;
+- no seed changes;
+- no generated types.
+
+## 14. Checks
+
+Local checks:
+
+- `npm run test -- EncounterVisitRepository.test.ts --run`: PASS, 1 file / 18 tests
+- `npm run lint`: PASS
+- `npm run test -- --run`: PASS, 48 files / 432 tests
+- `npm run build`: PASS
+
+Notes:
+
+- Existing React `act(...)` warnings appear in unrelated tests and remain non-blocking.
+- Existing Vite chunk size warning appears during build and remains non-blocking.
+
+GitHub Actions CI:
+
+- Pending after report commit.
+
+## 15. Final verdict
+
+`ENCOUNTER VISIT REPOSITORY IMPLEMENTED AND VERIFIED`
+
+## 16. Recommended next task
+
+`ENCOUNTER-VISIT-RPC-001C`

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md
@@ -30,7 +30,7 @@ https://github.com/NckNA/codex-test/pull/312
 
 ## 4. PR head reviewed before final report update
 
-`02059d7a9efc442cbaff296e1905ccfebabf360e`
+`12a7cbb5d7a5d8c9480b9b3d9e48c69f32c2d6c4`
 
 ## 5. Report update commit
 
@@ -293,7 +293,15 @@ Notes:
 
 GitHub Actions CI:
 
-- Pending after report commit.
+- Workflow: `CI`
+- Run id: `27816806057`
+- CI number: `556`
+- Tested commit: `12a7cbb5d7a5d8c9480b9b3d9e48c69f32c2d6c4`
+- Job: `validate`
+- ESLint: success
+- Tests: success
+- Build: success
+- Conclusion: success
 
 ## 15. Final verdict
 

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-REPOSITORY-001B_repository.md
@@ -30,7 +30,7 @@ https://github.com/NckNA/codex-test/pull/312
 
 ## 4. PR head reviewed before final report update
 
-`12a7cbb5d7a5d8c9480b9b3d9e48c69f32c2d6c4`
+`03b1034fe0ba6053968c997f51d80ef2142cb353`
 
 ## 5. Report update commit
 
@@ -294,9 +294,9 @@ Notes:
 GitHub Actions CI:
 
 - Workflow: `CI`
-- Run id: `27816806057`
-- CI number: `556`
-- Tested commit: `12a7cbb5d7a5d8c9480b9b3d9e48c69f32c2d6c4`
+- Run id: `27816932897`
+- CI number: `557`
+- Tested commit: `03b1034fe0ba6053968c997f51d80ef2142cb353`
 - Job: `validate`
 - ESLint: success
 - Tests: success

--- a/src/data/repositories/EncounterVisitRepository.test.ts
+++ b/src/data/repositories/EncounterVisitRepository.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR,
+  MAX_ENCOUNTER_VISIT_LIMIT,
+  RECORD_ID_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR,
+  PATIENT_REQUIRED_FOR_CLINICAL_WORKFLOW_ERROR,
+  SupabaseEncounterVisitRepository,
+  createEncounterVisitRepository,
+  mapClinicalEncounterRow,
+  mapCompletedServiceRow,
+  mapPatientVisitRow,
+  normalizeEncounterVisitLimit,
+  normalizeEncounterVisitOffset,
+  type EncounterVisitRepository,
+} from './EncounterVisitRepository';
+
+type QueryResult = {
+  data: Record<string, unknown>[] | null;
+  error: Error | null;
+};
+
+type SingleQueryResult = {
+  data: Record<string, unknown> | null;
+  error: Error | null;
+};
+
+type QueryCall = {
+  method: string;
+  args: unknown[];
+};
+
+function createRepository(result: QueryResult, singleResult: SingleQueryResult = { data: null, error: null }) {
+  const calls: QueryCall[] = [];
+  const chain = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    neq: vi.fn(),
+    in: vi.fn(),
+    gte: vi.fn(),
+    lte: vi.fn(),
+    order: vi.fn(),
+    range: vi.fn(),
+    maybeSingle: vi.fn(),
+  };
+
+  chain.select.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'select', args });
+    return chain;
+  });
+  chain.eq.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'eq', args });
+    return chain;
+  });
+  chain.neq.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'neq', args });
+    return chain;
+  });
+  chain.in.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'in', args });
+    return chain;
+  });
+  chain.gte.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'gte', args });
+    return chain;
+  });
+  chain.lte.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'lte', args });
+    return chain;
+  });
+  chain.order.mockImplementation((...args: unknown[]) => {
+    calls.push({ method: 'order', args });
+    return chain;
+  });
+  chain.range.mockImplementation(async (...args: unknown[]) => {
+    calls.push({ method: 'range', args });
+    return result;
+  });
+  chain.maybeSingle.mockImplementation(async (...args: unknown[]) => {
+    calls.push({ method: 'maybeSingle', args });
+    return singleResult;
+  });
+
+  const client = {
+    from: vi.fn((tableName: string) => {
+      calls.push({ method: 'from', args: [tableName] });
+      return chain;
+    }),
+  };
+  const repository = new SupabaseEncounterVisitRepository(client as unknown as SupabaseClient);
+  return { repository, client, calls };
+}
+
+function expectCall(calls: QueryCall[], method: string, ...args: unknown[]) {
+  expect(calls).toContainEqual({ method, args });
+}
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const patientId = '22222222-2222-2222-2222-222222222222';
+const visitId = '33333333-3333-3333-3333-333333333333';
+const encounterId = '44444444-4444-4444-4444-444444444444';
+const doctorUserId = '55555555-5555-5555-5555-555555555555';
+
+const visitRow = {
+  id: visitId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  appointment_id: 'appointment-1',
+  status: 'checked_in',
+  visit_type: 'regular',
+  arrived_at: '2026-06-19T08:00:00Z',
+  checked_in_at: '2026-06-19T08:05:00Z',
+  started_at: null,
+  completed_at: null,
+  cancelled_at: null,
+  archived_at: null,
+  created_by: 'admin-1',
+  updated_by: 'admin-2',
+  archived_by: null,
+  notes: 'Patient arrived',
+  metadata: { smoke: true },
+  created_at: '2026-06-19T08:00:01Z',
+  updated_at: '2026-06-19T08:00:02Z',
+};
+
+const encounterRow = {
+  id: encounterId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  visit_id: visitId,
+  appointment_id: 'appointment-1',
+  doctor_user_id: doctorUserId,
+  status: 'in_progress',
+  encounter_type: 'treatment',
+  started_at: '2026-06-19T08:15:00Z',
+  completed_at: null,
+  locked_at: null,
+  archived_at: null,
+  created_by: 'doctor-1',
+  updated_by: 'doctor-1',
+  locked_by: null,
+  archived_by: null,
+  chief_complaint_snapshot: 'Pain',
+  clinical_summary: 'Clinical summary',
+  correction_reason: null,
+  metadata: { clinical: true },
+  created_at: '2026-06-19T08:15:01Z',
+  updated_at: '2026-06-19T08:15:02Z',
+};
+
+const serviceRow = {
+  id: '66666666-6666-6666-6666-666666666666',
+  tenant_id: tenantId,
+  patient_id: patientId,
+  visit_id: visitId,
+  encounter_id: encounterId,
+  appointment_id: 'appointment-1',
+  finding_id: '77777777-7777-7777-7777-777777777777',
+  treatment_plan_id: '88888888-8888-8888-8888-888888888888',
+  treatment_stage_id: '99999999-9999-9999-9999-999999999999',
+  clinical_dictionary_item_id: 'service.cleaning',
+  service_code: 'CLEAN-1',
+  service_name: 'Professional cleaning',
+  tooth_number: '16',
+  tooth_surface: 'occlusal',
+  quantity: '2.50',
+  unit_price: '1000.25',
+  total_amount: '2500.50',
+  currency: 'KZT',
+  performed_by: doctorUserId,
+  performed_at: '2026-06-19T09:00:00Z',
+  status: 'completed',
+  correction_of_id: null,
+  correction_reason: null,
+  voided_at: null,
+  voided_by: null,
+  archived_at: null,
+  archived_by: null,
+  created_by: 'doctor-1',
+  updated_by: 'doctor-1',
+  metadata: { service: true },
+  created_at: '2026-06-19T09:00:01Z',
+  updated_at: '2026-06-19T09:00:02Z',
+};
+
+describe('EncounterVisitRepository', () => {
+  it('list methods require tenantId', async () => {
+    const { repository } = createRepository({ data: [], error: null });
+
+    await expect(repository.listPatientVisits({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+    await expect(repository.listClinicalEncounters({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+    await expect(repository.listCompletedServices({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+  });
+
+  it('get-by-id methods require tenantId and id', async () => {
+    const { repository } = createRepository({ data: [], error: null });
+
+    await expect(repository.getPatientVisitById({ tenantId: '', id: visitId })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+    await expect(repository.getClinicalEncounterById({ tenantId, id: '' })).rejects.toThrow(RECORD_ID_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+    await expect(repository.getCompletedServiceById({ tenantId, id: '' })).rejects.toThrow(RECORD_ID_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+  });
+
+  it('listPatientClinicalWorkflow requires tenantId and patientId', async () => {
+    const { repository } = createRepository({ data: [], error: null });
+
+    await expect(repository.listPatientClinicalWorkflow({ tenantId: '', patientId })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+    await expect(repository.listPatientClinicalWorkflow({ tenantId, patientId: '' })).rejects.toThrow(PATIENT_REQUIRED_FOR_CLINICAL_WORKFLOW_ERROR);
+  });
+
+  it('listPatientVisits queries patient_visits with tenant and optional filters', async () => {
+    const { repository, client, calls } = createRepository({ data: [visitRow], error: null });
+
+    const visits = await repository.listPatientVisits({
+      tenantId,
+      patientId,
+      appointmentId: 'appointment-1',
+      statuses: ['checked_in', 'in_progress'],
+      visitTypes: ['regular', 'emergency'],
+      arrivedFrom: '2026-06-01T00:00:00Z',
+      arrivedTo: '2026-06-30T00:00:00Z',
+      limit: 500,
+      offset: 5,
+    });
+
+    expect(client.from).toHaveBeenCalledWith('patient_visits');
+    expectCall(calls, 'select', '*');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'patient_id', patientId);
+    expectCall(calls, 'eq', 'appointment_id', 'appointment-1');
+    expectCall(calls, 'in', 'status', ['checked_in', 'in_progress']);
+    expectCall(calls, 'in', 'visit_type', ['regular', 'emergency']);
+    expectCall(calls, 'neq', 'status', 'archived');
+    expectCall(calls, 'gte', 'arrived_at', '2026-06-01T00:00:00Z');
+    expectCall(calls, 'lte', 'arrived_at', '2026-06-30T00:00:00Z');
+    expectCall(calls, 'order', 'arrived_at', { ascending: false });
+    expectCall(calls, 'order', 'created_at', { ascending: false });
+    expectCall(calls, 'range', 5, 204);
+    expect(visits[0]).toMatchObject({ id: visitId, tenantId, patientId, visitType: 'regular', metadata: { smoke: true } });
+  });
+
+  it('listPatientVisits includes archived only when requested', async () => {
+    const active = createRepository({ data: [], error: null });
+    await active.repository.listPatientVisits({ tenantId });
+    expectCall(active.calls, 'neq', 'status', 'archived');
+
+    const archived = createRepository({ data: [], error: null });
+    await archived.repository.listPatientVisits({ tenantId, includeArchived: true });
+    expect(archived.calls).not.toContainEqual({ method: 'neq', args: ['status', 'archived'] });
+  });
+
+  it('getPatientVisitById filters by tenant_id and id and returns null when missing', async () => {
+    const found = createRepository({ data: [], error: null }, { data: visitRow, error: null });
+    await expect(found.repository.getPatientVisitById({ tenantId, id: visitId })).resolves.toMatchObject({ id: visitId, tenantId });
+    expectCall(found.calls, 'eq', 'tenant_id', tenantId);
+    expectCall(found.calls, 'eq', 'id', visitId);
+    expectCall(found.calls, 'maybeSingle');
+
+    const missing = createRepository({ data: [], error: null }, { data: null, error: null });
+    await expect(missing.repository.getPatientVisitById({ tenantId, id: visitId })).resolves.toBeNull();
+  });
+
+  it('listClinicalEncounters queries clinical_encounters with tenant and optional filters', async () => {
+    const { repository, client, calls } = createRepository({ data: [encounterRow], error: null });
+
+    const encounters = await repository.listClinicalEncounters({
+      tenantId,
+      patientId,
+      visitId,
+      appointmentId: 'appointment-1',
+      doctorUserId,
+      statuses: ['draft', 'in_progress'],
+      encounterTypes: ['consultation', 'treatment'],
+      createdFrom: '2026-06-01T00:00:00Z',
+      createdTo: '2026-06-30T00:00:00Z',
+      limit: 10,
+      offset: 2,
+    });
+
+    expect(client.from).toHaveBeenCalledWith('clinical_encounters');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'patient_id', patientId);
+    expectCall(calls, 'eq', 'visit_id', visitId);
+    expectCall(calls, 'eq', 'appointment_id', 'appointment-1');
+    expectCall(calls, 'eq', 'doctor_user_id', doctorUserId);
+    expectCall(calls, 'in', 'status', ['draft', 'in_progress']);
+    expectCall(calls, 'in', 'encounter_type', ['consultation', 'treatment']);
+    expectCall(calls, 'neq', 'status', 'archived');
+    expectCall(calls, 'gte', 'created_at', '2026-06-01T00:00:00Z');
+    expectCall(calls, 'lte', 'created_at', '2026-06-30T00:00:00Z');
+    expectCall(calls, 'order', 'created_at', { ascending: false });
+    expectCall(calls, 'range', 2, 11);
+    expect(encounters[0]).toMatchObject({ id: encounterId, tenantId, patientId, doctorUserId, encounterType: 'treatment' });
+  });
+
+  it('listClinicalEncounters includes archived only when requested', async () => {
+    const active = createRepository({ data: [], error: null });
+    await active.repository.listClinicalEncounters({ tenantId });
+    expectCall(active.calls, 'neq', 'status', 'archived');
+
+    const archived = createRepository({ data: [], error: null });
+    await archived.repository.listClinicalEncounters({ tenantId, includeArchived: true });
+    expect(archived.calls).not.toContainEqual({ method: 'neq', args: ['status', 'archived'] });
+  });
+
+  it('getClinicalEncounterById filters by tenant_id and id', async () => {
+    const { repository, calls } = createRepository({ data: [], error: null }, { data: encounterRow, error: null });
+    await expect(repository.getClinicalEncounterById({ tenantId, id: encounterId })).resolves.toMatchObject({ id: encounterId, tenantId });
+    expectCall(calls, 'from', 'clinical_encounters');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'id', encounterId);
+    expectCall(calls, 'maybeSingle');
+  });
+
+  it('listCompletedServices queries completed_services with tenant and optional filters', async () => {
+    const { repository, client, calls } = createRepository({ data: [serviceRow], error: null });
+
+    const services = await repository.listCompletedServices({
+      tenantId,
+      patientId,
+      visitId,
+      encounterId,
+      appointmentId: 'appointment-1',
+      findingId: '77777777-7777-7777-7777-777777777777',
+      treatmentPlanId: '88888888-8888-8888-8888-888888888888',
+      treatmentStageId: '99999999-9999-9999-9999-999999999999',
+      clinicalDictionaryItemId: 'service.cleaning',
+      performedBy: doctorUserId,
+      statuses: ['completed', 'corrected'],
+      performedFrom: '2026-06-01T00:00:00Z',
+      performedTo: '2026-06-30T00:00:00Z',
+      limit: 20,
+      offset: 3,
+    });
+
+    expect(client.from).toHaveBeenCalledWith('completed_services');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'patient_id', patientId);
+    expectCall(calls, 'eq', 'visit_id', visitId);
+    expectCall(calls, 'eq', 'encounter_id', encounterId);
+    expectCall(calls, 'eq', 'appointment_id', 'appointment-1');
+    expectCall(calls, 'eq', 'finding_id', '77777777-7777-7777-7777-777777777777');
+    expectCall(calls, 'eq', 'treatment_plan_id', '88888888-8888-8888-8888-888888888888');
+    expectCall(calls, 'eq', 'treatment_stage_id', '99999999-9999-9999-9999-999999999999');
+    expectCall(calls, 'eq', 'clinical_dictionary_item_id', 'service.cleaning');
+    expectCall(calls, 'eq', 'performed_by', doctorUserId);
+    expectCall(calls, 'in', 'status', ['completed', 'corrected']);
+    expectCall(calls, 'neq', 'status', 'archived');
+    expectCall(calls, 'neq', 'status', 'voided');
+    expectCall(calls, 'gte', 'performed_at', '2026-06-01T00:00:00Z');
+    expectCall(calls, 'lte', 'performed_at', '2026-06-30T00:00:00Z');
+    expectCall(calls, 'order', 'performed_at', { ascending: false });
+    expectCall(calls, 'order', 'created_at', { ascending: false });
+    expectCall(calls, 'range', 3, 22);
+    expect(services[0]).toMatchObject({ id: serviceRow.id, tenantId, patientId, quantity: 2.5, unitPrice: 1000.25, totalAmount: 2500.5 });
+  });
+
+  it('listCompletedServices includes archived and voided only when requested', async () => {
+    const active = createRepository({ data: [], error: null });
+    await active.repository.listCompletedServices({ tenantId });
+    expectCall(active.calls, 'neq', 'status', 'archived');
+    expectCall(active.calls, 'neq', 'status', 'voided');
+
+    const all = createRepository({ data: [], error: null });
+    await all.repository.listCompletedServices({ tenantId, includeArchived: true, includeVoided: true });
+    expect(all.calls).not.toContainEqual({ method: 'neq', args: ['status', 'archived'] });
+    expect(all.calls).not.toContainEqual({ method: 'neq', args: ['status', 'voided'] });
+  });
+
+  it('getCompletedServiceById filters by tenant_id and id', async () => {
+    const { repository, calls } = createRepository({ data: [], error: null }, { data: serviceRow, error: null });
+    await expect(repository.getCompletedServiceById({ tenantId, id: String(serviceRow.id) })).resolves.toMatchObject({ id: serviceRow.id, serviceName: 'Professional cleaning' });
+    expectCall(calls, 'from', 'completed_services');
+    expectCall(calls, 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'eq', 'id', serviceRow.id);
+    expectCall(calls, 'maybeSingle');
+  });
+
+  it('listPatientClinicalWorkflow calls all three read lists with the same tenantId and patientId', async () => {
+    const { repository, calls } = createRepository({ data: [], error: null });
+    const workflow = await repository.listPatientClinicalWorkflow({ tenantId, patientId, includeArchived: true, limit: 5, offset: 1 });
+
+    expect(workflow).toEqual({ visits: [], encounters: [], completedServices: [] });
+    expectCall(calls, 'from', 'patient_visits');
+    expectCall(calls, 'from', 'clinical_encounters');
+    expectCall(calls, 'from', 'completed_services');
+    expect(calls.filter(call => call.method === 'eq' && call.args[0] === 'tenant_id' && call.args[1] === tenantId)).toHaveLength(3);
+    expect(calls.filter(call => call.method === 'eq' && call.args[0] === 'patient_id' && call.args[1] === patientId)).toHaveLength(3);
+  });
+
+  it('surfaces Supabase errors without hiding partial workflow failures', async () => {
+    const error = new Error('RLS denied');
+    const { repository } = createRepository({ data: null, error });
+
+    await expect(repository.listCompletedServices({ tenantId })).rejects.toThrow('RLS denied');
+    await expect(repository.listPatientClinicalWorkflow({ tenantId, patientId })).rejects.toThrow('RLS denied');
+  });
+
+  it('mappers convert snake_case rows to camelCase and default metadata', () => {
+    const visit = mapPatientVisitRow({ ...visitRow, metadata: null });
+    expect(visit).toMatchObject({ appointmentId: 'appointment-1', visitType: 'regular', checkedInAt: '2026-06-19T08:05:00Z', metadata: {} });
+
+    const encounter = mapClinicalEncounterRow({ ...encounterRow, metadata: undefined });
+    expect(encounter).toMatchObject({ visitId, doctorUserId, chiefComplaintSnapshot: 'Pain', clinicalSummary: 'Clinical summary', metadata: {} });
+
+    const service = mapCompletedServiceRow({ ...serviceRow, quantity: '1.25', unit_price: '200.10', total_amount: '250.125', metadata: [] });
+    expect(service).toMatchObject({ clinicalDictionaryItemId: 'service.cleaning', serviceName: 'Professional cleaning', quantity: 1.25, unitPrice: 200.1, totalAmount: 250.125, metadata: {} });
+  });
+
+  it('mappers reject missing required fields and invalid numbers instead of silently coercing', () => {
+    expect(() => mapPatientVisitRow({ ...visitRow, id: null })).toThrow('missing required field: id');
+    expect(() => mapCompletedServiceRow({ ...serviceRow, quantity: 'not-a-number' })).toThrow('invalid numeric field: quantity');
+  });
+
+  it('normalizes limit and offset safely', () => {
+    expect(normalizeEncounterVisitLimit()).toBe(50);
+    expect(normalizeEncounterVisitLimit(0)).toBe(1);
+    expect(normalizeEncounterVisitLimit(999)).toBe(MAX_ENCOUNTER_VISIT_LIMIT);
+    expect(normalizeEncounterVisitOffset()).toBe(0);
+    expect(normalizeEncounterVisitOffset(-5)).toBe(0);
+    expect(normalizeEncounterVisitOffset(2.9)).toBe(2);
+  });
+
+  it('factory creates only Supabase read repository and rejects local backend', () => {
+    const client = { from: vi.fn() } as unknown as SupabaseClient;
+    const repository: EncounterVisitRepository = createEncounterVisitRepository({ backend: 'supabase', client });
+
+    expect(repository).toBeInstanceOf(SupabaseEncounterVisitRepository);
+    expect(() => createEncounterVisitRepository({ backend: 'local' })).toThrow('requires Supabase backend');
+    expect('createPatientVisit' in repository).toBe(false);
+    expect('updatePatientVisit' in repository).toBe(false);
+    expect('deletePatientVisit' in repository).toBe(false);
+    expect('createClinicalEncounter' in repository).toBe(false);
+    expect('createCompletedService' in repository).toBe(false);
+    expect('voidCompletedService' in repository).toBe(false);
+  });
+});

--- a/src/data/repositories/EncounterVisitRepository.ts
+++ b/src/data/repositories/EncounterVisitRepository.ts
@@ -1,0 +1,596 @@
+import { supabase as defaultSupabase } from '../../lib/supabaseClient';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type PatientVisitStatus = 'checked_in' | 'in_progress' | 'completed' | 'cancelled' | 'archived';
+export type PatientVisitType = 'regular' | 'emergency' | 'consultation' | 'follow_up' | 'procedure' | 'other';
+
+export interface PatientVisit {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  appointmentId?: string | null;
+  status: PatientVisitStatus;
+  visitType: PatientVisitType;
+  arrivedAt: string;
+  checkedInAt?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  cancelledAt?: string | null;
+  archivedAt?: string | null;
+  createdBy?: string | null;
+  updatedBy?: string | null;
+  archivedBy?: string | null;
+  notes?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type ClinicalEncounterStatus = 'draft' | 'in_progress' | 'completed' | 'locked' | 'archived';
+export type ClinicalEncounterType =
+  | 'consultation'
+  | 'treatment'
+  | 'surgery'
+  | 'orthodontics'
+  | 'prosthetics'
+  | 'hygiene'
+  | 'emergency'
+  | 'follow_up'
+  | 'other';
+
+export interface ClinicalEncounter {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  visitId?: string | null;
+  appointmentId?: string | null;
+  doctorUserId?: string | null;
+  status: ClinicalEncounterStatus;
+  encounterType: ClinicalEncounterType;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  lockedAt?: string | null;
+  archivedAt?: string | null;
+  createdBy?: string | null;
+  updatedBy?: string | null;
+  lockedBy?: string | null;
+  archivedBy?: string | null;
+  chiefComplaintSnapshot?: string | null;
+  clinicalSummary?: string | null;
+  correctionReason?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CompletedServiceStatus = 'completed' | 'corrected' | 'voided' | 'archived';
+
+export interface CompletedService {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  visitId?: string | null;
+  encounterId?: string | null;
+  appointmentId?: string | null;
+  findingId?: string | null;
+  treatmentPlanId?: string | null;
+  treatmentStageId?: string | null;
+  clinicalDictionaryItemId?: string | null;
+  serviceCode?: string | null;
+  serviceName: string;
+  toothNumber?: string | null;
+  toothSurface?: string | null;
+  quantity: number;
+  unitPrice?: number | null;
+  totalAmount?: number | null;
+  currency: string;
+  performedBy?: string | null;
+  performedAt: string;
+  status: CompletedServiceStatus;
+  correctionOfId?: string | null;
+  correctionReason?: string | null;
+  voidedAt?: string | null;
+  voidedBy?: string | null;
+  archivedAt?: string | null;
+  archivedBy?: string | null;
+  createdBy?: string | null;
+  updatedBy?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListPatientVisitsOptions {
+  tenantId: string;
+  patientId?: string;
+  appointmentId?: string;
+  statuses?: PatientVisitStatus[];
+  visitTypes?: PatientVisitType[];
+  arrivedFrom?: string;
+  arrivedTo?: string;
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListClinicalEncountersOptions {
+  tenantId: string;
+  patientId?: string;
+  visitId?: string;
+  appointmentId?: string;
+  doctorUserId?: string;
+  statuses?: ClinicalEncounterStatus[];
+  encounterTypes?: ClinicalEncounterType[];
+  createdFrom?: string;
+  createdTo?: string;
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListCompletedServicesOptions {
+  tenantId: string;
+  patientId?: string;
+  visitId?: string;
+  encounterId?: string;
+  appointmentId?: string;
+  findingId?: string;
+  treatmentPlanId?: string;
+  treatmentStageId?: string;
+  clinicalDictionaryItemId?: string;
+  performedBy?: string;
+  statuses?: CompletedServiceStatus[];
+  performedFrom?: string;
+  performedTo?: string;
+  includeArchived?: boolean;
+  includeVoided?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GetByIdOptions {
+  tenantId: string;
+  id: string;
+}
+
+export interface PatientScopedOptions {
+  tenantId: string;
+  patientId: string;
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export type ListPatientClinicalWorkflowOptions = PatientScopedOptions;
+
+export interface PatientClinicalWorkflow {
+  visits: PatientVisit[];
+  encounters: ClinicalEncounter[];
+  completedServices: CompletedService[];
+}
+
+export interface EncounterVisitRepository {
+  listPatientVisits(options: ListPatientVisitsOptions): Promise<PatientVisit[]>;
+  getPatientVisitById(options: GetByIdOptions): Promise<PatientVisit | null>;
+  listClinicalEncounters(options: ListClinicalEncountersOptions): Promise<ClinicalEncounter[]>;
+  getClinicalEncounterById(options: GetByIdOptions): Promise<ClinicalEncounter | null>;
+  listCompletedServices(options: ListCompletedServicesOptions): Promise<CompletedService[]>;
+  getCompletedServiceById(options: GetByIdOptions): Promise<CompletedService | null>;
+  listPatientClinicalWorkflow(options: ListPatientClinicalWorkflowOptions): Promise<PatientClinicalWorkflow>;
+}
+
+export type EncounterVisitRepositoryBackend = 'supabase' | 'local';
+
+export interface CreateEncounterVisitRepositoryOptions {
+  backend: EncounterVisitRepositoryBackend;
+  client?: SupabaseClient;
+}
+
+export const ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR = 'Active clinic is required for encounter/visit access.';
+export const PATIENT_REQUIRED_FOR_CLINICAL_WORKFLOW_ERROR = 'Patient is required for patient clinical workflow access.';
+export const RECORD_ID_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR = 'Record id is required for encounter/visit access.';
+export const DEFAULT_ENCOUNTER_VISIT_LIMIT = 50;
+export const MAX_ENCOUNTER_VISIT_LIMIT = 200;
+
+type JsonObject = Record<string, unknown>;
+
+type PatientVisitRow = {
+  id: unknown;
+  tenant_id: unknown;
+  patient_id: unknown;
+  appointment_id?: unknown;
+  status: unknown;
+  visit_type: unknown;
+  arrived_at: unknown;
+  checked_in_at?: unknown;
+  started_at?: unknown;
+  completed_at?: unknown;
+  cancelled_at?: unknown;
+  archived_at?: unknown;
+  created_by?: unknown;
+  updated_by?: unknown;
+  archived_by?: unknown;
+  notes?: unknown;
+  metadata?: unknown;
+  created_at: unknown;
+  updated_at: unknown;
+};
+
+type ClinicalEncounterRow = {
+  id: unknown;
+  tenant_id: unknown;
+  patient_id: unknown;
+  visit_id?: unknown;
+  appointment_id?: unknown;
+  doctor_user_id?: unknown;
+  status: unknown;
+  encounter_type: unknown;
+  started_at?: unknown;
+  completed_at?: unknown;
+  locked_at?: unknown;
+  archived_at?: unknown;
+  created_by?: unknown;
+  updated_by?: unknown;
+  locked_by?: unknown;
+  archived_by?: unknown;
+  chief_complaint_snapshot?: unknown;
+  clinical_summary?: unknown;
+  correction_reason?: unknown;
+  metadata?: unknown;
+  created_at: unknown;
+  updated_at: unknown;
+};
+
+type CompletedServiceRow = {
+  id: unknown;
+  tenant_id: unknown;
+  patient_id: unknown;
+  visit_id?: unknown;
+  encounter_id?: unknown;
+  appointment_id?: unknown;
+  finding_id?: unknown;
+  treatment_plan_id?: unknown;
+  treatment_stage_id?: unknown;
+  clinical_dictionary_item_id?: unknown;
+  service_code?: unknown;
+  service_name: unknown;
+  tooth_number?: unknown;
+  tooth_surface?: unknown;
+  quantity: unknown;
+  unit_price?: unknown;
+  total_amount?: unknown;
+  currency: unknown;
+  performed_by?: unknown;
+  performed_at: unknown;
+  status: unknown;
+  correction_of_id?: unknown;
+  correction_reason?: unknown;
+  voided_at?: unknown;
+  voided_by?: unknown;
+  archived_at?: unknown;
+  archived_by?: unknown;
+  created_by?: unknown;
+  updated_by?: unknown;
+  metadata?: unknown;
+  created_at: unknown;
+  updated_at: unknown;
+};
+
+function isRecord(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function metadataObject(value: unknown): JsonObject {
+  return isRecord(value) ? value : {};
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+function requiredString(value: unknown, fieldName: string): string {
+  if (value === null || value === undefined) throw new Error(`Encounter/visit row is missing required field: ${fieldName}`);
+  const text = String(value);
+  if (text.trim().length === 0) throw new Error(`Encounter/visit row has empty required field: ${fieldName}`);
+  return text;
+}
+
+function requiredNumber(value: unknown, fieldName: string): number {
+  if (value === null || value === undefined) throw new Error(`Encounter/visit row is missing required field: ${fieldName}`);
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) throw new Error(`Encounter/visit row has invalid numeric field: ${fieldName}`);
+  return numberValue;
+}
+
+function nullableNumber(value: unknown, fieldName: string): number | null {
+  if (value === null || value === undefined) return null;
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) throw new Error(`Encounter/visit row has invalid numeric field: ${fieldName}`);
+  return numberValue;
+}
+
+function requireTenantId(tenantId: string | null | undefined): string {
+  if (!tenantId || tenantId.trim().length === 0) throw new Error(ACTIVE_CLINIC_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+  return tenantId;
+}
+
+function requirePatientId(patientId: string | null | undefined): string {
+  if (!patientId || patientId.trim().length === 0) throw new Error(PATIENT_REQUIRED_FOR_CLINICAL_WORKFLOW_ERROR);
+  return patientId;
+}
+
+function requireRecordId(id: string | null | undefined): string {
+  if (!id || id.trim().length === 0) throw new Error(RECORD_ID_REQUIRED_FOR_ENCOUNTER_VISIT_ERROR);
+  return id;
+}
+
+export function normalizeEncounterVisitLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_ENCOUNTER_VISIT_LIMIT;
+  return Math.max(1, Math.min(MAX_ENCOUNTER_VISIT_LIMIT, Math.floor(limit)));
+}
+
+export function normalizeEncounterVisitOffset(offset?: number): number {
+  if (offset === undefined || !Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.floor(offset));
+}
+
+export function mapPatientVisitRow(row: PatientVisitRow | Record<string, unknown>): PatientVisit {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    appointmentId: nullableString(row.appointment_id),
+    status: requiredString(row.status, 'status') as PatientVisitStatus,
+    visitType: requiredString(row.visit_type, 'visit_type') as PatientVisitType,
+    arrivedAt: requiredString(row.arrived_at, 'arrived_at'),
+    checkedInAt: nullableString(row.checked_in_at),
+    startedAt: nullableString(row.started_at),
+    completedAt: nullableString(row.completed_at),
+    cancelledAt: nullableString(row.cancelled_at),
+    archivedAt: nullableString(row.archived_at),
+    createdBy: nullableString(row.created_by),
+    updatedBy: nullableString(row.updated_by),
+    archivedBy: nullableString(row.archived_by),
+    notes: nullableString(row.notes),
+    metadata: metadataObject(row.metadata),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapClinicalEncounterRow(row: ClinicalEncounterRow | Record<string, unknown>): ClinicalEncounter {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    visitId: nullableString(row.visit_id),
+    appointmentId: nullableString(row.appointment_id),
+    doctorUserId: nullableString(row.doctor_user_id),
+    status: requiredString(row.status, 'status') as ClinicalEncounterStatus,
+    encounterType: requiredString(row.encounter_type, 'encounter_type') as ClinicalEncounterType,
+    startedAt: nullableString(row.started_at),
+    completedAt: nullableString(row.completed_at),
+    lockedAt: nullableString(row.locked_at),
+    archivedAt: nullableString(row.archived_at),
+    createdBy: nullableString(row.created_by),
+    updatedBy: nullableString(row.updated_by),
+    lockedBy: nullableString(row.locked_by),
+    archivedBy: nullableString(row.archived_by),
+    chiefComplaintSnapshot: nullableString(row.chief_complaint_snapshot),
+    clinicalSummary: nullableString(row.clinical_summary),
+    correctionReason: nullableString(row.correction_reason),
+    metadata: metadataObject(row.metadata),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapCompletedServiceRow(row: CompletedServiceRow | Record<string, unknown>): CompletedService {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    visitId: nullableString(row.visit_id),
+    encounterId: nullableString(row.encounter_id),
+    appointmentId: nullableString(row.appointment_id),
+    findingId: nullableString(row.finding_id),
+    treatmentPlanId: nullableString(row.treatment_plan_id),
+    treatmentStageId: nullableString(row.treatment_stage_id),
+    clinicalDictionaryItemId: nullableString(row.clinical_dictionary_item_id),
+    serviceCode: nullableString(row.service_code),
+    serviceName: requiredString(row.service_name, 'service_name'),
+    toothNumber: nullableString(row.tooth_number),
+    toothSurface: nullableString(row.tooth_surface),
+    quantity: requiredNumber(row.quantity, 'quantity'),
+    unitPrice: nullableNumber(row.unit_price, 'unit_price'),
+    totalAmount: nullableNumber(row.total_amount, 'total_amount'),
+    currency: requiredString(row.currency, 'currency'),
+    performedBy: nullableString(row.performed_by),
+    performedAt: requiredString(row.performed_at, 'performed_at'),
+    status: requiredString(row.status, 'status') as CompletedServiceStatus,
+    correctionOfId: nullableString(row.correction_of_id),
+    correctionReason: nullableString(row.correction_reason),
+    voidedAt: nullableString(row.voided_at),
+    voidedBy: nullableString(row.voided_by),
+    archivedAt: nullableString(row.archived_at),
+    archivedBy: nullableString(row.archived_by),
+    createdBy: nullableString(row.created_by),
+    updatedBy: nullableString(row.updated_by),
+    metadata: metadataObject(row.metadata),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export class SupabaseEncounterVisitRepository implements EncounterVisitRepository {
+  private readonly client: SupabaseClient;
+
+  constructor(client: SupabaseClient) {
+    this.client = client;
+  }
+
+  async listPatientVisits(options: ListPatientVisitsOptions): Promise<PatientVisit[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeEncounterVisitLimit(options.limit);
+    const offset = normalizeEncounterVisitOffset(options.offset);
+
+    let query = this.client
+      .from('patient_visits')
+      .select('*')
+      .eq('tenant_id', tenantId);
+
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.appointmentId) query = query.eq('appointment_id', options.appointmentId);
+    if (options.statuses?.length) query = query.in('status', options.statuses);
+    if (options.visitTypes?.length) query = query.in('visit_type', options.visitTypes);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+    if (options.arrivedFrom) query = query.gte('arrived_at', options.arrivedFrom);
+    if (options.arrivedTo) query = query.lte('arrived_at', options.arrivedTo);
+
+    const { data, error } = await query
+      .order('arrived_at', { ascending: false })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapPatientVisitRow);
+  }
+
+  async getPatientVisitById(options: GetByIdOptions): Promise<PatientVisit | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const id = requireRecordId(options.id);
+    const { data, error } = await this.client
+      .from('patient_visits')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data ? mapPatientVisitRow(data as Record<string, unknown>) : null;
+  }
+
+  async listClinicalEncounters(options: ListClinicalEncountersOptions): Promise<ClinicalEncounter[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeEncounterVisitLimit(options.limit);
+    const offset = normalizeEncounterVisitOffset(options.offset);
+
+    let query = this.client
+      .from('clinical_encounters')
+      .select('*')
+      .eq('tenant_id', tenantId);
+
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.visitId) query = query.eq('visit_id', options.visitId);
+    if (options.appointmentId) query = query.eq('appointment_id', options.appointmentId);
+    if (options.doctorUserId) query = query.eq('doctor_user_id', options.doctorUserId);
+    if (options.statuses?.length) query = query.in('status', options.statuses);
+    if (options.encounterTypes?.length) query = query.in('encounter_type', options.encounterTypes);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+    if (options.createdFrom) query = query.gte('created_at', options.createdFrom);
+    if (options.createdTo) query = query.lte('created_at', options.createdTo);
+
+    const { data, error } = await query
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapClinicalEncounterRow);
+  }
+
+  async getClinicalEncounterById(options: GetByIdOptions): Promise<ClinicalEncounter | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const id = requireRecordId(options.id);
+    const { data, error } = await this.client
+      .from('clinical_encounters')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data ? mapClinicalEncounterRow(data as Record<string, unknown>) : null;
+  }
+
+  async listCompletedServices(options: ListCompletedServicesOptions): Promise<CompletedService[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeEncounterVisitLimit(options.limit);
+    const offset = normalizeEncounterVisitOffset(options.offset);
+
+    let query = this.client
+      .from('completed_services')
+      .select('*')
+      .eq('tenant_id', tenantId);
+
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.visitId) query = query.eq('visit_id', options.visitId);
+    if (options.encounterId) query = query.eq('encounter_id', options.encounterId);
+    if (options.appointmentId) query = query.eq('appointment_id', options.appointmentId);
+    if (options.findingId) query = query.eq('finding_id', options.findingId);
+    if (options.treatmentPlanId) query = query.eq('treatment_plan_id', options.treatmentPlanId);
+    if (options.treatmentStageId) query = query.eq('treatment_stage_id', options.treatmentStageId);
+    if (options.clinicalDictionaryItemId) query = query.eq('clinical_dictionary_item_id', options.clinicalDictionaryItemId);
+    if (options.performedBy) query = query.eq('performed_by', options.performedBy);
+    if (options.statuses?.length) query = query.in('status', options.statuses);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+    if (!options.includeVoided) query = query.neq('status', 'voided');
+    if (options.performedFrom) query = query.gte('performed_at', options.performedFrom);
+    if (options.performedTo) query = query.lte('performed_at', options.performedTo);
+
+    const { data, error } = await query
+      .order('performed_at', { ascending: false })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapCompletedServiceRow);
+  }
+
+  async getCompletedServiceById(options: GetByIdOptions): Promise<CompletedService | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const id = requireRecordId(options.id);
+    const { data, error } = await this.client
+      .from('completed_services')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data ? mapCompletedServiceRow(data as Record<string, unknown>) : null;
+  }
+
+  async listPatientClinicalWorkflow(options: ListPatientClinicalWorkflowOptions): Promise<PatientClinicalWorkflow> {
+    const tenantId = requireTenantId(options.tenantId);
+    const patientId = requirePatientId(options.patientId);
+    const common = {
+      tenantId,
+      patientId,
+      includeArchived: options.includeArchived,
+      limit: options.limit,
+      offset: options.offset,
+    };
+
+    const [visits, encounters, completedServices] = await Promise.all([
+      this.listPatientVisits(common),
+      this.listClinicalEncounters(common),
+      this.listCompletedServices(common),
+    ]);
+
+    return { visits, encounters, completedServices };
+  }
+}
+
+export function createEncounterVisitRepository(options: CreateEncounterVisitRepositoryOptions): EncounterVisitRepository {
+  if (options.backend === 'local') {
+    throw new Error('Encounter/visit repository requires Supabase backend.');
+  }
+
+  const client = options.client ?? defaultSupabase;
+  if (!client) {
+    throw new Error('Supabase client is not configured for encounter/visit access.');
+  }
+
+  return new SupabaseEncounterVisitRepository(client as SupabaseClient);
+}


### PR DESCRIPTION
## Summary
- Adds a Supabase-only read-only encounter/visit repository for patient_visits, clinical_encounters, and completed_services.
- Adds typed camelCase domain models, query option types, mappers, get-by-id/list/workflow read methods, and bounded pagination.
- Adds unit coverage for tenant/id validation, table queries, filters, archived/voided handling, mapping, Supabase errors, and read-only/factory safety.

## Safety
- No migrations.
- No UI.
- No hooks.
- No Supabase cloud.
- No browser smoke.
- No write methods or localStorage fallback.
- No audit/activity RPC calls.

## Checks
- npm run lint: PASS
- npm run test -- --run: PASS (48 files / 432 tests)
- npm run build: PASS
- GitHub Actions CI #557: PASS on 03b1034fe0ba6053968c997f51d80ef2142cb353

## Verdict
ENCOUNTER VISIT REPOSITORY IMPLEMENTED AND VERIFIED