### PR TITLE
ENCOUNTER-VISIT-RPC-001C: add controlled encounter visit write RPCs

### DIFF
--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md
@@ -1,0 +1,189 @@
+# ENCOUNTER-VISIT-RPC-001C — Database Write RPCs Report
+
+## 1. Summary
+
+This task implements and verifies controlled PostgreSQL RPC functions to act as the secure, authenticated write paths for visits, clinical encounters, and completed services.
+
+All operations strictly validate tenant bounds, user roles, reference entity scopes, and status transitions, logging one audit event and one activity event in the same database transaction.
+
+Final Verdict: **ENCOUNTER VISIT RPC WRITE PATH IMPLEMENTED AND VERIFIED**
+
+## 2. Branch Name
+
+`feature/encounter-visit-rpc-001c`
+
+## 3. PR URL
+
+https://github.com/NckNA/codex-test/pull/312
+
+## 4. PR head reviewed before final report update
+
+`7ef074b8c687c72b42649ccf810e27c3f3ee2ef3`
+
+## 5. Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed files summary
+
+Expected report-only and migration changes:
+
+- `supabase/migrations/0015_create_encounter_visit_rpc.sql` (NEW)
+- `_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md` (NEW)
+
+No app code, UI, frontend repository write methods, or seed changes were made.
+
+## 7. Current RPC / Schema Recon
+
+### audit_events table
+- **Columns**: `id`, `tenant_id`, `actor_user_id`, `actor_role`, `actor_tenant_role`, `actor_display_name`, `action`, `category`, `severity`, `target_type`, `target_id`, `patient_id`, `appointment_id`, `visit_id`, `encounter_id`, `treatment_plan_id`, `treatment_stage_id`, `finding_id`, `file_id`, `payment_id`, `stock_movement_id`, `before_data`, `after_data`, `diff_data`, `redaction_level`, `reason`, `request_id`, `session_id`, `ip_address`, `user_agent`, `metadata`, `created_at`.
+- **Category constraints**: `auth`, `tenant`, `role_membership`, `patient`, `appointment`, `visit`, `encounter`, `finding`, `treatment_plan`, `completed_service`, `file`, `document`, `payment`, `stock`, `dictionary`, `billing_subscription`, `system`, `support_access`.
+- **Severity constraints**: `debug`, `info`, `warning`, `critical`.
+- **Redaction levels**: `none`, `standard`, `restricted`, `confidential`.
+
+### activity_events table
+- **Columns**: `id`, `tenant_id`, `patient_id`, `audit_event_id`, `actor_user_id`, `category`, `type`, `title`, `description`, `source_type`, `source_id`, `source_status`, `visibility`, `severity`, `occurred_at`, `metadata`, `is_archived`, `created_at`.
+- **Category constraints**: `patient`, `complaint`, `dental_chart`, `finding`, `treatment_plan`, `appointment`, `visit`, `encounter`, `completed_service`, `file`, `document`, `payment`, `stock`, `audit`, `system`.
+- **Visibility constraints**: `clinical`, `admin`, `financial`, `system`.
+
+### Helper signatures
+1. `public.record_audit_event_internal(...)`
+   - **Signature**: `public.record_audit_event_internal(p_tenant_id uuid, p_action text, p_category text, p_target_type text, p_target_id text, ...)`
+   - **Grants**: Revoked from `PUBLIC`, `anon`, and `authenticated`. Granted exclusively to `service_role`.
+   - **SECURITY DEFINER**: Enabled.
+   - **search_path**: `public, pg_temp`
+2. `public.record_activity_event_internal(...)`
+   - **Signature**: `public.record_activity_event_internal(p_tenant_id uuid, p_category text, p_type text, p_title text, p_source_type text, p_source_id text, ...)`
+   - **Grants**: Revoked from `PUBLIC`, `anon`, and `authenticated`. Granted exclusively to `service_role`.
+   - **SECURITY DEFINER**: Enabled.
+   - **search_path**: `public, pg_temp`
+3. `public.has_tenant_role(...)`
+   - **Signature**: `public.has_tenant_role(target_tenant_id uuid, allowed_roles app_role[]) RETURNS boolean`
+   - **Grants**: Revoked from `PUBLIC` and `anon`. Granted to `authenticated` and `service_role`.
+
+### app_role enum values
+- `platform_owner`, `platform_admin`, `clinic_owner`, `clinic_admin`, `doctor`, `registrar`, `cashier`, `marketer`, `support`.
+
+### Clinical workflow tables
+1. **`public.patient_visits`**
+   - **ID types**: `id` uuid, `patient_id` uuid, `appointment_id` uuid.
+   - **Status constraints**: `checked_in`, `in_progress`, `completed`, `cancelled`, `archived`.
+2. **`public.clinical_encounters`**
+   - **ID types**: `id` uuid, `patient_id` uuid, `visit_id` uuid, `appointment_id` uuid.
+   - **Status constraints**: `draft`, `in_progress`, `completed`, `locked`, `archived`.
+3. **`public.completed_services`**
+   - **ID types**: `id` uuid, `patient_id` uuid, `visit_id` uuid, `encounter_id` uuid, `appointment_id` uuid, `finding_id` uuid, `treatment_plan_id` uuid, `treatment_stage_id` uuid, `clinical_dictionary_item_id` text.
+   - **Status constraints**: `completed`, `corrected`, `voided`, `archived`.
+
+### Table grants before/after
+- **Before**: Direct INSERT/UPDATE/DELETE writes are fully revoked from `authenticated` and `anon` for all three tables. Only `SELECT` is allowed.
+- **After**: Direct writes remain fully blocked. Modification is only permitted through the newly created `SECURITY DEFINER` RPC functions.
+
+## 8. Migration Summary
+
+- **Migration filename**: `supabase/migrations/0015_create_encounter_visit_rpc.sql`
+- **RPC Functions created**:
+  1. `public.check_in_patient_visit(...)`
+  2. `public.start_patient_visit(...)`
+  3. `public.complete_patient_visit(...)`
+  4. `public.cancel_patient_visit(...)`
+  5. `public.create_clinical_encounter(...)`
+  6. `public.start_clinical_encounter(...)`
+  7. `public.complete_clinical_encounter(...)`
+  8. `public.record_completed_service(...)`
+  9. `public.void_completed_service(...)`
+- **Security & Grants**:
+  - Every function sets `SECURITY DEFINER` and a safe `search_path = public, pg_temp`.
+  - Execute permission is revoked from `PUBLIC` and `anon`.
+  - Execute permission is granted to `authenticated`.
+  - Roles are checked inside each function using `public.has_tenant_role`.
+  - Cross-tenant references are strictly validated.
+
+## 9. RPC Behavior
+
+1. **`check_in_patient_visit`**: Creates a visit row with status `checked_in`. Checks tenant and patient existence. Validates that the appointment belongs to the same patient and tenant, and checks that no other active visit exists for that appointment.
+2. **`start_patient_visit`**: Updates status to `in_progress`. Transitions are only allowed from `checked_in`.
+3. **`complete_patient_visit`**: Updates status to `completed`. Allowed from `checked_in` or `in_progress`. Blocked for the `registrar` role.
+4. **`cancel_patient_visit`**: Updates status to `cancelled`. Allowed from `checked_in` or `in_progress`. Requires a cancellation reason, which is written to the audit log and appended to visit notes.
+5. **`create_clinical_encounter`**: Creates a draft encounter. Validates that the patient, visit, and appointment exist and belong to the same tenant. If a doctor user ID is specified, verifies it has the appropriate clinic role.
+6. **`start_clinical_encounter`**: Updates status to `in_progress`. Allowed from `draft` status.
+7. **`complete_clinical_encounter`**: Updates status to `completed`. Allowed from `draft` or `in_progress` status.
+8. **`record_completed_service`**: Records a service fact (status `completed`). Validates referenced patient, visit, encounter, appointment, finding, plan, stage, and clinical dictionary item. Ensures quantity > 0, price >= 0, and name is non-empty.
+9. **`void_completed_service`**: Voids a service fact (status `voided`). Allowed from `completed` or `corrected`. Requires a reason, which is logged and saved in the correction reason column.
+
+## 10. Domain Boundary
+
+- **Appointment**: Represents booking intent, not actual attendance or clinical fact.
+- **Patient Visit**: Represents physical/administrative attendance context. Complete visit does not automatically record treatment.
+- **Clinical Encounter**: Represents doctor session / documentation context. Draft/in_progress/completed lifecycles.
+- **Completed Service**: Represents a billable/performed service fact. Plan stage/finding links do not modify treatment plans.
+- **Audit/Activity**: Security/compliance log and SAFE timeline feeds, not source clinical facts.
+
+## 11. Audit/Activity Behavior
+
+- Successful writes emit exactly one `audit_event` and one `activity_event` using internal helpers.
+- Categories used: `visit`, `encounter`, `completed_service`.
+- Metadata is kept concise (target IDs and transition tags) and contains no raw clinical summary/PHI payloads.
+
+## 12. RLS / Grants / Write Boundary
+
+- Direct table writes remain fully blocked for `authenticated` and `anon`.
+- Access is gated at the RPC level. No anonymous calls are possible.
+- Roles are strictly enforced (e.g. cashiers and no-tenant users are denied access).
+
+## 13. Local Validation
+
+- **Supabase status**: Running.
+- **npx supabase db reset**: PASS. Applied all 15 migrations successfully.
+- **Function existence & Security**: Verified.
+- **Direct write block test**: PASS. direct writes from an `authenticated` role return `insufficient_privilege`.
+- **Role simulations**:
+  - Clinic A Admin: Allowed all visit, encounter, and service writes.
+  - Clinic A Doctor: Allowed all visit, encounter, and service writes.
+  - Clinic A Registrar: Allowed checking in, starting, and cancelling visits. Blocked from completing visits, creating encounters, and recording services.
+  - Clinic A Cashier: Blocked from all writes.
+  - No Tenant: Blocked from all writes.
+  - Clinic B Admin: Blocked from editing Clinic A records (cross-tenant validation).
+- **Status transition tests**: Verified. Cannot complete a cancelled visit, cannot start a completed visit, etc.
+- **Invalid payloads**: Rejected correctly (empty names, negative prices, null tenants, zero quantity).
+- **Audit/Activity logging**: Verified. Triggering RPCs increments both `audit_events` and `activity_events` counts with correct categories and source IDs.
+- **Database cleanup**: Verified. All test rows with the smoke marker `metadata->>'smokeTest' = 'ENCOUNTER-VISIT-RPC-001C'` were successfully deleted.
+- **Final marker counts**:
+  - `patient_visits` = 0
+  - `clinical_encounters` = 0
+  - `completed_services` = 0
+  - `audit_events` = 0
+  - `activity_events` = 0
+
+## 14. What was intentionally NOT changed
+
+- No application code changes.
+- No UI components or pages updated.
+- No frontend repository write client methods added.
+- No hooks added.
+- No seed script changes.
+
+## 15. Checks
+
+- `git status --short`: Clean, showing only the migration file and this report.
+- `npm run lint`: **PASS**.
+- `npm run test -- --run`: **PASS** (432 tests passed across 48 files).
+- `npm run build`: **PASS** (Build succeeds).
+- **GitHub Actions CI**: pending
+
+## 16. Issues/Warnings
+
+- React `act(...)` warning in unrelated tests (pre-existing).
+- Vite chunk size warning (pre-existing).
+
+## 17. Final Verdict
+
+```
+ENCOUNTER VISIT RPC WRITE PATH IMPLEMENTED AND VERIFIED
+```
+
+## 18. Recommended Next Task
+
+```
+ENCOUNTER-VISIT-RPC-CLIENT-001D
+```

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md
@@ -14,11 +14,11 @@ Final Verdict: **ENCOUNTER VISIT RPC WRITE PATH IMPLEMENTED AND VERIFIED**
 
 ## 3. PR URL
 
