### PR TITLE
PAYMENTS-DEBTS-REPOSITORY-001B: add read-only finance repository

### DIFF
--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
@@ -1,4 +1,4 @@
-# PAYMENTS-DEBTS-REPOSITORY-001B — Finance read repository
+﻿# PAYMENTS-DEBTS-REPOSITORY-001B — Finance read repository
 
 ## Summary
 Implemented a read-only finance repository layer for the finance schema introduced by PAYMENTS-DEBTS-SCHEMA-001A.
@@ -14,7 +14,7 @@ No write paths, RPCs, UI, hooks, migrations, cloud actions, seed data, generated
 https://github.com/NckNA/codex-test/pull/324
 
 ## PR head reviewed before final report update
-cc360f548713074b0e7226fd4ac25421ceb9e1d7
+d380980a0d3087d453499f46b94ed57825dd4000
 
 ## Report update commit
 N/A because the final report update commit cannot reference itself before creation.
@@ -42,8 +42,8 @@ Reviewed existing repository conventions from the encounter/visit read repositor
 Finance schema dependency:
 
 - The implementation targets `0016_create_finance_model.sql` from PAYMENTS-DEBTS-SCHEMA-001A.
-- At implementation time, `origin/main` still contained migrations only through `0015`, because PR #323 had not yet been merged.
-- The repository therefore avoids changing migrations and documents local DB validation as partial until #323 lands on `main`.
+- `origin/main` now contains `0016_create_finance_model.sql` after PR #323 was merged.
+- This branch was rebased onto current `origin/main` and validated against the local finance tables created by `0016`.
 
 ## Repository design
 Added `src/data/repositories/FinanceRepository.ts`.
@@ -218,22 +218,17 @@ Covered scenarios:
 - no mocked write calls.
 
 ## Local validation
-Dependency caveat:
+`npx supabase db reset --no-seed` was rerun through the local Supabase reset tool after rebasing onto current origin/main.
 
-- `origin/main` did not contain `supabase/migrations/0016_create_finance_model.sql` at implementation time.
-- Clean `npx supabase db reset --no-seed` therefore applied migrations only through `0015`.
-- This confirms existing migrations still reset cleanly, but it cannot validate empty finance tables until PR #323 is merged into `main` or this branch is rebased onto a base that includes `0016`.
+Validation result:
 
-Commands run:
-
-- `npx supabase db reset --no-seed` — passed after Docker Desktop was started, applying migrations through `0015` on current `main`.
-- No seed data was inserted.
-- No local finance rows were created.
-
-Finance table read validation:
-
-- Not run against local DB because `0016` was not present on current `origin/main`.
-- Repository behavior was validated through mocked Supabase reads and TypeScript summary tests.
+- local reset passed with `0016_create_finance_model.sql` applied;
+- finance tables exist locally: `invoices`, `invoice_items`, `payments`, `payment_allocations`, `refunds`, `financial_adjustments`;
+- row counts are `0` for all six finance tables;
+- no seed data was inserted;
+- no invoice/payment/refund/adjustment rows were created;
+- repository empty-list and zero-summary behavior is covered by unit tests;
+- repository reads remain read-only and tenant-bound.
 
 ## What was intentionally NOT changed
 - no migrations;
@@ -259,23 +254,24 @@ Local checks:
 - `npm run test -- --run src/data/repositories/FinanceRepository.test.ts` — passed, 19 tests.
 - `npm run test -- --run` — passed, 59 files / 552 tests.
 - `npm run build` — passed.
-- `npx supabase db reset --no-seed` — passed for current main migrations through `0015`; finance table validation blocked until `0016` is on base.
+- `npx supabase db reset --no-seed` — passed through local Supabase reset after rebase; `0016_create_finance_model.sql` applied and finance tables validated empty.
 
 GitHub Actions CI:
 
-- TBD after PR creation.
+- Pending fresh CI after final report update.
 
 ## Issues / warnings
 Known limitations:
 
