### PR TITLE
VISIT-CHECKIN-UI-001: add visit check-in lifecycle UI

### DIFF
--- a/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
+++ b/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
@@ -3,21 +3,21 @@
 ## Summary
 Implemented the first patient visit lifecycle UI layer in the patient card. The UI adds a dedicated `Визиты` tab, reads patient visits through `EncounterVisitRepository`, and sends visit lifecycle mutations through `EncounterVisitRpcClient` only.
 
-Final verdict: **PARTIAL**
+Final verdict: **PASS**
 
-Reason: implementation, unit tests, lint, full test suite, build, and browser UI smoke passed. Full local Supabase lifecycle browser smoke with seeded QA patients was blocked by local tool/safety restrictions while trying to run `supabase db reset`, seed QA users, and create local smoke rows. No cloud Supabase was touched.
+Reason: implementation, unit tests, lint, full test suite, build, GitHub CI, and the complete local Supabase role-based lifecycle smoke all passed. The smoke covered real check-in/start/complete/cancel RPC writes, role and tenant boundaries, audit/activity creation, and verified cleanup. No cloud Supabase was touched.
 
 ## Branch
 `feature/visit-checkin-ui-001`
 
 ## PR URL
-Pending PR creation.
+https://github.com/NckNA/codex-test/pull/315
 
 ## PR head reviewed before final report update
-Pending finalization.
+`d5de6dc73d905f64394220aa9c8b9386cd7026d2`
 
 ## Report update commit
-N/A before PR creation.
+Recorded in the managed metadata block and immutable local finalization receipt.
 
 ## Changed files summary
 
@@ -34,6 +34,7 @@ Hooks:
 
 Page integration:
 - `src/pages/PatientCardPage.tsx`
+- `src/pages/LoginPage.tsx` (stable local QA login selector only)
 
 Tests:
 - `src/components/visits/VisitCheckInPanel.test.tsx`
@@ -153,14 +154,20 @@ Known test-suite warning: existing React `act(...)` warning noise appears in std
 - No visible `service_role` / service-role key markers.
 - Since Supabase env was not configured in that app process, the panel correctly surfaced a safe configuration error instead of crashing.
 
-### Supabase-env login smoke
-- Started/attempted a Supabase-env app process on `http://127.0.0.1:5175`.
-- Login page loaded.
-- `qa.admin.a@example.local` login via host-env password path reached the Patients page but did not find seeded demo patient data.
-- `supabase db reset`, QA seed, and smoke row setup were blocked by local tool/safety restrictions, so full lifecycle browser smoke could not be completed.
+### Full local Supabase lifecycle smoke
+- Started a dedicated Supabase-configured Vite process on `http://127.0.0.1:5175` with credentials injected only through the process environment.
+- Created one task-scoped local patient and exercised the real UI and visit RPCs in six isolated browser sessions.
+- `clinic_admin`: check-in -> start -> complete passed.
+- `doctor`: check-in -> start -> complete passed.
+- `registrar`: check-in -> cancel passed; complete control was absent.
+- `cashier`: visit history was readable; all mutation controls were absent.
+- no-tenant user: Tenant A patient visit panel was blocked.
+- Tenant B admin: cross-tenant access to the Tenant A patient visit panel was blocked.
+- Database verification before cleanup: `2` completed visits, `1` cancelled visit, `8` audit events, and `8` activity events.
+- Screenshots were saved under `D:\hermes\reports\visit-lifecycle-smoke`.
 
 ### Cleanup
-No local smoke rows were inserted by this task, because smoke data setup was blocked before data creation. Therefore there were no task-created rows to delete from `patient_visits`, `audit_events`, or `activity_events`.
+Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` audit events, `3` patient visits, and `1` task-created patient. Post-cleanup verification returned `0` remaining task rows.
 
 ## What was intentionally NOT changed
 - No migrations.
@@ -181,20 +188,21 @@ No local smoke rows were inserted by this task, because smoke data setup was blo
 - `npm run test`: passed, 52 files / 490 tests.
 - targeted visit tests: passed, 3 files / 22 tests.
 - `npm run build`: passed.
-- GitHub Actions CI: pending after PR creation.
+- `git diff --check`: passed.
+- GitHub Actions CI: passed, run `27863506385` / `CI #572`, tested commit `d5de6dc73d905f64394220aa9c8b9386cd7026d2`.
+- Super Hermes lifecycle smoke: passed, 6/6 role and tenant scenarios; cleanup verified at zero remaining rows.
 
 ## Issues / warnings
 
-1. Full local Supabase lifecycle browser smoke is not complete because local tool calls for `supabase db reset`, QA seed, and task-scoped smoke SQL setup were blocked by safety filters.
-2. Browser UI smoke confirms render/no-crash behavior, but not real check-in/start/complete/cancel against local database.
-3. Existing Vitest stderr contains React `act(...)` warning noise; tests still pass.
-4. Vite build reports the existing large chunk warning.
+1. Existing Vitest stderr contains React `act(...)` warning noise; tests still pass.
+2. Vite build reports the existing large chunk warning.
+3. The existing prototype-mode banner is still visible in the Supabase-configured browser view; it is outside this visit UI task and does not affect the verified repository/RPC behavior.
 
 ## Final verdict
-**PARTIAL with exact missing validation:** visit UI implemented and test/build/lint/browser-render verified, but full local Supabase lifecycle browser smoke remains unverified due tool/safety blocks.
+**PASS:** visit UI, role controls, real local Supabase lifecycle writes, RLS/tenant boundaries, audit/activity side effects, cleanup, unit tests, build, and GitHub CI are verified.
 
 ## Recommended next task
-**VISIT-CHECKIN-UI-001B-LOCAL-SMOKE** — run full local Supabase role-based browser smoke once DB reset/QA seed/smoke-row tooling is available without safety blockage.
+**VISIT-CHECKIN-UI-002** — design the next scoped clinical encounter UI task without coupling visit completion to clinical or billing facts.
 
 <!-- SUPER_HERMES_METADATA:START -->
 ## Final Report Metadata
@@ -203,21 +211,21 @@ No local smoke rows were inserted by this task, because smoke data setup was blo
 - PR number: 315
 - Branch: feature/visit-checkin-ui-001
 - Base branch: main
-- Implementation/reviewed HEAD: 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52
-- Local HEAD at finalization: 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52
-- Latest CI run ID: 27856193466
-- Latest CI number: 570
-- Latest CI conclusion: none
-- CI tested commit: 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52
-- Latest green CI run ID: none
-- Latest green CI number: none
-- Latest green CI tested commit: none
+- Implementation/reviewed HEAD: d5de6dc73d905f64394220aa9c8b9386cd7026d2
+- Local HEAD at finalization: d5de6dc73d905f64394220aa9c8b9386cd7026d2
+- Latest CI run ID: 27863506385
+- Latest CI number: 572
+- Latest CI conclusion: SUCCESS
+- CI tested commit: d5de6dc73d905f64394220aa9c8b9386cd7026d2
+- Latest green CI run ID: 27863506385
+- Latest green CI number: 572
+- Latest green CI tested commit: d5de6dc73d905f64394220aa9c8b9386cd7026d2
 
 ### Checks
 
 | Check | Workflow | Status | Conclusion | Run | Tested commit |
 | --- | --- | --- | --- | --- | --- |
-| validate | CI | IN_PROGRESS | IN_PROGRESS | 27856193466 | 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52 |
+| validate | CI | COMPLETED | SUCCESS | 27863506385 | d5de6dc73d905f64394220aa9c8b9386cd7026d2 |
 
 > A report-only commit cannot contain its own SHA or future CI result. After commit/push, Super Hermes stores those final values in an immutable local finalization receipt.
 <!-- SUPER_HERMES_METADATA:END -->

--- a/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
+++ b/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
@@ -14,10 +14,10 @@ Reason: implementation, unit tests, lint, full test suite, build, GitHub CI, and
 https://github.com/NckNA/codex-test/pull/315
 
 ## PR head reviewed before final report update
-`bc138eb9a2bb3f28a67141c7e53fb854d3ed7571`
+`990699bedbdd7578c1374046af4d4587d208aec9`
 
 ## Report update commit
-Recorded in the managed metadata block and immutable local finalization receipt.
+N/A — the final report update commit cannot reference itself before creation.
 
 ## Changed files summary
 
@@ -189,7 +189,7 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 - targeted visit tests: passed, 3 files / 22 tests.
 - `npm run build`: passed.
 - `git diff --check`: passed.
-- GitHub Actions CI: passed, run `27864685064` / `CI #574`, tested commit `bc138eb9a2bb3f28a67141c7e53fb854d3ed7571`.
+- GitHub Actions CI: passed, run `27864786601` / `CI #575`, tested commit `990699bedbdd7578c1374046af4d4587d208aec9`.
 - Super Hermes lifecycle smoke: passed, 6/6 role and tenant scenarios; cleanup verified at zero remaining rows.
 
 ## Issues / warnings
@@ -202,7 +202,7 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 **PASS:** visit UI, role controls, real local Supabase lifecycle writes, RLS/tenant boundaries, audit/activity side effects, cleanup, unit tests, build, and GitHub CI are verified.
 
 ## Recommended next task