-https://github.com/NckNA/codex-test/pull/312
+https://github.com/NckNA/codex-test/pull/313
 
 ## 4. PR head reviewed before final report update
 
-`7ef074b8c687c72b42649ccf810e27c3f3ee2ef3`
+`54c4d36d04e3b4e2d4a14a408a5d4a593245ed30`
 
 ## 5. Report update commit
 
@@ -169,7 +169,7 @@ No app code, UI, frontend repository write methods, or seed changes were made.
 - `npm run lint`: **PASS**.
 - `npm run test -- --run`: **PASS** (432 tests passed across 48 files).
 - `npm run build`: **PASS** (Build succeeds).
-- **GitHub Actions CI**: pending
+- GitHub Actions CI (Run ID: `27848239664`, CI: `#560` on head reviewed commit): **SUCCESS**.
 
 ## 16. Issues/Warnings
 

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-001C_rpc.md
@@ -18,7 +18,7 @@ https://github.com/NckNA/codex-test/pull/313
 
 ## 4. PR head reviewed before final report update
 
-`54c4d36d04e3b4e2d4a14a408a5d4a593245ed30`
+`baf7343f832e03278726282f19a5764dbe531763`
 
 ## 5. Report update commit
 
@@ -169,7 +169,7 @@ No app code, UI, frontend repository write methods, or seed changes were made.
 - `npm run lint`: **PASS**.
 - `npm run test -- --run`: **PASS** (432 tests passed across 48 files).
 - `npm run build`: **PASS** (Build succeeds).
-- GitHub Actions CI (Run ID: `27848239664`, CI: `#560` on head reviewed commit): **SUCCESS**.
+- GitHub Actions CI (Run ID: `27850290344`, CI: `#562` on head reviewed commit): **SUCCESS**.
 
 ## 16. Issues/Warnings
 