-1. Base dependency: `0016_create_finance_model.sql` is not yet present on `origin/main` at implementation time.
-2. Local finance-table DB validation remains pending until PR #323 is merged or this branch is rebased onto a base containing `0016`.
-3. Patient finance summary is preliminary and should not be treated as final accounting truth.
-4. Existing project test warnings remain: React `act(...)` warnings in unrelated UI tests and intentional error-handling stderr logs.
-5. `npm ci` reports existing dependency audit warnings; no dependency changes were made.
+1. Patient finance summary is preliminary and should not be treated as final accounting truth.
+2. Existing project test warnings remain: React `act(...)` warnings in unrelated UI tests and intentional error-handling stderr logs.
+3. 
+pm ci` reports existing dependency audit warnings; no dependency changes were made.
 
 ## Final verdict
-PARTIAL — read-only finance repository implemented and locally TypeScript-tested, but local DB validation against finance tables is pending because the schema migration dependency is not yet on `main`.
+PAYMENTS DEBTS REPOSITORY IMPLEMENTED AND VERIFIED
 
 ## Recommended next task
-PAYMENTS-DEBTS-RPC-001C, after PAYMENTS-DEBTS-SCHEMA-001A is merged and this repository branch is rebased/validated against `0016`.
+PAYMENTS-DEBTS-RPC-001C
+
+

--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
@@ -14,7 +14,7 @@ No write paths, RPCs, UI, hooks, migrations, cloud actions, seed data, generated
 https://github.com/NckNA/codex-test/pull/324
 
 ## PR head reviewed before final report update
-d380980a0d3087d453499f46b94ed57825dd4000
+14e0b53521c656ce7e470ca431ddd39bddc3db09
 
 ## Report update commit
 N/A because the final report update commit cannot reference itself before creation.
@@ -258,7 +258,7 @@ Local checks:
 
 GitHub Actions CI:
 
-- Pending fresh CI after final report update.
+- GitHub Actions CI #615 / run 27907475017: success on 14e0b53521c656ce7e470ca431ddd39bddc3db09.
 
 ## Issues / warnings
 Known limitations:

--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
@@ -1,0 +1,281 @@
+# PAYMENTS-DEBTS-REPOSITORY-001B — Finance read repository
+
+## Summary
+Implemented a read-only finance repository layer for the finance schema introduced by PAYMENTS-DEBTS-SCHEMA-001A.
+
+This task adds typed read models, Supabase read methods, snake_case-to-camelCase mappers, patient finance facts aggregation, and a preliminary TypeScript patient finance summary helper.
+
+No write paths, RPCs, UI, hooks, migrations, cloud actions, seed data, generated types, stock, documents, timeline, or reports UI were implemented.
+
+## Branch name
+`feature/payments-debts-repository-001b`
+
+## PR URL
+TBD after PR creation.
+
+## PR head reviewed before final report update
+TBD after PR creation.
+
+## Report update commit
+N/A because the final report update commit cannot reference itself before creation.
+
+## Changed files summary
+Expected changed files:
+
+- `src/data/repositories/FinanceRepository.ts`
+- `src/data/repositories/FinanceRepository.test.ts`
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md`
+
+No migration, UI, hook, repository outside finance, seed, cloud, generated type, stock, document, timeline, or report UI files were intentionally changed.
+
+## Pre-read summary
+Reviewed existing repository conventions from the encounter/visit read repository:
+
+- repository is class-based;
+- Supabase client is injected through constructor/factory;
+- tenantId is required before querying;
+- DB rows are mapped into camelCase domain models;
+- list methods use Supabase `.select()`, `.eq()`, optional filters, ordering, and pagination;
+- get methods use `.maybeSingle()` and return `null` when missing;
+- repository tests mock the Supabase query chain.
+
+Finance schema dependency:
+
+- The implementation targets `0016_create_finance_model.sql` from PAYMENTS-DEBTS-SCHEMA-001A.
+- At implementation time, `origin/main` still contained migrations only through `0015`, because PR #323 had not yet been merged.
+- The repository therefore avoids changing migrations and documents local DB validation as partial until #323 lands on `main`.
+
+## Repository design
+Added `src/data/repositories/FinanceRepository.ts`.
+
+Structure:
+
+- `FinanceRepository` interface;
+- `SupabaseFinanceRepository` class;
+- `createFinanceRepository` factory;
+- finance domain type aliases;
+- row mappers;
+- `computePatientFinanceSummary` helper.
+
+Supabase usage:
+
+- uses injected `SupabaseClient`;
+- defaults to the existing app `supabase` client through the factory;
+- supports only the Supabase backend;
+- rejects local backend for finance reads.
+
+Tenant boundary:
+
+- every public repository method requires `tenantId`;
+- every query filters `tenant_id` before returning rows;
+- patient-scoped facts/summary require both `tenantId` and `patientId`.
+
+## Methods added
+Read-only methods:
+
+1. `listInvoices`
+2. `getInvoiceById`
+3. `listInvoiceItems`
+4. `listPayments`
+5. `getPaymentById`
+6. `listPaymentAllocations`
+7. `listRefunds`
+8. `listFinancialAdjustments`
+9. `getPatientFinanceFacts`
+10. `getPatientFinanceSummary`
+
+## Domain models and mapping
+Added domain models for:
+
+- `Invoice`
+- `InvoiceItem`
+- `Payment`
+- `PaymentAllocation`
+- `Refund`
+- `FinancialAdjustment`
+- `PatientFinanceFacts`
+- `PatientFinanceSummary`
+
+Mapping behavior:
+
+- converts DB snake_case fields to camelCase;
+- preserves nullable fields;
+- preserves metadata as a plain object;
+- coerces numeric DB values into numbers;
+- throws on missing required fields.
+
+## Query behavior
+Filters:
+
+- all methods require and filter by `tenant_id`;
+- patient-scoped list methods filter by `patient_id` when provided;
+- invoice item reads can filter by `invoice_id` and `completed_service_id`;
+- payment reads can filter by `payment_method` and status;
+- allocations can filter by payment, invoice, invoice item, and patient;
+- refunds can filter by payment and status;
+- adjustments can filter by invoice, invoice item, payment, type, and status.
+
+Archived/voided handling:
+
+- invoice, invoice item, payment, refund, and adjustment list methods exclude `archived` by default;
+- payment allocations exclude `voided` and `archived` by default;
+- patient finance summary ignores voided/archived/rejected facts.
+
+Ordering:
+
+- invoices: `created_at desc`;
+- invoice items: `created_at desc`;
+- payments: `received_at desc`;
+- allocations: `allocated_at desc`;
+- refunds: `requested_at desc`;
+- adjustments: `created_at desc`.
+
+Pagination:
+
+- list methods support `limit` and `offset`;
+- limit is clamped to 1..200;
+- default limit is 50.
+
+## Patient finance summary
+Added a preliminary TypeScript read helper.
+
+Included:
+
+- active invoice total;
+- payment amount;
+- allocated payment amount;
+- completed refund amount;
+- discount amount;
+- write-off amount;
+- net adjustment amount;
+- balance amount;
+- credit amount;
+- open/unpaid/partially-paid invoice counts;
+- last payment timestamp.
+
+Excluded:
+
+- voided/archived invoices;
+- voided/archived payments;
+- voided/archived allocations;
+- non-completed refunds;
+- rejected/voided/archived adjustments;
+- `patients.balance`.
+
+Formula limitation:
+
+- The helper is intentionally conservative and preliminary.
+- It is not a final accounting ledger, not a write authority, and not a replacement for future RPC-controlled balance logic.
+- It does not mutate invoices, payments, completed services, or patient rows.
+
+## Safety boundaries
+The repository intentionally performs no financial writes.
+
+Blocked by design:
+
+- no `insert`;
+- no `update`;
+- no `delete`;
+- no `upsert`;
+- no `rpc`;
+- no raw SQL;
+- no localStorage fallback;
+- no frontend service-role usage;
+- no `patients.balance` source-of-truth use;
+- no `completed_services` mutation;
+- no UI or React imports.
+
+The repository is a read layer only. Future writes remain reserved for `PAYMENTS-DEBTS-RPC-001C`.
+
+## Tests
+Added `src/data/repositories/FinanceRepository.test.ts`.
+
+Covered scenarios:
+
+- tenantId required before querying;
+- patientId required for patient facts/summary;
+- IDs required for get methods;
+- invoice mapping;
+- invoice item mapping including `completed_service_id`;
+- payment mapping including `payment_method` and `received_at`;
+- allocation mapping;
+- refund mapping;
+- adjustment mapping;
+- invoice filters and pagination;
+- invoice item filters;
+- payment filters;
+- allocation filters;
+- refund filters;
+- adjustment filters;
+- patient facts aggregation;
+- zero summary when no facts exist;
+- summary ignores voided/archived facts;
+- overpayment/credit handling;
+- Supabase error propagation;
+- empty list behavior;
+- pagination normalization;
+- factory behavior;
+- no mocked write calls.
+
+## Local validation
+Dependency caveat:
+
+- `origin/main` did not contain `supabase/migrations/0016_create_finance_model.sql` at implementation time.
+- Clean `npx supabase db reset --no-seed` therefore applied migrations only through `0015`.
+- This confirms existing migrations still reset cleanly, but it cannot validate empty finance tables until PR #323 is merged into `main` or this branch is rebased onto a base that includes `0016`.
+
+Commands run:
+
+- `npx supabase db reset --no-seed` — passed after Docker Desktop was started, applying migrations through `0015` on current `main`.
+- No seed data was inserted.
+- No local finance rows were created.
+
+Finance table read validation:
+
+- Not run against local DB because `0016` was not present on current `origin/main`.
+- Repository behavior was validated through mocked Supabase reads and TypeScript summary tests.
+
+## What was intentionally NOT changed
+- no migrations;
+- no SQL schema edits;
+- no UI;
+- no hooks;
+- no RPC;
+- no frontend RPC client;
+- no Supabase cloud;
+- no seed;
+- no generated types;
+- no payment integrations;
+- no stock;
+- no documents;
+- no timeline;
+- no reports UI.
+
+## Checks
+Local checks:
+
+- `npm ci` — passed, with existing dependency audit warnings.
+- `npm run lint` — passed.
+- `npm run test -- --run src/data/repositories/FinanceRepository.test.ts` — passed, 19 tests.
+- `npm run test -- --run` — passed, 59 files / 552 tests.
+- `npm run build` — passed.
+- `npx supabase db reset --no-seed` — passed for current main migrations through `0015`; finance table validation blocked until `0016` is on base.
+
+GitHub Actions CI:
+
+- TBD after PR creation.
+
+## Issues / warnings
+Known limitations:
+
+1. Base dependency: `0016_create_finance_model.sql` is not yet present on `origin/main` at implementation time.
+2. Local finance-table DB validation remains pending until PR #323 is merged or this branch is rebased onto a base containing `0016`.
+3. Patient finance summary is preliminary and should not be treated as final accounting truth.
+4. Existing project test warnings remain: React `act(...)` warnings in unrelated UI tests and intentional error-handling stderr logs.
+5. `npm ci` reports existing dependency audit warnings; no dependency changes were made.
+
+## Final verdict
+PARTIAL — read-only finance repository implemented and locally TypeScript-tested, but local DB validation against finance tables is pending because the schema migration dependency is not yet on `main`.
+
+## Recommended next task
+PAYMENTS-DEBTS-RPC-001C, after PAYMENTS-DEBTS-SCHEMA-001A is merged and this repository branch is rebased/validated against `0016`.

--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md
@@ -11,10 +11,10 @@ No write paths, RPCs, UI, hooks, migrations, cloud actions, seed data, generated
 `feature/payments-debts-repository-001b`
 
 ## PR URL
-TBD after PR creation.
+https://github.com/NckNA/codex-test/pull/324
 
 ## PR head reviewed before final report update
-TBD after PR creation.
+cc360f548713074b0e7226fd4ac25421ceb9e1d7
 
 ## Report update commit
 N/A because the final report update commit cannot reference itself before creation.