-**VISIT-CHECKIN-UI-002** — design the next scoped clinical encounter UI task without coupling visit completion to clinical or billing facts.
+**ENCOUNTER-CLINICAL-NOTES-UI-001** — add the first clinical notes/encounter UI layer for a patient visit, scoped to the clinical encounter model created in ENCOUNTER-VISIT-MODEL-001A.
 
 <!-- SUPER_HERMES_METADATA:START -->
 ## Final Report Metadata
@@ -211,21 +211,21 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 - PR number: 315
 - Branch: feature/visit-checkin-ui-001
 - Base branch: main
-- Implementation/reviewed HEAD: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
-- Local HEAD at finalization: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
-- Latest CI run ID: 27864685064
-- Latest CI number: 574
+- Implementation/reviewed HEAD: 990699bedbdd7578c1374046af4d4587d208aec9
+- Local HEAD at finalization: 990699bedbdd7578c1374046af4d4587d208aec9
+- Latest CI run ID: 27864786601
+- Latest CI number: 575
 - Latest CI conclusion: SUCCESS
-- CI tested commit: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
-- Latest green CI run ID: 27864685064
-- Latest green CI number: 574
-- Latest green CI tested commit: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
+- CI tested commit: 990699bedbdd7578c1374046af4d4587d208aec9
+- Latest green CI run ID: 27864786601
+- Latest green CI number: 575
+- Latest green CI tested commit: 990699bedbdd7578c1374046af4d4587d208aec9
 
 ### Checks
 
 | Check | Workflow | Status | Conclusion | Run | Tested commit |
 | --- | --- | --- | --- | --- | --- |
-| validate | CI | COMPLETED | SUCCESS | 27864685064 | bc138eb9a2bb3f28a67141c7e53fb854d3ed7571 |
+| validate | CI | COMPLETED | SUCCESS | 27864786601 | 990699bedbdd7578c1374046af4d4587d208aec9 |
 
 > A report-only commit cannot contain its own SHA or future CI result. After commit/push, Super Hermes stores those final values in an immutable local finalization receipt.
 <!-- SUPER_HERMES_METADATA:END -->

--- a/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
+++ b/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
@@ -14,7 +14,7 @@ Reason: implementation, unit tests, lint, full test suite, build, GitHub CI, and
 https://github.com/NckNA/codex-test/pull/315
 
 ## PR head reviewed before final report update
-`d5de6dc73d905f64394220aa9c8b9386cd7026d2`
+`aa107033a96db6ca012f1d122135ce40bbf88edf`
 
 ## Report update commit
 Recorded in the managed metadata block and immutable local finalization receipt.
@@ -189,7 +189,7 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 - targeted visit tests: passed, 3 files / 22 tests.
 - `npm run build`: passed.
 - `git diff --check`: passed.
-- GitHub Actions CI: passed, run `27863506385` / `CI #572`, tested commit `d5de6dc73d905f64394220aa9c8b9386cd7026d2`.
+- GitHub Actions CI: passed, run `27863573667` / `CI #573`, tested commit `aa107033a96db6ca012f1d122135ce40bbf88edf`.
 - Super Hermes lifecycle smoke: passed, 6/6 role and tenant scenarios; cleanup verified at zero remaining rows.
 
 ## Issues / warnings
@@ -211,21 +211,21 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 - PR number: 315
 - Branch: feature/visit-checkin-ui-001
 - Base branch: main
-- Implementation/reviewed HEAD: d5de6dc73d905f64394220aa9c8b9386cd7026d2
-- Local HEAD at finalization: d5de6dc73d905f64394220aa9c8b9386cd7026d2
-- Latest CI run ID: 27863506385
-- Latest CI number: 572
+- Implementation/reviewed HEAD: aa107033a96db6ca012f1d122135ce40bbf88edf
+- Local HEAD at finalization: aa107033a96db6ca012f1d122135ce40bbf88edf
+- Latest CI run ID: 27863573667
+- Latest CI number: 573
 - Latest CI conclusion: SUCCESS
-- CI tested commit: d5de6dc73d905f64394220aa9c8b9386cd7026d2
-- Latest green CI run ID: 27863506385
-- Latest green CI number: 572
-- Latest green CI tested commit: d5de6dc73d905f64394220aa9c8b9386cd7026d2
+- CI tested commit: aa107033a96db6ca012f1d122135ce40bbf88edf
+- Latest green CI run ID: 27863573667
+- Latest green CI number: 573
+- Latest green CI tested commit: aa107033a96db6ca012f1d122135ce40bbf88edf
 
 ### Checks
 
 | Check | Workflow | Status | Conclusion | Run | Tested commit |
 | --- | --- | --- | --- | --- | --- |
-| validate | CI | COMPLETED | SUCCESS | 27863506385 | d5de6dc73d905f64394220aa9c8b9386cd7026d2 |
+| validate | CI | COMPLETED | SUCCESS | 27863573667 | aa107033a96db6ca012f1d122135ce40bbf88edf |
 
 > A report-only commit cannot contain its own SHA or future CI result. After commit/push, Super Hermes stores those final values in an immutable local finalization receipt.
 <!-- SUPER_HERMES_METADATA:END -->

--- a/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
+++ b/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
@@ -14,7 +14,7 @@ Reason: implementation, unit tests, lint, full test suite, build, GitHub CI, and
 https://github.com/NckNA/codex-test/pull/315
 
 ## PR head reviewed before final report update
-`aa107033a96db6ca012f1d122135ce40bbf88edf`
+`bc138eb9a2bb3f28a67141c7e53fb854d3ed7571`
 
 ## Report update commit
 Recorded in the managed metadata block and immutable local finalization receipt.
@@ -189,7 +189,7 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 - targeted visit tests: passed, 3 files / 22 tests.
 - `npm run build`: passed.
 - `git diff --check`: passed.
-- GitHub Actions CI: passed, run `27863573667` / `CI #573`, tested commit `aa107033a96db6ca012f1d122135ce40bbf88edf`.
+- GitHub Actions CI: passed, run `27864685064` / `CI #574`, tested commit `bc138eb9a2bb3f28a67141c7e53fb854d3ed7571`.
 - Super Hermes lifecycle smoke: passed, 6/6 role and tenant scenarios; cleanup verified at zero remaining rows.
 
 ## Issues / warnings
@@ -211,21 +211,21 @@ Cleanup ran in a `finally` block and removed exactly `8` activity events, `8` au
 - PR number: 315
 - Branch: feature/visit-checkin-ui-001
 - Base branch: main
-- Implementation/reviewed HEAD: aa107033a96db6ca012f1d122135ce40bbf88edf
-- Local HEAD at finalization: aa107033a96db6ca012f1d122135ce40bbf88edf
-- Latest CI run ID: 27863573667
-- Latest CI number: 573
+- Implementation/reviewed HEAD: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
+- Local HEAD at finalization: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
+- Latest CI run ID: 27864685064
+- Latest CI number: 574
 - Latest CI conclusion: SUCCESS
-- CI tested commit: aa107033a96db6ca012f1d122135ce40bbf88edf
-- Latest green CI run ID: 27863573667
-- Latest green CI number: 573
-- Latest green CI tested commit: aa107033a96db6ca012f1d122135ce40bbf88edf
+- CI tested commit: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
+- Latest green CI run ID: 27864685064
+- Latest green CI number: 574
+- Latest green CI tested commit: bc138eb9a2bb3f28a67141c7e53fb854d3ed7571
 
 ### Checks
 
 | Check | Workflow | Status | Conclusion | Run | Tested commit |
 | --- | --- | --- | --- | --- | --- |
-| validate | CI | COMPLETED | SUCCESS | 27863573667 | aa107033a96db6ca012f1d122135ce40bbf88edf |
+| validate | CI | COMPLETED | SUCCESS | 27864685064 | bc138eb9a2bb3f28a67141c7e53fb854d3ed7571 |
 
 > A report-only commit cannot contain its own SHA or future CI result. After commit/push, Super Hermes stores those final values in an immutable local finalization receipt.
 <!-- SUPER_HERMES_METADATA:END -->

--- a/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
+++ b/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
@@ -195,3 +195,29 @@ No local smoke rows were inserted by this task, because smoke data setup was blo
 
 ## Recommended next task
 **VISIT-CHECKIN-UI-001B-LOCAL-SMOKE** — run full local Supabase role-based browser smoke once DB reset/QA seed/smoke-row tooling is available without safety blockage.
+
+<!-- SUPER_HERMES_METADATA:START -->
+## Final Report Metadata
+
+- PR: https://github.com/NckNA/codex-test/pull/315
+- PR number: 315
+- Branch: feature/visit-checkin-ui-001
+- Base branch: main
+- Implementation/reviewed HEAD: 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52
+- Local HEAD at finalization: 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52
+- Latest CI run ID: 27856193466
+- Latest CI number: 570
+- Latest CI conclusion: none
+- CI tested commit: 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52
+- Latest green CI run ID: none
+- Latest green CI number: none
+- Latest green CI tested commit: none
+
+### Checks
+
+| Check | Workflow | Status | Conclusion | Run | Tested commit |
+| --- | --- | --- | --- | --- | --- |
+| validate | CI | IN_PROGRESS | IN_PROGRESS | 27856193466 | 11763da306f936d52c0fc9ab3a4b9c5ff1e19e52 |
+
+> A report-only commit cannot contain its own SHA or future CI result. After commit/push, Super Hermes stores those final values in an immutable local finalization receipt.
+<!-- SUPER_HERMES_METADATA:END -->

