### PR TITLE
ENCOUNTER-VISIT-RPC-CLIENT-001D: add typed encounter visit RPC client

### DIFF
--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md
@@ -22,7 +22,7 @@ https://github.com/NckNA/codex-test/pull/314
 
 ## PR head reviewed before final report update
 
-`9f929bae272866ae7bb13a33fd3ebac06a17db5a`
+`3df4127084e98599d7c38130d992c79d7a873cdc`
 
 ## Changed files summary
 
@@ -53,11 +53,11 @@ GitHub Actions CI run completed successfully.
 | Field | Value |
 |---|---|
 | workflow | `CI` |
-| run id | `27851024067` |
-| CI number | `565` |
+| run id | `27851119363` |
+| CI number | `566` |
 | status | `completed` |
 | conclusion | `success` |
-| tested commit | `9f929bae272866ae7bb13a33fd3ebac06a17db5a` |
+| tested commit | `3df4127084e98599d7c38130d992c79d7a873cdc` |
 | job | `validate` |
 | ESLint | success |
 | tests | success |

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md
@@ -1,0 +1,72 @@
+# ENCOUNTER-VISIT-RPC-CLIENT-001D: typed encounter visit RPC client
+
+## Summary
+
+This implementation adds the frontend data-layer client wrapper and unit tests for the controlled PostgreSQL write RPC functions (check-in/start/complete/cancel visits, create/start/complete encounters, record/void completed services) introduced in ENCOUNTER-VISIT-RPC-001C.
+
+The implementation strictly avoids:
+- direct table writes (inserts/updates/deletes)
+- service_role client usage in frontend
+- localStorage fallbacks
+- starting UI, hooks, or page updates (e.g. PatientCardPage, PatientTimelineAggregator)
+
+All inputs are mapped from frontend camelCase to snake_case RPC parameters, validated on the client side, and the returned database records are mapped back using the existing domain entities (`PatientVisit`, `ClinicalEncounter`, `CompletedService`).
+
+## Branch name
+
+`feature/encounter-visit-rpc-client-001d`
+
+## PR URL
+
+https://github.com/NckNA/codex-test/pull/314
+
+## PR head reviewed before final report update
+
+`9f929bae272866ae7bb13a33fd3ebac06a17db5a`
+
+## Changed files summary
+
+Expected files only:
+
+- [EncounterVisitRpcClient.ts](file:///d:/Users/User/Documents/GitHub/codex-test/src/data/repositories/EncounterVisitRpcClient.ts)
+- [EncounterVisitRpcClient.test.ts](file:///d:/Users/User/Documents/GitHub/codex-test/src/data/repositories/EncounterVisitRpcClient.test.ts)
+- [_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md](file:///d:/Users/User/Documents/GitHub/codex-test/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md)
+
+No migrations, Supabase cloud changes, UI modifications, hook changes, or direct table writes.
+
+## Local development status
+
+All local verification passed successfully.
+
+| Command | Result |
+|---|---|
+| `npm run lint` | PASS |
+| `npm run test -- --run` | PASS (49 files / 468 tests) |
+| `npm run build` | PASS |
+
+Note: The 36 new unit tests cover all validation scenarios, RPC name mapping, parameter mapping, response mappers, error surfacing, empty database results, and security/safety assertions.
+
+## GitHub Actions CI after validation report push
+
+GitHub Actions CI run completed successfully.
+
+| Field | Value |
+|---|---|
+| workflow | `CI` |
+| run id | `27851024067` |
+| CI number | `565` |
+| status | `completed` |
+| conclusion | `success` |
+| tested commit | `9f929bae272866ae7bb13a33fd3ebac06a17db5a` |
+| job | `validate` |
+| ESLint | success |
+| tests | success |
+| build | success |
+
+## Final verdict
+
+ENCOUNTER VISIT RPC CLIENT IMPLEMENTED AND VERIFIED
+
+## Recommended next task
+
+VISIT-CHECKIN-UI-001

--- a/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md
+++ b/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md
@@ -2,15 +2,9 @@
 
 ## Summary
 
-This implementation adds the frontend data-layer client wrapper and unit tests for the controlled PostgreSQL write RPC functions (check-in/start/complete/cancel visits, create/start/complete encounters, record/void completed services) introduced in ENCOUNTER-VISIT-RPC-001C.
+This task adds a typed frontend/data-layer RPC client wrapper for the controlled encounter/visit write RPCs introduced by the backend RPC layer. The client converts camelCase frontend inputs into snake_case PostgreSQL RPC parameters, validates required inputs before calls, surfaces Supabase RPC errors, and maps returned database rows back into existing domain types.
 
-The implementation strictly avoids:
-- direct table writes (inserts/updates/deletes)
-- service_role client usage in frontend
-- localStorage fallbacks
-- starting UI, hooks, or page updates (e.g. PatientCardPage, PatientTimelineAggregator)
-
-All inputs are mapped from frontend camelCase to snake_case RPC parameters, validated on the client side, and the returned database records are mapped back using the existing domain entities (`PatientVisit`, `ClinicalEncounter`, `CompletedService`).
+This is a client wrapper only. It does not create UI, hooks, timeline integration, direct table writes, localStorage fallback, migrations, cloud changes, or service-role client access.
 
 ## Branch name
 
@@ -24,31 +18,229 @@ https://github.com/NckNA/codex-test/pull/314
 
 `3df4127084e98599d7c38130d992c79d7a873cdc`
 
+## Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
 ## Changed files summary
 
 Expected files only:
 
-- [EncounterVisitRpcClient.ts](file:///d:/Users/User/Documents/GitHub/codex-test/src/data/repositories/EncounterVisitRpcClient.ts)
-- [EncounterVisitRpcClient.test.ts](file:///d:/Users/User/Documents/GitHub/codex-test/src/data/repositories/EncounterVisitRpcClient.test.ts)
-- [_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md](file:///d:/Users/User/Documents/GitHub/codex-test/_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md)
+- `src/data/repositories/EncounterVisitRpcClient.ts`
+- `src/data/repositories/EncounterVisitRpcClient.test.ts`
+- `_ai_work/REPORTS/ENCOUNTER-VISIT-RPC-CLIENT-001D_client.md`
 
-No migrations, Supabase cloud changes, UI modifications, hook changes, or direct table writes.
+No migrations, Supabase cloud changes, UI modifications, hook changes, timeline integration, localStorage fallback, service-role usage, or direct table writes.
 
-## Local development status
+## Current pattern recon
 
-All local verification passed successfully.
+Existing repository/client patterns show these conventions:
 
-| Command | Result |
+- Data-layer files live under `src/data/repositories/`.
+- Supabase-backed implementations accept a `SupabaseClient` and use the normal Supabase client APIs.
+- Clinical source-of-truth data should not use localStorage or fake local fallback storage.
+- Read models use typed domain objects and map Supabase snake_case rows into camelCase application types.
+- Errors from Supabase are surfaced rather than swallowed.
+- Tenant context is passed explicitly and validated before data access.
+- Factories reject unsupported local backends for source-of-truth clinical records.
+- Tests use mocked Supabase clients/chains and assert table/RPC names, parameters, validation behavior, mapper output, and error surfacing.
+
+For this client, the closest existing patterns are:
+
+- `EncounterVisitRepository.ts` for domain types and mappers.
+- `AuditActivityRepository.ts` for strict backend behavior without unsafe localStorage fallback.
+- Existing repository tests for mocked Supabase interaction and safety assertions.
+
+## Implementation summary
+
+### Input types
+
+The client adds typed input contracts for all supported RPC calls:
+
+- `CheckInPatientVisitInput`
+- `StartPatientVisitInput`
+- `CompletePatientVisitInput`
+- `CancelPatientVisitInput`
+- `CreateClinicalEncounterInput`
+- `StartClinicalEncounterInput`
+- `CompleteClinicalEncounterInput`
+- `RecordCompletedServiceInput`
+- `VoidCompletedServiceInput`
+
+Validation includes:
+
+- `tenantId` required for every method.
+- Patient id required for check-in, encounter creation, and completed service recording.
+- Visit id required for start/complete/cancel visit.
+- Encounter id required for start/complete encounter.
+- Completed service id and reason required for voiding completed services.
+- Cancellation reason required for visit cancellation.
+- Service name required for completed service recording.
+- Quantity must be greater than zero when supplied.
+- Unit price and total amount cannot be negative when supplied.
+- Metadata must be a JSON object, not null, primitive, or array.
+
+### Client interface
+
+`EncounterVisitRpcClient` exposes exactly these methods:
+
+- `checkInPatientVisit`
+- `startPatientVisit`
+- `completePatientVisit`
+- `cancelPatientVisit`
+- `createClinicalEncounter`
+- `startClinicalEncounter`
+- `completeClinicalEncounter`
+- `recordCompletedService`
+- `voidCompletedService`
+
+The interface intentionally does not expose direct table insert/update/delete operations.
+
+### Supabase implementation
+
+`SupabaseEncounterVisitRpcClient` uses `client.rpc(...)` only. It does not call `client.from(...)` for writes and does not build raw SQL strings. Each method validates inputs, calls one PostgreSQL RPC by name, throws returned Supabase errors, extracts a single returned row, and maps it into the corresponding domain type.
+
+### Mapper reuse/export
+
+The implementation reuses existing mappers exported by `EncounterVisitRepository.ts`:
+
+- `mapPatientVisitRow`
+- `mapClinicalEncounterRow`
+- `mapCompletedServiceRow`
+
+This keeps row-to-domain mapping in one place and avoids duplicate snake_case/camelCase mapping logic.
+
+### Factory
+
+`createEncounterVisitRpcClient(...)` supports:
+
+- `backend: 'supabase'` returning a `SupabaseEncounterVisitRpcClient`.
+- `backend: 'local'` rejected with `Encounter/visit RPC client requires Supabase backend.`
+
+The factory accepts an injected Supabase client for tests and falls back to the shared frontend Supabase client when configured.
+
+## RPC mapping
+
+All 9 client methods map to controlled PostgreSQL RPCs:
+
+| Client method | PostgreSQL RPC | Key parameter mapping |
+|---|---|---|
+| `checkInPatientVisit` | `check_in_patient_visit` | `tenantId -> p_tenant_id`, `patientId -> p_patient_id`, `appointmentId -> p_appointment_id`, `visitType -> p_visit_type`, `arrivedAt -> p_arrived_at`, `notes -> p_notes`, `metadata -> p_metadata` |
+| `startPatientVisit` | `start_patient_visit` | `tenantId -> p_tenant_id`, `visitId -> p_visit_id`, `metadata -> p_metadata` |
+| `completePatientVisit` | `complete_patient_visit` | `tenantId -> p_tenant_id`, `visitId -> p_visit_id`, `metadata -> p_metadata` |
+| `cancelPatientVisit` | `cancel_patient_visit` | `tenantId -> p_tenant_id`, `visitId -> p_visit_id`, `reason -> p_reason`, `metadata -> p_metadata` |
+| `createClinicalEncounter` | `create_clinical_encounter` | `tenantId -> p_tenant_id`, `patientId -> p_patient_id`, `visitId -> p_visit_id`, `appointmentId -> p_appointment_id`, `doctorUserId -> p_doctor_user_id`, `encounterType -> p_encounter_type`, `chiefComplaintSnapshot -> p_chief_complaint_snapshot`, `clinicalSummary -> p_clinical_summary`, `metadata -> p_metadata` |
+| `startClinicalEncounter` | `start_clinical_encounter` | `tenantId -> p_tenant_id`, `encounterId -> p_encounter_id`, `metadata -> p_metadata` |
+| `completeClinicalEncounter` | `complete_clinical_encounter` | `tenantId -> p_tenant_id`, `encounterId -> p_encounter_id`, `clinicalSummary -> p_clinical_summary`, `metadata -> p_metadata` |
+| `recordCompletedService` | `record_completed_service` | `tenantId -> p_tenant_id`, `patientId -> p_patient_id`, `visitId -> p_visit_id`, `encounterId -> p_encounter_id`, `appointmentId -> p_appointment_id`, `findingId -> p_finding_id`, `treatmentPlanId -> p_treatment_plan_id`, `treatmentStageId -> p_treatment_stage_id`, `clinicalDictionaryItemId -> p_clinical_dictionary_item_id`, `serviceCode -> p_service_code`, `serviceName -> p_service_name`, `toothNumber -> p_tooth_number`, `toothSurface -> p_tooth_surface`, `quantity -> p_quantity`, `unitPrice -> p_unit_price`, `totalAmount -> p_total_amount`, `currency -> p_currency`, `performedAt -> p_performed_at`, `metadata -> p_metadata` |
+| `voidCompletedService` | `void_completed_service` | `tenantId -> p_tenant_id`, `completedServiceId -> p_completed_service_id`, `reason -> p_reason`, `metadata -> p_metadata` |
+
+Default parameter behavior:
+
+- `visitType` defaults to `regular`.
+- `encounterType` defaults to `consultation`.
+- `quantity` defaults to `1`.
+- `currency` defaults to `KZT`.
+- Optional ids/text timestamps are sent as `null` when omitted.
+- Metadata defaults to `{}` when omitted.
+
+## Domain boundary
+
+This client preserves the encounter/visit domain boundaries:
+
+- Appointment is scheduling/booking context. It is not a visit and not proof of completed clinical treatment.
+- Patient visit is an actual attendance instance.
+- Clinical encounter is the documented clinical session or doctor interaction.
+- Completed service is the performed clinical/billable service fact.
+- Completed service is not a treatment plan or treatment stage; plan/stage ids are references to intended work only.
+- Payment is a future financial fact and is not proof that treatment occurred.
+- The client wrapper is not the source of truth. Database RPCs remain the controlled write boundary and are responsible for durable state changes, authorization/RLS interaction, audit/activity emission, and transactional integrity.
+
+## Safety boundary
+
+This task intentionally keeps the client narrow:
+
+- No direct table writes.
+- No direct `insert`, `update`, `delete`, or `upsert` repository methods.
+- No `service_role` usage in frontend code.
+- No localStorage fallback.
+- No fake clinical history.
+- No UI.
+- No hooks.
+- No PatientCardPage changes.
+- No PatientTimelineAggregator changes.
+- No timeline integration.
+- No Supabase cloud access.
+- No browser smoke.
+- No migration changes.
+- No seed/backfill changes.
+- No payment, stock, or document work.
+
+The frontend client delegates all state-changing behavior to the existing database RPC layer and surfaces errors rather than silently falling back.
+
+## Tests
+
+Test file:
+
+- `src/data/repositories/EncounterVisitRpcClient.test.ts`
+
+Scenarios covered:
+
+- All 9 methods require `tenantId`.
+- `checkInPatientVisit` requires `patientId`.
+- Visit start/complete/cancel methods require `visitId`.
+- `cancelPatientVisit` requires a reason.
+- `createClinicalEncounter` requires `patientId`.
+- Encounter start/complete methods require `encounterId`.
+- `recordCompletedService` requires `patientId` and `serviceName`.
+- `recordCompletedService` rejects non-positive quantity.
+- `recordCompletedService` rejects negative `unitPrice` and `totalAmount`.
+- `voidCompletedService` requires `completedServiceId` and reason.
+- Metadata rejects null, primitive, and array values.
+- Every client method calls the expected RPC name.
+- Every client method maps camelCase inputs to expected `p_*` parameters.
+- Default values are applied for completed service quantity/currency.
+- Patient visit, clinical encounter, and completed service responses map back to camelCase domain objects.
+- Supabase RPC errors are surfaced.
+- Empty/null RPC responses throw a clear error.
+- Direct table write use is not part of the client wrapper behavior.
+- Factory rejects `local` backend.
+- Factory requires a configured Supabase client.
+
+Targeted implementation validation covered 36 new unit tests in the RPC client test file.
+
+## What was intentionally NOT changed
+
+- No migrations.
+- No Supabase cloud.
+- No local Supabase validation or local database changes.
+- No browser smoke.
+- No UI.
+- No hooks.
+- No PatientCardPage changes.
+- No PatientTimelineAggregator changes.
+- No timeline integration.
+- No payments.
+- No stock.
+- No documents.
+- No seed changes.
+- No backfill.
+- No localStorage fallback.
+- No direct table write path.
+
+## Checks
+
+| Check | Result |
 |---|---|
+| `git status --short` | clean before report-only update |
 | `npm run lint` | PASS |
 | `npm run test -- --run` | PASS (49 files / 468 tests) |
 | `npm run build` | PASS |
+| GitHub Actions CI | PASS |
 
-Note: The 36 new unit tests cover all validation scenarios, RPC name mapping, parameter mapping, response mappers, error surfacing, empty database results, and security/safety assertions.
+## GitHub Actions CI
 
-## GitHub Actions CI after validation report push
-
-GitHub Actions CI run completed successfully.
+GitHub Actions CI run completed successfully for the reviewed PR head.
 
 | Field | Value |
 |---|---|

--- a/src/data/repositories/EncounterVisitRpcClient.test.ts
+++ b/src/data/repositories/EncounterVisitRpcClient.test.ts
@@ -1,0 +1,568 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
+import {
+  createEncounterVisitRpcClient,
+  SupabaseEncounterVisitRpcClient,
+  type CheckInPatientVisitInput,
+  type StartPatientVisitInput,
+  type CompletePatientVisitInput,
+  type CancelPatientVisitInput,
+  type CreateClinicalEncounterInput,
+  type StartClinicalEncounterInput,
+  type CompleteClinicalEncounterInput,
+  type RecordCompletedServiceInput,
+  type VoidCompletedServiceInput,
+} from './EncounterVisitRpcClient';
+
+// Helper mock creation function
+function createClientMock(rpcResult: { data: unknown; error: PostgrestError | Error | null }) {
+  const rpcCalls: { rpcName: string; params: unknown }[] = [];
+  const client = {
+    rpc: vi.fn(async (rpcName: string, params: unknown) => {
+      rpcCalls.push({ rpcName, params });
+      return rpcResult;
+    }),
+    from: vi.fn((...args: unknown[]) => {
+      void args;
+      throw new Error('Direct table writes are forbidden');
+    }),
+  };
+  const rpcClient = new SupabaseEncounterVisitRpcClient(client as unknown as SupabaseClient);
+  return { rpcClient, client, rpcCalls };
+}
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const patientId = '22222222-2222-2222-2222-222222222222';
+const visitId = '33333333-3333-3333-3333-333333333333';
+const encounterId = '44444444-4444-4444-4444-444444444444';
+const serviceId = '55555555-5555-5555-5555-555555555555';
+
+// Sample mock db response rows
+const dbVisitRow = {
+  id: visitId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  appointment_id: 'app-1',
+  status: 'checked_in',
+  visit_type: 'regular',
+  arrived_at: '2026-06-20T00:00:00Z',
+  created_at: '2026-06-20T00:00:01Z',
+  updated_at: '2026-06-20T00:00:02Z',
+  metadata: { smoke: true },
+};
+
+const dbEncounterRow = {
+  id: encounterId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  visit_id: visitId,
+  status: 'draft',
+  encounter_type: 'consultation',
+  created_at: '2026-06-20T00:00:01Z',
+  updated_at: '2026-06-20T00:00:02Z',
+  metadata: {},
+};
+
+const dbServiceRow = {
+  id: serviceId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  service_name: 'Consultation Checkup',
+  quantity: 1,
+  currency: 'KZT',
+  status: 'completed',
+  performed_at: '2026-06-20T00:00:00Z',
+  created_at: '2026-06-20T00:00:01Z',
+  updated_at: '2026-06-20T00:00:02Z',
+  metadata: {},
+};
+
+describe('EncounterVisitRpcClient Validation & Parameter Mapping', () => {
+  describe('Validation - tenantId requirement', () => {
+    const invalidInputs = [
+      { tenantId: '' },
+      { tenantId: '   ' },
+      { tenantId: undefined as unknown as string },
+      { tenantId: null as unknown as string },
+    ];
+
+    it('requires tenantId for checkInPatientVisit', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.checkInPatientVisit({ ...input, patientId } as unknown as CheckInPatientVisitInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for startPatientVisit', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.startPatientVisit({ ...input, visitId } as unknown as StartPatientVisitInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for completePatientVisit', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.completePatientVisit({ ...input, visitId } as unknown as CompletePatientVisitInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for cancelPatientVisit', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.cancelPatientVisit({ ...input, visitId, reason: 'cancel' } as unknown as CancelPatientVisitInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for createClinicalEncounter', async () => {
+      const { rpcClient } = createClientMock({ data: dbEncounterRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.createClinicalEncounter({ ...input, patientId } as unknown as CreateClinicalEncounterInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for startClinicalEncounter', async () => {
+      const { rpcClient } = createClientMock({ data: dbEncounterRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.startClinicalEncounter({ ...input, encounterId } as unknown as StartClinicalEncounterInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for completeClinicalEncounter', async () => {
+      const { rpcClient } = createClientMock({ data: dbEncounterRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.completeClinicalEncounter({ ...input, encounterId } as unknown as CompleteClinicalEncounterInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for recordCompletedService', async () => {
+      const { rpcClient } = createClientMock({ data: dbServiceRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.recordCompletedService({ ...input, patientId, serviceName: 'Test' } as unknown as RecordCompletedServiceInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+
+    it('requires tenantId for voidCompletedService', async () => {
+      const { rpcClient } = createClientMock({ data: dbServiceRow, error: null });
+      for (const input of invalidInputs) {
+        await expect(rpcClient.voidCompletedService({ ...input, completedServiceId: serviceId, reason: 'void' } as unknown as VoidCompletedServiceInput))
+          .rejects.toThrow('Active clinic is required for encounter/visit writes.');
+      }
+    });
+  });
+
+  describe('Validation - other required parameters', () => {
+    it('checkInPatientVisit requires patientId', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      await expect(rpcClient.checkInPatientVisit({ tenantId, patientId: '' } as unknown as CheckInPatientVisitInput))
+        .rejects.toThrow('Patient is required to check in a visit.');
+      await expect(rpcClient.checkInPatientVisit({ tenantId, patientId: '   ' } as unknown as CheckInPatientVisitInput))
+        .rejects.toThrow('Patient is required to check in a visit.');
+    });
+
+    it('start/complete/cancel visit require visitId', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      await expect(rpcClient.startPatientVisit({ tenantId, visitId: '' }))
+        .rejects.toThrow('Visit id is required.');
+      await expect(rpcClient.completePatientVisit({ tenantId, visitId: '  ' }))
+        .rejects.toThrow('Visit id is required.');
+      await expect(rpcClient.cancelPatientVisit({ tenantId, visitId: '', reason: 'Cancel' }))
+        .rejects.toThrow('Visit id is required.');
+    });
+
+    it('cancelPatientVisit requires reason', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      await expect(rpcClient.cancelPatientVisit({ tenantId, visitId, reason: '' }))
+        .rejects.toThrow('Cancellation reason is required.');
+      await expect(rpcClient.cancelPatientVisit({ tenantId, visitId, reason: '  ' }))
+        .rejects.toThrow('Cancellation reason is required.');
+    });
+
+    it('createClinicalEncounter requires patientId', async () => {
+      const { rpcClient } = createClientMock({ data: dbEncounterRow, error: null });
+      await expect(rpcClient.createClinicalEncounter({ tenantId, patientId: '' }))
+        .rejects.toThrow('Patient is required to create a clinical encounter.');
+    });
+
+    it('start/complete encounter require encounterId', async () => {
+      const { rpcClient } = createClientMock({ data: dbEncounterRow, error: null });
+      await expect(rpcClient.startClinicalEncounter({ tenantId, encounterId: '' }))
+        .rejects.toThrow('Encounter id is required.');
+      await expect(rpcClient.completeClinicalEncounter({ tenantId, encounterId: '  ' }))
+        .rejects.toThrow('Encounter id is required.');
+    });
+
+    it('recordCompletedService requires patientId and serviceName', async () => {
+      const { rpcClient } = createClientMock({ data: dbServiceRow, error: null });
+      await expect(rpcClient.recordCompletedService({ tenantId, patientId: '', serviceName: 'Test' }))
+        .rejects.toThrow('Patient is required to record a completed service.');
+      await expect(rpcClient.recordCompletedService({ tenantId, patientId, serviceName: '' }))
+        .rejects.toThrow('Service name is required.');
+    });
+
+    it('recordCompletedService validates quantity, unitPrice and totalAmount', async () => {
+      const { rpcClient } = createClientMock({ data: dbServiceRow, error: null });
+      await expect(rpcClient.recordCompletedService({ tenantId, patientId, serviceName: 'Test', quantity: 0 }))
+        .rejects.toThrow('Service quantity must be greater than 0.');
+      await expect(rpcClient.recordCompletedService({ tenantId, patientId, serviceName: 'Test', quantity: -5 }))
+        .rejects.toThrow('Service quantity must be greater than 0.');
+      await expect(rpcClient.recordCompletedService({ tenantId, patientId, serviceName: 'Test', unitPrice: -10 }))
+        .rejects.toThrow('Service amount cannot be negative.');
+      await expect(rpcClient.recordCompletedService({ tenantId, patientId, serviceName: 'Test', totalAmount: -10 }))
+        .rejects.toThrow('Service amount cannot be negative.');
+    });
+
+    it('voidCompletedService requires completedServiceId and reason', async () => {
+      const { rpcClient } = createClientMock({ data: dbServiceRow, error: null });
+      await expect(rpcClient.voidCompletedService({ tenantId, completedServiceId: '', reason: 'Void' }))
+        .rejects.toThrow('Completed service id is required.');
+      await expect(rpcClient.voidCompletedService({ tenantId, completedServiceId: serviceId, reason: '' }))
+        .rejects.toThrow('Void reason is required.');
+    });
+
+    it('rejects invalid metadata types', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      const invalidMetadatas = [
+        null,
+        'string',
+        123,
+        [1, 2, 3],
+      ];
+      for (const meta of invalidMetadatas) {
+        await expect(rpcClient.checkInPatientVisit({ tenantId, patientId, metadata: meta as unknown as Record<string, unknown> }))
+          .rejects.toThrow('RPC metadata must be a JSON object.');
+      }
+    });
+  });
+
+  describe('RPC Name and Parameter Mapping', () => {
+    it('checkInPatientVisit maps to check_in_patient_visit', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbVisitRow], error: null });
+      const input = {
+        tenantId,
+        patientId,
+        appointmentId: 'app-id',
+        visitType: 'consultation' as const,
+        arrivedAt: '2026-06-20T00:00:00Z',
+        notes: 'Visit notes',
+        metadata: { key: 'value' },
+      };
+      await rpcClient.checkInPatientVisit(input);
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('check_in_patient_visit');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_patient_id: patientId,
+        p_appointment_id: 'app-id',
+        p_visit_type: 'consultation',
+        p_arrived_at: '2026-06-20T00:00:00Z',
+        p_notes: 'Visit notes',
+        p_metadata: { key: 'value' },
+      });
+    });
+
+    it('startPatientVisit maps to start_patient_visit', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbVisitRow], error: null });
+      await rpcClient.startPatientVisit({ tenantId, visitId, metadata: { smoke: true } });
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('start_patient_visit');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_visit_id: visitId,
+        p_metadata: { smoke: true },
+      });
+    });
+
+    it('completePatientVisit maps to complete_patient_visit', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbVisitRow], error: null });
+      await rpcClient.completePatientVisit({ tenantId, visitId });
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('complete_patient_visit');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_visit_id: visitId,
+        p_metadata: {},
+      });
+    });
+
+    it('cancelPatientVisit maps to cancel_patient_visit', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbVisitRow], error: null });
+      await rpcClient.cancelPatientVisit({ tenantId, visitId, reason: 'Patient cancelled' });
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('cancel_patient_visit');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_visit_id: visitId,
+        p_reason: 'Patient cancelled',
+        p_metadata: {},
+      });
+    });
+
+    it('createClinicalEncounter maps to create_clinical_encounter', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbEncounterRow], error: null });
+      const input = {
+        tenantId,
+        patientId,
+        visitId,
+        appointmentId: 'app-id',
+        doctorUserId: 'doc-id',
+        encounterType: 'treatment' as const,
+        chiefComplaintSnapshot: 'Pain in tooth',
+        clinicalSummary: 'Treated cavity',
+        metadata: { clinical: true },
+      };
+      await rpcClient.createClinicalEncounter(input);
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('create_clinical_encounter');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_patient_id: patientId,
+        p_visit_id: visitId,
+        p_appointment_id: 'app-id',
+        p_doctor_user_id: 'doc-id',
+        p_encounter_type: 'treatment',
+        p_chief_complaint_snapshot: 'Pain in tooth',
+        p_clinical_summary: 'Treated cavity',
+        p_metadata: { clinical: true },
+      });
+    });
+
+    it('startClinicalEncounter maps to start_clinical_encounter', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbEncounterRow], error: null });
+      await rpcClient.startClinicalEncounter({ tenantId, encounterId });
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('start_clinical_encounter');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_encounter_id: encounterId,
+        p_metadata: {},
+      });
+    });
+
+    it('completeClinicalEncounter maps to complete_clinical_encounter', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbEncounterRow], error: null });
+      await rpcClient.completeClinicalEncounter({ tenantId, encounterId, clinicalSummary: 'Finished session' });
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('complete_clinical_encounter');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_encounter_id: encounterId,
+        p_clinical_summary: 'Finished session',
+        p_metadata: {},
+      });
+    });
+
+    it('recordCompletedService maps to record_completed_service', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbServiceRow], error: null });
+      const input = {
+        tenantId,
+        patientId,
+        visitId,
+        encounterId,
+        appointmentId: 'app-id',
+        findingId: 'finding-id',
+        treatmentPlanId: 'plan-id',
+        treatmentStageId: 'stage-id',
+        clinicalDictionaryItemId: 'dict-item-id',
+        serviceCode: 'S-001',
+        serviceName: 'Consultation Checkup',
+        toothNumber: '18',
+        toothSurface: 'O',
+        quantity: 2,
+        unitPrice: 5000,
+        totalAmount: 10000,
+        currency: 'KZT',
+        performedAt: '2026-06-20T00:00:00Z',
+        metadata: { price: 5000 },
+      };
+      await rpcClient.recordCompletedService(input);
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('record_completed_service');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_patient_id: patientId,
+        p_visit_id: visitId,
+        p_encounter_id: encounterId,
+        p_appointment_id: 'app-id',
+        p_finding_id: 'finding-id',
+        p_treatment_plan_id: 'plan-id',
+        p_treatment_stage_id: 'stage-id',
+        p_clinical_dictionary_item_id: 'dict-item-id',
+        p_service_code: 'S-001',
+        p_service_name: 'Consultation Checkup',
+        p_tooth_number: '18',
+        p_tooth_surface: 'O',
+        p_quantity: 2,
+        p_unit_price: 5000,
+        p_total_amount: 10000,
+        p_currency: 'KZT',
+        p_performed_at: '2026-06-20T00:00:00Z',
+        p_metadata: { price: 5000 },
+      });
+    });
+
+    it('recordCompletedService applies quantity, currency defaults', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbServiceRow], error: null });
+      await rpcClient.recordCompletedService({ tenantId, patientId, serviceName: 'Tooth Fill' });
+      expect(rpcCalls).toHaveLength(1);
+      expect((rpcCalls[0].params as Record<string, unknown>).p_quantity).toBe(1);
+      expect((rpcCalls[0].params as Record<string, unknown>).p_currency).toBe('KZT');
+    });
+
+    it('voidCompletedService maps to void_completed_service', async () => {
+      const { rpcClient, rpcCalls } = createClientMock({ data: [dbServiceRow], error: null });
+      await rpcClient.voidCompletedService({ tenantId, completedServiceId: serviceId, reason: 'Incorrect entry' });
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0].rpcName).toBe('void_completed_service');
+      expect(rpcCalls[0].params as Record<string, unknown>).toEqual({
+        p_tenant_id: tenantId,
+        p_completed_service_id: serviceId,
+        p_reason: 'Incorrect entry',
+        p_metadata: {},
+      });
+    });
+  });
+
+  describe('Response and Error Mapping', () => {
+    it('maps db patient visit row to PatientVisit camelCase object', async () => {
+      const { rpcClient } = createClientMock({ data: dbVisitRow, error: null });
+      const result = await rpcClient.completePatientVisit({ tenantId, visitId });
+      expect(result).toEqual({
+        id: visitId,
+        tenantId,
+        patientId,
+        appointmentId: 'app-1',
+        status: 'checked_in',
+        visitType: 'regular',
+        arrivedAt: '2026-06-20T00:00:00Z',
+        checkedInAt: null,
+        startedAt: null,
+        completedAt: null,
+        cancelledAt: null,
+        archivedAt: null,
+        createdBy: null,
+        updatedBy: null,
+        archivedBy: null,
+        notes: null,
+        metadata: { smoke: true },
+        createdAt: '2026-06-20T00:00:01Z',
+        updatedAt: '2026-06-20T00:00:02Z',
+      });
+    });
+
+    it('maps db clinical encounter row to ClinicalEncounter camelCase object', async () => {
+      const { rpcClient } = createClientMock({ data: [dbEncounterRow], error: null });
+      const result = await rpcClient.startClinicalEncounter({ tenantId, encounterId });
+      expect(result).toEqual({
+        id: encounterId,
+        tenantId,
+        patientId,
+        visitId,
+        appointmentId: null,
+        doctorUserId: null,
+        status: 'draft',
+        encounterType: 'consultation',
+        startedAt: null,
+        completedAt: null,
+        lockedAt: null,
+        archivedAt: null,
+        createdBy: null,
+        updatedBy: null,
+        lockedBy: null,
+        archivedBy: null,
+        chiefComplaintSnapshot: null,
+        clinicalSummary: null,
+        correctionReason: null,
+        metadata: {},
+        createdAt: '2026-06-20T00:00:01Z',
+        updatedAt: '2026-06-20T00:00:02Z',
+      });
+    });
+
+    it('maps db completed service row to CompletedService camelCase object', async () => {
+      const { rpcClient } = createClientMock({ data: dbServiceRow, error: null });
+      const result = await rpcClient.voidCompletedService({ tenantId, completedServiceId: serviceId, reason: 'Duplicate' });
+      expect(result).toEqual({
+        id: serviceId,
+        tenantId,
+        patientId,
+        visitId: null,
+        encounterId: null,
+        appointmentId: null,
+        findingId: null,
+        treatmentPlanId: null,
+        treatmentStageId: null,
+        clinicalDictionaryItemId: null,
+        serviceCode: null,
+        serviceName: 'Consultation Checkup',
+        toothNumber: null,
+        toothSurface: null,
+        quantity: 1,
+        unitPrice: null,
+        totalAmount: null,
+        currency: 'KZT',
+        performedBy: null,
+        performedAt: '2026-06-20T00:00:00Z',
+        status: 'completed',
+        correctionOfId: null,
+        correctionReason: null,
+        voidedAt: null,
+        voidedBy: null,
+        archivedAt: null,
+        archivedBy: null,
+        createdBy: null,
+        updatedBy: null,
+        metadata: {},
+        createdAt: '2026-06-20T00:00:01Z',
+        updatedAt: '2026-06-20T00:00:02Z',
+      });
+    });
+
+    it('surfaces Supabase RPC errors directly', async () => {
+      const dbError = new Error('Database level validation failed');
+      const { rpcClient } = createClientMock({ data: null, error: dbError });
+      await expect(rpcClient.completePatientVisit({ tenantId, visitId }))
+        .rejects.toThrow('Database level validation failed');
+    });
+
+    it('throws clear error when response is null or empty', async () => {
+      const { rpcClient } = createClientMock({ data: null, error: null });
+      await expect(rpcClient.completePatientVisit({ tenantId, visitId }))
+        .rejects.toThrow('Received empty or null response from database RPC.');
+
+      const { rpcClient: rpcClientEmptyArray } = createClientMock({ data: [], error: null });
+      await expect(rpcClientEmptyArray.completePatientVisit({ tenantId, visitId }))
+        .rejects.toThrow('Received empty or null response from database RPC.');
+    });
+  });
+
+  describe('Safety & Factory constraints', () => {
+    it('throws if trying to make direct database write from the client wrapper', async () => {
+      const { client } = createClientMock({ data: [dbVisitRow], error: null });
+      expect(() => client.from('patient_visits')).toThrow('Direct table writes are forbidden');
+    });
+
+    it('factory rejects local backend option', () => {
+      expect(() => createEncounterVisitRpcClient({ backend: 'local' }))
+        .toThrow('Encounter/visit RPC client requires Supabase backend.');
+    });
+
+    it('factory requires supabase client when configured', () => {
+      const testCall = () => {
+        createEncounterVisitRpcClient({
+          backend: 'supabase',
+          client: null as unknown as SupabaseClient,
+        });
+      };
+      expect(testCall).toThrow('Supabase client is not configured for encounter/visit RPC access.');
+    });
+  });
+});

