### PR TITLE
TEST-ENV-ISOLATION-001: isolate auth/login tests from local env

### DIFF
--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,8 +1,14 @@
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
+
+vi.mock('../lib/supabaseClient', () => ({
+  isSupabaseConfigured: false,
+  supabase: null,
+}));
+
 import { AuthProvider, useAuth } from './AuthContext';
 
 describe('AuthContext (Dev Fallback)', () => {

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -56,6 +56,8 @@ describe('LoginPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+    vi.stubEnv('VITE_ENABLE_QA_LOGIN_SHORTCUT', 'false');
+    vi.stubEnv(QA_LOGIN_SECRET_ENV_NAME, '');
     document.body.innerHTML = '';
   });
 


### PR DESCRIPTION
Fixes local .env.local side effects in AuthContext/LoginPage tests.\n\nScope:\n- test-only environment isolation fix\n- no product behavior changes\n- no finance changes\n- no Supabase migrations\n- no cloud changes\n- no seed files\n- no generated types\n- no HEP-V2 work\n\nValidation:\n- npm run lint: passed\n- npm run test -- --run: passed\n- npm run build: passed