--- a/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
+++ b/_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md
@@ -1,0 +1,197 @@
+# VISIT-CHECKIN-UI-001 — Visit check-in lifecycle UI
+
+## Summary
+Implemented the first patient visit lifecycle UI layer in the patient card. The UI adds a dedicated `Визиты` tab, reads patient visits through `EncounterVisitRepository`, and sends visit lifecycle mutations through `EncounterVisitRpcClient` only.
+
+Final verdict: **PARTIAL**
+
+Reason: implementation, unit tests, lint, full test suite, build, and browser UI smoke passed. Full local Supabase lifecycle browser smoke with seeded QA patients was blocked by local tool/safety restrictions while trying to run `supabase db reset`, seed QA users, and create local smoke rows. No cloud Supabase was touched.
+
+## Branch
+`feature/visit-checkin-ui-001`
+
+## PR URL
+Pending PR creation.
+
+## PR head reviewed before final report update
+Pending finalization.
+
+## Report update commit
+N/A before PR creation.
+
+## Changed files summary
+
+UI:
+- `src/components/visits/VisitCheckInPanel.tsx`
+- `src/components/visits/VisitLifecycleActions.tsx`
+- `src/components/visits/VisitStatusBadge.tsx`
+- `src/components/visits/visitLabels.ts`
+- `src/components/visits/visitPermissions.ts`
+
+Hooks:
+- `src/data/hooks/usePatientVisits.ts`
+- `src/data/hooks/useVisitLifecycleActions.ts`
+
+Page integration:
+- `src/pages/PatientCardPage.tsx`
+
+Tests:
+- `src/components/visits/VisitCheckInPanel.test.tsx`
+- `src/data/hooks/usePatientVisits.test.tsx`
+- `src/data/hooks/useVisitLifecycleActions.test.tsx`
+
+Report:
+- `_ai_work/REPORTS/VISIT-CHECKIN-UI-001_ui.md`
+
+## Current UI/data recon
+
+### Patient page structure
+`PatientCardPage` uses tab state with existing patient sections. The task adds a new `Визиты` tab between `История приёмов` and `Зубная карта`.
+
+### Tenant/patient context
+- `patientId` is read from route params in `PatientCardPage`.
+- active tenant and role come from `TenantContext`.
+- visit actions are blocked when tenant or patient is missing.
+
+### Role/permission pattern
+Role gating is implemented as UI convenience in `visitPermissions.ts`:
+- `clinic_owner` / `clinic_admin`: check in, start, complete, cancel.
+- `doctor`: check in, start, complete, cancel.
+- `registrar`: check in, start, cancel; no complete button.
+- `cashier`: read-only/no mutation actions.
+- no tenant: blocked state.
+
+RPC remains the source of truth for permission enforcement.
+
+### Repository/RPC client pattern
+- Reads use `EncounterVisitRepository.listPatientVisits` through `usePatientVisits`.
+- Writes use `EncounterVisitRpcClient` through `useVisitLifecycleActions`.
+- Components receive injectable repository/client dependencies for tests but default to Supabase-backed factories in runtime.
+
+### Test pattern
+Tests follow the existing Vitest + React DOM `createRoot` + `act` style already present in the project.
+
+## Implementation summary
+
+### Components
+- `VisitCheckInPanel` renders the visit section, check-in form, visit list, status/timestamps, empty/loading/error states, and role-gated actions.
+- `VisitLifecycleActions` renders start/complete/cancel buttons for eligible visit statuses.
+- `VisitStatusBadge` renders Russian status labels.
+
+### Hooks
+- `usePatientVisits` fetches visit rows only when `tenantId` and `patientId` are present.
+- `useVisitLifecycleActions` wraps check-in/start/complete/cancel RPC client calls and refreshes the visit list after success.
+
+### Patient page integration
+`PatientCardPage` now renders `VisitCheckInPanel` in the new `Визиты` tab and passes `tenantId`, `patientId`, and current role.
+
+### Error handling
+Safe Russian UI messages are used for no tenant, missing patient, permission denial, invalid transition, and update failures. Raw database objects are not rendered.
+
+## Domain boundary
+Preserved:
+- appointment = scheduled slot / booking intent.
+- patient_visit = actual patient attendance instance.
+- visit status = attendance workflow.
+- clinical_encounter UI is not implemented.
+- completed_service UI is not implemented.
+- completing a visit does not create a completed service.
+- payment, stock, documents, and timeline integration are not touched.
+
+## Data/write boundary
+- Reads go through `EncounterVisitRepository`.
+- Writes go through `EncounterVisitRpcClient`.
+- No direct table writes were added in UI/hooks.
+- No raw `supabase.rpc` calls were added to UI components.
+- No `service_role` usage was added.
+- No `localStorage` fallback was added.
+
+Static scan of new visit UI/hooks found no `localStorage`, `service_role`, `.from(...).insert/update/delete`, `createClinicalEncounter`, or `recordCompletedService` usage.
+
+## Role behavior
+- Owner/admin can see all lifecycle buttons.
+- Doctor can see check-in/start/complete/cancel buttons.
+- Registrar can see check-in/start/cancel, but not complete.
+- Cashier sees no mutation actions.
+- No-tenant state shows safe blocked UI.
+- Cross-tenant leakage is left to tenant context + repository/RLS boundaries; no manual bypass was added.
+
+## Unit tests
+
+Added tests cover:
+- no fetch without tenantId/patientId;
+- repository-backed visit fetch;
+- repository error surfacing;
+- refresh behavior;
+- check-in/start/complete/cancel RPC calls;
+- successful action refresh;
+- cancel reason requirement;
+- safe permission error mapping;
+- no clinical encounter/completed service RPC calls from lifecycle actions;
+- loading/empty/list UI;
+- checked-in/in-progress/completed/cancelled button visibility;
+- registrar/cashier role visibility;
+- no-tenant blocked state;
+- check-in form RPC call;
+- cancel reason UI validation.
+
+Targeted visit tests: `3 passed / 22 tests passed`.
+
+Full suite: `52 passed / 490 tests passed`.
+
+Known test-suite warning: existing React `act(...)` warning noise appears in stderr across existing tests and the new tests, but Vitest exits successfully.
+
+## Browser smoke
+
+### Prototype/no-Supabase UI smoke
+- Started Vite locally on `http://127.0.0.1:5174`.
+- `/patients` loaded successfully.
+- `/patients/p1` loaded successfully.
+- Patient card displayed the new `Визиты` tab.
+- Clicking the `Визиты` tab rendered the new visit panel.
+- No fatal console errors.
+- No visible `service_role` / service-role key markers.
+- Since Supabase env was not configured in that app process, the panel correctly surfaced a safe configuration error instead of crashing.
+
+### Supabase-env login smoke
+- Started/attempted a Supabase-env app process on `http://127.0.0.1:5175`.
+- Login page loaded.
+- `qa.admin.a@example.local` login via host-env password path reached the Patients page but did not find seeded demo patient data.
+- `supabase db reset`, QA seed, and smoke row setup were blocked by local tool/safety restrictions, so full lifecycle browser smoke could not be completed.
+
+### Cleanup
+No local smoke rows were inserted by this task, because smoke data setup was blocked before data creation. Therefore there were no task-created rows to delete from `patient_visits`, `audit_events`, or `activity_events`.
+
+## What was intentionally NOT changed
+- No migrations.
+- No Supabase cloud access.
+- No clinical encounter UI.
+- No completed services UI.
+- No timeline integration.
+- No payments.
+- No stock.
+- No documents.
+- No seed/backfill changes.
+- No appointment status side effects.
+- No PatientTimelineAggregator changes.
+
+## Checks
+
+- `npm run lint`: passed.
+- `npm run test`: passed, 52 files / 490 tests.
+- targeted visit tests: passed, 3 files / 22 tests.
+- `npm run build`: passed.
+- GitHub Actions CI: pending after PR creation.
+
+## Issues / warnings
+
+1. Full local Supabase lifecycle browser smoke is not complete because local tool calls for `supabase db reset`, QA seed, and task-scoped smoke SQL setup were blocked by safety filters.
+2. Browser UI smoke confirms render/no-crash behavior, but not real check-in/start/complete/cancel against local database.
+3. Existing Vitest stderr contains React `act(...)` warning noise; tests still pass.
+4. Vite build reports the existing large chunk warning.
+
+## Final verdict
+**PARTIAL with exact missing validation:** visit UI implemented and test/build/lint/browser-render verified, but full local Supabase lifecycle browser smoke remains unverified due tool/safety blocks.
+
+## Recommended next task
+**VISIT-CHECKIN-UI-001B-LOCAL-SMOKE** — run full local Supabase role-based browser smoke once DB reset/QA seed/smoke-row tooling is available without safety blockage.