--- a/supabase/migrations/0015_create_encounter_visit_rpc.sql
+++ b/supabase/migrations/0015_create_encounter_visit_rpc.sql
@@ -1,0 +1,1093 @@
+-- 0015_create_encounter_visit_rpc.sql
+-- SECURITY DEFINER write RPC paths for patient visits, clinical encounters, and completed services.
+
+-- 1. check_in_patient_visit
+CREATE OR REPLACE FUNCTION public.check_in_patient_visit(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_appointment_id uuid DEFAULT NULL,
+  p_visit_type text DEFAULT 'regular',
+  p_arrived_at timestamptz DEFAULT now(),
+  p_notes text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.patient_visits
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_patient_ok boolean;
+  v_appointment_ok boolean;
+  v_active_visit_exists boolean;
+  v_visit public.patient_visits;
+  v_audit_id uuid;
+  v_activity_id uuid;
+BEGIN
+  -- 1. Verify tenant is not null
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  -- 2. Verify role permissions
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  -- 3. Verify patient exists in tenant
+  SELECT EXISTS (
+    SELECT 1 FROM public.patients
+    WHERE id = p_patient_id AND tenant_id = p_tenant_id
+  ) INTO v_patient_ok;
+  IF NOT v_patient_ok THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  -- 4. Verify appointment belongs to patient and tenant (if provided)
+  IF p_appointment_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.appointments
+      WHERE id = p_appointment_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_appointment_ok;
+    IF NOT v_appointment_ok THEN
+      RAISE EXCEPTION 'Appointment not found or does not belong to this patient/tenant';
+    END IF;
+
+    -- 5. Reject if appointment already has an active (non-cancelled, non-archived) visit
+    SELECT EXISTS (
+      SELECT 1 FROM public.patient_visits
+      WHERE appointment_id = p_appointment_id AND tenant_id = p_tenant_id AND status NOT IN ('cancelled', 'archived')
+    ) INTO v_active_visit_exists;
+    IF v_active_visit_exists THEN
+      RAISE EXCEPTION 'Active visit already exists for this appointment';
+    END IF;
+  END IF;
+
+  -- 6. Insert visit
+  INSERT INTO public.patient_visits (
+    tenant_id,
+    patient_id,
+    appointment_id,
+    status,
+    visit_type,
+    arrived_at,
+    checked_in_at,
+    created_by,
+    updated_by,
+    notes,
+    metadata
+  ) VALUES (
+    p_tenant_id,
+    p_patient_id,
+    p_appointment_id,
+    'checked_in',
+    p_visit_type,
+    COALESCE(p_arrived_at, now()),
+    now(),
+    auth.uid(),
+    auth.uid(),
+    p_notes,
+    p_metadata
+  ) RETURNING * INTO v_visit;
+
+  -- 7. Log audit event
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'patient_visit_checked_in',
+    'visit',
+    'patient_visit',
+    v_visit.id::text,
+    auth.uid(),
+    p_patient_id => p_patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_visit_id => v_visit.id,
+    p_metadata => p_metadata
+  );
+
+  -- 8. Log activity event
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'visit',
+    'patient_visit_checked_in',
+    'Patient visit checked in',
+    'patient_visit',
+    v_visit.id::text,
+    p_patient_id => p_patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'checked_in',
+    p_visibility => 'admin',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_visit;
+END;
+$$;
+
+-- 2. start_patient_visit
+CREATE OR REPLACE FUNCTION public.start_patient_visit(
+  p_tenant_id uuid,
+  p_visit_id uuid,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.patient_visits
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_visit public.patient_visits;
+  v_audit_id uuid;
+  v_activity_id uuid;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  -- Select visit for update to prevent concurrent updates
+  SELECT * INTO v_visit FROM public.patient_visits
+  WHERE id = p_visit_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF v_visit.id IS NULL THEN
+    RAISE EXCEPTION 'Patient visit not found in this tenant';
+  END IF;
+
+  -- Validate transition
+  IF v_visit.status <> 'checked_in' THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot start visit from status %', v_visit.status;
+  END IF;
+
+  -- Update visit
+  UPDATE public.patient_visits
+  SET status = 'in_progress',
+      started_at = COALESCE(started_at, now()),
+      updated_by = auth.uid()
+  WHERE id = p_visit_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_visit;
+
+  -- Log audit event
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'patient_visit_started',
+    'visit',
+    'patient_visit',
+    p_visit_id::text,
+    auth.uid(),
+    p_patient_id => v_visit.patient_id,
+    p_appointment_id => v_visit.appointment_id::text,
+    p_visit_id => p_visit_id,
+    p_metadata => p_metadata
+  );
+
+  -- Log activity event
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'visit',
+    'patient_visit_started',
+    'Patient visit started',
+    'patient_visit',
+    p_visit_id::text,
+    p_patient_id => v_visit.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'in_progress',
+    p_visibility => 'admin',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_visit;
+END;
+$$;
+
+-- 3. complete_patient_visit
+CREATE OR REPLACE FUNCTION public.complete_patient_visit(
+  p_tenant_id uuid,
+  p_visit_id uuid,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.patient_visits
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_visit public.patient_visits;
+  v_audit_id uuid;
+  v_activity_id uuid;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  SELECT * INTO v_visit FROM public.patient_visits
+  WHERE id = p_visit_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF v_visit.id IS NULL THEN
+    RAISE EXCEPTION 'Patient visit not found in this tenant';
+  END IF;
+
+  IF v_visit.status NOT IN ('checked_in', 'in_progress') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot complete visit from status %', v_visit.status;
+  END IF;
+
+  UPDATE public.patient_visits
+  SET status = 'completed',
+      completed_at = now(),
+      updated_by = auth.uid()
+  WHERE id = p_visit_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_visit;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'patient_visit_completed',
+    'visit',
+    'patient_visit',
+    p_visit_id::text,
+    auth.uid(),
+    p_patient_id => v_visit.patient_id,
+    p_appointment_id => v_visit.appointment_id::text,
+    p_visit_id => p_visit_id,
+    p_metadata => p_metadata
+  );
+
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'visit',
+    'patient_visit_completed',
+    'Patient visit completed',
+    'patient_visit',
+    p_visit_id::text,
+    p_patient_id => v_visit.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'completed',
+    p_visibility => 'admin',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_visit;
+END;
+$$;
+
+-- 4. cancel_patient_visit
+CREATE OR REPLACE FUNCTION public.cancel_patient_visit(
+  p_tenant_id uuid,
+  p_visit_id uuid,
+  p_reason text,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.patient_visits
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_visit public.patient_visits;
+  v_audit_id uuid;
+  v_activity_id uuid;
+  v_final_metadata jsonb;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN
+    RAISE EXCEPTION 'Cancellation reason is required';
+  END IF;
+
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  SELECT * INTO v_visit FROM public.patient_visits
+  WHERE id = p_visit_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF v_visit.id IS NULL THEN
+    RAISE EXCEPTION 'Patient visit not found in this tenant';
+  END IF;
+
+  IF v_visit.status NOT IN ('checked_in', 'in_progress') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot cancel visit from status %', v_visit.status;
+  END IF;
+
+  v_final_metadata := COALESCE(p_metadata, '{}'::jsonb) || jsonb_build_object('cancellation_reason', p_reason);
+
+  UPDATE public.patient_visits
+  SET status = 'cancelled',
+      cancelled_at = now(),
+      notes = CASE 
+        WHEN notes IS NULL OR length(btrim(notes)) = 0 THEN 'Cancellation reason: ' || p_reason
+        ELSE notes || E'\nCancellation reason: ' || p_reason
+      END,
+      metadata = v_final_metadata,
+      updated_by = auth.uid()
+  WHERE id = p_visit_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_visit;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'patient_visit_cancelled',
+    'visit',
+    'patient_visit',
+    p_visit_id::text,
+    auth.uid(),
+    p_patient_id => v_visit.patient_id,
+    p_appointment_id => v_visit.appointment_id::text,
+    p_visit_id => p_visit_id,
+    p_reason => p_reason,
+    p_metadata => v_final_metadata
+  );
+
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'visit',
+    'patient_visit_cancelled',
+    'Patient visit cancelled',
+    'patient_visit',
+    p_visit_id::text,
+    p_patient_id => v_visit.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_description => p_reason,
+    p_source_status => 'cancelled',
+    p_visibility => 'admin',
+    p_metadata => v_final_metadata
+  );
+
+  RETURN v_visit;
+END;
+$$;
+
+-- 5. create_clinical_encounter
+CREATE OR REPLACE FUNCTION public.create_clinical_encounter(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_visit_id uuid DEFAULT NULL,
+  p_appointment_id uuid DEFAULT NULL,
+  p_doctor_user_id uuid DEFAULT NULL,
+  p_encounter_type text DEFAULT 'consultation',
+  p_chief_complaint_snapshot text DEFAULT NULL,
+  p_clinical_summary text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.clinical_encounters
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_patient_ok boolean;
+  v_visit_ok boolean;
+  v_appointment_ok boolean;
+  v_doctor_ok boolean;
+  v_doc_user_id uuid;
+  v_encounter public.clinical_encounters;
+  v_audit_id uuid;
+  v_activity_id uuid;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  -- 1. Check permissions
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  -- 2. Verify patient belongs to tenant
+  SELECT EXISTS (
+    SELECT 1 FROM public.patients
+    WHERE id = p_patient_id AND tenant_id = p_tenant_id
+  ) INTO v_patient_ok;
+  IF NOT v_patient_ok THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  -- 3. Verify visit (if provided)
+  IF p_visit_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.patient_visits
+      WHERE id = p_visit_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_visit_ok;
+    IF NOT v_visit_ok THEN
+      RAISE EXCEPTION 'Visit not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 4. Verify appointment (if provided)
+  IF p_appointment_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.appointments
+      WHERE id = p_appointment_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_appointment_ok;
+    IF NOT v_appointment_ok THEN
+      RAISE EXCEPTION 'Appointment not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 5. Set doctor user ID
+  v_doc_user_id := COALESCE(p_doctor_user_id, auth.uid());
+
+  -- 6. Verify doctor user belongs to tenant and has allowed role
+  SELECT EXISTS (
+    SELECT 1 FROM public.tenant_users
+    WHERE user_id = v_doc_user_id AND tenant_id = p_tenant_id 
+      AND role IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role)
+  ) INTO v_doctor_ok;
+  IF NOT v_doctor_ok THEN
+    RAISE EXCEPTION 'Doctor user not authorized or does not belong to this tenant';
+  END IF;
+
+  -- 7. Insert encounter
+  INSERT INTO public.clinical_encounters (
+    tenant_id,
+    patient_id,
+    visit_id,
+    appointment_id,
+    doctor_user_id,
+    status,
+    encounter_type,
+    created_by,
+    updated_by,
+    chief_complaint_snapshot,
+    clinical_summary,
+    metadata
+  ) VALUES (
+    p_tenant_id,
+    p_patient_id,
+    p_visit_id,
+    p_appointment_id,
+    v_doc_user_id,
+    'draft',
+    p_encounter_type,
+    auth.uid(),
+    auth.uid(),
+    p_chief_complaint_snapshot,
+    p_clinical_summary,
+    p_metadata
+  ) RETURNING * INTO v_encounter;
+
+  -- 8. Log audit event
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'clinical_encounter_created',
+    'encounter',
+    'clinical_encounter',
+    v_encounter.id::text,
+    auth.uid(),
+    p_patient_id => p_patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_visit_id => p_visit_id,
+    p_encounter_id => v_encounter.id,
+    p_metadata => p_metadata
+  );
+
+  -- 9. Log activity event
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'encounter',
+    'clinical_encounter_created',
+    'Clinical encounter created',
+    'clinical_encounter',
+    v_encounter.id::text,
+    p_patient_id => p_patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'draft',
+    p_visibility => 'clinical',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_encounter;
+END;
+$$;
+
+-- 6. start_clinical_encounter
+CREATE OR REPLACE FUNCTION public.start_clinical_encounter(
+  p_tenant_id uuid,
+  p_encounter_id uuid,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.clinical_encounters
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_encounter public.clinical_encounters;
+  v_audit_id uuid;
+  v_activity_id uuid;
+END_TIME timestamptz;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  SELECT * INTO v_encounter FROM public.clinical_encounters
+  WHERE id = p_encounter_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF v_encounter.id IS NULL THEN
+    RAISE EXCEPTION 'Clinical encounter not found in this tenant';
+  END IF;
+
+  IF v_encounter.status <> 'draft' THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot start encounter from status %', v_encounter.status;
+  END IF;
+
+  UPDATE public.clinical_encounters
+  SET status = 'in_progress',
+      started_at = COALESCE(started_at, now()),
+      updated_by = auth.uid()
+  WHERE id = p_encounter_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_encounter;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'clinical_encounter_started',
+    'encounter',
+    'clinical_encounter',
+    p_encounter_id::text,
+    auth.uid(),
+    p_patient_id => v_encounter.patient_id,
+    p_appointment_id => v_encounter.appointment_id::text,
+    p_visit_id => v_encounter.visit_id,
+    p_encounter_id => p_encounter_id,
+    p_metadata => p_metadata
+  );
+
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'encounter',
+    'clinical_encounter_started',
+    'Clinical encounter started',
+    'clinical_encounter',
+    p_encounter_id::text,
+    p_patient_id => v_encounter.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'in_progress',
+    p_visibility => 'clinical',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_encounter;
+END;
+$$;
+
+-- 7. complete_clinical_encounter
+CREATE OR REPLACE FUNCTION public.complete_clinical_encounter(
+  p_tenant_id uuid,
+  p_encounter_id uuid,
+  p_clinical_summary text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.clinical_encounters
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_encounter public.clinical_encounters;
+  v_audit_id uuid;
+  v_activity_id uuid;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  SELECT * INTO v_encounter FROM public.clinical_encounters
+  WHERE id = p_encounter_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF v_encounter.id IS NULL THEN
+    RAISE EXCEPTION 'Clinical encounter not found in this tenant';
+  END IF;
+
+  IF v_encounter.status NOT IN ('draft', 'in_progress') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot complete encounter from status %', v_encounter.status;
+  END IF;
+
+  UPDATE public.clinical_encounters
+  SET status = 'completed',
+      completed_at = now(),
+      clinical_summary = COALESCE(p_clinical_summary, clinical_summary),
+      updated_by = auth.uid()
+  WHERE id = p_encounter_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_encounter;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'clinical_encounter_completed',
+    'encounter',
+    'clinical_encounter',
+    p_encounter_id::text,
+    auth.uid(),
+    p_patient_id => v_encounter.patient_id,
+    p_appointment_id => v_encounter.appointment_id::text,
+    p_visit_id => v_encounter.visit_id,
+    p_encounter_id => p_encounter_id,
+    p_metadata => p_metadata
+  );
+
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'encounter',
+    'clinical_encounter_completed',
+    'Clinical encounter completed',
+    'clinical_encounter',
+    p_encounter_id::text,
+    p_patient_id => v_encounter.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'completed',
+    p_visibility => 'clinical',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_encounter;
+END;
+$$;
+
+-- 8. record_completed_service
+CREATE OR REPLACE FUNCTION public.record_completed_service(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_visit_id uuid DEFAULT NULL,
+  p_encounter_id uuid DEFAULT NULL,
+  p_appointment_id uuid DEFAULT NULL,
+  p_finding_id uuid DEFAULT NULL,
+  p_treatment_plan_id uuid DEFAULT NULL,
+  p_treatment_stage_id uuid DEFAULT NULL,
+  p_clinical_dictionary_item_id text DEFAULT NULL,
+  p_service_code text DEFAULT NULL,
+  p_service_name text DEFAULT NULL,
+  p_tooth_number text DEFAULT NULL,
+  p_tooth_surface text DEFAULT NULL,
+  p_quantity numeric DEFAULT 1,
+  p_unit_price numeric DEFAULT NULL,
+  p_total_amount numeric DEFAULT NULL,
+  p_currency text DEFAULT 'KZT',
+  p_performed_at timestamptz DEFAULT now(),
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.completed_services
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_patient_ok boolean;
+  v_visit_ok boolean;
+  v_encounter_ok boolean;
+  v_appointment_ok boolean;
+  v_finding_ok boolean;
+  v_plan_ok boolean;
+  v_stage_ok boolean;
+  v_dict_ok boolean;
+  v_service public.completed_services;
+  v_audit_id uuid;
+  v_activity_id uuid;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  IF p_service_name IS NULL OR length(btrim(p_service_name)) = 0 THEN
+    RAISE EXCEPTION 'Service name is required';
+  END IF;
+
+  IF p_quantity IS NULL OR p_quantity <= 0 THEN
+    RAISE EXCEPTION 'Quantity must be greater than zero';
+  END IF;
+
+  IF p_unit_price IS NOT NULL AND p_unit_price < 0 THEN
+    RAISE EXCEPTION 'Unit price cannot be negative';
+  END IF;
+
+  IF p_total_amount IS NOT NULL AND p_total_amount < 0 THEN
+    RAISE EXCEPTION 'Total amount cannot be negative';
+  END IF;
+
+  IF p_currency IS NULL OR length(btrim(p_currency)) = 0 THEN
+    RAISE EXCEPTION 'Currency is required';
+  END IF;
+
+  -- 1. Check permissions
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  -- 2. Verify patient
+  SELECT EXISTS (
+    SELECT 1 FROM public.patients
+    WHERE id = p_patient_id AND tenant_id = p_tenant_id
+  ) INTO v_patient_ok;
+  IF NOT v_patient_ok THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  -- 3. Verify visit
+  IF p_visit_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.patient_visits
+      WHERE id = p_visit_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_visit_ok;
+    IF NOT v_visit_ok THEN
+      RAISE EXCEPTION 'Visit not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 4. Verify encounter
+  IF p_encounter_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.clinical_encounters
+      WHERE id = p_encounter_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_encounter_ok;
+    IF NOT v_encounter_ok THEN
+      RAISE EXCEPTION 'Encounter not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 5. Verify appointment
+  IF p_appointment_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.appointments
+      WHERE id = p_appointment_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_appointment_ok;
+    IF NOT v_appointment_ok THEN
+      RAISE EXCEPTION 'Appointment not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 6. Verify finding
+  IF p_finding_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.findings
+      WHERE id = p_finding_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_finding_ok;
+    IF NOT v_finding_ok THEN
+      RAISE EXCEPTION 'Finding not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 7. Verify treatment plan
+  IF p_treatment_plan_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.treatment_plans
+      WHERE id = p_treatment_plan_id AND tenant_id = p_tenant_id AND patient_id = p_patient_id
+    ) INTO v_plan_ok;
+    IF NOT v_plan_ok THEN
+      RAISE EXCEPTION 'Treatment plan not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 8. Verify treatment stage
+  IF p_treatment_stage_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.treatment_stages s
+      JOIN public.treatment_plans p ON s.treatment_plan_id = p.id
+      WHERE s.id = p_treatment_stage_id AND p.tenant_id = p_tenant_id AND p.patient_id = p_patient_id
+    ) INTO v_stage_ok;
+    IF NOT v_stage_ok THEN
+      RAISE EXCEPTION 'Treatment stage not found or does not belong to this patient/tenant';
+    END IF;
+  END IF;
+
+  -- 9. Verify dictionary item
+  IF p_clinical_dictionary_item_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.clinical_dictionary_items
+      WHERE id = p_clinical_dictionary_item_id AND tenant_id = p_tenant_id
+    ) INTO v_dict_ok;
+    IF NOT v_dict_ok THEN
+      RAISE EXCEPTION 'Clinical dictionary item not found in this tenant';
+    END IF;
+  END IF;
+
+  -- 10. Insert completed service
+  INSERT INTO public.completed_services (
+    tenant_id,
+    patient_id,
+    visit_id,
+    encounter_id,
+    appointment_id,
+    finding_id,
+    treatment_plan_id,
+    treatment_stage_id,
+    clinical_dictionary_item_id,
+    service_code,
+    service_name,
+    tooth_number,
+    tooth_surface,
+    quantity,
+    unit_price,
+    total_amount,
+    currency,
+    performed_by,
+    performed_at,
+    status,
+    created_by,
+    updated_by,
+    metadata
+  ) VALUES (
+    p_tenant_id,
+    p_patient_id,
+    p_visit_id,
+    p_encounter_id,
+    p_appointment_id,
+    p_finding_id,
+    p_treatment_plan_id,
+    p_treatment_stage_id,
+    p_clinical_dictionary_item_id,
+    p_service_code,
+    p_service_name,
+    p_tooth_number,
+    p_tooth_surface,
+    p_quantity,
+    p_unit_price,
+    p_total_amount,
+    p_currency,
+    auth.uid(),
+    COALESCE(p_performed_at, now()),
+    'completed',
+    auth.uid(),
+    auth.uid(),
+    p_metadata
+  ) RETURNING * INTO v_service;
+
+  -- 11. Log audit event
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'completed_service_recorded',
+    'completed_service',
+    'completed_service',
+    v_service.id::text,
+    auth.uid(),
+    p_patient_id => p_patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_visit_id => p_visit_id,
+    p_encounter_id => p_encounter_id,
+    p_treatment_plan_id => p_treatment_plan_id::text,
+    p_treatment_stage_id => p_treatment_stage_id::text,
+    p_finding_id => p_finding_id::text,
+    p_metadata => p_metadata
+  );
+
+  -- 12. Log activity event
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'completed_service',
+    'completed_service_recorded',
+    'Completed service recorded',
+    'completed_service',
+    v_service.id::text,
+    p_patient_id => p_patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_source_status => 'completed',
+    p_visibility => 'clinical',
+    p_metadata => p_metadata
+  );
+
+  RETURN v_service;
+END;
+$$;
+
+-- 9. void_completed_service
+CREATE OR REPLACE FUNCTION public.void_completed_service(
+  p_tenant_id uuid,
+  p_completed_service_id uuid,
+  p_reason text,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.completed_services
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role_ok boolean;
+  v_service public.completed_services;
+  v_audit_id uuid;
+  v_activity_id uuid;
+  v_final_metadata jsonb;
+BEGIN
+  IF p_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant ID is required';
+  END IF;
+
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN
+    RAISE EXCEPTION 'Reason for voiding is required';
+  END IF;
+
+  -- 1. Check permissions
+  v_role_ok := public.has_tenant_role(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
+  );
+  IF NOT v_role_ok THEN
+    RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
+  END IF;
+
+  -- 2. Select service for update
+  SELECT * INTO v_service FROM public.completed_services
+  WHERE id = p_completed_service_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF v_service.id IS NULL THEN
+    RAISE EXCEPTION 'Completed service not found in this tenant';
+  END IF;
+
+  -- 3. Check allowed status transitions
+  IF v_service.status = 'voided' THEN
+    RAISE EXCEPTION 'Completed service is already voided';
+  END IF;
+  IF v_service.status = 'archived' THEN
+    RAISE EXCEPTION 'Completed service is archived and cannot be voided';
+  END IF;
+  IF v_service.status NOT IN ('completed', 'corrected') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot void service with status %', v_service.status;
+  END IF;
+
+  v_final_metadata := COALESCE(p_metadata, '{}'::jsonb) || jsonb_build_object('void_reason', p_reason);
+
+  -- 4. Update service
+  UPDATE public.completed_services
+  SET status = 'voided',
+      voided_at = now(),
+      voided_by = auth.uid(),
+      correction_reason = p_reason,
+      metadata = v_final_metadata,
+      updated_by = auth.uid()
+  WHERE id = p_completed_service_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_service;
+
+  -- 5. Log audit event
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id,
+    'completed_service_voided',
+    'completed_service',
+    'completed_service',
+    p_completed_service_id::text,
+    auth.uid(),
+    p_patient_id => v_service.patient_id,
+    p_appointment_id => v_service.appointment_id::text,
+    p_visit_id => v_service.visit_id,
+    p_encounter_id => v_service.encounter_id,
+    p_treatment_plan_id => v_service.treatment_plan_id::text,
+    p_treatment_stage_id => v_service.treatment_stage_id::text,
+    p_finding_id => v_service.finding_id::text,
+    p_reason => p_reason,
+    p_metadata => v_final_metadata
+  );
+
+  -- 6. Log activity event
+  v_activity_id := public.record_activity_event_internal(
+    p_tenant_id,
+    'completed_service',
+    'completed_service_voided',
+    'Completed service voided',
+    'completed_service',
+    p_completed_service_id::text,
+    p_patient_id => v_service.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => auth.uid(),
+    p_description => p_reason,
+    p_source_status => 'voided',
+    p_visibility => 'clinical',
+    p_metadata => v_final_metadata
+  );
+
+  RETURN v_service;
+END;
+$$;
+
+-- Revoke default PUBLIC execute privilege from all new functions
+REVOKE ALL ON FUNCTION public.check_in_patient_visit(uuid, uuid, uuid, text, timestamptz, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.check_in_patient_visit(uuid, uuid, uuid, text, timestamptz, text, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.start_patient_visit(uuid, uuid, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.start_patient_visit(uuid, uuid, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.complete_patient_visit(uuid, uuid, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.complete_patient_visit(uuid, uuid, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.cancel_patient_visit(uuid, uuid, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.cancel_patient_visit(uuid, uuid, text, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.create_clinical_encounter(uuid, uuid, uuid, uuid, uuid, text, text, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.create_clinical_encounter(uuid, uuid, uuid, uuid, uuid, text, text, text, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.start_clinical_encounter(uuid, uuid, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.start_clinical_encounter(uuid, uuid, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.complete_clinical_encounter(uuid, uuid, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.complete_clinical_encounter(uuid, uuid, text, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.record_completed_service(uuid, uuid, uuid, uuid, uuid, uuid, uuid, uuid, text, text, text, text, text, numeric, numeric, numeric, text, timestamptz, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.record_completed_service(uuid, uuid, uuid, uuid, uuid, uuid, uuid, uuid, text, text, text, text, text, numeric, numeric, numeric, text, timestamptz, jsonb) FROM anon;
+
+REVOKE ALL ON FUNCTION public.void_completed_service(uuid, uuid, text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.void_completed_service(uuid, uuid, text, jsonb) FROM anon;
+
+-- Grant EXECUTE to authenticated users
+GRANT EXECUTE ON FUNCTION public.check_in_patient_visit(uuid, uuid, uuid, text, timestamptz, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.start_patient_visit(uuid, uuid, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_patient_visit(uuid, uuid, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_patient_visit(uuid, uuid, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_clinical_encounter(uuid, uuid, uuid, uuid, uuid, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.start_clinical_encounter(uuid, uuid, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_clinical_encounter(uuid, uuid, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.record_completed_service(uuid, uuid, uuid, uuid, uuid, uuid, uuid, uuid, text, text, text, text, text, numeric, numeric, numeric, text, timestamptz, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.void_completed_service(uuid, uuid, text, jsonb) TO authenticated;

--- a/supabase/migrations/0015_create_encounter_visit_rpc.sql
+++ b/supabase/migrations/0015_create_encounter_visit_rpc.sql
@@ -16,6 +16,7 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_patient_ok boolean;
   v_appointment_ok boolean;
@@ -23,13 +24,22 @@ DECLARE
   v_visit public.patient_visits;
   v_audit_id uuid;
   v_activity_id uuid;
+  v_event_metadata jsonb;
 BEGIN
-  -- 1. Verify tenant is not null
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
+  -- Verify tenant is not null
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
 
-  -- 2. Verify role permissions
+  -- Verify role permissions
   v_role_ok := public.has_tenant_role(
     p_tenant_id,
     ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role, 'doctor'::public.app_role]
@@ -38,7 +48,7 @@ BEGIN
     RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
   END IF;
 
-  -- 3. Verify patient exists in tenant
+  -- Verify patient exists in tenant
   SELECT EXISTS (
     SELECT 1 FROM public.patients
     WHERE id = p_patient_id AND tenant_id = p_tenant_id
@@ -47,7 +57,7 @@ BEGIN
     RAISE EXCEPTION 'Patient not found in this tenant';
   END IF;
 
-  -- 4. Verify appointment belongs to patient and tenant (if provided)
+  -- Verify appointment belongs to patient and tenant (if provided)
   IF p_appointment_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.appointments
@@ -57,7 +67,7 @@ BEGIN
       RAISE EXCEPTION 'Appointment not found or does not belong to this patient/tenant';
     END IF;
 
-    -- 5. Reject if appointment already has an active (non-cancelled, non-archived) visit
+    -- Reject if appointment already has an active (non-cancelled, non-archived) visit
     SELECT EXISTS (
       SELECT 1 FROM public.patient_visits
       WHERE appointment_id = p_appointment_id AND tenant_id = p_tenant_id AND status NOT IN ('cancelled', 'archived')
@@ -67,7 +77,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 6. Insert visit
+  -- Insert visit
   INSERT INTO public.patient_visits (
     tenant_id,
     patient_id,
@@ -91,10 +101,21 @@ BEGIN
     auth.uid(),
     auth.uid(),
     p_notes,
-    p_metadata
+    v_metadata
   ) RETURNING * INTO v_visit;
 
-  -- 7. Log audit event
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'patient_visit_checked_in',
+    'patientId', p_patient_id,
+    'visitId', v_visit.id,
+    'appointmentId', p_appointment_id,
+    'toStatus', 'checked_in',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
+
+  -- Log audit event
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
     'patient_visit_checked_in',
@@ -105,10 +126,10 @@ BEGIN
     p_patient_id => p_patient_id,
     p_appointment_id => p_appointment_id::text,
     p_visit_id => v_visit.id,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
-  -- 8. Log activity event
+  -- Log activity event
   v_activity_id := public.record_activity_event_internal(
     p_tenant_id,
     'visit',
@@ -121,7 +142,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'checked_in',
     p_visibility => 'admin',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_visit;
@@ -139,11 +160,22 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_visit public.patient_visits;
+  v_old_status text;
   v_audit_id uuid;
   v_activity_id uuid;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -165,9 +197,12 @@ BEGIN
     RAISE EXCEPTION 'Patient visit not found in this tenant';
   END IF;
 
+  -- Capture old status
+  v_old_status := v_visit.status;
+
   -- Validate transition
-  IF v_visit.status <> 'checked_in' THEN
-    RAISE EXCEPTION 'Invalid status transition: cannot start visit from status %', v_visit.status;
+  IF v_old_status <> 'checked_in' THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot start visit from status %', v_old_status;
   END IF;
 
   -- Update visit
@@ -177,6 +212,18 @@ BEGIN
       updated_by = auth.uid()
   WHERE id = p_visit_id AND tenant_id = p_tenant_id
   RETURNING * INTO v_visit;
+
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'patient_visit_started',
+    'patientId', v_visit.patient_id,
+    'visitId', p_visit_id,
+    'appointmentId', v_visit.appointment_id,
+    'fromStatus', v_old_status,
+    'toStatus', 'in_progress',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
 
   -- Log audit event
   v_audit_id := public.record_audit_event_internal(
@@ -189,7 +236,7 @@ BEGIN
     p_patient_id => v_visit.patient_id,
     p_appointment_id => v_visit.appointment_id::text,
     p_visit_id => p_visit_id,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   -- Log activity event
@@ -205,7 +252,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'in_progress',
     p_visibility => 'admin',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_visit;
@@ -223,11 +270,22 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_visit public.patient_visits;
+  v_old_status text;
   v_audit_id uuid;
   v_activity_id uuid;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -248,8 +306,11 @@ BEGIN
     RAISE EXCEPTION 'Patient visit not found in this tenant';
   END IF;
 
-  IF v_visit.status NOT IN ('checked_in', 'in_progress') THEN
-    RAISE EXCEPTION 'Invalid status transition: cannot complete visit from status %', v_visit.status;
+  -- Capture old status
+  v_old_status := v_visit.status;
+
+  IF v_old_status NOT IN ('checked_in', 'in_progress') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot complete visit from status %', v_old_status;
   END IF;
 
   UPDATE public.patient_visits
@@ -258,6 +319,18 @@ BEGIN
       updated_by = auth.uid()
   WHERE id = p_visit_id AND tenant_id = p_tenant_id
   RETURNING * INTO v_visit;
+
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'patient_visit_completed',
+    'patientId', v_visit.patient_id,
+    'visitId', p_visit_id,
+    'appointmentId', v_visit.appointment_id,
+    'fromStatus', v_old_status,
+    'toStatus', 'completed',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
 
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
@@ -269,7 +342,7 @@ BEGIN
     p_patient_id => v_visit.patient_id,
     p_appointment_id => v_visit.appointment_id::text,
     p_visit_id => p_visit_id,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   v_activity_id := public.record_activity_event_internal(
@@ -284,7 +357,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'completed',
     p_visibility => 'admin',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_visit;
@@ -303,12 +376,23 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_visit public.patient_visits;
+  v_old_status text;
   v_audit_id uuid;
   v_activity_id uuid;
   v_final_metadata jsonb;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -333,11 +417,14 @@ BEGIN
     RAISE EXCEPTION 'Patient visit not found in this tenant';
   END IF;
 
-  IF v_visit.status NOT IN ('checked_in', 'in_progress') THEN
-    RAISE EXCEPTION 'Invalid status transition: cannot cancel visit from status %', v_visit.status;
+  -- Capture old status
+  v_old_status := v_visit.status;
+
+  IF v_old_status NOT IN ('checked_in', 'in_progress') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot cancel visit from status %', v_old_status;
   END IF;
 
-  v_final_metadata := COALESCE(p_metadata, '{}'::jsonb) || jsonb_build_object('cancellation_reason', p_reason);
+  v_final_metadata := COALESCE(v_metadata, '{}'::jsonb) || jsonb_build_object('cancellation_reason', p_reason);
 
   UPDATE public.patient_visits
   SET status = 'cancelled',
@@ -351,6 +438,18 @@ BEGIN
   WHERE id = p_visit_id AND tenant_id = p_tenant_id
   RETURNING * INTO v_visit;
 
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'patient_visit_cancelled',
+    'patientId', v_visit.patient_id,
+    'visitId', p_visit_id,
+    'appointmentId', v_visit.appointment_id,
+    'fromStatus', v_old_status,
+    'toStatus', 'cancelled',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
+
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
     'patient_visit_cancelled',
@@ -362,7 +461,7 @@ BEGIN
     p_appointment_id => v_visit.appointment_id::text,
     p_visit_id => p_visit_id,
     p_reason => p_reason,
-    p_metadata => v_final_metadata
+    p_metadata => v_event_metadata
   );
 
   v_activity_id := public.record_activity_event_internal(
@@ -378,7 +477,7 @@ BEGIN
     p_description => p_reason,
     p_source_status => 'cancelled',
     p_visibility => 'admin',
-    p_metadata => v_final_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_visit;
@@ -402,6 +501,7 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_patient_ok boolean;
   v_visit_ok boolean;
@@ -411,12 +511,21 @@ DECLARE
   v_encounter public.clinical_encounters;
   v_audit_id uuid;
   v_activity_id uuid;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
 
-  -- 1. Check permissions
+  -- Check permissions
   v_role_ok := public.has_tenant_role(
     p_tenant_id,
     ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
@@ -425,7 +534,7 @@ BEGIN
     RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
   END IF;
 
-  -- 2. Verify patient belongs to tenant
+  -- Verify patient belongs to tenant
   SELECT EXISTS (
     SELECT 1 FROM public.patients
     WHERE id = p_patient_id AND tenant_id = p_tenant_id
@@ -434,7 +543,7 @@ BEGIN
     RAISE EXCEPTION 'Patient not found in this tenant';
   END IF;
 
-  -- 3. Verify visit (if provided)
+  -- Verify visit (if provided)
   IF p_visit_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.patient_visits
@@ -445,7 +554,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 4. Verify appointment (if provided)
+  -- Verify appointment (if provided)
   IF p_appointment_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.appointments
@@ -456,10 +565,10 @@ BEGIN
     END IF;
   END IF;
 
-  -- 5. Set doctor user ID
+  -- Set doctor user ID
   v_doc_user_id := COALESCE(p_doctor_user_id, auth.uid());
 
-  -- 6. Verify doctor user belongs to tenant and has allowed role
+  -- Verify doctor user belongs to tenant and has allowed role
   SELECT EXISTS (
     SELECT 1 FROM public.tenant_users
     WHERE user_id = v_doc_user_id AND tenant_id = p_tenant_id 
@@ -469,7 +578,7 @@ BEGIN
     RAISE EXCEPTION 'Doctor user not authorized or does not belong to this tenant';
   END IF;
 
-  -- 7. Insert encounter
+  -- Insert encounter
   INSERT INTO public.clinical_encounters (
     tenant_id,
     patient_id,
@@ -495,10 +604,22 @@ BEGIN
     auth.uid(),
     p_chief_complaint_snapshot,
     p_clinical_summary,
-    p_metadata
+    v_metadata
   ) RETURNING * INTO v_encounter;
 
-  -- 8. Log audit event
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'clinical_encounter_created',
+    'patientId', p_patient_id,
+    'visitId', p_visit_id,
+    'encounterId', v_encounter.id,
+    'appointmentId', p_appointment_id,
+    'toStatus', 'draft',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
+
+  -- Log audit event
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
     'clinical_encounter_created',
@@ -510,10 +631,10 @@ BEGIN
     p_appointment_id => p_appointment_id::text,
     p_visit_id => p_visit_id,
     p_encounter_id => v_encounter.id,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
-  -- 9. Log activity event
+  -- Log activity event
   v_activity_id := public.record_activity_event_internal(
     p_tenant_id,
     'encounter',
@@ -526,7 +647,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'draft',
     p_visibility => 'clinical',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_encounter;
@@ -544,12 +665,22 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_encounter public.clinical_encounters;
+  v_old_status text;
   v_audit_id uuid;
   v_activity_id uuid;
-END_TIME timestamptz;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -570,8 +701,11 @@ BEGIN
     RAISE EXCEPTION 'Clinical encounter not found in this tenant';
   END IF;
 
-  IF v_encounter.status <> 'draft' THEN
-    RAISE EXCEPTION 'Invalid status transition: cannot start encounter from status %', v_encounter.status;
+  -- Capture old status
+  v_old_status := v_encounter.status;
+
+  IF v_old_status <> 'draft' THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot start encounter from status %', v_old_status;
   END IF;
 
   UPDATE public.clinical_encounters
@@ -580,6 +714,19 @@ BEGIN
       updated_by = auth.uid()
   WHERE id = p_encounter_id AND tenant_id = p_tenant_id
   RETURNING * INTO v_encounter;
+
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'clinical_encounter_started',
+    'patientId', v_encounter.patient_id,
+    'encounterId', p_encounter_id,
+    'visitId', v_encounter.visit_id,
+    'appointmentId', v_encounter.appointment_id,
+    'fromStatus', v_old_status,
+    'toStatus', 'in_progress',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
 
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
@@ -592,7 +739,7 @@ BEGIN
     p_appointment_id => v_encounter.appointment_id::text,
     p_visit_id => v_encounter.visit_id,
     p_encounter_id => p_encounter_id,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   v_activity_id := public.record_activity_event_internal(
@@ -607,7 +754,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'in_progress',
     p_visibility => 'clinical',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_encounter;
@@ -626,11 +773,22 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_encounter public.clinical_encounters;
+  v_old_status text;
   v_audit_id uuid;
   v_activity_id uuid;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -651,8 +809,11 @@ BEGIN
     RAISE EXCEPTION 'Clinical encounter not found in this tenant';
   END IF;
 
-  IF v_encounter.status NOT IN ('draft', 'in_progress') THEN
-    RAISE EXCEPTION 'Invalid status transition: cannot complete encounter from status %', v_encounter.status;
+  -- Capture old status
+  v_old_status := v_encounter.status;
+
+  IF v_old_status NOT IN ('draft', 'in_progress') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot complete encounter from status %', v_old_status;
   END IF;
 
   UPDATE public.clinical_encounters
@@ -662,6 +823,19 @@ BEGIN
       updated_by = auth.uid()
   WHERE id = p_encounter_id AND tenant_id = p_tenant_id
   RETURNING * INTO v_encounter;
+
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'clinical_encounter_completed',
+    'patientId', v_encounter.patient_id,
+    'encounterId', p_encounter_id,
+    'visitId', v_encounter.visit_id,
+    'appointmentId', v_encounter.appointment_id,
+    'fromStatus', v_old_status,
+    'toStatus', 'completed',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
 
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
@@ -674,7 +848,7 @@ BEGIN
     p_appointment_id => v_encounter.appointment_id::text,
     p_visit_id => v_encounter.visit_id,
     p_encounter_id => p_encounter_id,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   v_activity_id := public.record_activity_event_internal(
@@ -689,7 +863,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'completed',
     p_visibility => 'clinical',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_encounter;
@@ -723,6 +897,7 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_patient_ok boolean;
   v_visit_ok boolean;
@@ -735,7 +910,16 @@ DECLARE
   v_service public.completed_services;
   v_audit_id uuid;
   v_activity_id uuid;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -760,7 +944,7 @@ BEGIN
     RAISE EXCEPTION 'Currency is required';
   END IF;
 
-  -- 1. Check permissions
+  -- Check permissions
   v_role_ok := public.has_tenant_role(
     p_tenant_id,
     ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
@@ -769,7 +953,7 @@ BEGIN
     RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
   END IF;
 
-  -- 2. Verify patient
+  -- Verify patient
   SELECT EXISTS (
     SELECT 1 FROM public.patients
     WHERE id = p_patient_id AND tenant_id = p_tenant_id
@@ -778,7 +962,7 @@ BEGIN
     RAISE EXCEPTION 'Patient not found in this tenant';
   END IF;
 
-  -- 3. Verify visit
+  -- Verify visit
   IF p_visit_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.patient_visits
@@ -789,7 +973,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 4. Verify encounter
+  -- Verify encounter
   IF p_encounter_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.clinical_encounters
@@ -800,7 +984,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 5. Verify appointment
+  -- Verify appointment
   IF p_appointment_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.appointments
@@ -811,7 +995,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 6. Verify finding
+  -- Verify finding
   IF p_finding_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.findings
@@ -822,7 +1006,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 7. Verify treatment plan
+  -- Verify treatment plan
   IF p_treatment_plan_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.treatment_plans
@@ -833,7 +1017,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 8. Verify treatment stage
+  -- Verify treatment stage
   IF p_treatment_stage_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.treatment_stages s
@@ -845,7 +1029,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 9. Verify dictionary item
+  -- Verify dictionary item
   IF p_clinical_dictionary_item_id IS NOT NULL THEN
     SELECT EXISTS (
       SELECT 1 FROM public.clinical_dictionary_items
@@ -856,7 +1040,7 @@ BEGIN
     END IF;
   END IF;
 
-  -- 10. Insert completed service
+  -- Insert completed service
   INSERT INTO public.completed_services (
     tenant_id,
     patient_id,
@@ -904,10 +1088,23 @@ BEGIN
     'completed',
     auth.uid(),
     auth.uid(),
-    p_metadata
+    v_metadata
   ) RETURNING * INTO v_service;
 
-  -- 11. Log audit event
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'completed_service_recorded',
+    'patientId', p_patient_id,
+    'visitId', p_visit_id,
+    'encounterId', p_encounter_id,
+    'completedServiceId', v_service.id,
+    'appointmentId', p_appointment_id,
+    'toStatus', 'completed',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
+
+  -- Log audit event
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
     'completed_service_recorded',
@@ -922,10 +1119,10 @@ BEGIN
     p_treatment_plan_id => p_treatment_plan_id::text,
     p_treatment_stage_id => p_treatment_stage_id::text,
     p_finding_id => p_finding_id::text,
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
-  -- 12. Log activity event
+  -- Log activity event
   v_activity_id := public.record_activity_event_internal(
     p_tenant_id,
     'completed_service',
@@ -938,7 +1135,7 @@ BEGIN
     p_actor_user_id => auth.uid(),
     p_source_status => 'completed',
     p_visibility => 'clinical',
-    p_metadata => p_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_service;
@@ -957,12 +1154,23 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
+  v_metadata jsonb := p_metadata;
   v_role_ok boolean;
   v_service public.completed_services;
+  v_old_status text;
   v_audit_id uuid;
   v_activity_id uuid;
   v_final_metadata jsonb;
+  v_event_metadata jsonb;
 BEGIN
+  -- Validate metadata
+  IF v_metadata IS NULL THEN
+    v_metadata := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
   IF p_tenant_id IS NULL THEN
     RAISE EXCEPTION 'Tenant ID is required';
   END IF;
@@ -971,7 +1179,7 @@ BEGIN
     RAISE EXCEPTION 'Reason for voiding is required';
   END IF;
 
-  -- 1. Check permissions
+  -- Check permissions
   v_role_ok := public.has_tenant_role(
     p_tenant_id,
     ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'doctor'::public.app_role]
@@ -980,7 +1188,7 @@ BEGIN
     RAISE EXCEPTION 'Access denied: insufficient permissions for this tenant';
   END IF;
 
-  -- 2. Select service for update
+  -- Select service for update
   SELECT * INTO v_service FROM public.completed_services
   WHERE id = p_completed_service_id AND tenant_id = p_tenant_id
   FOR UPDATE;
@@ -989,20 +1197,23 @@ BEGIN
     RAISE EXCEPTION 'Completed service not found in this tenant';
   END IF;
 
-  -- 3. Check allowed status transitions
-  IF v_service.status = 'voided' THEN
+  -- Capture old status
+  v_old_status := v_service.status;
+
+  -- Check allowed status transitions
+  IF v_old_status = 'voided' THEN
     RAISE EXCEPTION 'Completed service is already voided';
   END IF;
-  IF v_service.status = 'archived' THEN
+  IF v_old_status = 'archived' THEN
     RAISE EXCEPTION 'Completed service is archived and cannot be voided';
   END IF;
-  IF v_service.status NOT IN ('completed', 'corrected') THEN
-    RAISE EXCEPTION 'Invalid status transition: cannot void service with status %', v_service.status;
+  IF v_old_status NOT IN ('completed', 'corrected') THEN
+    RAISE EXCEPTION 'Invalid status transition: cannot void service with status %', v_old_status;
   END IF;
 
-  v_final_metadata := COALESCE(p_metadata, '{}'::jsonb) || jsonb_build_object('void_reason', p_reason);
+  v_final_metadata := COALESCE(v_metadata, '{}'::jsonb) || jsonb_build_object('void_reason', p_reason);
 
-  -- 4. Update service
+  -- Update service
   UPDATE public.completed_services
   SET status = 'voided',
       voided_at = now(),
@@ -1013,7 +1224,21 @@ BEGIN
   WHERE id = p_completed_service_id AND tenant_id = p_tenant_id
   RETURNING * INTO v_service;
 
-  -- 5. Log audit event
+  -- Build sanitized event metadata
+  v_event_metadata := jsonb_strip_nulls(jsonb_build_object(
+    'rpc', 'ENCOUNTER-VISIT-RPC-001C',
+    'action', 'completed_service_voided',
+    'patientId', v_service.patient_id,
+    'completedServiceId', p_completed_service_id,
+    'visitId', v_service.visit_id,
+    'encounterId', v_service.encounter_id,
+    'appointmentId', v_service.appointment_id,
+    'fromStatus', v_old_status,
+    'toStatus', 'voided',
+    'smokeTest', COALESCE(v_metadata->>'smokeTest', NULL)
+  ));
+
+  -- Log audit event
   v_audit_id := public.record_audit_event_internal(
     p_tenant_id,
     'completed_service_voided',
@@ -1029,10 +1254,10 @@ BEGIN
     p_treatment_stage_id => v_service.treatment_stage_id::text,
     p_finding_id => v_service.finding_id::text,
     p_reason => p_reason,
-    p_metadata => v_final_metadata
+    p_metadata => v_event_metadata
   );
 
-  -- 6. Log activity event
+  -- Log activity event
   v_activity_id := public.record_activity_event_internal(
     p_tenant_id,
     'completed_service',
@@ -1046,7 +1271,7 @@ BEGIN
     p_description => p_reason,
     p_source_status => 'voided',
     p_visibility => 'clinical',
-    p_metadata => v_final_metadata
+    p_metadata => v_event_metadata
   );
 
   RETURN v_service;


### PR DESCRIPTION
This pull request implements the controlled PostgreSQL write RPC paths for patient visits, clinical encounters, and completed services, satisfying the requirements of ENCOUNTER-VISIT-RPC-001C.