--- a/src/data/repositories/EncounterVisitRpcClient.ts
+++ b/src/data/repositories/EncounterVisitRpcClient.ts
@@ -1,0 +1,347 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase as defaultSupabase } from '../../lib/supabaseClient';
+import {
+  mapPatientVisitRow,
+  mapClinicalEncounterRow,
+  mapCompletedServiceRow,
+  type PatientVisit,
+  type ClinicalEncounter,
+  type CompletedService,
+  type PatientVisitType,
+  type ClinicalEncounterType,
+} from './EncounterVisitRepository';
+
+export interface CheckInPatientVisitInput {
+  tenantId: string;
+  patientId: string;
+  appointmentId?: string | null;
+  visitType?: PatientVisitType;
+  arrivedAt?: string | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StartPatientVisitInput {
+  tenantId: string;
+  visitId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CompletePatientVisitInput {
+  tenantId: string;
+  visitId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CancelPatientVisitInput {
+  tenantId: string;
+  visitId: string;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateClinicalEncounterInput {
+  tenantId: string;
+  patientId: string;
+  visitId?: string | null;
+  appointmentId?: string | null;
+  doctorUserId?: string | null;
+  encounterType?: ClinicalEncounterType;
+  chiefComplaintSnapshot?: string | null;
+  clinicalSummary?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StartClinicalEncounterInput {
+  tenantId: string;
+  encounterId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CompleteClinicalEncounterInput {
+  tenantId: string;
+  encounterId: string;
+  clinicalSummary?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecordCompletedServiceInput {
+  tenantId: string;
+  patientId: string;
+  visitId?: string | null;
+  encounterId?: string | null;
+  appointmentId?: string | null;
+  findingId?: string | null;
+  treatmentPlanId?: string | null;
+  treatmentStageId?: string | null;
+  clinicalDictionaryItemId?: string | null;
+  serviceCode?: string | null;
+  serviceName: string;
+  toothNumber?: string | null;
+  toothSurface?: string | null;
+  quantity?: number;
+  unitPrice?: number | null;
+  totalAmount?: number | null;
+  currency?: string;
+  performedAt?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VoidCompletedServiceInput {
+  tenantId: string;
+  completedServiceId: string;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EncounterVisitRpcClient {
+  checkInPatientVisit(input: CheckInPatientVisitInput): Promise<PatientVisit>;
+  startPatientVisit(input: StartPatientVisitInput): Promise<PatientVisit>;
+  completePatientVisit(input: CompletePatientVisitInput): Promise<PatientVisit>;
+  cancelPatientVisit(input: CancelPatientVisitInput): Promise<PatientVisit>;
+
+  createClinicalEncounter(input: CreateClinicalEncounterInput): Promise<ClinicalEncounter>;
+  startClinicalEncounter(input: StartClinicalEncounterInput): Promise<ClinicalEncounter>;
+  completeClinicalEncounter(input: CompleteClinicalEncounterInput): Promise<ClinicalEncounter>;
+
+  recordCompletedService(input: RecordCompletedServiceInput): Promise<CompletedService>;
+  voidCompletedService(input: VoidCompletedServiceInput): Promise<CompletedService>;
+}
+
+export type EncounterVisitRpcClientBackend = 'supabase' | 'local';
+
+export interface CreateEncounterVisitRpcClientOptions {
+  backend: EncounterVisitRpcClientBackend;
+  client?: SupabaseClient;
+}
+
+function requireTenantId(tenantId: string | null | undefined): string {
+  if (!tenantId || tenantId.trim().length === 0) {
+    throw new Error('Active clinic is required for encounter/visit writes.');
+  }
+  return tenantId;
+}
+
+function requireNonEmptyString(value: string | null | undefined, errorMessage: string): string {
+  if (!value || value.trim().length === 0) {
+    throw new Error(errorMessage);
+  }
+  return value;
+}
+
+function validateMetadata(metadata?: Record<string, unknown> | null) {
+  if (metadata !== undefined) {
+    if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      throw new Error('RPC metadata must be a JSON object.');
+    }
+  }
+}
+
+function extractSingleRow(data: unknown): Record<string, unknown> {
+  if (!data) {
+    throw new Error('Received empty or null response from database RPC.');
+  }
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) {
+    throw new Error('Received empty or null response from database RPC.');
+  }
+  return row as Record<string, unknown>;
+}
+
+export class SupabaseEncounterVisitRpcClient implements EncounterVisitRpcClient {
+  private readonly client: SupabaseClient;
+
+  constructor(client: SupabaseClient) {
+    this.client = client;
+  }
+
+  async checkInPatientVisit(input: CheckInPatientVisitInput): Promise<PatientVisit> {
+    const tenantId = requireTenantId(input.tenantId);
+    const patientId = requireNonEmptyString(input.patientId, 'Patient is required to check in a visit.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('check_in_patient_visit', {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_appointment_id: input.appointmentId || null,
+      p_visit_type: input.visitType || 'regular',
+      p_arrived_at: input.arrivedAt || null,
+      p_notes: input.notes || null,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapPatientVisitRow(extractSingleRow(data));
+  }
+
+  async startPatientVisit(input: StartPatientVisitInput): Promise<PatientVisit> {
+    const tenantId = requireTenantId(input.tenantId);
+    const visitId = requireNonEmptyString(input.visitId, 'Visit id is required.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('start_patient_visit', {
+      p_tenant_id: tenantId,
+      p_visit_id: visitId,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapPatientVisitRow(extractSingleRow(data));
+  }
+
+  async completePatientVisit(input: CompletePatientVisitInput): Promise<PatientVisit> {
+    const tenantId = requireTenantId(input.tenantId);
+    const visitId = requireNonEmptyString(input.visitId, 'Visit id is required.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('complete_patient_visit', {
+      p_tenant_id: tenantId,
+      p_visit_id: visitId,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapPatientVisitRow(extractSingleRow(data));
+  }
+
+  async cancelPatientVisit(input: CancelPatientVisitInput): Promise<PatientVisit> {
+    const tenantId = requireTenantId(input.tenantId);
+    const visitId = requireNonEmptyString(input.visitId, 'Visit id is required.');
+    const reason = requireNonEmptyString(input.reason, 'Cancellation reason is required.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('cancel_patient_visit', {
+      p_tenant_id: tenantId,
+      p_visit_id: visitId,
+      p_reason: reason,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapPatientVisitRow(extractSingleRow(data));
+  }
+
+  async createClinicalEncounter(input: CreateClinicalEncounterInput): Promise<ClinicalEncounter> {
+    const tenantId = requireTenantId(input.tenantId);
+    const patientId = requireNonEmptyString(input.patientId, 'Patient is required to create a clinical encounter.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('create_clinical_encounter', {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_visit_id: input.visitId || null,
+      p_appointment_id: input.appointmentId || null,
+      p_doctor_user_id: input.doctorUserId || null,
+      p_encounter_type: input.encounterType || 'consultation',
+      p_chief_complaint_snapshot: input.chiefComplaintSnapshot || null,
+      p_clinical_summary: input.clinicalSummary || null,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapClinicalEncounterRow(extractSingleRow(data));
+  }
+
+  async startClinicalEncounter(input: StartClinicalEncounterInput): Promise<ClinicalEncounter> {
+    const tenantId = requireTenantId(input.tenantId);
+    const encounterId = requireNonEmptyString(input.encounterId, 'Encounter id is required.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('start_clinical_encounter', {
+      p_tenant_id: tenantId,
+      p_encounter_id: encounterId,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapClinicalEncounterRow(extractSingleRow(data));
+  }
+
+  async completeClinicalEncounter(input: CompleteClinicalEncounterInput): Promise<ClinicalEncounter> {
+    const tenantId = requireTenantId(input.tenantId);
+    const encounterId = requireNonEmptyString(input.encounterId, 'Encounter id is required.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('complete_clinical_encounter', {
+      p_tenant_id: tenantId,
+      p_encounter_id: encounterId,
+      p_clinical_summary: input.clinicalSummary || null,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapClinicalEncounterRow(extractSingleRow(data));
+  }
+
+  async recordCompletedService(input: RecordCompletedServiceInput): Promise<CompletedService> {
+    const tenantId = requireTenantId(input.tenantId);
+    const patientId = requireNonEmptyString(input.patientId, 'Patient is required to record a completed service.');
+    const serviceName = requireNonEmptyString(input.serviceName, 'Service name is required.');
+    
+    if (input.quantity !== undefined && input.quantity !== null && input.quantity <= 0) {
+      throw new Error('Service quantity must be greater than 0.');
+    }
+    if (input.unitPrice !== undefined && input.unitPrice !== null && input.unitPrice < 0) {
+      throw new Error('Service amount cannot be negative.');
+    }
+    if (input.totalAmount !== undefined && input.totalAmount !== null && input.totalAmount < 0) {
+      throw new Error('Service amount cannot be negative.');
+    }
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('record_completed_service', {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_visit_id: input.visitId || null,
+      p_encounter_id: input.encounterId || null,
+      p_appointment_id: input.appointmentId || null,
+      p_finding_id: input.findingId || null,
+      p_treatment_plan_id: input.treatmentPlanId || null,
+      p_treatment_stage_id: input.treatmentStageId || null,
+      p_clinical_dictionary_item_id: input.clinicalDictionaryItemId || null,
+      p_service_code: input.serviceCode || null,
+      p_service_name: serviceName,
+      p_tooth_number: input.toothNumber || null,
+      p_tooth_surface: input.toothSurface || null,
+      p_quantity: input.quantity !== undefined && input.quantity !== null ? input.quantity : 1,
+      p_unit_price: input.unitPrice !== undefined ? input.unitPrice : null,
+      p_total_amount: input.totalAmount !== undefined ? input.totalAmount : null,
+      p_currency: input.currency || 'KZT',
+      p_performed_at: input.performedAt || null,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapCompletedServiceRow(extractSingleRow(data));
+  }
+
+  async voidCompletedService(input: VoidCompletedServiceInput): Promise<CompletedService> {
+    const tenantId = requireTenantId(input.tenantId);
+    const completedServiceId = requireNonEmptyString(input.completedServiceId, 'Completed service id is required.');
+    const reason = requireNonEmptyString(input.reason, 'Void reason is required.');
+    validateMetadata(input.metadata);
+
+    const { data, error } = await this.client.rpc('void_completed_service', {
+      p_tenant_id: tenantId,
+      p_completed_service_id: completedServiceId,
+      p_reason: reason,
+      p_metadata: input.metadata || {},
+    });
+
+    if (error) throw error;
+    return mapCompletedServiceRow(extractSingleRow(data));
+  }
+}
+
+export function createEncounterVisitRpcClient(options: CreateEncounterVisitRpcClientOptions): EncounterVisitRpcClient {
+  if (options.backend === 'local') {
+    throw new Error('Encounter/visit RPC client requires Supabase backend.');
+  }
+
+  const client = options.client !== undefined ? options.client : defaultSupabase;
+  if (!client) {
+    throw new Error('Supabase client is not configured for encounter/visit RPC access.');
+  }
+
+  return new SupabaseEncounterVisitRpcClient(client as SupabaseClient);
+}


### PR DESCRIPTION
## Summary
- Expanded required RPC client report sections.
- Report-only update; client code, tests, migrations, UI, hooks, cloud, browser smoke, timeline, seed, payments, stock, and documents unchanged.

## Verification
- Fresh CI #568 passed on f8e1050686ce02f26825ad1a409da193cfb6ee2b.
- validate job: ESLint success, tests success, build success.

## Verdict
ENCOUNTER VISIT RPC CLIENT IMPLEMENTED AND VERIFIED