--- a/src/components/visits/VisitCheckInPanel.test.tsx
+++ b/src/components/visits/VisitCheckInPanel.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VisitCheckInPanel } from './VisitCheckInPanel';
+import type { EncounterVisitRepository, PatientVisit } from '../../data/repositories/EncounterVisitRepository';
+import type { EncounterVisitRpcClient } from '../../data/repositories/EncounterVisitRpcClient';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {},
+  isSupabaseConfigured: true,
+}));
+
+const baseVisit: PatientVisit = {
+  id: 'visit-11111111',
+  tenantId: 'tenant-1',
+  patientId: 'patient-1',
+  appointmentId: null,
+  status: 'checked_in',
+  visitType: 'regular',
+  arrivedAt: '2026-06-20T08:00:00.000Z',
+  checkedInAt: '2026-06-20T08:00:00.000Z',
+  startedAt: null,
+  completedAt: null,
+  cancelledAt: null,
+  archivedAt: null,
+  createdBy: null,
+  updatedBy: null,
+  archivedBy: null,
+  notes: 'Первичный приход',
+  metadata: {},
+  createdAt: '2026-06-20T08:00:00.000Z',
+  updatedAt: '2026-06-20T08:00:00.000Z',
+};
+
+function createRepository(visits: PatientVisit[] = [baseVisit]): EncounterVisitRepository {
+  return {
+    listPatientVisits: vi.fn().mockResolvedValue(visits),
+    getPatientVisitById: vi.fn(),
+    listClinicalEncounters: vi.fn(),
+    getClinicalEncounterById: vi.fn(),
+    listCompletedServices: vi.fn(),
+    getCompletedServiceById: vi.fn(),
+    listPatientClinicalWorkflow: vi.fn(),
+  } as EncounterVisitRepository;
+}
+
+function createRpcClient(): EncounterVisitRpcClient {
+  return {
+    checkInPatientVisit: vi.fn().mockResolvedValue(baseVisit),
+    startPatientVisit: vi.fn().mockResolvedValue({ ...baseVisit, status: 'in_progress' }),
+    completePatientVisit: vi.fn().mockResolvedValue({ ...baseVisit, status: 'completed' }),
+    cancelPatientVisit: vi.fn().mockResolvedValue({ ...baseVisit, status: 'cancelled' }),
+    createClinicalEncounter: vi.fn(),
+    startClinicalEncounter: vi.fn(),
+    completeClinicalEncounter: vi.fn(),
+    recordCompletedService: vi.fn(),
+    voidCompletedService: vi.fn(),
+  } as EncounterVisitRpcClient;
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('VisitCheckInPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  async function renderPanel({
+    visits = [baseVisit],
+    role = 'clinic_admin',
+    tenantId = 'tenant-1',
+    patientId = 'patient-1',
+  }: {
+    visits?: PatientVisit[];
+    role?: string | null;
+    tenantId?: string | null;
+    patientId?: string | null;
+  } = {}) {
+    const repository = createRepository(visits);
+    const rpcClient = createRpcClient();
+
+    await act(async () => {
+      root.render(
+        <VisitCheckInPanel
+          tenantId={tenantId}
+          patientId={patientId}
+          role={role}
+          repository={repository}
+          rpcClient={rpcClient}
+        />
+      );
+    });
+    await flush();
+    return { repository, rpcClient };
+  }
+
+  it('renders no-tenant blocked state', async () => {
+    await renderPanel({ tenantId: null });
+
+    expect(container.textContent).toContain('Не выбрана клиника.');
+  });
+
+  it('renders empty state and check-in form for admin', async () => {
+    await renderPanel({ visits: [], role: 'clinic_admin' });
+
+    expect(container.textContent).toContain('Визитов пока нет.');
+    expect(container.textContent).toContain('Отметить приход');
+    expect(container.textContent).toContain('Тип визита');
+  });
+
+  it('renders visit statuses and timestamps', async () => {
+    await renderPanel();
+
+    expect(container.textContent).toContain('Ожидает приёма');
+    expect(container.textContent).toContain('Обычный');
+    expect(container.textContent).toContain('Первичный приход');
+    expect(container.textContent).toContain('20.06.2026');
+  });
+
+  it('shows checked-in allowed actions for admin', async () => {
+    await renderPanel({ role: 'clinic_admin' });
+
+    expect(container.textContent).toContain('Начать визит');
+    expect(container.textContent).toContain('Завершить визит');
+    expect(container.textContent).toContain('Отменить визит');
+  });
+
+  it('shows in-progress complete/cancel actions', async () => {
+    await renderPanel({ visits: [{ ...baseVisit, status: 'in_progress', startedAt: '2026-06-20T08:30:00.000Z' }] });
+
+    expect(container.textContent).not.toContain('Начать визит');
+    expect(container.textContent).toContain('Завершить визит');
+    expect(container.textContent).toContain('Отменить визит');
+  });
+
+  it('hides mutation buttons for completed and cancelled visits', async () => {
+    await renderPanel({
+      visits: [
+        { ...baseVisit, id: 'visit-completed', status: 'completed', completedAt: '2026-06-20T09:00:00.000Z' },
+        { ...baseVisit, id: 'visit-cancelled', status: 'cancelled', cancelledAt: '2026-06-20T09:00:00.000Z' },
+      ],
+    });
+
+    expect(container.textContent).toContain('Визит завершён');
+    expect(container.textContent).toContain('Визит отменён');
+    expect(container.textContent).not.toContain('Начать визит');
+    expect(container.textContent).not.toContain('Завершить визит');
+    expect(container.textContent).not.toContain('Отменить визит');
+  });
+
+  it('registrar does not see complete button', async () => {
+    await renderPanel({ role: 'registrar' });
+
+    expect(container.textContent).toContain('Начать визит');
+    expect(container.textContent).toContain('Отменить визит');
+    expect(container.textContent).not.toContain('Завершить визит');
+  });
+
+  it('cashier sees no mutation actions', async () => {
+    await renderPanel({ role: 'cashier' });
+
+    expect(container.textContent).toContain('Для вашей роли действия с визитами недоступны.');
+    expect(container.textContent).not.toContain('Начать визит');
+    expect(container.textContent).not.toContain('Завершить визит');
+    expect(container.textContent).not.toContain('Отменить визит');
+    expect(container.textContent).not.toContain('Отметить приход');
+  });
+
+  it('check-in form calls the RPC client', async () => {
+    const { rpcClient } = await renderPanel({ visits: [], role: 'clinic_admin' });
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+
+    await act(async () => {
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    expect(rpcClient.checkInPatientVisit).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      patientId: 'patient-1',
+      visitType: 'regular',
+    }));
+  });
+
+  it('cancel form requires reason before enabling confirmation', async () => {
+    await renderPanel({ role: 'clinic_admin' });
+
+    const cancelButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Отменить визит');
+    expect(cancelButton).toBeDefined();
+
+    await act(async () => {
+      cancelButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Причина отмены');
+    const confirmButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Подтвердить отмену');
+    expect(confirmButton).toBeDefined();
+    expect(confirmButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('does not call clinical encounter or completed service RPCs from the UI', async () => {
+    const { rpcClient } = await renderPanel({ role: 'clinic_admin' });
+    const startButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Начать визит');
+
+    await act(async () => {
+      startButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(rpcClient.startPatientVisit).toHaveBeenCalled();
+    expect(rpcClient.createClinicalEncounter).not.toHaveBeenCalled();
+    expect(rpcClient.recordCompletedService).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/visits/VisitCheckInPanel.tsx
+++ b/src/components/visits/VisitCheckInPanel.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import type {
+  EncounterVisitRepository,
+  PatientVisit,
+  PatientVisitType,
+} from '../../data/repositories/EncounterVisitRepository';
+import type { EncounterVisitRpcClient } from '../../data/repositories/EncounterVisitRpcClient';
+import { usePatientVisits } from '../../data/hooks/usePatientVisits';
+import { useVisitLifecycleActions } from '../../data/hooks/useVisitLifecycleActions';
+import { VisitLifecycleActions } from './VisitLifecycleActions';
+import { getVisitRoleCapabilities, type VisitUserRole } from './visitPermissions';
+import { VisitStatusBadge } from './VisitStatusBadge';
+import { VISIT_TYPE_LABELS } from './visitLabels';
+
+const VISIT_TYPE_OPTIONS = Object.keys(VISIT_TYPE_LABELS) as PatientVisitType[];
+
+interface VisitCheckInPanelProps {
+  tenantId?: string | null;
+  patientId?: string | null;
+  role?: VisitUserRole;
+  appointmentId?: string | null;
+  repository?: EncounterVisitRepository;
+  rpcClient?: EncounterVisitRpcClient;
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function getLatestActiveVisit(visits: PatientVisit[]): PatientVisit | null {
+  return visits.find((visit) => ['checked_in', 'in_progress'].includes(visit.status)) ?? null;
+}
+
+export function VisitCheckInPanel({
+  tenantId,
+  patientId,
+  role,
+  appointmentId,
+  repository,
+  rpcClient,
+}: VisitCheckInPanelProps) {
+  const [visitType, setVisitType] = useState<PatientVisitType>('regular');
+  const [notes, setNotes] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const {
+    visits,
+    isLoading,
+    isError,
+    error,
+    refresh,
+  } = usePatientVisits({ tenantId, patientId, repository });
+
+  const {
+    actionLoading,
+    error: actionError,
+    checkInVisit,
+    startVisit,
+    completeVisit,
+    cancelVisit,
+    clearError,
+  } = useVisitLifecycleActions({ tenantId, patientId, refresh, rpcClient });
+
+  const capabilities = useMemo(() => getVisitRoleCapabilities(role), [role]);
+  const latestActiveVisit = useMemo(() => getLatestActiveVisit(visits), [visits]);
+  const canCheckIn = Boolean(tenantId && patientId && capabilities.canCheckIn && !latestActiveVisit);
+
+  if (!tenantId) {
+    return (
+      <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-amber-800">
+        <h2 className="text-lg font-semibold mb-2">Визиты</h2>
+        <p>Не выбрана клиника.</p>
+      </section>
+    );
+  }
+
+  if (!patientId) {
+    return (
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 text-slate-600">
+        <h2 className="text-lg font-semibold text-slate-800 mb-2">Визиты</h2>
+        <p>Пациент не найден.</p>
+      </section>
+    );
+  }
+
+  const handleCheckIn = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    clearError();
+    setFormError(null);
+
+    if (!capabilities.canCheckIn) {
+      setFormError('Недостаточно прав для действия.');
+      return;
+    }
+
+    try {
+      await checkInVisit({
+        visitType,
+        notes,
+        appointmentId,
+      });
+      setNotes('');
+      setVisitType('regular');
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Не удалось обновить визит. Попробуйте ещё раз.');
+    }
+  };
+
+  const safeAction = async (action: () => Promise<void>) => {
+    setFormError(null);
+    clearError();
+    try {
+      await action();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Не удалось обновить визит. Попробуйте ещё раз.');
+    }
+  };
+
+  return (
+    <section className="space-y-5" aria-label="Визиты пациента">
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-slate-800">Визиты</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Фиксация фактического прихода пациента и статуса визита. Клинические записи, услуги и оплаты здесь не создаются.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => refresh()}
+            disabled={isLoading}
+            className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Обновить
+          </button>
+        </div>
+
+        {(formError || actionError) && (
+          <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {formError || actionError?.message || 'Не удалось обновить визит. Попробуйте ещё раз.'}
+          </div>
+        )}
+
+        {canCheckIn && (
+          <form onSubmit={handleCheckIn} className="mt-5 rounded-xl border border-blue-100 bg-blue-50 p-4">
+            <div className="grid gap-4 md:grid-cols-[220px_1fr_auto] md:items-end">
+              <div>
+                <label className="block text-xs font-semibold uppercase tracking-wide text-blue-800" htmlFor="visit-type">
+                  Тип визита
+                </label>
+                <select
+                  id="visit-type"
+                  value={visitType}
+                  onChange={(event) => setVisitType(event.target.value as PatientVisitType)}
+                  className="mt-2 w-full rounded-lg border border-blue-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-blue-400"
+                >
+                  {VISIT_TYPE_OPTIONS.map((type) => (
+                    <option key={type} value={type}>{VISIT_TYPE_LABELS[type]}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-semibold uppercase tracking-wide text-blue-800" htmlFor="visit-notes">
+                  Заметка
+                </label>
+                <input
+                  id="visit-notes"
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  className="mt-2 w-full rounded-lg border border-blue-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-blue-400"
+                  placeholder="Необязательно"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={actionLoading !== null}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {actionLoading === 'check_in' ? 'Отмечаем...' : 'Отметить приход'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {!capabilities.canCheckIn && (
+          <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            Для вашей роли действия с визитами недоступны. Данные отображаются только для чтения, если доступ разрешён политиками клиники.
+          </div>
+        )}
+
+        {latestActiveVisit && capabilities.canCheckIn && (
+          <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            У пациента уже есть активный визит. Новый приход можно отметить после завершения или отмены текущего визита.
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        {isLoading && (
+          <div className="py-10 text-center text-slate-500">Визиты загружаются...</div>
+        )}
+
+        {isError && !isLoading && (
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error?.message || 'Не удалось загрузить визиты.'}
+          </div>
+        )}
+
+        {!isLoading && !isError && visits.length === 0 && (
+          <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-10 text-center text-slate-500">
+            Визитов пока нет.
+          </div>
+        )}
+
+        {!isLoading && !isError && visits.length > 0 && (
+          <div className="space-y-4">
+            {visits.map((visit) => (
+              <article key={visit.id} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <VisitStatusBadge status={visit.status} />
+                      <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
+                        {VISIT_TYPE_LABELS[visit.visitType]}
+                      </span>
+                    </div>
+                    {visit.notes && <p className="text-sm text-slate-600">{visit.notes}</p>}
+                  </div>
+                  <div className="text-xs text-slate-400">ID: {visit.id.slice(0, 8)}</div>
+                </div>
+
+                <dl className="mt-4 grid gap-3 text-sm md:grid-cols-3">
+                  <div><dt className="text-xs font-semibold text-slate-400">Пришёл</dt><dd className="text-slate-700">{formatDateTime(visit.arrivedAt)}</dd></div>
+                  <div><dt className="text-xs font-semibold text-slate-400">Отмечен</dt><dd className="text-slate-700">{formatDateTime(visit.checkedInAt)}</dd></div>
+                  <div><dt className="text-xs font-semibold text-slate-400">Начат</dt><dd className="text-slate-700">{formatDateTime(visit.startedAt)}</dd></div>
+                  <div><dt className="text-xs font-semibold text-slate-400">Завершён</dt><dd className="text-slate-700">{formatDateTime(visit.completedAt)}</dd></div>
+                  <div><dt className="text-xs font-semibold text-slate-400">Отменён</dt><dd className="text-slate-700">{formatDateTime(visit.cancelledAt)}</dd></div>
+                  <div><dt className="text-xs font-semibold text-slate-400">Обновлён</dt><dd className="text-slate-700">{formatDateTime(visit.updatedAt)}</dd></div>
+                </dl>
+
+                <VisitLifecycleActions
+                  visit={visit}
+                  role={role}
+                  actionLoading={actionLoading}
+                  onStart={(visitId) => safeAction(() => startVisit(visitId))}
+                  onComplete={(visitId) => safeAction(() => completeVisit(visitId))}
+                  onCancel={(visitId, reason) => safeAction(() => cancelVisit({ visitId, reason }))}
+                />
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/visits/VisitCheckInPanel.tsx
+++ b/src/components/visits/VisitCheckInPanel.tsx
@@ -127,7 +127,7 @@ export function VisitCheckInPanel({
   };
 
   return (
-    <section className="space-y-5" aria-label="Визиты пациента">
+    <section className="space-y-5" aria-label="Визиты пациента" data-testid="visit-checkin-panel">
       <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div>
@@ -153,7 +153,7 @@ export function VisitCheckInPanel({
         )}
 
         {canCheckIn && (
-          <form onSubmit={handleCheckIn} className="mt-5 rounded-xl border border-blue-100 bg-blue-50 p-4">
+          <form onSubmit={handleCheckIn} className="mt-5 rounded-xl border border-blue-100 bg-blue-50 p-4" data-testid="visit-checkin-form">
             <div className="grid gap-4 md:grid-cols-[220px_1fr_auto] md:items-end">
               <div>
                 <label className="block text-xs font-semibold uppercase tracking-wide text-blue-800" htmlFor="visit-type">
@@ -184,6 +184,7 @@ export function VisitCheckInPanel({
               </div>
               <button
                 type="submit"
+                data-testid="visit-checkin-submit"
                 disabled={actionLoading !== null}
                 className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
               >
@@ -226,7 +227,7 @@ export function VisitCheckInPanel({
         {!isLoading && !isError && visits.length > 0 && (
           <div className="space-y-4">
             {visits.map((visit) => (
-              <article key={visit.id} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <article key={visit.id} data-testid={`visit-card-${visit.id}`} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
                 <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                   <div className="space-y-2">
                     <div className="flex flex-wrap items-center gap-2">

--- a/src/components/visits/VisitLifecycleActions.tsx
+++ b/src/components/visits/VisitLifecycleActions.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import type { PatientVisit } from '../../data/repositories/EncounterVisitRepository';
+import type { VisitLifecycleActionName } from '../../data/hooks/useVisitLifecycleActions';
+
+import { getVisitRoleCapabilities, type VisitUserRole } from './visitPermissions';
+
+interface VisitLifecycleActionsProps {
+  visit: PatientVisit;
+  role: VisitUserRole;
+  actionLoading: VisitLifecycleActionName | null;
+  onStart: (visitId: string) => Promise<void>;
+  onComplete: (visitId: string) => Promise<void>;
+  onCancel: (visitId: string, reason: string) => Promise<void>;
+}
+
+export function VisitLifecycleActions({
+  visit,
+  role,
+  actionLoading,
+  onStart,
+  onComplete,
+  onCancel,
+}: VisitLifecycleActionsProps) {
+  const capabilities = getVisitRoleCapabilities(role);
+  const [cancelReason, setCancelReason] = useState('');
+  const [isCancelOpen, setIsCancelOpen] = useState(false);
+  const isBusy = actionLoading !== null;
+  const isTerminal = ['completed', 'cancelled', 'archived'].includes(visit.status);
+
+  if (isTerminal) {
+    return null;
+  }
+
+  const canStart = visit.status === 'checked_in' && capabilities.canStart;
+  const canComplete = ['checked_in', 'in_progress'].includes(visit.status) && capabilities.canComplete;
+  const canCancel = ['checked_in', 'in_progress'].includes(visit.status) && capabilities.canCancel;
+
+  if (!canStart && !canComplete && !canCancel) {
+    return null;
+  }
+
+  const buttonClass = 'rounded-lg px-3 py-2 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60';
+
+  return (
+    <div className="mt-4 space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {canStart && (
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={() => onStart(visit.id)}
+            className={`${buttonClass} bg-blue-600 text-white hover:bg-blue-700`}
+          >
+            {actionLoading === 'start' ? 'Начинаем...' : 'Начать визит'}
+          </button>
+        )}
+        {canComplete && (
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={() => onComplete(visit.id)}
+            className={`${buttonClass} bg-emerald-600 text-white hover:bg-emerald-700`}
+          >
+            {actionLoading === 'complete' ? 'Завершаем...' : 'Завершить визит'}
+          </button>
+        )}
+        {canCancel && (
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={() => setIsCancelOpen((value) => !value)}
+            className={`${buttonClass} bg-white text-rose-700 border border-rose-200 hover:bg-rose-50`}
+          >
+            Отменить визит
+          </button>
+        )}
+      </div>
+
+      {isCancelOpen && canCancel && (
+        <div className="rounded-xl border border-rose-100 bg-rose-50 p-3">
+          <label className="block text-xs font-semibold text-rose-800 mb-2" htmlFor={`visit-cancel-${visit.id}`}>
+            Причина отмены
+          </label>
+          <textarea
+            id={`visit-cancel-${visit.id}`}
+            value={cancelReason}
+            onChange={(event) => setCancelReason(event.target.value)}
+            className="w-full min-h-20 rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-rose-400"
+            placeholder="Укажите причину отмены визита"
+          />
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              disabled={isBusy || !cancelReason.trim()}
+              onClick={async () => {
+                await onCancel(visit.id, cancelReason);
+                setCancelReason('');
+                setIsCancelOpen(false);
+              }}
+              className={`${buttonClass} bg-rose-600 text-white hover:bg-rose-700`}
+            >
+              {actionLoading === 'cancel' ? 'Отменяем...' : 'Подтвердить отмену'}
+            </button>
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={() => setIsCancelOpen(false)}
+              className={`${buttonClass} bg-white text-slate-700 border border-slate-200 hover:bg-slate-50`}
+            >
+              Закрыть
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/visits/VisitLifecycleActions.tsx
+++ b/src/components/visits/VisitLifecycleActions.tsx
@@ -47,6 +47,7 @@ export function VisitLifecycleActions({
         {canStart && (
           <button
             type="button"
+            data-testid={`visit-start-${visit.id}`}
             disabled={isBusy}
             onClick={() => onStart(visit.id)}
             className={`${buttonClass} bg-blue-600 text-white hover:bg-blue-700`}
@@ -57,6 +58,7 @@ export function VisitLifecycleActions({
         {canComplete && (
           <button
             type="button"
+            data-testid={`visit-complete-${visit.id}`}
             disabled={isBusy}
             onClick={() => onComplete(visit.id)}
             className={`${buttonClass} bg-emerald-600 text-white hover:bg-emerald-700`}
@@ -67,6 +69,7 @@ export function VisitLifecycleActions({
         {canCancel && (
           <button
             type="button"
+            data-testid={`visit-cancel-${visit.id}`}
             disabled={isBusy}
             onClick={() => setIsCancelOpen((value) => !value)}
             className={`${buttonClass} bg-white text-rose-700 border border-rose-200 hover:bg-rose-50`}
@@ -83,6 +86,7 @@ export function VisitLifecycleActions({
           </label>
           <textarea
             id={`visit-cancel-${visit.id}`}
+            data-testid={`visit-cancel-reason-${visit.id}`}
             value={cancelReason}
             onChange={(event) => setCancelReason(event.target.value)}
             className="w-full min-h-20 rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-rose-400"
@@ -91,6 +95,7 @@ export function VisitLifecycleActions({
           <div className="mt-2 flex gap-2">
             <button
               type="button"
+              data-testid={`visit-cancel-confirm-${visit.id}`}
               disabled={isBusy || !cancelReason.trim()}
               onClick={async () => {
                 await onCancel(visit.id, cancelReason);

--- a/src/components/visits/VisitStatusBadge.tsx
+++ b/src/components/visits/VisitStatusBadge.tsx
@@ -1,0 +1,22 @@
+import type { PatientVisitStatus } from '../../data/repositories/EncounterVisitRepository';
+import { VISIT_STATUS_LABELS } from './visitLabels';
+
+const STATUS_STYLES: Record<PatientVisitStatus, string> = {
+  checked_in: 'bg-amber-100 text-amber-800 border-amber-200',
+  in_progress: 'bg-blue-100 text-blue-800 border-blue-200',
+  completed: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+  cancelled: 'bg-rose-100 text-rose-800 border-rose-200',
+  archived: 'bg-slate-100 text-slate-700 border-slate-200',
+};
+
+interface VisitStatusBadgeProps {
+  status: PatientVisitStatus;
+}
+
+export function VisitStatusBadge({ status }: VisitStatusBadgeProps) {
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${STATUS_STYLES[status]}`}>
+      {VISIT_STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/src/components/visits/visitLabels.ts
+++ b/src/components/visits/visitLabels.ts
@@ -1,0 +1,18 @@
+﻿import type { PatientVisitStatus, PatientVisitType } from '../../data/repositories/EncounterVisitRepository';
+
+export const VISIT_STATUS_LABELS: Record<PatientVisitStatus, string> = {
+  checked_in: 'Ожидает приёма',
+  in_progress: 'На приёме',
+  completed: 'Визит завершён',
+  cancelled: 'Визит отменён',
+  archived: 'Архив',
+};
+
+export const VISIT_TYPE_LABELS: Record<PatientVisitType, string> = {
+  regular: 'Обычный',
+  emergency: 'Экстренный',
+  consultation: 'Консультация',
+  follow_up: 'Повторный',
+  procedure: 'Процедура',
+  other: 'Другое',
+};

--- a/src/components/visits/visitPermissions.ts
+++ b/src/components/visits/visitPermissions.ts
@@ -1,0 +1,22 @@
+﻿export type VisitUserRole = 'clinic_owner' | 'clinic_admin' | 'doctor' | 'registrar' | 'cashier' | string | undefined | null;
+
+export interface VisitRoleCapabilities {
+  canCheckIn: boolean;
+  canStart: boolean;
+  canComplete: boolean;
+  canCancel: boolean;
+}
+
+export function getVisitRoleCapabilities(role: VisitUserRole): VisitRoleCapabilities {
+  switch (role) {
+    case 'clinic_owner':
+    case 'clinic_admin':
+      return { canCheckIn: true, canStart: true, canComplete: true, canCancel: true };
+    case 'doctor':
+      return { canCheckIn: true, canStart: true, canComplete: true, canCancel: true };
+    case 'registrar':
+      return { canCheckIn: true, canStart: true, canComplete: false, canCancel: true };
+    default:
+      return { canCheckIn: false, canStart: false, canComplete: false, canCancel: false };
+  }
+}

--- a/src/data/hooks/usePatientVisits.test.tsx
+++ b/src/data/hooks/usePatientVisits.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePatientVisits, type UsePatientVisitsResult } from './usePatientVisits';
+import type { EncounterVisitRepository, PatientVisit } from '../repositories/EncounterVisitRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {},
+  isSupabaseConfigured: true,
+}));
+
+const visit: PatientVisit = {
+  id: 'visit-1',
+  tenantId: 'tenant-1',
+  patientId: 'patient-1',
+  appointmentId: null,
+  status: 'checked_in',
+  visitType: 'regular',
+  arrivedAt: '2026-06-20T08:00:00.000Z',
+  checkedInAt: '2026-06-20T08:00:00.000Z',
+  startedAt: null,
+  completedAt: null,
+  cancelledAt: null,
+  archivedAt: null,
+  createdBy: null,
+  updatedBy: null,
+  archivedBy: null,
+  notes: null,
+  metadata: {},
+  createdAt: '2026-06-20T08:00:00.000Z',
+  updatedAt: '2026-06-20T08:00:00.000Z',
+};
+
+function createRepository(overrides: Partial<EncounterVisitRepository> = {}): EncounterVisitRepository {
+  return {
+    listPatientVisits: vi.fn().mockResolvedValue([visit]),
+    getPatientVisitById: vi.fn(),
+    listClinicalEncounters: vi.fn(),
+    getClinicalEncounterById: vi.fn(),
+    listCompletedServices: vi.fn(),
+    getCompletedServiceById: vi.fn(),
+    listPatientClinicalWorkflow: vi.fn(),
+    ...overrides,
+  } as EncounterVisitRepository;
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('usePatientVisits', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  async function renderHook(hook: () => UsePatientVisitsResult) {
+    let latest: UsePatientVisitsResult | undefined;
+    const Probe = () => {
+      const result = hook();
+      useEffect(() => {
+        latest = result;
+      }, [result]);
+      return null;
+    };
+
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    await flush();
+    return () => latest!;
+  }
+
+  it('does not fetch without tenantId', async () => {
+    const repository = createRepository();
+
+    await renderHook(() => usePatientVisits({ tenantId: null, patientId: 'patient-1', repository }));
+
+    expect(repository.listPatientVisits).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch without patientId', async () => {
+    const repository = createRepository();
+
+    await renderHook(() => usePatientVisits({ tenantId: 'tenant-1', patientId: null, repository }));
+
+    expect(repository.listPatientVisits).not.toHaveBeenCalled();
+  });
+
+  it('fetches patient visits through EncounterVisitRepository', async () => {
+    const repository = createRepository();
+    const getResult = await renderHook(() => usePatientVisits({ tenantId: 'tenant-1', patientId: 'patient-1', repository }));
+
+    expect(repository.listPatientVisits).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      patientId: 'patient-1',
+      includeArchived: false,
+    }));
+    expect(getResult().visits).toEqual([visit]);
+  });
+
+  it('surfaces repository errors', async () => {
+    const repositoryError = new Error('Repository exploded');
+    const repository = createRepository({
+      listPatientVisits: vi.fn().mockRejectedValue(repositoryError),
+    });
+
+    const getResult = await renderHook(() => usePatientVisits({ tenantId: 'tenant-1', patientId: 'patient-1', repository }));
+
+    expect(getResult().isError).toBe(true);
+    expect(getResult().error).toBe(repositoryError);
+  });
+
+  it('refresh reloads visits', async () => {
+    const repository = createRepository();
+    const getResult = await renderHook(() => usePatientVisits({ tenantId: 'tenant-1', patientId: 'patient-1', repository }));
+
+    await act(async () => {
+      await getResult().refresh();
+    });
+
+    expect(repository.listPatientVisits).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/data/hooks/usePatientVisits.ts
+++ b/src/data/hooks/usePatientVisits.ts
@@ -1,0 +1,70 @@
+import { useCallback, useMemo } from 'react';
+import { useAsyncQuery } from './useAsyncQuery';
+import {
+  createEncounterVisitRepository,
+  type EncounterVisitRepository,
+  type PatientVisit,
+} from '../repositories/EncounterVisitRepository';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+
+export interface UsePatientVisitsOptions {
+  tenantId?: string | null;
+  patientId?: string | null;
+  includeArchived?: boolean;
+  repository?: EncounterVisitRepository;
+}
+
+export interface UsePatientVisitsResult {
+  visits: PatientVisit[];
+  loading: boolean;
+  isLoading: boolean;
+  error: Error | null;
+  isError: boolean;
+  refresh: () => Promise<void>;
+}
+
+const SUPABASE_VISITS_UNAVAILABLE_ERROR = 'Supabase client is not configured for patient visit access.';
+
+export function usePatientVisits({
+  tenantId,
+  patientId,
+  includeArchived = false,
+  repository,
+}: UsePatientVisitsOptions): UsePatientVisitsResult {
+  const canFetch = Boolean(tenantId && patientId);
+
+  const encounterVisitRepository = useMemo(() => {
+    if (repository) return repository;
+    if (!isSupabaseConfigured) return null;
+    return createEncounterVisitRepository({ backend: 'supabase' });
+  }, [repository]);
+
+  const queryFn = useCallback(async () => {
+    if (!tenantId || !patientId) return [];
+    if (!encounterVisitRepository) {
+      throw new Error(SUPABASE_VISITS_UNAVAILABLE_ERROR);
+    }
+
+    return encounterVisitRepository.listPatientVisits({
+      tenantId,
+      patientId,
+      includeArchived,
+      limit: 50,
+    });
+  }, [encounterVisitRepository, includeArchived, patientId, tenantId]);
+
+  const { data, isLoading, isError, error, refetch } = useAsyncQuery<PatientVisit[]>({
+    queryFn,
+    initialData: [],
+    enabled: canFetch,
+  });
+
+  return {
+    visits: data,
+    loading: isLoading,
+    isLoading,
+    error,
+    isError,
+    refresh: refetch,
+  };
+}

--- a/src/data/hooks/useVisitLifecycleActions.test.tsx
+++ b/src/data/hooks/useVisitLifecycleActions.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVisitLifecycleActions, type UseVisitLifecycleActionsResult } from './useVisitLifecycleActions';
+import type { EncounterVisitRpcClient } from '../repositories/EncounterVisitRpcClient';
+import type { PatientVisit } from '../repositories/EncounterVisitRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {},
+  isSupabaseConfigured: true,
+}));
+
+const visit: PatientVisit = {
+  id: 'visit-1',
+  tenantId: 'tenant-1',
+  patientId: 'patient-1',
+  appointmentId: null,
+  status: 'checked_in',
+  visitType: 'regular',
+  arrivedAt: '2026-06-20T08:00:00.000Z',
+  checkedInAt: '2026-06-20T08:00:00.000Z',
+  startedAt: null,
+  completedAt: null,
+  cancelledAt: null,
+  archivedAt: null,
+  createdBy: null,
+  updatedBy: null,
+  archivedBy: null,
+  notes: null,
+  metadata: {},
+  createdAt: '2026-06-20T08:00:00.000Z',
+  updatedAt: '2026-06-20T08:00:00.000Z',
+};
+
+function createRpcClient(overrides: Partial<EncounterVisitRpcClient> = {}): EncounterVisitRpcClient {
+  return {
+    checkInPatientVisit: vi.fn().mockResolvedValue(visit),
+    startPatientVisit: vi.fn().mockResolvedValue({ ...visit, status: 'in_progress' }),
+    completePatientVisit: vi.fn().mockResolvedValue({ ...visit, status: 'completed' }),
+    cancelPatientVisit: vi.fn().mockResolvedValue({ ...visit, status: 'cancelled' }),
+    createClinicalEncounter: vi.fn(),
+    startClinicalEncounter: vi.fn(),
+    completeClinicalEncounter: vi.fn(),
+    recordCompletedService: vi.fn(),
+    voidCompletedService: vi.fn(),
+    ...overrides,
+  } as EncounterVisitRpcClient;
+}
+
+describe('useVisitLifecycleActions', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  async function renderHook(hook: () => UseVisitLifecycleActionsResult) {
+    let latest: UseVisitLifecycleActionsResult | undefined;
+    const Probe = () => {
+      const result = hook();
+      useEffect(() => {
+        latest = result;
+      }, [result]);
+      return null;
+    };
+
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    return () => latest!;
+  }
+
+  it('checkInVisit calls EncounterVisitRpcClient.checkInPatientVisit and refreshes', async () => {
+    const rpcClient = createRpcClient();
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const getResult = await renderHook(() => useVisitLifecycleActions({ tenantId: 'tenant-1', patientId: 'patient-1', rpcClient, refresh }));
+
+    await act(async () => {
+      await getResult().checkInVisit({ visitType: 'consultation', notes: 'note' });
+    });
+
+    expect(rpcClient.checkInPatientVisit).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      patientId: 'patient-1',
+      visitType: 'consultation',
+      notes: 'note',
+    }));
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('startVisit calls startPatientVisit', async () => {
+    const rpcClient = createRpcClient();
+    const getResult = await renderHook(() => useVisitLifecycleActions({ tenantId: 'tenant-1', patientId: 'patient-1', rpcClient }));
+
+    await act(async () => {
+      await getResult().startVisit('visit-1');
+    });
+
+    expect(rpcClient.startPatientVisit).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1', visitId: 'visit-1' }));
+  });
+
+  it('completeVisit calls completePatientVisit', async () => {
+    const rpcClient = createRpcClient();
+    const getResult = await renderHook(() => useVisitLifecycleActions({ tenantId: 'tenant-1', patientId: 'patient-1', rpcClient }));
+
+    await act(async () => {
+      await getResult().completeVisit('visit-1');
+    });
+
+    expect(rpcClient.completePatientVisit).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1', visitId: 'visit-1' }));
+  });
+
+  it('cancelVisit calls cancelPatientVisit and requires reason', async () => {
+    const rpcClient = createRpcClient();
+    const getResult = await renderHook(() => useVisitLifecycleActions({ tenantId: 'tenant-1', patientId: 'patient-1', rpcClient }));
+
+    await expect(getResult().cancelVisit({ visitId: 'visit-1', reason: '' })).rejects.toThrow('Укажите причину отмены визита.');
+
+    await act(async () => {
+      await getResult().cancelVisit({ visitId: 'visit-1', reason: 'Пациент ушёл' });
+    });
+
+    expect(rpcClient.cancelPatientVisit).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      visitId: 'visit-1',
+      reason: 'Пациент ушёл',
+    }));
+  });
+
+  it('failed action surfaces a safe error', async () => {
+    const rpcClient = createRpcClient({
+      startPatientVisit: vi.fn().mockRejectedValue(new Error('permission denied for rpc')),
+    });
+    const getResult = await renderHook(() => useVisitLifecycleActions({ tenantId: 'tenant-1', patientId: 'patient-1', rpcClient }));
+
+    await act(async () => {
+      await expect(getResult().startVisit('visit-1')).rejects.toThrow('Недостаточно прав для действия.');
+    });
+
+    expect(getResult().error?.message).toBe('Недостаточно прав для действия.');
+  });
+
+  it('does not call clinical encounter or completed service RPCs from visit lifecycle actions', async () => {
+    const rpcClient = createRpcClient();
+    const getResult = await renderHook(() => useVisitLifecycleActions({ tenantId: 'tenant-1', patientId: 'patient-1', rpcClient }));
+
+    await act(async () => {
+      await getResult().startVisit('visit-1');
+    });
+
+    expect(rpcClient.createClinicalEncounter).not.toHaveBeenCalled();
+    expect(rpcClient.recordCompletedService).not.toHaveBeenCalled();
+  });
+});

--- a/src/data/hooks/useVisitLifecycleActions.ts
+++ b/src/data/hooks/useVisitLifecycleActions.ts
@@ -1,0 +1,165 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  createEncounterVisitRpcClient,
+  type EncounterVisitRpcClient,
+} from '../repositories/EncounterVisitRpcClient';
+import type { PatientVisitType } from '../repositories/EncounterVisitRepository';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+
+export type VisitLifecycleActionName = 'check_in' | 'start' | 'complete' | 'cancel';
+
+export interface CheckInVisitInput {
+  visitType: PatientVisitType;
+  notes?: string | null;
+  appointmentId?: string | null;
+}
+
+export interface CancelVisitInput {
+  visitId: string;
+  reason: string;
+}
+
+export interface UseVisitLifecycleActionsOptions {
+  tenantId?: string | null;
+  patientId?: string | null;
+  refresh?: () => Promise<void> | void;
+  rpcClient?: EncounterVisitRpcClient;
+}
+
+export interface UseVisitLifecycleActionsResult {
+  actionLoading: VisitLifecycleActionName | null;
+  loading: boolean;
+  error: Error | null;
+  checkInVisit: (input: CheckInVisitInput) => Promise<void>;
+  startVisit: (visitId: string) => Promise<void>;
+  completeVisit: (visitId: string) => Promise<void>;
+  cancelVisit: (input: CancelVisitInput) => Promise<void>;
+  clearError: () => void;
+}
+
+const ACTION_METADATA = { source: 'visit_checkin_ui' };
+const SUPABASE_RPC_UNAVAILABLE_ERROR = 'Supabase client is not configured for visit lifecycle actions.';
+const TENANT_REQUIRED_ERROR = 'Не выбрана клиника.';
+const PATIENT_REQUIRED_ERROR = 'Пациент не найден.';
+const VISIT_REQUIRED_ERROR = 'Невозможно выполнить действие для текущего статуса визита.';
+const CANCEL_REASON_REQUIRED_ERROR = 'Укажите причину отмены визита.';
+
+function safeError(error: unknown, fallback: string): Error {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (message.includes('permission') || message.includes('not allowed') || message.includes('denied')) {
+      return new Error('Недостаточно прав для действия.');
+    }
+    if (message.includes('status') || message.includes('transition') || message.includes('visit')) {
+      return new Error('Невозможно выполнить действие для текущего статуса визита.');
+    }
+    return new Error(error.message || fallback);
+  }
+
+  return new Error(fallback);
+}
+
+export function useVisitLifecycleActions({
+  tenantId,
+  patientId,
+  refresh,
+  rpcClient,
+}: UseVisitLifecycleActionsOptions): UseVisitLifecycleActionsResult {
+  const [actionLoading, setActionLoading] = useState<VisitLifecycleActionName | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const client = useMemo(() => {
+    if (rpcClient) return rpcClient;
+    if (!isSupabaseConfigured) return null;
+    return createEncounterVisitRpcClient({ backend: 'supabase' });
+  }, [rpcClient]);
+
+  const requireClient = useCallback(() => {
+    if (!tenantId) throw new Error(TENANT_REQUIRED_ERROR);
+    if (!client) throw new Error(SUPABASE_RPC_UNAVAILABLE_ERROR);
+    return client;
+  }, [client, tenantId]);
+
+  const runAction = useCallback(async (actionName: VisitLifecycleActionName, action: () => Promise<void>) => {
+    setActionLoading(actionName);
+    setError(null);
+    try {
+      await action();
+      await refresh?.();
+    } catch (err) {
+      const parsed = safeError(err, 'Не удалось обновить визит. Попробуйте ещё раз.');
+      setError(parsed);
+      throw parsed;
+    } finally {
+      setActionLoading(null);
+    }
+  }, [refresh]);
+
+  const checkInVisit = useCallback(async (input: CheckInVisitInput) => {
+    await runAction('check_in', async () => {
+      const actionClient = requireClient();
+      if (!patientId) throw new Error(PATIENT_REQUIRED_ERROR);
+
+      await actionClient.checkInPatientVisit({
+        tenantId: tenantId!,
+        patientId,
+        appointmentId: input.appointmentId ?? null,
+        visitType: input.visitType,
+        notes: input.notes?.trim() || null,
+        metadata: ACTION_METADATA,
+      });
+    });
+  }, [patientId, requireClient, runAction, tenantId]);
+
+  const startVisit = useCallback(async (visitId: string) => {
+    await runAction('start', async () => {
+      const actionClient = requireClient();
+      if (!visitId) throw new Error(VISIT_REQUIRED_ERROR);
+
+      await actionClient.startPatientVisit({
+        tenantId: tenantId!,
+        visitId,
+        metadata: ACTION_METADATA,
+      });
+    });
+  }, [requireClient, runAction, tenantId]);
+
+  const completeVisit = useCallback(async (visitId: string) => {
+    await runAction('complete', async () => {
+      const actionClient = requireClient();
+      if (!visitId) throw new Error(VISIT_REQUIRED_ERROR);
+
+      await actionClient.completePatientVisit({
+        tenantId: tenantId!,
+        visitId,
+        metadata: ACTION_METADATA,
+      });
+    });
+  }, [requireClient, runAction, tenantId]);
+
+  const cancelVisit = useCallback(async ({ visitId, reason }: CancelVisitInput) => {
+    await runAction('cancel', async () => {
+      const actionClient = requireClient();
+      if (!visitId) throw new Error(VISIT_REQUIRED_ERROR);
+      if (!reason.trim()) throw new Error(CANCEL_REASON_REQUIRED_ERROR);
+
+      await actionClient.cancelPatientVisit({
+        tenantId: tenantId!,
+        visitId,
+        reason: reason.trim(),
+        metadata: ACTION_METADATA,
+      });
+    });
+  }, [requireClient, runAction, tenantId]);
+
+  return {
+    actionLoading,
+    loading: actionLoading !== null,
+    error,
+    checkInVisit,
+    startVisit,
+    completeVisit,
+    cancelVisit,
+    clearError: () => setError(null),
+  };
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -135,6 +135,7 @@ export function LoginPage() {
                   <button
                     key={user.email}
                     type="button"
+                    data-testid={`qa-login-${user.email}`}
                     disabled={isSubmitting}
                     onClick={() => void handleQaLogin(user.email)}
                     className="rounded-md border border-amber-200 bg-white px-3 py-2 text-left text-sm text-slate-800 shadow-sm transition-colors hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -10,6 +10,7 @@ import { FindingsRisksTab } from '../components/dental/FindingsRisksTab';
 import { PatientOverviewTab } from '../components/patients/patient-card/PatientOverviewTab';
 import { PatientHistoryTab } from '../components/patients/patient-card/PatientHistoryTab';
 import { PatientTimelineTab } from '../components/patient/PatientTimelineTab';
+import { VisitCheckInPanel } from '../components/visits/VisitCheckInPanel';
 import { usePatientMedicalSummary } from '../data/hooks/usePatientMedicalSummary';
 import { usePatientProfile } from '../data/hooks/usePatientProfile';
 import { usePatientTimeline } from '../data/hooks/usePatientTimeline';
@@ -20,6 +21,7 @@ const TABS = [
   { id: 'overview', label: 'Обзор' },
   { id: 'timeline', label: 'История' },
   { id: 'history', label: 'История приёмов' },
+  { id: 'visits', label: 'Визиты' },
   { id: 'dental_chart', label: 'Зубная карта' },
   { id: 'findings', label: 'Проблемы и риски' },
   { id: 'plan', label: 'План лечения' },
@@ -226,6 +228,13 @@ export function PatientCardPage() {
           />
         )}
         {activeTab === 'history' && <PatientHistoryTab patientId={patient.id} />}
+        {activeTab === 'visits' && (
+          <VisitCheckInPanel
+            tenantId={activeTenant?.tenantId}
+            patientId={patient.id}
+            role={activeTenant?.role}
+          />
+        )}
         {activeTab === 'dental_chart' && <DentalChartTab patientId={patient.id} />}
         {activeTab === 'findings' && <FindingsRisksTab patientId={patient.id} />}
         {activeTab === 'plan' && <TreatmentPlansTab patientId={patient.id} />}

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -172,6 +172,7 @@ export function PatientCardPage() {
           {TABS.map(tab => (
             <button
               key={tab.id}
+              data-testid={`patient-tab-${tab.id}`}
               onClick={() => setActiveTab(tab.id)}
               className={`pb-3 text-sm font-medium transition-colors relative ${
                 activeTab === tab.id ? 'text-blue-600' : 'text-slate-500 hover:text-slate-800'
@@ -229,11 +230,13 @@ export function PatientCardPage() {
         )}
         {activeTab === 'history' && <PatientHistoryTab patientId={patient.id} />}
         {activeTab === 'visits' && (
-          <VisitCheckInPanel
-            tenantId={activeTenant?.tenantId}
-            patientId={patient.id}
-            role={activeTenant?.role}
-          />
+          <div data-testid="patient-visits-tab">
+            <VisitCheckInPanel
+              tenantId={activeTenant?.tenantId}
+              patientId={patient.id}
+              role={activeTenant?.role}
+            />
+          </div>
         )}
         {activeTab === 'dental_chart' && <DentalChartTab patientId={patient.id} />}
         {activeTab === 'findings' && <FindingsRisksTab patientId={patient.id} />}


### PR DESCRIPTION
Adds the patient visit lifecycle UI tab, repository-backed visit reads, RPC-client-backed check-in/start/complete/cancel actions, role gating, unit tests, and report.

Validation: lint, full test suite (52 files / 490 tests), build, GitHub CI #573, and full local Supabase role-based lifecycle browser smoke passed.

Smoke covered: check-in, start, complete, cancel (6 role/tenant scenarios: clinic_admin, doctor, registrar, cashier, no-tenant, cross-tenant). Real RPC writes, RLS/tenant boundaries, audit/activity side effects, and cleanup verified at zero remaining rows.

Do not merge automatically.