--- a/src/data/repositories/FinanceRepository.test.ts
+++ b/src/data/repositories/FinanceRepository.test.ts
@@ -1,0 +1,544 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR,
+  PATIENT_REQUIRED_FOR_FINANCE_ERROR,
+  RECORD_ID_REQUIRED_FOR_FINANCE_ERROR,
+  SupabaseFinanceRepository,
+  computePatientFinanceSummary,
+  createFinanceRepository,
+  mapFinancialAdjustmentRow,
+  mapInvoiceItemRow,
+  mapInvoiceRow,
+  mapPaymentAllocationRow,
+  mapPaymentRow,
+  mapRefundRow,
+  normalizeFinanceLimit,
+  normalizeFinanceOffset,
+  type PatientFinanceFacts,
+} from './FinanceRepository';
+
+type QueryResult = {
+  data: Record<string, unknown>[] | null;
+  error: Error | null;
+};
+
+type SingleQueryResult = {
+  data: Record<string, unknown> | null;
+  error: Error | null;
+};
+
+type QueryCall = {
+  table?: string;
+  method: string;
+  args: unknown[];
+};
+
+type RepositoryFixture = {
+  repository: SupabaseFinanceRepository;
+  client: {
+    from: ReturnType<typeof vi.fn>;
+    insert: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+    rpc: ReturnType<typeof vi.fn>;
+  };
+  calls: QueryCall[];
+};
+
+function createRepository(
+  resultsByTable: Record<string, QueryResult> = {},
+  singleByTable: Record<string, SingleQueryResult> = {},
+): RepositoryFixture {
+  const calls: QueryCall[] = [];
+
+  const client = {
+    from: vi.fn((tableName: string) => {
+      calls.push({ table: tableName, method: 'from', args: [tableName] });
+      const chain = {
+        select: vi.fn(),
+        eq: vi.fn(),
+        neq: vi.fn(),
+        in: vi.fn(),
+        order: vi.fn(),
+        range: vi.fn(),
+        maybeSingle: vi.fn(),
+      };
+
+      chain.select.mockImplementation((...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'select', args });
+        return chain;
+      });
+      chain.eq.mockImplementation((...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'eq', args });
+        return chain;
+      });
+      chain.neq.mockImplementation((...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'neq', args });
+        return chain;
+      });
+      chain.in.mockImplementation((...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'in', args });
+        return chain;
+      });
+      chain.order.mockImplementation((...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'order', args });
+        return chain;
+      });
+      chain.range.mockImplementation(async (...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'range', args });
+        return resultsByTable[tableName] ?? { data: [], error: null };
+      });
+      chain.maybeSingle.mockImplementation(async (...args: unknown[]) => {
+        calls.push({ table: tableName, method: 'maybeSingle', args });
+        return singleByTable[tableName] ?? { data: null, error: null };
+      });
+      return chain;
+    }),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    upsert: vi.fn(),
+    rpc: vi.fn(),
+  };
+
+  return {
+    repository: new SupabaseFinanceRepository(client as unknown as SupabaseClient),
+    client,
+    calls,
+  };
+}
+
+function expectCall(calls: QueryCall[], table: string, method: string, ...args: unknown[]) {
+  expect(calls).toContainEqual({ table, method, args });
+}
+
+function expectNoWriteCalls(client: RepositoryFixture['client']) {
+  expect(client.insert).not.toHaveBeenCalled();
+  expect(client.update).not.toHaveBeenCalled();
+  expect(client.delete).not.toHaveBeenCalled();
+  expect(client.upsert).not.toHaveBeenCalled();
+  expect(client.rpc).not.toHaveBeenCalled();
+}
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const patientId = '22222222-2222-2222-2222-222222222222';
+const invoiceId = '33333333-3333-3333-3333-333333333333';
+const invoiceItemId = '44444444-4444-4444-4444-444444444444';
+const paymentId = '55555555-5555-5555-5555-555555555555';
+const completedServiceId = '66666666-6666-6666-6666-666666666666';
+
+const invoiceRow = {
+  id: invoiceId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  invoice_number: 'INV-1',
+  status: 'issued',
+  currency: 'KZT',
+  issue_date: '2026-06-21T00:00:00Z',
+  due_date: '2026-06-30T00:00:00Z',
+  subtotal_amount: '12000.00',
+  discount_amount: '1000.00',
+  adjustment_amount: '0.00',
+  total_amount: '11000.00',
+  paid_amount: '4000.00',
+  refunded_amount: '0.00',
+  written_off_amount: '0.00',
+  balance_amount: '7000.00',
+  notes: 'Initial bill',
+  metadata: { source: 'test' },
+  created_by: 'user-1',
+  issued_by: 'user-2',
+  voided_by: null,
+  void_reason: null,
+  issued_at: '2026-06-21T01:00:00Z',
+  voided_at: null,
+  archived_at: null,
+  created_at: '2026-06-21T01:00:01Z',
+  updated_at: '2026-06-21T01:00:02Z',
+};
+
+const invoiceItemRow = {
+  id: invoiceItemId,
+  tenant_id: tenantId,
+  invoice_id: invoiceId,
+  patient_id: patientId,
+  completed_service_id: completedServiceId,
+  service_name: 'Consultation',
+  service_code: 'CONS-1',
+  tooth_number: '16',
+  tooth_surface: 'occlusal',
+  quantity: '1.000',
+  unit_price: '12000.00',
+  discount_amount: '1000.00',
+  adjustment_amount: '0.00',
+  total_amount: '11000.00',
+  status: 'active',
+  notes: null,
+  metadata: { billable: true },
+  created_by: 'user-1',
+  voided_by: null,
+  void_reason: null,
+  voided_at: null,
+  archived_at: null,
+  created_at: '2026-06-21T01:00:01Z',
+  updated_at: '2026-06-21T01:00:02Z',
+};
+
+const paymentRow = {
+  id: paymentId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  status: 'received',
+  payment_method: 'kaspi',
+  amount: '5000.00',
+  currency: 'KZT',
+  received_at: '2026-06-21T02:00:00Z',
+  external_reference: 'KSP-1',
+  payer_name: 'Patient',
+  notes: null,
+  metadata: { terminal: 'kaspi' },
+  received_by: 'cashier-1',
+  voided_by: null,
+  void_reason: null,
+  voided_at: null,
+  archived_at: null,
+  created_at: '2026-06-21T02:00:01Z',
+  updated_at: '2026-06-21T02:00:02Z',
+};
+
+const allocationRow = {
+  id: '77777777-7777-7777-7777-777777777777',
+  tenant_id: tenantId,
+  patient_id: patientId,
+  payment_id: paymentId,
+  invoice_id: invoiceId,
+  invoice_item_id: invoiceItemId,
+  amount: '4000.00',
+  currency: 'KZT',
+  status: 'active',
+  allocated_at: '2026-06-21T02:10:00Z',
+  metadata: { allocation: true },
+  created_by: 'cashier-1',
+  voided_by: null,
+  void_reason: null,
+  voided_at: null,
+  created_at: '2026-06-21T02:10:01Z',
+  updated_at: '2026-06-21T02:10:02Z',
+};
+
+const refundRow = {
+  id: '88888888-8888-8888-8888-888888888888',
+  tenant_id: tenantId,
+  patient_id: patientId,
+  payment_id: paymentId,
+  status: 'completed',
+  refund_method: 'kaspi',
+  amount: '500.00',
+  currency: 'KZT',
+  reason: 'Overpayment return',
+  requested_by: 'cashier-1',
+  approved_by: 'admin-1',
+  completed_by: 'cashier-1',
+  requested_at: '2026-06-21T03:00:00Z',
+  approved_at: '2026-06-21T03:10:00Z',
+  completed_at: '2026-06-21T03:20:00Z',
+  rejected_at: null,
+  voided_at: null,
+  voided_by: null,
+  void_reason: null,
+  external_reference: 'RFD-1',
+  metadata: { refund: true },
+  created_at: '2026-06-21T03:00:01Z',
+  updated_at: '2026-06-21T03:00:02Z',
+};
+
+const adjustmentRow = {
+  id: '99999999-9999-9999-9999-999999999999',
+  tenant_id: tenantId,
+  patient_id: patientId,
+  invoice_id: invoiceId,
+  invoice_item_id: invoiceItemId,
+  payment_id: null,
+  adjustment_type: 'write_off',
+  status: 'approved',
+  amount: '1000.00',
+  currency: 'KZT',
+  reason: 'Manager approval',
+  approved_by: 'admin-1',
+  created_by: 'admin-1',
+  voided_by: null,
+  approved_at: '2026-06-21T04:00:00Z',
+  voided_at: null,
+  void_reason: null,
+  metadata: { adjustment: true },
+  created_at: '2026-06-21T04:00:01Z',
+  updated_at: '2026-06-21T04:00:02Z',
+};
+
+describe('FinanceRepository', () => {
+  it('requires tenantId before querying finance tables', async () => {
+    const { repository, client } = createRepository();
+
+    await expect(repository.listInvoices({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR);
+    await expect(repository.listPayments({ tenantId: '' })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR);
+    await expect(repository.getInvoiceById({ tenantId: '', invoiceId })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR);
+    await expect(repository.getPaymentById({ tenantId: '', paymentId })).rejects.toThrow(ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('requires patientId for patient finance facts and summary', async () => {
+    const { repository } = createRepository();
+
+    await expect(repository.getPatientFinanceFacts({ tenantId, patientId: '' })).rejects.toThrow(PATIENT_REQUIRED_FOR_FINANCE_ERROR);
+    await expect(repository.getPatientFinanceSummary({ tenantId, patientId: '' })).rejects.toThrow(PATIENT_REQUIRED_FOR_FINANCE_ERROR);
+  });
+
+  it('requires ids for get methods', async () => {
+    const { repository } = createRepository();
+
+    await expect(repository.getInvoiceById({ tenantId, invoiceId: '' })).rejects.toThrow(RECORD_ID_REQUIRED_FOR_FINANCE_ERROR);
+    await expect(repository.getPaymentById({ tenantId, paymentId: '' })).rejects.toThrow(RECORD_ID_REQUIRED_FOR_FINANCE_ERROR);
+  });
+
+  it('maps finance rows from snake_case to camelCase and preserves nulls/metadata', () => {
+    expect(mapInvoiceRow(invoiceRow)).toMatchObject({
+      id: invoiceId,
+      tenantId,
+      patientId,
+      invoiceNumber: 'INV-1',
+      totalAmount: 11000,
+      voidedBy: null,
+      metadata: { source: 'test' },
+    });
+    expect(mapInvoiceItemRow(invoiceItemRow)).toMatchObject({ completedServiceId, serviceName: 'Consultation', unitPrice: 12000 });
+    expect(mapPaymentRow(paymentRow)).toMatchObject({ paymentMethod: 'kaspi', receivedAt: '2026-06-21T02:00:00Z' });
+    expect(mapPaymentAllocationRow(allocationRow)).toMatchObject({ invoiceId, invoiceItemId, amount: 4000 });
+    expect(mapRefundRow(refundRow)).toMatchObject({ reason: 'Overpayment return', refundMethod: 'kaspi', status: 'completed' });
+    expect(mapFinancialAdjustmentRow(adjustmentRow)).toMatchObject({ adjustmentType: 'write_off', reason: 'Manager approval' });
+  });
+
+  it('listInvoices is tenant-bound, excludes archived by default, filters and paginates', async () => {
+    const { repository, calls, client } = createRepository({ invoices: { data: [invoiceRow], error: null } });
+
+    const invoices = await repository.listInvoices({ tenantId, patientId, status: ['issued', 'partially_paid'], limit: 10, offset: 5 });
+
+    expect(client.from).toHaveBeenCalledWith('invoices');
+    expectCall(calls, 'invoices', 'select', '*');
+    expectCall(calls, 'invoices', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'invoices', 'eq', 'patient_id', patientId);
+    expectCall(calls, 'invoices', 'in', 'status', ['issued', 'partially_paid']);
+    expectCall(calls, 'invoices', 'neq', 'status', 'archived');
+    expectCall(calls, 'invoices', 'order', 'created_at', { ascending: false });
+    expectCall(calls, 'invoices', 'range', 5, 14);
+    expect(invoices).toHaveLength(1);
+    expectNoWriteCalls(client);
+  });
+
+  it('getInvoiceById filters by id and tenant_id and returns null when missing', async () => {
+    const found = createRepository({}, { invoices: { data: invoiceRow, error: null } });
+    await expect(found.repository.getInvoiceById({ tenantId, invoiceId })).resolves.toMatchObject({ id: invoiceId, tenantId });
+    expectCall(found.calls, 'invoices', 'eq', 'tenant_id', tenantId);
+    expectCall(found.calls, 'invoices', 'eq', 'id', invoiceId);
+    expectCall(found.calls, 'invoices', 'maybeSingle');
+
+    const missing = createRepository({}, { invoices: { data: null, error: null } });
+    await expect(missing.repository.getInvoiceById({ tenantId, invoiceId })).resolves.toBeNull();
+  });
+
+  it('listInvoiceItems filters by invoiceId, completedServiceId, patientId and status', async () => {
+    const { repository, calls } = createRepository({ invoice_items: { data: [invoiceItemRow], error: null } });
+
+    await repository.listInvoiceItems({ tenantId, invoiceId, patientId, completedServiceId, status: 'active' });
+
+    expectCall(calls, 'invoice_items', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'invoice_items', 'eq', 'invoice_id', invoiceId);
+    expectCall(calls, 'invoice_items', 'eq', 'patient_id', patientId);
+    expectCall(calls, 'invoice_items', 'eq', 'completed_service_id', completedServiceId);
+    expectCall(calls, 'invoice_items', 'in', 'status', ['active']);
+  });
+
+  it('listPayments filters by patientId, paymentMethod and status', async () => {
+    const { repository, calls } = createRepository({ payments: { data: [paymentRow], error: null } });
+
+    await repository.listPayments({ tenantId, patientId, paymentMethod: 'kaspi', status: 'received' });
+
+    expectCall(calls, 'payments', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'payments', 'eq', 'patient_id', patientId);
+    expectCall(calls, 'payments', 'in', 'payment_method', ['kaspi']);
+    expectCall(calls, 'payments', 'in', 'status', ['received']);
+    expectCall(calls, 'payments', 'order', 'received_at', { ascending: false });
+  });
+
+  it('getPaymentById filters by id and tenant_id and returns null when missing', async () => {
+    const found = createRepository({}, { payments: { data: paymentRow, error: null } });
+    await expect(found.repository.getPaymentById({ tenantId, paymentId })).resolves.toMatchObject({ id: paymentId, tenantId });
+    expectCall(found.calls, 'payments', 'eq', 'tenant_id', tenantId);
+    expectCall(found.calls, 'payments', 'eq', 'id', paymentId);
+
+    const missing = createRepository({}, { payments: { data: null, error: null } });
+    await expect(missing.repository.getPaymentById({ tenantId, paymentId })).resolves.toBeNull();
+  });
+
+  it('listPaymentAllocations filters by payment/invoice/item/patient and excludes voided by default', async () => {
+    const { repository, calls } = createRepository({ payment_allocations: { data: [allocationRow], error: null } });
+
+    await repository.listPaymentAllocations({ tenantId, paymentId, invoiceId, invoiceItemId, patientId });
+
+    expectCall(calls, 'payment_allocations', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'payment_allocations', 'eq', 'payment_id', paymentId);
+    expectCall(calls, 'payment_allocations', 'eq', 'invoice_id', invoiceId);
+    expectCall(calls, 'payment_allocations', 'eq', 'invoice_item_id', invoiceItemId);
+    expectCall(calls, 'payment_allocations', 'eq', 'patient_id', patientId);
+    expectCall(calls, 'payment_allocations', 'neq', 'status', 'voided');
+    expectCall(calls, 'payment_allocations', 'neq', 'status', 'archived');
+  });
+
+  it('listRefunds filters by paymentId/status and orders by requested_at', async () => {
+    const { repository, calls } = createRepository({ refunds: { data: [refundRow], error: null } });
+
+    await repository.listRefunds({ tenantId, patientId, paymentId, status: 'completed' });
+
+    expectCall(calls, 'refunds', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'refunds', 'eq', 'payment_id', paymentId);
+    expectCall(calls, 'refunds', 'in', 'status', ['completed']);
+    expectCall(calls, 'refunds', 'order', 'requested_at', { ascending: false });
+  });
+
+  it('listFinancialAdjustments filters by invoice/type/status', async () => {
+    const { repository, calls } = createRepository({ financial_adjustments: { data: [adjustmentRow], error: null } });
+
+    await repository.listFinancialAdjustments({ tenantId, patientId, invoiceId, invoiceItemId, adjustmentType: 'write_off', status: 'approved' });
+
+    expectCall(calls, 'financial_adjustments', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'financial_adjustments', 'eq', 'patient_id', patientId);
+    expectCall(calls, 'financial_adjustments', 'eq', 'invoice_id', invoiceId);
+    expectCall(calls, 'financial_adjustments', 'eq', 'invoice_item_id', invoiceItemId);
+    expectCall(calls, 'financial_adjustments', 'in', 'adjustment_type', ['write_off']);
+    expectCall(calls, 'financial_adjustments', 'in', 'status', ['approved']);
+  });
+
+  it('getPatientFinanceFacts reads all finance facts tenant-bound without writes', async () => {
+    const { repository, calls, client } = createRepository({
+      invoices: { data: [invoiceRow], error: null },
+      invoice_items: { data: [invoiceItemRow], error: null },
+      payments: { data: [paymentRow], error: null },
+      payment_allocations: { data: [allocationRow], error: null },
+      refunds: { data: [refundRow], error: null },
+      financial_adjustments: { data: [adjustmentRow], error: null },
+    });
+
+    const facts = await repository.getPatientFinanceFacts({ tenantId, patientId });
+
+    expect(facts.invoices).toHaveLength(1);
+    expect(facts.invoiceItems).toHaveLength(1);
+    expect(facts.payments).toHaveLength(1);
+    expect(facts.paymentAllocations).toHaveLength(1);
+    expect(facts.refunds).toHaveLength(1);
+    expect(facts.financialAdjustments).toHaveLength(1);
+    for (const table of ['invoices', 'invoice_items', 'payments', 'payment_allocations', 'refunds', 'financial_adjustments']) {
+      expectCall(calls, table, 'eq', 'tenant_id', tenantId);
+      expectCall(calls, table, 'eq', 'patient_id', patientId);
+    }
+    expectNoWriteCalls(client);
+  });
+
+  it('getPatientFinanceSummary returns zero summary for no finance facts', async () => {
+    const { repository } = createRepository();
+
+    await expect(repository.getPatientFinanceSummary({ tenantId, patientId })).resolves.toMatchObject({
+      tenantId,
+      patientId,
+      invoiceTotalAmount: 0,
+      paidAmount: 0,
+      allocatedPaymentAmount: 0,
+      refundedAmount: 0,
+      balanceAmount: 0,
+      creditAmount: 0,
+      lastPaymentAt: null,
+    });
+  });
+
+  it('computePatientFinanceSummary ignores voided/archived facts and handles balance/credit conservatively', () => {
+    const facts: PatientFinanceFacts = {
+      invoices: [
+        mapInvoiceRow({ ...invoiceRow, status: 'issued', total_amount: '10000.00', balance_amount: '6000.00' }),
+        mapInvoiceRow({ ...invoiceRow, id: 'archived-invoice', status: 'archived', total_amount: '9999.00', balance_amount: '9999.00' }),
+      ],
+      invoiceItems: [mapInvoiceItemRow(invoiceItemRow)],
+      payments: [
+        mapPaymentRow({ ...paymentRow, amount: '12000.00', received_at: '2026-06-21T02:00:00Z' }),
+        mapPaymentRow({ ...paymentRow, id: 'void-payment', status: 'voided', amount: '9999.00', received_at: '2026-06-22T02:00:00Z' }),
+      ],
+      paymentAllocations: [
+        mapPaymentAllocationRow({ ...allocationRow, amount: '9000.00' }),
+        mapPaymentAllocationRow({ ...allocationRow, id: 'void-allocation', status: 'voided', amount: '9999.00' }),
+      ],
+      refunds: [
+        mapRefundRow({ ...refundRow, amount: '500.00', status: 'completed' }),
+        mapRefundRow({ ...refundRow, id: 'pending-refund', status: 'pending', amount: '9999.00' }),
+      ],
+      financialAdjustments: [
+        mapFinancialAdjustmentRow({ ...adjustmentRow, adjustment_type: 'write_off', amount: '1000.00', status: 'approved' }),
+        mapFinancialAdjustmentRow({ ...adjustmentRow, id: 'discount-adjustment', adjustment_type: 'discount', amount: '500.00', status: 'active' }),
+        mapFinancialAdjustmentRow({ ...adjustmentRow, id: 'archived-adjustment', adjustment_type: 'write_off', amount: '9999.00', status: 'archived' }),
+      ],
+    };
+
+    const summary = computePatientFinanceSummary(tenantId, patientId, facts);
+
+    expect(summary).toMatchObject({
+      invoiceTotalAmount: 10000,
+      paidAmount: 12000,
+      allocatedPaymentAmount: 9000,
+      refundedAmount: 500,
+      discountAmount: 500,
+      writeOffAmount: 1000,
+      balanceAmount: 0,
+      creditAmount: 0,
+      unpaidInvoiceCount: 1,
+      openInvoiceCount: 1,
+      lastPaymentAt: '2026-06-21T02:00:00Z',
+    });
+  });
+
+  it('computePatientFinanceSummary reports overpayment as credit without reading patient balance', () => {
+    const facts: PatientFinanceFacts = {
+      invoices: [mapInvoiceRow({ ...invoiceRow, total_amount: '3000.00', balance_amount: '0.00', status: 'paid' })],
+      invoiceItems: [],
+      payments: [mapPaymentRow({ ...paymentRow, amount: '5000.00' })],
+      paymentAllocations: [mapPaymentAllocationRow({ ...allocationRow, amount: '5000.00' })],
+      refunds: [],
+      financialAdjustments: [],
+    };
+
+    const summary = computePatientFinanceSummary(tenantId, patientId, facts);
+
+    expect(summary.balanceAmount).toBe(0);
+    expect(summary.creditAmount).toBe(2000);
+  });
+
+  it('surfaces Supabase errors and empty lists safely', async () => {
+    const error = new Error('read failed');
+    const failing = createRepository({ invoices: { data: null, error } });
+    await expect(failing.repository.listInvoices({ tenantId })).rejects.toThrow(error);
+
+    const empty = createRepository({ invoices: { data: [], error: null } });
+    await expect(empty.repository.listInvoices({ tenantId })).resolves.toEqual([]);
+  });
+
+  it('normalizes finance pagination bounds', () => {
+    expect(normalizeFinanceLimit(undefined)).toBe(50);
+    expect(normalizeFinanceLimit(999)).toBe(200);
+    expect(normalizeFinanceLimit(0)).toBe(1);
+    expect(normalizeFinanceOffset(undefined)).toBe(0);
+    expect(normalizeFinanceOffset(-10)).toBe(0);
+  });
+
+  it('creates Supabase repository and rejects unsupported local backend', () => {
+    const { client } = createRepository();
+    expect(createFinanceRepository({ backend: 'supabase', client: client as unknown as SupabaseClient })).toBeInstanceOf(SupabaseFinanceRepository);
+    expect(() => createFinanceRepository({ backend: 'local' })).toThrow('Finance repository requires Supabase backend.');
+  });
+});

--- a/src/data/repositories/FinanceRepository.ts
+++ b/src/data/repositories/FinanceRepository.ts
@@ -1,0 +1,740 @@
+import { supabase as defaultSupabase } from '../../lib/supabaseClient';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type InvoiceStatus = 'draft' | 'issued' | 'partially_paid' | 'paid' | 'voided' | 'written_off' | 'archived';
+export type InvoiceItemStatus = 'active' | 'voided' | 'adjusted' | 'archived';
+export type PaymentStatus = 'received' | 'allocated' | 'partially_allocated' | 'refunded' | 'partially_refunded' | 'voided' | 'archived';
+export type PaymentMethod = 'cash' | 'kaspi' | 'halyk_terminal' | 'card' | 'bank_transfer' | 'insurance' | 'osms' | 'mixed' | 'other';
+export type RefundStatus = 'pending' | 'approved' | 'completed' | 'rejected' | 'voided' | 'archived';
+export type RefundMethod = 'cash' | 'kaspi' | 'halyk_terminal' | 'card' | 'bank_transfer' | 'other';
+export type FinancialAdjustmentType = 'discount' | 'correction' | 'write_off' | 'surcharge' | 'void';
+export type FinancialAdjustmentStatus = 'active' | 'approved' | 'rejected' | 'voided' | 'archived';
+
+export interface Invoice {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  invoiceNumber: string | null;
+  status: InvoiceStatus;
+  currency: string;
+  issueDate: string | null;
+  dueDate: string | null;
+  subtotalAmount: number;
+  discountAmount: number;
+  adjustmentAmount: number;
+  totalAmount: number;
+  paidAmount: number;
+  refundedAmount: number;
+  writtenOffAmount: number;
+  balanceAmount: number;
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  createdBy: string | null;
+  issuedBy: string | null;
+  voidedBy: string | null;
+  voidReason: string | null;
+  issuedAt: string | null;
+  voidedAt: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InvoiceItem {
+  id: string;
+  tenantId: string;
+  invoiceId: string;
+  patientId: string;
+  completedServiceId: string | null;
+  serviceName: string;
+  serviceCode: string | null;
+  toothNumber: string | null;
+  toothSurface: string | null;
+  quantity: number;
+  unitPrice: number;
+  discountAmount: number;
+  adjustmentAmount: number;
+  totalAmount: number;
+  status: InvoiceItemStatus;
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  createdBy: string | null;
+  voidedBy: string | null;
+  voidReason: string | null;
+  voidedAt: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Payment {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  status: PaymentStatus;
+  paymentMethod: PaymentMethod;
+  amount: number;
+  currency: string;
+  receivedAt: string;
+  externalReference: string | null;
+  payerName: string | null;
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  receivedBy: string | null;
+  voidedBy: string | null;
+  voidReason: string | null;
+  voidedAt: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaymentAllocation {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  paymentId: string;
+  invoiceId: string | null;
+  invoiceItemId: string | null;
+  amount: number;
+  currency: string;
+  status: 'active' | 'voided' | 'archived';
+  allocatedAt: string;
+  metadata: Record<string, unknown>;
+  createdBy: string | null;
+  voidedBy: string | null;
+  voidReason: string | null;
+  voidedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Refund {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  paymentId: string;
+  status: RefundStatus;
+  refundMethod: RefundMethod;
+  amount: number;
+  currency: string;
+  reason: string;
+  requestedBy: string | null;
+  approvedBy: string | null;
+  completedBy: string | null;
+  requestedAt: string;
+  approvedAt: string | null;
+  completedAt: string | null;
+  rejectedAt: string | null;
+  voidedAt: string | null;
+  voidedBy: string | null;
+  voidReason: string | null;
+  externalReference: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FinancialAdjustment {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  invoiceId: string | null;
+  invoiceItemId: string | null;
+  paymentId: string | null;
+  adjustmentType: FinancialAdjustmentType;
+  status: FinancialAdjustmentStatus;
+  amount: number;
+  currency: string;
+  reason: string;
+  approvedBy: string | null;
+  createdBy: string | null;
+  voidedBy: string | null;
+  approvedAt: string | null;
+  voidedAt: string | null;
+  voidReason: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PatientFinanceFacts {
+  invoices: Invoice[];
+  invoiceItems: InvoiceItem[];
+  payments: Payment[];
+  paymentAllocations: PaymentAllocation[];
+  refunds: Refund[];
+  financialAdjustments: FinancialAdjustment[];
+}
+
+export interface PatientFinanceSummary {
+  tenantId: string;
+  patientId: string;
+  invoiceTotalAmount: number;
+  paidAmount: number;
+  allocatedPaymentAmount: number;
+  refundedAmount: number;
+  discountAmount: number;
+  writeOffAmount: number;
+  adjustmentAmount: number;
+  balanceAmount: number;
+  creditAmount: number;
+  openInvoiceCount: number;
+  unpaidInvoiceCount: number;
+  partiallyPaidInvoiceCount: number;
+  lastPaymentAt: string | null;
+}
+
+export interface ListInvoicesOptions {
+  tenantId: string;
+  patientId?: string;
+  status?: InvoiceStatus | InvoiceStatus[];
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GetInvoiceByIdOptions {
+  tenantId: string;
+  invoiceId: string;
+}
+
+export interface ListInvoiceItemsOptions {
+  tenantId: string;
+  invoiceId?: string;
+  patientId?: string;
+  completedServiceId?: string;
+  status?: InvoiceItemStatus | InvoiceItemStatus[];
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListPaymentsOptions {
+  tenantId: string;
+  patientId?: string;
+  status?: PaymentStatus | PaymentStatus[];
+  paymentMethod?: PaymentMethod | PaymentMethod[];
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GetPaymentByIdOptions {
+  tenantId: string;
+  paymentId: string;
+}
+
+export interface ListPaymentAllocationsOptions {
+  tenantId: string;
+  paymentId?: string;
+  invoiceId?: string;
+  invoiceItemId?: string;
+  patientId?: string;
+  includeVoided?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListRefundsOptions {
+  tenantId: string;
+  patientId?: string;
+  paymentId?: string;
+  status?: RefundStatus | RefundStatus[];
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListFinancialAdjustmentsOptions {
+  tenantId: string;
+  patientId?: string;
+  invoiceId?: string;
+  invoiceItemId?: string;
+  paymentId?: string;
+  adjustmentType?: FinancialAdjustmentType | FinancialAdjustmentType[];
+  status?: FinancialAdjustmentStatus | FinancialAdjustmentStatus[];
+  includeArchived?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PatientFinanceOptions {
+  tenantId: string;
+  patientId: string;
+}
+
+export interface FinanceRepository {
+  listInvoices(options: ListInvoicesOptions): Promise<Invoice[]>;
+  getInvoiceById(options: GetInvoiceByIdOptions): Promise<Invoice | null>;
+  listInvoiceItems(options: ListInvoiceItemsOptions): Promise<InvoiceItem[]>;
+  listPayments(options: ListPaymentsOptions): Promise<Payment[]>;
+  getPaymentById(options: GetPaymentByIdOptions): Promise<Payment | null>;
+  listPaymentAllocations(options: ListPaymentAllocationsOptions): Promise<PaymentAllocation[]>;
+  listRefunds(options: ListRefundsOptions): Promise<Refund[]>;
+  listFinancialAdjustments(options: ListFinancialAdjustmentsOptions): Promise<FinancialAdjustment[]>;
+  getPatientFinanceFacts(options: PatientFinanceOptions): Promise<PatientFinanceFacts>;
+  getPatientFinanceSummary(options: PatientFinanceOptions): Promise<PatientFinanceSummary>;
+}
+
+export type FinanceRepositoryBackend = 'supabase' | 'local';
+
+export interface CreateFinanceRepositoryOptions {
+  backend: FinanceRepositoryBackend;
+  client?: SupabaseClient;
+}
+
+export const ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR = 'Active clinic is required for finance access.';
+export const PATIENT_REQUIRED_FOR_FINANCE_ERROR = 'Patient is required for finance access.';
+export const RECORD_ID_REQUIRED_FOR_FINANCE_ERROR = 'Record id is required for finance access.';
+export const DEFAULT_FINANCE_LIMIT = 50;
+export const MAX_FINANCE_LIMIT = 200;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function metadataObject(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+function requiredString(value: unknown, fieldName: string): string {
+  if (value === null || value === undefined) throw new Error(`Finance row is missing required field: ${fieldName}`);
+  const text = String(value);
+  if (text.trim().length === 0) throw new Error(`Finance row has empty required field: ${fieldName}`);
+  return text;
+}
+
+function requiredNumber(value: unknown, fieldName: string): number {
+  if (value === null || value === undefined) throw new Error(`Finance row is missing required field: ${fieldName}`);
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numberValue)) throw new Error(`Finance row has invalid numeric field: ${fieldName}`);
+  return numberValue;
+}
+
+function requireTenantId(tenantId: string | null | undefined): string {
+  if (!tenantId || tenantId.trim().length === 0) throw new Error(ACTIVE_CLINIC_REQUIRED_FOR_FINANCE_ERROR);
+  return tenantId;
+}
+
+function requirePatientId(patientId: string | null | undefined): string {
+  if (!patientId || patientId.trim().length === 0) throw new Error(PATIENT_REQUIRED_FOR_FINANCE_ERROR);
+  return patientId;
+}
+
+function requireRecordId(id: string | null | undefined): string {
+  if (!id || id.trim().length === 0) throw new Error(RECORD_ID_REQUIRED_FOR_FINANCE_ERROR);
+  return id;
+}
+
+function toArray<T extends string>(value?: T | T[]): T[] | null {
+  if (!value) return null;
+  return Array.isArray(value) ? value : [value];
+}
+
+export function normalizeFinanceLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_FINANCE_LIMIT;
+  return Math.max(1, Math.min(MAX_FINANCE_LIMIT, Math.floor(limit)));
+}
+
+export function normalizeFinanceOffset(offset?: number): number {
+  if (offset === undefined || !Number.isFinite(offset)) return 0;
+  return Math.max(0, Math.floor(offset));
+}
+
+export function mapInvoiceRow(row: Record<string, unknown>): Invoice {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    invoiceNumber: nullableString(row.invoice_number),
+    status: requiredString(row.status, 'status') as InvoiceStatus,
+    currency: requiredString(row.currency, 'currency'),
+    issueDate: nullableString(row.issue_date),
+    dueDate: nullableString(row.due_date),
+    subtotalAmount: requiredNumber(row.subtotal_amount, 'subtotal_amount'),
+    discountAmount: requiredNumber(row.discount_amount, 'discount_amount'),
+    adjustmentAmount: requiredNumber(row.adjustment_amount, 'adjustment_amount'),
+    totalAmount: requiredNumber(row.total_amount, 'total_amount'),
+    paidAmount: requiredNumber(row.paid_amount, 'paid_amount'),
+    refundedAmount: requiredNumber(row.refunded_amount, 'refunded_amount'),
+    writtenOffAmount: requiredNumber(row.written_off_amount, 'written_off_amount'),
+    balanceAmount: requiredNumber(row.balance_amount, 'balance_amount'),
+    notes: nullableString(row.notes),
+    metadata: metadataObject(row.metadata),
+    createdBy: nullableString(row.created_by),
+    issuedBy: nullableString(row.issued_by),
+    voidedBy: nullableString(row.voided_by),
+    voidReason: nullableString(row.void_reason),
+    issuedAt: nullableString(row.issued_at),
+    voidedAt: nullableString(row.voided_at),
+    archivedAt: nullableString(row.archived_at),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapInvoiceItemRow(row: Record<string, unknown>): InvoiceItem {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    invoiceId: requiredString(row.invoice_id, 'invoice_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    completedServiceId: nullableString(row.completed_service_id),
+    serviceName: requiredString(row.service_name, 'service_name'),
+    serviceCode: nullableString(row.service_code),
+    toothNumber: nullableString(row.tooth_number),
+    toothSurface: nullableString(row.tooth_surface),
+    quantity: requiredNumber(row.quantity, 'quantity'),
+    unitPrice: requiredNumber(row.unit_price, 'unit_price'),
+    discountAmount: requiredNumber(row.discount_amount, 'discount_amount'),
+    adjustmentAmount: requiredNumber(row.adjustment_amount, 'adjustment_amount'),
+    totalAmount: requiredNumber(row.total_amount, 'total_amount'),
+    status: requiredString(row.status, 'status') as InvoiceItemStatus,
+    notes: nullableString(row.notes),
+    metadata: metadataObject(row.metadata),
+    createdBy: nullableString(row.created_by),
+    voidedBy: nullableString(row.voided_by),
+    voidReason: nullableString(row.void_reason),
+    voidedAt: nullableString(row.voided_at),
+    archivedAt: nullableString(row.archived_at),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapPaymentRow(row: Record<string, unknown>): Payment {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    status: requiredString(row.status, 'status') as PaymentStatus,
+    paymentMethod: requiredString(row.payment_method, 'payment_method') as PaymentMethod,
+    amount: requiredNumber(row.amount, 'amount'),
+    currency: requiredString(row.currency, 'currency'),
+    receivedAt: requiredString(row.received_at, 'received_at'),
+    externalReference: nullableString(row.external_reference),
+    payerName: nullableString(row.payer_name),
+    notes: nullableString(row.notes),
+    metadata: metadataObject(row.metadata),
+    receivedBy: nullableString(row.received_by),
+    voidedBy: nullableString(row.voided_by),
+    voidReason: nullableString(row.void_reason),
+    voidedAt: nullableString(row.voided_at),
+    archivedAt: nullableString(row.archived_at),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapPaymentAllocationRow(row: Record<string, unknown>): PaymentAllocation {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    paymentId: requiredString(row.payment_id, 'payment_id'),
+    invoiceId: nullableString(row.invoice_id),
+    invoiceItemId: nullableString(row.invoice_item_id),
+    amount: requiredNumber(row.amount, 'amount'),
+    currency: requiredString(row.currency, 'currency'),
+    status: requiredString(row.status, 'status') as PaymentAllocation['status'],
+    allocatedAt: requiredString(row.allocated_at, 'allocated_at'),
+    metadata: metadataObject(row.metadata),
+    createdBy: nullableString(row.created_by),
+    voidedBy: nullableString(row.voided_by),
+    voidReason: nullableString(row.void_reason),
+    voidedAt: nullableString(row.voided_at),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapRefundRow(row: Record<string, unknown>): Refund {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    paymentId: requiredString(row.payment_id, 'payment_id'),
+    status: requiredString(row.status, 'status') as RefundStatus,
+    refundMethod: requiredString(row.refund_method, 'refund_method') as RefundMethod,
+    amount: requiredNumber(row.amount, 'amount'),
+    currency: requiredString(row.currency, 'currency'),
+    reason: requiredString(row.reason, 'reason'),
+    requestedBy: nullableString(row.requested_by),
+    approvedBy: nullableString(row.approved_by),
+    completedBy: nullableString(row.completed_by),
+    requestedAt: requiredString(row.requested_at, 'requested_at'),
+    approvedAt: nullableString(row.approved_at),
+    completedAt: nullableString(row.completed_at),
+    rejectedAt: nullableString(row.rejected_at),
+    voidedAt: nullableString(row.voided_at),
+    voidedBy: nullableString(row.voided_by),
+    voidReason: nullableString(row.void_reason),
+    externalReference: nullableString(row.external_reference),
+    metadata: metadataObject(row.metadata),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapFinancialAdjustmentRow(row: Record<string, unknown>): FinancialAdjustment {
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    invoiceId: nullableString(row.invoice_id),
+    invoiceItemId: nullableString(row.invoice_item_id),
+    paymentId: nullableString(row.payment_id),
+    adjustmentType: requiredString(row.adjustment_type, 'adjustment_type') as FinancialAdjustmentType,
+    status: requiredString(row.status, 'status') as FinancialAdjustmentStatus,
+    amount: requiredNumber(row.amount, 'amount'),
+    currency: requiredString(row.currency, 'currency'),
+    reason: requiredString(row.reason, 'reason'),
+    approvedBy: nullableString(row.approved_by),
+    createdBy: nullableString(row.created_by),
+    voidedBy: nullableString(row.voided_by),
+    approvedAt: nullableString(row.approved_at),
+    voidedAt: nullableString(row.voided_at),
+    voidReason: nullableString(row.void_reason),
+    metadata: metadataObject(row.metadata),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+function isActiveStatus(status: string): boolean {
+  return status !== 'voided' && status !== 'archived' && status !== 'rejected';
+}
+
+function sumBy<T>(rows: T[], selector: (row: T) => number): number {
+  return Number(rows.reduce((total, row) => total + selector(row), 0).toFixed(2));
+}
+
+function latestDate(values: Array<string | null | undefined>): string | null {
+  const dates = values.filter((value): value is string => Boolean(value));
+  if (dates.length === 0) return null;
+  return dates.sort().at(-1) ?? null;
+}
+
+export function computePatientFinanceSummary(
+  tenantId: string,
+  patientId: string,
+  facts: PatientFinanceFacts,
+): PatientFinanceSummary {
+  const activeInvoices = facts.invoices.filter((invoice) => invoice.status !== 'voided' && invoice.status !== 'archived');
+  const activePayments = facts.payments.filter((payment) => payment.status !== 'voided' && payment.status !== 'archived');
+  const activeAllocations = facts.paymentAllocations.filter((allocation) => isActiveStatus(allocation.status));
+  const completedRefunds = facts.refunds.filter((refund) => refund.status === 'completed');
+  const activeAdjustments = facts.financialAdjustments.filter((adjustment) => isActiveStatus(adjustment.status));
+
+  const invoiceTotalAmount = sumBy(activeInvoices, (invoice) => invoice.totalAmount);
+  const paidAmount = sumBy(activePayments, (payment) => payment.amount);
+  const allocatedPaymentAmount = sumBy(activeAllocations, (allocation) => allocation.amount);
+  const refundedAmount = sumBy(completedRefunds, (refund) => refund.amount);
+  const discountAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'discount'), (adjustment) => adjustment.amount);
+  const writeOffAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'write_off'), (adjustment) => adjustment.amount);
+  const surchargeAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'surcharge'), (adjustment) => adjustment.amount);
+  const correctionAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'correction'), (adjustment) => adjustment.amount);
+  const adjustmentAmount = Number((surchargeAmount + correctionAmount - discountAmount - writeOffAmount).toFixed(2));
+  const amountDue = Number((invoiceTotalAmount + surchargeAmount + correctionAmount + refundedAmount - allocatedPaymentAmount - discountAmount - writeOffAmount).toFixed(2));
+  const balanceAmount = Math.max(0, amountDue);
+  const creditAmount = Math.max(0, Number((-amountDue).toFixed(2)));
+
+  return {
+    tenantId,
+    patientId,
+    invoiceTotalAmount,
+    paidAmount,
+    allocatedPaymentAmount,
+    refundedAmount,
+    discountAmount,
+    writeOffAmount,
+    adjustmentAmount,
+    balanceAmount,
+    creditAmount,
+    openInvoiceCount: activeInvoices.filter((invoice) => ['draft', 'issued', 'partially_paid', 'written_off'].includes(invoice.status)).length,
+    unpaidInvoiceCount: activeInvoices.filter((invoice) => invoice.balanceAmount > 0 && invoice.status !== 'paid').length,
+    partiallyPaidInvoiceCount: activeInvoices.filter((invoice) => invoice.status === 'partially_paid').length,
+    lastPaymentAt: latestDate(activePayments.map((payment) => payment.receivedAt)),
+  };
+}
+
+export class SupabaseFinanceRepository implements FinanceRepository {
+  private readonly client: SupabaseClient;
+
+  constructor(client: SupabaseClient) {
+    this.client = client;
+  }
+
+  async listInvoices(options: ListInvoicesOptions): Promise<Invoice[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeFinanceLimit(options.limit);
+    const offset = normalizeFinanceOffset(options.offset);
+
+    let query = this.client.from('invoices').select('*').eq('tenant_id', tenantId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    const statuses = toArray(options.status);
+    if (statuses?.length) query = query.in('status', statuses);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+
+    const { data, error } = await query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapInvoiceRow);
+  }
+
+  async getInvoiceById(options: GetInvoiceByIdOptions): Promise<Invoice | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const invoiceId = requireRecordId(options.invoiceId);
+    const { data, error } = await this.client
+      .from('invoices')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', invoiceId)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapInvoiceRow(data as Record<string, unknown>) : null;
+  }
+
+  async listInvoiceItems(options: ListInvoiceItemsOptions): Promise<InvoiceItem[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeFinanceLimit(options.limit);
+    const offset = normalizeFinanceOffset(options.offset);
+
+    let query = this.client.from('invoice_items').select('*').eq('tenant_id', tenantId);
+    if (options.invoiceId) query = query.eq('invoice_id', options.invoiceId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.completedServiceId) query = query.eq('completed_service_id', options.completedServiceId);
+    const statuses = toArray(options.status);
+    if (statuses?.length) query = query.in('status', statuses);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+
+    const { data, error } = await query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapInvoiceItemRow);
+  }
+
+  async listPayments(options: ListPaymentsOptions): Promise<Payment[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeFinanceLimit(options.limit);
+    const offset = normalizeFinanceOffset(options.offset);
+
+    let query = this.client.from('payments').select('*').eq('tenant_id', tenantId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    const statuses = toArray(options.status);
+    if (statuses?.length) query = query.in('status', statuses);
+    const methods = toArray(options.paymentMethod);
+    if (methods?.length) query = query.in('payment_method', methods);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+
+    const { data, error } = await query.order('received_at', { ascending: false }).range(offset, offset + limit - 1);
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapPaymentRow);
+  }
+
+  async getPaymentById(options: GetPaymentByIdOptions): Promise<Payment | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const paymentId = requireRecordId(options.paymentId);
+    const { data, error } = await this.client
+      .from('payments')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .eq('id', paymentId)
+      .maybeSingle();
+    if (error) throw error;
+    return data ? mapPaymentRow(data as Record<string, unknown>) : null;
+  }
+
+  async listPaymentAllocations(options: ListPaymentAllocationsOptions): Promise<PaymentAllocation[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeFinanceLimit(options.limit);
+    const offset = normalizeFinanceOffset(options.offset);
+
+    let query = this.client.from('payment_allocations').select('*').eq('tenant_id', tenantId);
+    if (options.paymentId) query = query.eq('payment_id', options.paymentId);
+    if (options.invoiceId) query = query.eq('invoice_id', options.invoiceId);
+    if (options.invoiceItemId) query = query.eq('invoice_item_id', options.invoiceItemId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (!options.includeVoided) {
+      query = query.neq('status', 'voided').neq('status', 'archived');
+    }
+
+    const { data, error } = await query.order('allocated_at', { ascending: false }).range(offset, offset + limit - 1);
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapPaymentAllocationRow);
+  }
+
+  async listRefunds(options: ListRefundsOptions): Promise<Refund[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeFinanceLimit(options.limit);
+    const offset = normalizeFinanceOffset(options.offset);
+
+    let query = this.client.from('refunds').select('*').eq('tenant_id', tenantId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.paymentId) query = query.eq('payment_id', options.paymentId);
+    const statuses = toArray(options.status);
+    if (statuses?.length) query = query.in('status', statuses);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+
+    const { data, error } = await query.order('requested_at', { ascending: false }).range(offset, offset + limit - 1);
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapRefundRow);
+  }
+
+  async listFinancialAdjustments(options: ListFinancialAdjustmentsOptions): Promise<FinancialAdjustment[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const limit = normalizeFinanceLimit(options.limit);
+    const offset = normalizeFinanceOffset(options.offset);
+
+    let query = this.client.from('financial_adjustments').select('*').eq('tenant_id', tenantId);
+    if (options.patientId) query = query.eq('patient_id', options.patientId);
+    if (options.invoiceId) query = query.eq('invoice_id', options.invoiceId);
+    if (options.invoiceItemId) query = query.eq('invoice_item_id', options.invoiceItemId);
+    if (options.paymentId) query = query.eq('payment_id', options.paymentId);
+    const types = toArray(options.adjustmentType);
+    if (types?.length) query = query.in('adjustment_type', types);
+    const statuses = toArray(options.status);
+    if (statuses?.length) query = query.in('status', statuses);
+    if (!options.includeArchived) query = query.neq('status', 'archived');
+
+    const { data, error } = await query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapFinancialAdjustmentRow);
+  }
+
+  async getPatientFinanceFacts(options: PatientFinanceOptions): Promise<PatientFinanceFacts> {
+    const tenantId = requireTenantId(options.tenantId);
+    const patientId = requirePatientId(options.patientId);
+    const [invoices, invoiceItems, payments, paymentAllocations, refunds, financialAdjustments] = await Promise.all([
+      this.listInvoices({ tenantId, patientId, includeArchived: true, limit: MAX_FINANCE_LIMIT }),
+      this.listInvoiceItems({ tenantId, patientId, includeArchived: true, limit: MAX_FINANCE_LIMIT }),
+      this.listPayments({ tenantId, patientId, includeArchived: true, limit: MAX_FINANCE_LIMIT }),
+      this.listPaymentAllocations({ tenantId, patientId, includeVoided: true, limit: MAX_FINANCE_LIMIT }),
+      this.listRefunds({ tenantId, patientId, includeArchived: true, limit: MAX_FINANCE_LIMIT }),
+      this.listFinancialAdjustments({ tenantId, patientId, includeArchived: true, limit: MAX_FINANCE_LIMIT }),
+    ]);
+    return { invoices, invoiceItems, payments, paymentAllocations, refunds, financialAdjustments };
+  }
+
+  async getPatientFinanceSummary(options: PatientFinanceOptions): Promise<PatientFinanceSummary> {
+    const tenantId = requireTenantId(options.tenantId);
+    const patientId = requirePatientId(options.patientId);
+    const facts = await this.getPatientFinanceFacts({ tenantId, patientId });
+    return computePatientFinanceSummary(tenantId, patientId, facts);
+  }
+}
+
+export function createFinanceRepository(options: CreateFinanceRepositoryOptions): FinanceRepository {
+  if (options.backend === 'local') {
+    throw new Error('Finance repository requires Supabase backend.');
+  }
+  const client = options.client ?? defaultSupabase;
+  if (!client) {
+    throw new Error('Supabase client is not configured for finance access.');
+  }
+  return new SupabaseFinanceRepository(client as SupabaseClient);
+}


### PR DESCRIPTION
Read-only finance repository implementation. Adds FinanceRepository, repository tests, and report only. No migrations, UI, hooks, RPC, cloud, seed, generated types, stock, documents, timeline, or payment integrations. Local validation passed against migration 0016 finance tables, repository tests pass, full test suite/build pass, and final verdict is PAYMENTS DEBTS REPOSITORY IMPLEMENTED AND VERIFIED.

Checks:
- Local Supabase reset passed after rebase onto current main with 0016_create_finance_model.sql applied.
- Finance tables validated empty: invoices, invoice_items, payments, payment_allocations, refunds, financial_adjustments.
- FinanceRepository test passed.
- Full lint/test/build passed.

Next task: PAYMENTS-DEBTS-RPC-001C.