### PR TITLE
PAYMENTS-DEBTS-RPC-CLIENT-001D: add finance RPC client

### DIFF
--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md
@@ -16,11 +16,11 @@ No UI, React hooks, migrations, SQL edits, cloud Supabase, seed data, generated 
 
 ## 3. PR URL
 
-- PR URL: Pending until PR creation. This report will be updated with the final PR URL after the branch is pushed and the PR exists.
+- PR URL: https://github.com/NckNA/codex-test/pull/328
 
 ## 4. PR Head Reviewed Before Final Report Update
 
-- PR head reviewed before final report update: Pending until PR creation.
+- PR head reviewed before final report update: b8280f8f891391f194f558f6edff2c3c6b8477b2
 
 ## 5. Report Update Commit
 
@@ -265,3 +265,4 @@ PAYMENTS DEBTS RPC CLIENT IMPLEMENTED AND VERIFIED
 ## 19. Recommended Next Task
 
 PATIENT-FINANCE-UI-001
+

--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md
@@ -20,7 +20,7 @@ No UI, React hooks, migrations, SQL edits, cloud Supabase, seed data, generated 
 
 ## 4. PR Head Reviewed Before Final Report Update
 
-- PR head reviewed before final report update: b8280f8f891391f194f558f6edff2c3c6b8477b2
+- PR head reviewed before final report update: e27317557c35d0df6df43ac1381faf67777b45de
 
 ## 5. Report Update Commit
 
@@ -239,9 +239,7 @@ Local checks:
 - `npm run test -- --run`: passed, 61 files / 620 tests.
 - `npm run build`: passed.
 
-GitHub Actions CI:
-
-- Pending until PR creation and push.
+GitHub Actions CI: pending fresh run after report update push.
 
 ## 17. Issues / Warnings
 
@@ -265,4 +263,32 @@ PAYMENTS DEBTS RPC CLIENT IMPLEMENTED AND VERIFIED
 ## 19. Recommended Next Task
 
 PATIENT-FINANCE-UI-001
+
+
+## Encoding/message fix
+
+- Restored proper UTF-8 Russian validation and operation error messages in FinanceRpcClient.ts.
+- Replaced mojibake strings such as Рќ, Рџ, СЃ, and С‚ with proper messages, including:
+  - Не выбрана клиника.
+  - Пациент не выбран.
+  - Счёт не выбран.
+  - Название услуги обязательно.
+  - Количество должно быть больше 0.
+  - Сумма должна быть больше 0.
+  - Причина обязательна.
+  - Не удалось выполнить финансовую операцию.
+- Updated FinanceRpcClient.test.ts expectations to use proper UTF-8 messages.
+- Added a mojibake guard in expectFinanceClientError so validation/error assertions fail if corrupted fragments return.
+
+## Fresh validation after encoding fix
+
+- 
+pm run lint: passed
+- 
+pm run test -- --run src/data/repositories/FinanceRpcClient.test.ts: passed, 40/40
+- 
+pm run test -- --run: passed, 61 files / 620 tests
+- 
+pm run build: passed
+- Existing unrelated warnings remain: React ct(...) warnings and Vite chunk-size warning.
 

--- a/_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md
+++ b/_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md
@@ -1,0 +1,267 @@
+﻿# PAYMENTS-DEBTS-RPC-CLIENT-001D: Finance RPC Client
+
+## 1. Summary
+
+Implemented a typed frontend RPC client for the controlled finance invoice/payment write RPCs introduced by `supabase/migrations/0017_create_finance_rpc.sql`.
+
+The client centralizes all finance write RPC calls in one repository-layer module, validates required frontend inputs before calling Supabase, maps camelCase frontend inputs to exact SQL `p_*` RPC parameters, maps returned snake_case rows to existing camelCase finance domain models, and normalizes validation/Supabase errors into a predictable client error shape.
+
+No UI, React hooks, migrations, SQL edits, cloud Supabase, seed data, generated types, refunds/write-offs/discounts, stock, documents, timeline, or reports UI were added.
+
+## 2. Branch
+
+- Branch: `feature/payments-debts-rpc-client-001d`
+- Base branch: `main`
+- Base commit before implementation: `258e3174ea7c22a0e7f8f5c35089fde9225a84df`
+
+## 3. PR URL
+
+- PR URL: Pending until PR creation. This report will be updated with the final PR URL after the branch is pushed and the PR exists.
+
+## 4. PR Head Reviewed Before Final Report Update
+
+- PR head reviewed before final report update: Pending until PR creation.
+
+## 5. Report Update Commit
+
+- Report update commit: N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed Files Summary
+
+Expected changed files:
+
+- `src/data/repositories/FinanceRpcClient.ts`
+- `src/data/repositories/FinanceRpcClient.test.ts`
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md`
+
+No migration, UI, hook, cloud, seed, generated type, stock, document, timeline, HEP-V2, or finance report UI files were changed.
+
+## 7. Pre-read Summary
+
+Reviewed the finance workflow context from the existing reports and implementation files:
+
+- Finance schema report and migration `0016_create_finance_model.sql` define invoices, invoice items, payments, and payment allocations.
+- Finance repository report and `FinanceRepository.ts` provide existing domain models and snake_case-to-camelCase mappers for `Invoice`, `InvoiceItem`, `Payment`, and `PaymentAllocation`.
+- Finance RPC report and `0017_create_finance_rpc.sql` define the controlled SECURITY DEFINER finance write RPCs.
+- Existing RPC client pattern from `EncounterVisitRpcClient.ts` uses injected Supabase client dependencies, repository-layer methods, explicit validation, `.rpc(...)` calls, and deterministic test mocks.
+
+## 8. Client Design
+
+File added:
+
+- `src/data/repositories/FinanceRpcClient.ts`
+
+The client exposes:
+
+- `FinanceRpcClientError`
+- `FinanceRpcClient` interface
+- `SupabaseFinanceRpcClient` implementation
+- `createFinanceRpcClient(client)` factory
+- typed input types for all controlled finance RPC write operations
+
+Supabase client injection:
+
+- The client receives a `SupabaseClient` instance through the constructor/factory.
+- It does not create a privileged client.
+- It does not use service role credentials.
+- It does not read from localStorage.
+
+Input validation:
+
+- Required IDs are validated before RPC calls.
+- Amount and quantity constraints are validated before RPC calls.
+- Metadata is accepted only as a plain object when provided.
+- Invalid frontend inputs throw `FinanceRpcClientError` before any `.rpc(...)` call.
+
+Result mapping:
+
+- The client reuses existing exported mappers from `FinanceRepository.ts`:
+  - `mapInvoiceRow`
+  - `mapInvoiceItemRow`
+  - `mapPaymentRow`
+  - `mapPaymentAllocationRow`
+
+## 9. RPC Mapping
+
+Implemented methods and RPC mappings:
+
+- `createInvoice` -> `create_invoice`
+- `addInvoiceItem` -> `add_invoice_item`
+- `issueInvoice` -> `issue_invoice`
+- `voidInvoice` -> `void_invoice`
+- `recordPayment` -> `record_payment`
+- `allocatePayment` -> `allocate_payment`
+- `voidPaymentAllocation` -> `void_payment_allocation`
+- `voidPayment` -> `void_payment`
+
+Parameter mapping uses exact SQL `p_*` names:
+
+- `tenantId` -> `p_tenant_id`
+- `patientId` -> `p_patient_id`
+- `invoiceId` -> `p_invoice_id`
+- `invoiceItemId` -> `p_invoice_item_id`
+- `paymentId` -> `p_payment_id`
+- `allocationId` -> `p_allocation_id`
+- `serviceName` -> `p_service_name`
+- `quantity` -> `p_quantity`
+- `unitPrice` -> `p_unit_price`
+- `discountAmount` -> `p_discount_amount`
+- `adjustmentAmount` -> `p_adjustment_amount`
+- `completedServiceId` -> `p_completed_service_id`
+- `serviceCode` -> `p_service_code`
+- `toothNumber` -> `p_tooth_number`
+- `toothSurface` -> `p_tooth_surface`
+- `paymentMethod` -> `p_payment_method`
+- `receivedAt` -> `p_received_at`
+- `externalReference` -> `p_external_reference`
+- `payerName` -> `p_payer_name`
+- `currency` -> `p_currency`
+- `dueDate` -> `p_due_date`
+- `notes` -> `p_notes`
+- `metadata` -> `p_metadata`
+- `reason` -> `p_reason`
+
+## 10. Domain / Result Mapping
+
+Returned database rows are mapped to existing finance domain models:
+
+- `Invoice`
+- `InvoiceItem`
+- `Payment`
+- `PaymentAllocation`
+
+Mapping preserves:
+
+- nullable fields;
+- metadata objects;
+- numeric amount conventions from the existing repository mappers;
+- timestamp string conventions from the existing repository mappers.
+
+## 11. Error Handling
+
+Validation errors throw `FinanceRpcClientError` with:
+
+- operation name;
+- safe user-facing message;
+- optional code for Supabase errors.
+
+Supabase RPC errors are normalized to `FinanceRpcClientError` and include the operation name without dumping raw Supabase response objects or secrets.
+
+Safe validation messages include:
+
+- `Не выбрана клиника.`
+- `Пациент не выбран.`
+- `Счёт не выбран.`
+- `Название услуги обязательно.`
+- `Количество должно быть больше 0.`
+- `Сумма должна быть больше 0.`
+- `Причина обязательна.`
+- `Не удалось выполнить финансовую операцию.`
+
+## 12. Safety Boundaries
+
+Confirmed by implementation and tests:
+
+- no direct `.from(...).insert`;
+- no direct `.from(...).update`;
+- no direct `.from(...).delete`;
+- no direct `.from(...).upsert`;
+- no `localStorage`;
+- no `service_role`;
+- no `patients.balance` access or mutation;
+- no `completed_services` mutation;
+- no refunds/write-offs/discount features added;
+- no UI imports;
+- no React hooks;
+- no cloud Supabase;
+- no migrations;
+- no seed;
+- no generated types;
+- no HEP-V2 work.
+
+## 13. Tests
+
+Added:
+
+- `src/data/repositories/FinanceRpcClient.test.ts`
+
+Coverage includes 40 tests:
+
+- all 8 RPC methods call the expected Supabase `.rpc(...)` names;
+- all required `p_*` parameter mappings are verified;
+- missing required IDs are rejected;
+- invalid amounts/quantity are rejected;
+- invalid payment method is rejected;
+- metadata must be a plain object;
+- invoice/item/payment/allocation result mapping to camelCase is verified;
+- nullable fields and metadata preservation are verified;
+- Supabase RPC errors are normalized;
+- null data is handled safely;
+- direct table writes and forbidden dependencies are guarded.
+
+## 14. Local Validation
+
+Local Supabase validation:
+
+- `npx supabase db reset --no-seed`: passed.
+- Migration `0017_create_finance_rpc.sql` applied after `0016_create_finance_model.sql`.
+- Local RPC catalog check confirmed the 8 public finance RPCs exist.
+- The 8 public finance RPCs were verified as `SECURITY DEFINER` with `search_path = public, pg_temp`.
+- Supabase cloud was not used.
+
+Optional local functional RPC smoke was not run in this task because the requested scope was frontend typed client plus unit/local validation and browser smoke was explicitly forbidden.
+
+## 15. What Was Intentionally Not Changed
+
+Intentionally not changed:
+
+- no Supabase migrations;
+- no SQL function edits;
+- no UI;
+- no React hooks;
+- no cloud Supabase;
+- no seed data;
+- no generated types;
+- no refunds/write-offs/discounts;
+- no stock;
+- no documents;
+- no timeline;
+- no reports UI;
+- no HEP-V2 work.
+
+## 16. Checks
+
+Local checks:
+
+- `git status --short`: expected scoped changes only.
+- `npm run lint`: passed.
+- `npm run test -- --run src/data/repositories/FinanceRpcClient.test.ts`: passed, 40/40 tests.
+- `npm run test -- --run`: passed, 61 files / 620 tests.
+- `npm run build`: passed.
+
+GitHub Actions CI:
+
+- Pending until PR creation and push.
+
+## 17. Issues / Warnings
+
+Existing unrelated warnings:
+
+- old React `act(...)` warnings remain in unrelated UI test files;
+- Vite chunk-size warning remains for the main application bundle.
+
+These warnings are pre-existing project noise and do not block this finance RPC client task.
+
+Skipped by instruction:
+
+- browser smoke was not run;
+- Supabase cloud was not touched;
+- UI integration was not started.
+
+## 18. Final Verdict
+
+PAYMENTS DEBTS RPC CLIENT IMPLEMENTED AND VERIFIED
+
+## 19. Recommended Next Task
+
+PATIENT-FINANCE-UI-001

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -40,8 +40,19 @@ function createClientMock(rpcResult: RpcResult) {
   return { rpcClient, client, rpcCalls };
 }
 
-function expectFinanceClientError(promise: Promise<unknown>, message: string) {
-  return expect(promise).rejects.toMatchObject({ name: 'FinanceRpcClientError', message });
+const MOJIBAKE_FRAGMENTS = ['Рќ', 'Рџ', 'СЃ', 'С‚'];
+
+async function expectFinanceClientError(promise: Promise<unknown>, message: string) {
+  try {
+    await promise;
+    throw new Error('Expected FinanceRpcClientError to be thrown');
+  } catch (error) {
+    expect(error).toMatchObject({ name: 'FinanceRpcClientError', message });
+    const actualMessage = error instanceof Error ? error.message : String(error);
+    for (const fragment of MOJIBAKE_FRAGMENTS) {
+      expect(actualMessage).not.toContain(fragment);
+    }
+  }
 }
 
 function expectNoDirectWriteCalls(client: ClientMock) {
@@ -328,93 +339,93 @@ describe('FinanceRpcClient RPC mapping', () => {
 describe('FinanceRpcClient validation', () => {
   it('createInvoice rejects missing tenantId', async () => {
     const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
-    await expectFinanceClientError(rpcClient.createInvoice({ tenantId: '', patientId }), 'РќРµ РІС‹Р±СЂР°РЅР° РєР»РёРЅРёРєР°.');
+    await expectFinanceClientError(rpcClient.createInvoice({ tenantId: '', patientId }), 'Не выбрана клиника.');
   });
 
   it('createInvoice rejects missing patientId', async () => {
     const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
-    await expectFinanceClientError(rpcClient.createInvoice({ tenantId, patientId: '  ' }), 'РџР°С†РёРµРЅС‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    await expectFinanceClientError(rpcClient.createInvoice({ tenantId, patientId: '  ' }), 'Пациент не выбран.');
   });
 
   it('addInvoiceItem rejects empty serviceName', async () => {
     const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
-    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: '' }), 'РќР°Р·РІР°РЅРёРµ СѓСЃР»СѓРіРё РѕР±СЏР·Р°С‚РµР»СЊРЅРѕ.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: '' }), 'Название услуги обязательно.');
   });
 
   it('addInvoiceItem rejects quantity <= 0', async () => {
     const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
-    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', quantity: 0 }), 'РљРѕР»РёС‡РµСЃС‚РІРѕ РґРѕР»Р¶РЅРѕ Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
-    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', quantity: -1 }), 'РљРѕР»РёС‡РµСЃС‚РІРѕ РґРѕР»Р¶РЅРѕ Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', quantity: 0 }), 'Количество должно быть больше 0.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', quantity: -1 }), 'Количество должно быть больше 0.');
   });
 
   it('addInvoiceItem rejects negative unitPrice', async () => {
     const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
-    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', unitPrice: -1 }), 'Р¦РµРЅР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', unitPrice: -1 }), 'Цена не может быть отрицательной.');
   });
 
   it('addInvoiceItem rejects negative discountAmount', async () => {
     const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
-    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', discountAmount: -1 }), 'РЎРєРёРґРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', discountAmount: -1 }), 'Скидка не может быть отрицательной.');
   });
 
   it('addInvoiceItem rejects negative adjustmentAmount', async () => {
     const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
-    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', adjustmentAmount: -1 }), 'РљРѕСЂСЂРµРєС‚РёСЂРѕРІРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', adjustmentAmount: -1 }), 'Корректировка не может быть отрицательной.');
   });
 
   it('recordPayment rejects amount <= 0', async () => {
     const { rpcClient } = createClientMock({ data: paymentRow, error: null });
-    await expectFinanceClientError(rpcClient.recordPayment({ tenantId, patientId, amount: 0, paymentMethod: 'cash' }), 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    await expectFinanceClientError(rpcClient.recordPayment({ tenantId, patientId, amount: 0, paymentMethod: 'cash' }), 'Сумма должна быть больше 0.');
   });
 
   it('recordPayment rejects invalid paymentMethod', async () => {
     const { rpcClient } = createClientMock({ data: paymentRow, error: null });
     await expectFinanceClientError(
       rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'crypto' as PaymentMethod }),
-      'РќРµРєРѕСЂСЂРµРєС‚РЅС‹Р№ СЃРїРѕСЃРѕР± РѕРїР»Р°С‚С‹.',
+      'Некорректный способ оплаты.',
     );
   });
 
   it('allocatePayment rejects amount <= 0', async () => {
     const { rpcClient } = createClientMock({ data: paymentAllocationRow, error: null });
-    await expectFinanceClientError(rpcClient.allocatePayment({ tenantId, paymentId, amount: -1, invoiceId }), 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    await expectFinanceClientError(rpcClient.allocatePayment({ tenantId, paymentId, amount: -1, invoiceId }), 'Сумма должна быть больше 0.');
   });
 
   it('allocatePayment rejects missing invoiceId and invoiceItemId', async () => {
     const { rpcClient } = createClientMock({ data: paymentAllocationRow, error: null });
-    await expectFinanceClientError(rpcClient.allocatePayment({ tenantId, paymentId, amount: 100 }), 'РќСѓР¶РЅРѕ РІС‹Р±СЂР°С‚СЊ СЃС‡С‘С‚ РёР»Рё РїРѕР·РёС†РёСЋ СЃС‡С‘С‚Р°.');
+    await expectFinanceClientError(rpcClient.allocatePayment({ tenantId, paymentId, amount: 100 }), 'Нужно выбрать счёт или позицию счёта.');
   });
 
   it('invoice operations reject missing invoiceId', async () => {
     const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
-    await expectFinanceClientError(rpcClient.issueInvoice({ tenantId, invoiceId: '' } as IssueInvoiceInput), 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
-    await expectFinanceClientError(rpcClient.voidInvoice({ tenantId, invoiceId: ' ', reason: 'Void' } as VoidInvoiceInput), 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    await expectFinanceClientError(rpcClient.issueInvoice({ tenantId, invoiceId: '' } as IssueInvoiceInput), 'Счёт не выбран.');
+    await expectFinanceClientError(rpcClient.voidInvoice({ tenantId, invoiceId: ' ', reason: 'Void' } as VoidInvoiceInput), 'Счёт не выбран.');
   });
 
   it('voidInvoice requires reason', async () => {
     const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
-    await expectFinanceClientError(rpcClient.voidInvoice({ tenantId, invoiceId, reason: ' ' }), 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    await expectFinanceClientError(rpcClient.voidInvoice({ tenantId, invoiceId, reason: ' ' }), 'Причина обязательна.');
   });
 
   it('voidPaymentAllocation requires reason', async () => {
     const { rpcClient } = createClientMock({ data: paymentAllocationRow, error: null });
-    await expectFinanceClientError(rpcClient.voidPaymentAllocation({ tenantId, allocationId, reason: '' }), 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    await expectFinanceClientError(rpcClient.voidPaymentAllocation({ tenantId, allocationId, reason: '' }), 'Причина обязательна.');
   });
 
   it('voidPayment requires reason', async () => {
     const { rpcClient } = createClientMock({ data: paymentRow, error: null });
-    await expectFinanceClientError(rpcClient.voidPayment({ tenantId, paymentId, reason: '' }), 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    await expectFinanceClientError(rpcClient.voidPayment({ tenantId, paymentId, reason: '' }), 'Причина обязательна.');
   });
 
   it('metadata must be a plain object if provided', async () => {
     const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
     await expectFinanceClientError(
       rpcClient.createInvoice({ tenantId, patientId, metadata: null as unknown as Record<string, unknown> }),
-      'РњРµС‚Р°РґР°РЅРЅС‹Рµ РґРѕР»Р¶РЅС‹ Р±С‹С‚СЊ РѕР±СЉРµРєС‚РѕРј.',
+      'Метаданные должны быть объектом.',
     );
     await expectFinanceClientError(
       rpcClient.createInvoice({ tenantId, patientId, metadata: ['bad'] as unknown as Record<string, unknown> }),
-      'РњРµС‚Р°РґР°РЅРЅС‹Рµ РґРѕР»Р¶РЅС‹ Р±С‹С‚СЊ РѕР±СЉРµРєС‚РѕРј.',
+      'Метаданные должны быть объектом.',
     );
   });
 });
@@ -479,7 +490,7 @@ describe('FinanceRpcClient error behavior', () => {
       name: 'FinanceRpcClientError',
       operation: 'createInvoice',
       code: '42501',
-      message: 'РќРµ СѓРґР°Р»РѕСЃСЊ РІС‹РїРѕР»РЅРёС‚СЊ С„РёРЅР°РЅСЃРѕРІСѓСЋ РѕРїРµСЂР°С†РёСЋ. Access denied',
+      message: 'Не удалось выполнить финансовую операцию. Access denied',
     });
   });
 
@@ -488,7 +499,7 @@ describe('FinanceRpcClient error behavior', () => {
     await expect(rpcClient.createInvoice({ tenantId, patientId })).rejects.toMatchObject({
       name: 'FinanceRpcClientError',
       operation: 'createInvoice',
-      message: 'РќРµ СѓРґР°Р»РѕСЃСЊ РІС‹РїРѕР»РЅРёС‚СЊ С„РёРЅР°РЅСЃРѕРІСѓСЋ РѕРїРµСЂР°С†РёСЋ.',
+      message: 'Не удалось выполнить финансовую операцию.',
     });
   });
 });

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -1,0 +1,557 @@
+﻿import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
+import {
+  createFinanceRpcClient,
+  SupabaseFinanceRpcClient,
+  type CreateInvoiceInput,
+  type IssueInvoiceInput,
+  type VoidInvoiceInput,
+} from './FinanceRpcClient';
+import type { PaymentMethod } from './FinanceRepository';
+
+type RpcResult = { data: unknown; error: PostgrestError | Error | null };
+type RpcCall = { rpcName: string; params: Record<string, unknown> };
+
+type ClientMock = {
+  rpc: ReturnType<typeof vi.fn>;
+  from: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  upsert: ReturnType<typeof vi.fn>;
+};
+
+function createClientMock(rpcResult: RpcResult) {
+  const rpcCalls: RpcCall[] = [];
+  const client: ClientMock = {
+    rpc: vi.fn(async (rpcName: string, params: Record<string, unknown>) => {
+      rpcCalls.push({ rpcName, params });
+      return rpcResult;
+    }),
+    from: vi.fn(() => {
+      throw new Error('Direct table access is forbidden');
+    }),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    upsert: vi.fn(),
+  };
+  const rpcClient = new SupabaseFinanceRpcClient(client as unknown as SupabaseClient);
+  return { rpcClient, client, rpcCalls };
+}
+
+function expectFinanceClientError(promise: Promise<unknown>, message: string) {
+  return expect(promise).rejects.toMatchObject({ name: 'FinanceRpcClientError', message });
+}
+
+function expectNoDirectWriteCalls(client: ClientMock) {
+  expect(client.from).not.toHaveBeenCalled();
+  expect(client.insert).not.toHaveBeenCalled();
+  expect(client.update).not.toHaveBeenCalled();
+  expect(client.delete).not.toHaveBeenCalled();
+  expect(client.upsert).not.toHaveBeenCalled();
+}
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const patientId = '22222222-2222-2222-2222-222222222222';
+const invoiceId = '33333333-3333-3333-3333-333333333333';
+const invoiceItemId = '44444444-4444-4444-4444-444444444444';
+const paymentId = '55555555-5555-5555-5555-555555555555';
+const allocationId = '66666666-6666-6666-6666-666666666666';
+const completedServiceId = '77777777-7777-7777-7777-777777777777';
+
+const invoiceRow = {
+  id: invoiceId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  invoice_number: 'INV-1',
+  status: 'issued',
+  currency: 'KZT',
+  issue_date: '2026-06-21T00:00:00Z',
+  due_date: null,
+  subtotal_amount: '12000.00',
+  discount_amount: '1000.00',
+  adjustment_amount: '0.00',
+  total_amount: '11000.00',
+  paid_amount: '4000.00',
+  refunded_amount: '0.00',
+  written_off_amount: '0.00',
+  balance_amount: '7000.00',
+  notes: null,
+  metadata: { source: 'test' },
+  created_by: 'user-1',
+  issued_by: 'user-2',
+  voided_by: null,
+  void_reason: null,
+  issued_at: '2026-06-21T01:00:00Z',
+  voided_at: null,
+  archived_at: null,
+  created_at: '2026-06-21T01:00:01Z',
+  updated_at: '2026-06-21T01:00:02Z',
+};
+
+const invoiceItemRow = {
+  id: invoiceItemId,
+  tenant_id: tenantId,
+  invoice_id: invoiceId,
+  patient_id: patientId,
+  completed_service_id: completedServiceId,
+  service_name: 'Consultation',
+  service_code: null,
+  tooth_number: null,
+  tooth_surface: null,
+  quantity: '2.00',
+  unit_price: '6000.00',
+  discount_amount: '1000.00',
+  adjustment_amount: '0.00',
+  total_amount: '11000.00',
+  status: 'active',
+  notes: null,
+  metadata: { source: 'item' },
+  created_by: 'user-1',
+  voided_by: null,
+  void_reason: null,
+  voided_at: null,
+  archived_at: null,
+  created_at: '2026-06-21T01:00:01Z',
+  updated_at: '2026-06-21T01:00:02Z',
+};
+
+const paymentRow = {
+  id: paymentId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  status: 'received',
+  payment_method: 'cash',
+  amount: '11000.00',
+  currency: 'KZT',
+  received_at: '2026-06-21T02:00:00Z',
+  external_reference: null,
+  payer_name: null,
+  notes: null,
+  metadata: { source: 'payment' },
+  received_by: 'user-1',
+  voided_by: null,
+  void_reason: null,
+  voided_at: null,
+  archived_at: null,
+  created_at: '2026-06-21T02:00:01Z',
+  updated_at: '2026-06-21T02:00:02Z',
+};
+
+const paymentAllocationRow = {
+  id: allocationId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  payment_id: paymentId,
+  invoice_id: invoiceId,
+  invoice_item_id: null,
+  amount: '11000.00',
+  currency: 'KZT',
+  status: 'active',
+  allocated_at: '2026-06-21T03:00:00Z',
+  metadata: { source: 'allocation' },
+  created_by: 'user-1',
+  voided_by: null,
+  void_reason: null,
+  voided_at: null,
+  created_at: '2026-06-21T03:00:01Z',
+  updated_at: '2026-06-21T03:00:02Z',
+};
+
+function sourceText() {
+  return [
+    createFinanceRpcClient,
+    SupabaseFinanceRpcClient,
+    ...Object.values(Object.getOwnPropertyDescriptors(SupabaseFinanceRpcClient.prototype))
+      .map((descriptor) => descriptor.value)
+      .filter((value): value is (...args: never[]) => unknown => typeof value === 'function'),
+  ].map((value) => value.toString()).join('\n');
+}
+
+describe('FinanceRpcClient RPC mapping', () => {
+  it('createInvoice calls create_invoice with exact p_* params', async () => {
+    const { rpcClient, rpcCalls, client } = createClientMock({ data: [invoiceRow], error: null });
+    const input: CreateInvoiceInput = {
+      tenantId,
+      patientId,
+      currency: 'KZT',
+      dueDate: '2026-06-30T00:00:00Z',
+      notes: 'Initial invoice',
+      metadata: { source: 'ui' },
+    };
+
+    await rpcClient.createInvoice(input);
+
+    expect(rpcCalls).toEqual([{ rpcName: 'create_invoice', params: {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_currency: 'KZT',
+      p_due_date: '2026-06-30T00:00:00Z',
+      p_notes: 'Initial invoice',
+      p_metadata: { source: 'ui' },
+    } }]);
+    expectNoDirectWriteCalls(client);
+  });
+
+  it('addInvoiceItem calls add_invoice_item with exact p_* params and defaults', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [invoiceItemRow], error: null });
+    await rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Consultation' });
+
+    expect(rpcCalls).toEqual([{ rpcName: 'add_invoice_item', params: {
+      p_tenant_id: tenantId,
+      p_invoice_id: invoiceId,
+      p_service_name: 'Consultation',
+      p_quantity: 1,
+      p_unit_price: 0,
+      p_discount_amount: 0,
+      p_adjustment_amount: 0,
+      p_completed_service_id: null,
+      p_service_code: null,
+      p_tooth_number: null,
+      p_tooth_surface: null,
+      p_notes: null,
+      p_metadata: {},
+    } }]);
+  });
+
+  it('addInvoiceItem maps all optional p_* params', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [invoiceItemRow], error: null });
+    await rpcClient.addInvoiceItem({
+      tenantId,
+      invoiceId,
+      serviceName: 'Filling',
+      quantity: 2,
+      unitPrice: 5000,
+      discountAmount: 500,
+      adjustmentAmount: 100,
+      completedServiceId,
+      serviceCode: 'FILL',
+      toothNumber: '16',
+      toothSurface: 'O',
+      notes: 'Notes',
+      metadata: { tooth: true },
+    });
+
+    expect(rpcCalls[0]).toEqual({ rpcName: 'add_invoice_item', params: {
+      p_tenant_id: tenantId,
+      p_invoice_id: invoiceId,
+      p_service_name: 'Filling',
+      p_quantity: 2,
+      p_unit_price: 5000,
+      p_discount_amount: 500,
+      p_adjustment_amount: 100,
+      p_completed_service_id: completedServiceId,
+      p_service_code: 'FILL',
+      p_tooth_number: '16',
+      p_tooth_surface: 'O',
+      p_notes: 'Notes',
+      p_metadata: { tooth: true },
+    } });
+  });
+
+  it('issueInvoice calls issue_invoice', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: invoiceRow, error: null });
+    await rpcClient.issueInvoice({ tenantId, invoiceId });
+    expect(rpcCalls).toEqual([{ rpcName: 'issue_invoice', params: { p_tenant_id: tenantId, p_invoice_id: invoiceId } }]);
+  });
+
+  it('voidInvoice calls void_invoice', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: invoiceRow, error: null });
+    await rpcClient.voidInvoice({ tenantId, invoiceId, reason: 'Wrong patient' });
+    expect(rpcCalls).toEqual([{ rpcName: 'void_invoice', params: { p_tenant_id: tenantId, p_invoice_id: invoiceId, p_reason: 'Wrong patient' } }]);
+  });
+
+  it('recordPayment calls record_payment with exact p_* params', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [paymentRow], error: null });
+    await rpcClient.recordPayment({
+      tenantId,
+      patientId,
+      amount: 11000,
+      paymentMethod: 'kaspi',
+      currency: 'KZT',
+      receivedAt: '2026-06-21T02:00:00Z',
+      externalReference: 'KSP-1',
+      payerName: 'Patient',
+      notes: 'Paid',
+      metadata: { terminal: true },
+    });
+
+    expect(rpcCalls).toEqual([{ rpcName: 'record_payment', params: {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_amount: 11000,
+      p_payment_method: 'kaspi',
+      p_currency: 'KZT',
+      p_received_at: '2026-06-21T02:00:00Z',
+      p_external_reference: 'KSP-1',
+      p_payer_name: 'Patient',
+      p_notes: 'Paid',
+      p_metadata: { terminal: true },
+    } }]);
+  });
+
+  it('allocatePayment calls allocate_payment', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [paymentAllocationRow], error: null });
+    await rpcClient.allocatePayment({ tenantId, paymentId, amount: 11000, invoiceId, metadata: { allocation: true } });
+    expect(rpcCalls).toEqual([{ rpcName: 'allocate_payment', params: {
+      p_tenant_id: tenantId,
+      p_payment_id: paymentId,
+      p_amount: 11000,
+      p_invoice_id: invoiceId,
+      p_invoice_item_id: null,
+      p_metadata: { allocation: true },
+    } }]);
+  });
+
+  it('voidPaymentAllocation calls void_payment_allocation', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [paymentAllocationRow], error: null });
+    await rpcClient.voidPaymentAllocation({ tenantId, allocationId, reason: 'Correction' });
+    expect(rpcCalls).toEqual([{ rpcName: 'void_payment_allocation', params: {
+      p_tenant_id: tenantId,
+      p_allocation_id: allocationId,
+      p_reason: 'Correction',
+    } }]);
+  });
+
+  it('voidPayment calls void_payment', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [paymentRow], error: null });
+    await rpcClient.voidPayment({ tenantId, paymentId, reason: 'Duplicate' });
+    expect(rpcCalls).toEqual([{ rpcName: 'void_payment', params: {
+      p_tenant_id: tenantId,
+      p_payment_id: paymentId,
+      p_reason: 'Duplicate',
+    } }]);
+  });
+});
+
+describe('FinanceRpcClient validation', () => {
+  it('createInvoice rejects missing tenantId', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
+    await expectFinanceClientError(rpcClient.createInvoice({ tenantId: '', patientId }), 'РќРµ РІС‹Р±СЂР°РЅР° РєР»РёРЅРёРєР°.');
+  });
+
+  it('createInvoice rejects missing patientId', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
+    await expectFinanceClientError(rpcClient.createInvoice({ tenantId, patientId: '  ' }), 'РџР°С†РёРµРЅС‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+  });
+
+  it('addInvoiceItem rejects empty serviceName', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: '' }), 'РќР°Р·РІР°РЅРёРµ СѓСЃР»СѓРіРё РѕР±СЏР·Р°С‚РµР»СЊРЅРѕ.');
+  });
+
+  it('addInvoiceItem rejects quantity <= 0', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', quantity: 0 }), 'РљРѕР»РёС‡РµСЃС‚РІРѕ РґРѕР»Р¶РЅРѕ Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', quantity: -1 }), 'РљРѕР»РёС‡РµСЃС‚РІРѕ РґРѕР»Р¶РЅРѕ Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+  });
+
+  it('addInvoiceItem rejects negative unitPrice', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', unitPrice: -1 }), 'Р¦РµРЅР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+  });
+
+  it('addInvoiceItem rejects negative discountAmount', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', discountAmount: -1 }), 'РЎРєРёРґРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+  });
+
+  it('addInvoiceItem rejects negative adjustmentAmount', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceItemRow, error: null });
+    await expectFinanceClientError(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Test', adjustmentAmount: -1 }), 'РљРѕСЂСЂРµРєС‚РёСЂРѕРІРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+  });
+
+  it('recordPayment rejects amount <= 0', async () => {
+    const { rpcClient } = createClientMock({ data: paymentRow, error: null });
+    await expectFinanceClientError(rpcClient.recordPayment({ tenantId, patientId, amount: 0, paymentMethod: 'cash' }), 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+  });
+
+  it('recordPayment rejects invalid paymentMethod', async () => {
+    const { rpcClient } = createClientMock({ data: paymentRow, error: null });
+    await expectFinanceClientError(
+      rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'crypto' as PaymentMethod }),
+      'РќРµРєРѕСЂСЂРµРєС‚РЅС‹Р№ СЃРїРѕСЃРѕР± РѕРїР»Р°С‚С‹.',
+    );
+  });
+
+  it('allocatePayment rejects amount <= 0', async () => {
+    const { rpcClient } = createClientMock({ data: paymentAllocationRow, error: null });
+    await expectFinanceClientError(rpcClient.allocatePayment({ tenantId, paymentId, amount: -1, invoiceId }), 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+  });
+
+  it('allocatePayment rejects missing invoiceId and invoiceItemId', async () => {
+    const { rpcClient } = createClientMock({ data: paymentAllocationRow, error: null });
+    await expectFinanceClientError(rpcClient.allocatePayment({ tenantId, paymentId, amount: 100 }), 'РќСѓР¶РЅРѕ РІС‹Р±СЂР°С‚СЊ СЃС‡С‘С‚ РёР»Рё РїРѕР·РёС†РёСЋ СЃС‡С‘С‚Р°.');
+  });
+
+  it('invoice operations reject missing invoiceId', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
+    await expectFinanceClientError(rpcClient.issueInvoice({ tenantId, invoiceId: '' } as IssueInvoiceInput), 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    await expectFinanceClientError(rpcClient.voidInvoice({ tenantId, invoiceId: ' ', reason: 'Void' } as VoidInvoiceInput), 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+  });
+
+  it('voidInvoice requires reason', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
+    await expectFinanceClientError(rpcClient.voidInvoice({ tenantId, invoiceId, reason: ' ' }), 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+  });
+
+  it('voidPaymentAllocation requires reason', async () => {
+    const { rpcClient } = createClientMock({ data: paymentAllocationRow, error: null });
+    await expectFinanceClientError(rpcClient.voidPaymentAllocation({ tenantId, allocationId, reason: '' }), 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+  });
+
+  it('voidPayment requires reason', async () => {
+    const { rpcClient } = createClientMock({ data: paymentRow, error: null });
+    await expectFinanceClientError(rpcClient.voidPayment({ tenantId, paymentId, reason: '' }), 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+  });
+
+  it('metadata must be a plain object if provided', async () => {
+    const { rpcClient } = createClientMock({ data: invoiceRow, error: null });
+    await expectFinanceClientError(
+      rpcClient.createInvoice({ tenantId, patientId, metadata: null as unknown as Record<string, unknown> }),
+      'РњРµС‚Р°РґР°РЅРЅС‹Рµ РґРѕР»Р¶РЅС‹ Р±С‹С‚СЊ РѕР±СЉРµРєС‚РѕРј.',
+    );
+    await expectFinanceClientError(
+      rpcClient.createInvoice({ tenantId, patientId, metadata: ['bad'] as unknown as Record<string, unknown> }),
+      'РњРµС‚Р°РґР°РЅРЅС‹Рµ РґРѕР»Р¶РЅС‹ Р±С‹С‚СЊ РѕР±СЉРµРєС‚РѕРј.',
+    );
+  });
+});
+
+describe('FinanceRpcClient result mapping', () => {
+  it('createInvoice maps returned invoice row to camelCase', async () => {
+    const { rpcClient } = createClientMock({ data: [invoiceRow], error: null });
+    const invoice = await rpcClient.createInvoice({ tenantId, patientId });
+    expect(invoice.tenantId).toBe(tenantId);
+    expect(invoice.patientId).toBe(patientId);
+    expect(invoice.invoiceNumber).toBe('INV-1');
+    expect(invoice.balanceAmount).toBe(7000);
+  });
+
+  it('addInvoiceItem maps returned invoice item row to camelCase', async () => {
+    const { rpcClient } = createClientMock({ data: [invoiceItemRow], error: null });
+    const item = await rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Consultation' });
+    expect(item.invoiceId).toBe(invoiceId);
+    expect(item.completedServiceId).toBe(completedServiceId);
+    expect(item.serviceName).toBe('Consultation');
+    expect(item.totalAmount).toBe(11000);
+  });
+
+  it('recordPayment maps returned payment row to camelCase', async () => {
+    const { rpcClient } = createClientMock({ data: [paymentRow], error: null });
+    const payment = await rpcClient.recordPayment({ tenantId, patientId, amount: 11000, paymentMethod: 'cash' });
+    expect(payment.paymentMethod).toBe('cash');
+    expect(payment.externalReference).toBeNull();
+    expect(payment.amount).toBe(11000);
+  });
+
+  it('allocatePayment maps returned allocation row to camelCase', async () => {
+    const { rpcClient } = createClientMock({ data: [paymentAllocationRow], error: null });
+    const allocation = await rpcClient.allocatePayment({ tenantId, paymentId, invoiceId, amount: 11000 });
+    expect(allocation.paymentId).toBe(paymentId);
+    expect(allocation.invoiceId).toBe(invoiceId);
+    expect(allocation.invoiceItemId).toBeNull();
+    expect(allocation.amount).toBe(11000);
+  });
+
+  it('nullable fields are preserved', async () => {
+    const { rpcClient } = createClientMock({ data: [invoiceRow], error: null });
+    const invoice = await rpcClient.createInvoice({ tenantId, patientId });
+    expect(invoice.dueDate).toBeNull();
+    expect(invoice.notes).toBeNull();
+    expect(invoice.voidedAt).toBeNull();
+  });
+
+  it('metadata objects are preserved', async () => {
+    const { rpcClient } = createClientMock({ data: [paymentAllocationRow], error: null });
+    const allocation = await rpcClient.allocatePayment({ tenantId, paymentId, invoiceId, amount: 11000 });
+    expect(allocation.metadata).toEqual({ source: 'allocation' });
+  });
+});
+
+describe('FinanceRpcClient error behavior', () => {
+  it('normalizes Supabase RPC errors with operation context', async () => {
+    const error = Object.assign(new Error('Access denied'), { code: '42501' });
+    const { rpcClient } = createClientMock({ data: null, error });
+
+    await expect(rpcClient.createInvoice({ tenantId, patientId })).rejects.toMatchObject({
+      name: 'FinanceRpcClientError',
+      operation: 'createInvoice',
+      code: '42501',
+      message: 'РќРµ СѓРґР°Р»РѕСЃСЊ РІС‹РїРѕР»РЅРёС‚СЊ С„РёРЅР°РЅСЃРѕРІСѓСЋ РѕРїРµСЂР°С†РёСЋ. Access denied',
+    });
+  });
+
+  it('null data with no error is handled safely', async () => {
+    const { rpcClient } = createClientMock({ data: null, error: null });
+    await expect(rpcClient.createInvoice({ tenantId, patientId })).rejects.toMatchObject({
+      name: 'FinanceRpcClientError',
+      operation: 'createInvoice',
+      message: 'РќРµ СѓРґР°Р»РѕСЃСЊ РІС‹РїРѕР»РЅРёС‚СЊ С„РёРЅР°РЅСЃРѕРІСѓСЋ РѕРїРµСЂР°С†РёСЋ.',
+    });
+  });
+});
+
+describe('FinanceRpcClient safety boundaries', () => {
+  it('factory creates a Supabase-backed client and rejects local backend', () => {
+    const client = { rpc: vi.fn() } as unknown as SupabaseClient;
+    expect(createFinanceRpcClient({ backend: 'supabase', client })).toBeInstanceOf(SupabaseFinanceRpcClient);
+    expect(() => createFinanceRpcClient({ backend: 'local', client })).toThrow('Finance RPC client requires Supabase backend.');
+  });
+
+  it('client never calls from/insert/update/delete/upsert during a write operation', async () => {
+    const { rpcClient, client } = createClientMock({ data: [paymentRow], error: null });
+    await rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash' });
+    expect(client.rpc).toHaveBeenCalledOnce();
+    expectNoDirectWriteCalls(client);
+  });
+
+  it('source has no raw direct table write calls', () => {
+    const source = sourceText();
+    expect(source).not.toContain('.from(');
+    expect(source).not.toContain('.insert(');
+    expect(source).not.toContain('.update(');
+    expect(source).not.toContain('.delete(');
+    expect(source).not.toContain('.upsert(');
+  });
+
+  it('source does not use localStorage or privileged service keys', () => {
+    const source = sourceText();
+    expect(source).not.toContain('localStorage');
+    expect(source).not.toContain('service_role');
+    expect(source).not.toContain('SERVICE_ROLE');
+  });
+
+  it('source does not import React or UI modules', () => {
+    const source = sourceText();
+    expect(source).not.toContain('react');
+    expect(source).not.toContain('src/components');
+    expect(source).not.toContain('src/pages');
+    expect(source).not.toContain('data/hooks');
+  });
+
+  it('source does not mutate completed services or patient balance', () => {
+    const source = sourceText();
+    expect(source).not.toContain('completed_services');
+    expect(source).not.toContain('patients.balance');
+    expect(source).not.toContain('balance =');
+  });
+
+  it('client exposes only controlled invoice/payment RPC methods', () => {
+    const methods = Object.getOwnPropertyNames(SupabaseFinanceRpcClient.prototype);
+    expect(methods).toEqual(expect.arrayContaining([
+      'createInvoice',
+      'addInvoiceItem',
+      'issueInvoice',
+      'voidInvoice',
+      'recordPayment',
+      'allocatePayment',
+      'voidPaymentAllocation',
+      'voidPayment',
+    ]));
+    expect(methods.some((method) => method.toLowerCase().includes('refund'))).toBe(false);
+    expect(methods.some((method) => method.toLowerCase().includes('writeoff'))).toBe(false);
+  });
+});
+

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -118,7 +118,7 @@ export interface CreateFinanceRpcClientOptions {
   client?: SupabaseClient;
 }
 
-const FINANCE_RPC_OPERATION_FAILED_MESSAGE = 'РќРµ СѓРґР°Р»РѕСЃСЊ РІС‹РїРѕР»РЅРёС‚СЊ С„РёРЅР°РЅСЃРѕРІСѓСЋ РѕРїРµСЂР°С†РёСЋ.';
+const FINANCE_RPC_OPERATION_FAILED_MESSAGE = 'Не удалось выполнить финансовую операцию.';
 const PAYMENT_METHODS: readonly PaymentMethod[] = [
   'cash',
   'kaspi',
@@ -143,7 +143,7 @@ function requireNonEmptyString(value: string | null | undefined, message: string
 }
 
 function requireTenantId(tenantId: string | null | undefined): string {
-  return requireNonEmptyString(tenantId, 'РќРµ РІС‹Р±СЂР°РЅР° РєР»РёРЅРёРєР°.');
+  return requireNonEmptyString(tenantId, 'Не выбрана клиника.');
 }
 
 function requirePositiveNumber(value: number | null | undefined, message: string): number {
@@ -162,7 +162,7 @@ function requireNonNegativeNumber(value: number | null | undefined, message: str
 
 function validateMetadata(metadata?: Record<string, unknown> | null) {
   if (metadata !== undefined && !isPlainObject(metadata)) {
-    throw new FinanceRpcClientError({ operation: 'validation', message: 'РњРµС‚Р°РґР°РЅРЅС‹Рµ РґРѕР»Р¶РЅС‹ Р±С‹С‚СЊ РѕР±СЉРµРєС‚РѕРј.' });
+    throw new FinanceRpcClientError({ operation: 'validation', message: 'Метаданные должны быть объектом.' });
   }
 }
 
@@ -208,9 +208,9 @@ async function callRpc(
 }
 
 function validatePaymentMethod(paymentMethod: PaymentMethod | null | undefined): PaymentMethod {
-  const method = requireNonEmptyString(paymentMethod, 'РЎРїРѕСЃРѕР± РѕРїР»Р°С‚С‹ РѕР±СЏР·Р°С‚РµР»РµРЅ.') as PaymentMethod;
+  const method = requireNonEmptyString(paymentMethod, 'Способ оплаты обязателен.') as PaymentMethod;
   if (!PAYMENT_METHODS.includes(method)) {
-    throw new FinanceRpcClientError({ operation: 'validation', message: 'РќРµРєРѕСЂСЂРµРєС‚РЅС‹Р№ СЃРїРѕСЃРѕР± РѕРїР»Р°С‚С‹.' });
+    throw new FinanceRpcClientError({ operation: 'validation', message: 'Некорректный способ оплаты.' });
   }
   return method;
 }
@@ -225,7 +225,7 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async createInvoice(input: CreateInvoiceInput): Promise<Invoice> {
     const operation = 'createInvoice';
     const tenantId = requireTenantId(input.tenantId);
-    const patientId = requireNonEmptyString(input.patientId, 'РџР°С†РёРµРЅС‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const patientId = requireNonEmptyString(input.patientId, 'Пациент не выбран.');
     const row = await callRpc(this.client, operation, 'create_invoice', {
       p_tenant_id: tenantId,
       p_patient_id: patientId,
@@ -240,12 +240,12 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async addInvoiceItem(input: AddInvoiceItemInput): Promise<InvoiceItem> {
     const operation = 'addInvoiceItem';
     const tenantId = requireTenantId(input.tenantId);
-    const invoiceId = requireNonEmptyString(input.invoiceId, 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
-    const serviceName = requireNonEmptyString(input.serviceName, 'РќР°Р·РІР°РЅРёРµ СѓСЃР»СѓРіРё РѕР±СЏР·Р°С‚РµР»СЊРЅРѕ.');
-    const quantity = input.quantity === undefined ? 1 : requirePositiveNumber(input.quantity, 'РљРѕР»РёС‡РµСЃС‚РІРѕ РґРѕР»Р¶РЅРѕ Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
-    const unitPrice = input.unitPrice === undefined ? 0 : requireNonNegativeNumber(input.unitPrice, 'Р¦РµРЅР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
-    const discountAmount = input.discountAmount === undefined ? 0 : requireNonNegativeNumber(input.discountAmount, 'РЎРєРёРґРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
-    const adjustmentAmount = input.adjustmentAmount === undefined ? 0 : requireNonNegativeNumber(input.adjustmentAmount, 'РљРѕСЂСЂРµРєС‚РёСЂРѕРІРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+    const invoiceId = requireNonEmptyString(input.invoiceId, 'Счёт не выбран.');
+    const serviceName = requireNonEmptyString(input.serviceName, 'Название услуги обязательно.');
+    const quantity = input.quantity === undefined ? 1 : requirePositiveNumber(input.quantity, 'Количество должно быть больше 0.');
+    const unitPrice = input.unitPrice === undefined ? 0 : requireNonNegativeNumber(input.unitPrice, 'Цена не может быть отрицательной.');
+    const discountAmount = input.discountAmount === undefined ? 0 : requireNonNegativeNumber(input.discountAmount, 'Скидка не может быть отрицательной.');
+    const adjustmentAmount = input.adjustmentAmount === undefined ? 0 : requireNonNegativeNumber(input.adjustmentAmount, 'Корректировка не может быть отрицательной.');
 
     const row = await callRpc(this.client, operation, 'add_invoice_item', {
       p_tenant_id: tenantId,
@@ -268,7 +268,7 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async issueInvoice(input: IssueInvoiceInput): Promise<Invoice> {
     const operation = 'issueInvoice';
     const tenantId = requireTenantId(input.tenantId);
-    const invoiceId = requireNonEmptyString(input.invoiceId, 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const invoiceId = requireNonEmptyString(input.invoiceId, 'Счёт не выбран.');
     const row = await callRpc(this.client, operation, 'issue_invoice', {
       p_tenant_id: tenantId,
       p_invoice_id: invoiceId,
@@ -279,8 +279,8 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async voidInvoice(input: VoidInvoiceInput): Promise<Invoice> {
     const operation = 'voidInvoice';
     const tenantId = requireTenantId(input.tenantId);
-    const invoiceId = requireNonEmptyString(input.invoiceId, 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
-    const reason = requireNonEmptyString(input.reason, 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    const invoiceId = requireNonEmptyString(input.invoiceId, 'Счёт не выбран.');
+    const reason = requireNonEmptyString(input.reason, 'Причина обязательна.');
     const row = await callRpc(this.client, operation, 'void_invoice', {
       p_tenant_id: tenantId,
       p_invoice_id: invoiceId,
@@ -292,8 +292,8 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async recordPayment(input: RecordPaymentInput): Promise<Payment> {
     const operation = 'recordPayment';
     const tenantId = requireTenantId(input.tenantId);
-    const patientId = requireNonEmptyString(input.patientId, 'РџР°С†РёРµРЅС‚ РЅРµ РІС‹Р±СЂР°РЅ.');
-    const amount = requirePositiveNumber(input.amount, 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    const patientId = requireNonEmptyString(input.patientId, 'Пациент не выбран.');
+    const amount = requirePositiveNumber(input.amount, 'Сумма должна быть больше 0.');
     const paymentMethod = validatePaymentMethod(input.paymentMethod);
     const row = await callRpc(this.client, operation, 'record_payment', {
       p_tenant_id: tenantId,
@@ -313,10 +313,10 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async allocatePayment(input: AllocatePaymentInput): Promise<PaymentAllocation> {
     const operation = 'allocatePayment';
     const tenantId = requireTenantId(input.tenantId);
-    const paymentId = requireNonEmptyString(input.paymentId, 'РџР»Р°С‚С‘Р¶ РЅРµ РІС‹Р±СЂР°РЅ.');
-    const amount = requirePositiveNumber(input.amount, 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    const paymentId = requireNonEmptyString(input.paymentId, 'Платёж не выбран.');
+    const amount = requirePositiveNumber(input.amount, 'Сумма должна быть больше 0.');
     if (!input.invoiceId && !input.invoiceItemId) {
-      throw new FinanceRpcClientError({ operation: 'validation', message: 'РќСѓР¶РЅРѕ РІС‹Р±СЂР°С‚СЊ СЃС‡С‘С‚ РёР»Рё РїРѕР·РёС†РёСЋ СЃС‡С‘С‚Р°.' });
+      throw new FinanceRpcClientError({ operation: 'validation', message: 'Нужно выбрать счёт или позицию счёта.' });
     }
     const row = await callRpc(this.client, operation, 'allocate_payment', {
       p_tenant_id: tenantId,
@@ -332,8 +332,8 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async voidPaymentAllocation(input: VoidPaymentAllocationInput): Promise<PaymentAllocation> {
     const operation = 'voidPaymentAllocation';
     const tenantId = requireTenantId(input.tenantId);
-    const allocationId = requireNonEmptyString(input.allocationId, 'Р Р°СЃРїСЂРµРґРµР»РµРЅРёРµ РїР»Р°С‚РµР¶Р° РЅРµ РІС‹Р±СЂР°РЅРѕ.');
-    const reason = requireNonEmptyString(input.reason, 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    const allocationId = requireNonEmptyString(input.allocationId, 'Распределение платежа не выбрано.');
+    const reason = requireNonEmptyString(input.reason, 'Причина обязательна.');
     const row = await callRpc(this.client, operation, 'void_payment_allocation', {
       p_tenant_id: tenantId,
       p_allocation_id: allocationId,
@@ -345,8 +345,8 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
   async voidPayment(input: VoidPaymentInput): Promise<Payment> {
     const operation = 'voidPayment';
     const tenantId = requireTenantId(input.tenantId);
-    const paymentId = requireNonEmptyString(input.paymentId, 'РџР»Р°С‚С‘Р¶ РЅРµ РІС‹Р±СЂР°РЅ.');
-    const reason = requireNonEmptyString(input.reason, 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    const paymentId = requireNonEmptyString(input.paymentId, 'Платёж не выбран.');
+    const reason = requireNonEmptyString(input.reason, 'Причина обязательна.');
     const row = await callRpc(this.client, operation, 'void_payment', {
       p_tenant_id: tenantId,
       p_payment_id: paymentId,

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -1,0 +1,371 @@
+﻿import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase as defaultSupabase } from '../../lib/supabaseClient';
+import {
+  mapInvoiceItemRow,
+  mapInvoiceRow,
+  mapPaymentAllocationRow,
+  mapPaymentRow,
+  type Invoice,
+  type InvoiceItem,
+  type Payment,
+  type PaymentAllocation,
+  type PaymentMethod,
+} from './FinanceRepository';
+
+export interface FinanceRpcClientErrorDetails {
+  operation: string;
+  code?: string;
+  message: string;
+}
+
+export class FinanceRpcClientError extends Error {
+  readonly operation: string;
+  readonly code?: string;
+
+  constructor(details: FinanceRpcClientErrorDetails) {
+    super(details.message);
+    this.name = 'FinanceRpcClientError';
+    this.operation = details.operation;
+    this.code = details.code;
+  }
+}
+
+export interface CreateInvoiceInput {
+  tenantId: string;
+  patientId: string;
+  currency?: string;
+  dueDate?: string | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AddInvoiceItemInput {
+  tenantId: string;
+  invoiceId: string;
+  serviceName: string;
+  quantity?: number;
+  unitPrice?: number;
+  discountAmount?: number;
+  adjustmentAmount?: number;
+  completedServiceId?: string | null;
+  serviceCode?: string | null;
+  toothNumber?: string | null;
+  toothSurface?: string | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IssueInvoiceInput {
+  tenantId: string;
+  invoiceId: string;
+}
+
+export interface VoidInvoiceInput {
+  tenantId: string;
+  invoiceId: string;
+  reason: string;
+}
+
+export interface RecordPaymentInput {
+  tenantId: string;
+  patientId: string;
+  amount: number;
+  paymentMethod: PaymentMethod;
+  currency?: string;
+  receivedAt?: string | null;
+  externalReference?: string | null;
+  payerName?: string | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AllocatePaymentInput {
+  tenantId: string;
+  paymentId: string;
+  amount: number;
+  invoiceId?: string | null;
+  invoiceItemId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VoidPaymentAllocationInput {
+  tenantId: string;
+  allocationId: string;
+  reason: string;
+}
+
+export interface VoidPaymentInput {
+  tenantId: string;
+  paymentId: string;
+  reason: string;
+}
+
+export interface FinanceRpcClient {
+  createInvoice(input: CreateInvoiceInput): Promise<Invoice>;
+  addInvoiceItem(input: AddInvoiceItemInput): Promise<InvoiceItem>;
+  issueInvoice(input: IssueInvoiceInput): Promise<Invoice>;
+  voidInvoice(input: VoidInvoiceInput): Promise<Invoice>;
+  recordPayment(input: RecordPaymentInput): Promise<Payment>;
+  allocatePayment(input: AllocatePaymentInput): Promise<PaymentAllocation>;
+  voidPaymentAllocation(input: VoidPaymentAllocationInput): Promise<PaymentAllocation>;
+  voidPayment(input: VoidPaymentInput): Promise<Payment>;
+}
+
+export type FinanceRpcClientBackend = 'supabase' | 'local';
+
+export interface CreateFinanceRpcClientOptions {
+  backend: FinanceRpcClientBackend;
+  client?: SupabaseClient;
+}
+
+const FINANCE_RPC_OPERATION_FAILED_MESSAGE = 'РќРµ СѓРґР°Р»РѕСЃСЊ РІС‹РїРѕР»РЅРёС‚СЊ С„РёРЅР°РЅСЃРѕРІСѓСЋ РѕРїРµСЂР°С†РёСЋ.';
+const PAYMENT_METHODS: readonly PaymentMethod[] = [
+  'cash',
+  'kaspi',
+  'halyk_terminal',
+  'card',
+  'bank_transfer',
+  'insurance',
+  'osms',
+  'mixed',
+  'other',
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireNonEmptyString(value: string | null | undefined, message: string): string {
+  if (!value || value.trim().length === 0) {
+    throw new FinanceRpcClientError({ operation: 'validation', message });
+  }
+  return value;
+}
+
+function requireTenantId(tenantId: string | null | undefined): string {
+  return requireNonEmptyString(tenantId, 'РќРµ РІС‹Р±СЂР°РЅР° РєР»РёРЅРёРєР°.');
+}
+
+function requirePositiveNumber(value: number | null | undefined, message: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new FinanceRpcClientError({ operation: 'validation', message });
+  }
+  return value;
+}
+
+function requireNonNegativeNumber(value: number | null | undefined, message: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new FinanceRpcClientError({ operation: 'validation', message });
+  }
+  return value;
+}
+
+function validateMetadata(metadata?: Record<string, unknown> | null) {
+  if (metadata !== undefined && !isPlainObject(metadata)) {
+    throw new FinanceRpcClientError({ operation: 'validation', message: 'РњРµС‚Р°РґР°РЅРЅС‹Рµ РґРѕР»Р¶РЅС‹ Р±С‹С‚СЊ РѕР±СЉРµРєС‚РѕРј.' });
+  }
+}
+
+function normalizeMetadata(metadata?: Record<string, unknown> | null): Record<string, unknown> {
+  validateMetadata(metadata);
+  return metadata ?? {};
+}
+
+function extractSingleRow(data: unknown, operation: string): Record<string, unknown> {
+  if (!data) {
+    throw new FinanceRpcClientError({ operation, message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+  }
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || !isPlainObject(row)) {
+    throw new FinanceRpcClientError({ operation, message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+  }
+  return row;
+}
+
+function normalizeRpcError(error: unknown, operation: string): FinanceRpcClientError {
+  if (error instanceof FinanceRpcClientError) return error;
+  if (error instanceof Error) {
+    const errorWithCode = error as unknown as { code?: unknown };
+    const code = typeof errorWithCode.code === 'string' ? errorWithCode.code : undefined;
+    return new FinanceRpcClientError({
+      operation,
+      code,
+      message: `${FINANCE_RPC_OPERATION_FAILED_MESSAGE} ${error.message}`.trim(),
+    });
+  }
+  return new FinanceRpcClientError({ operation, message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+}
+
+async function callRpc(
+  client: SupabaseClient,
+  operation: string,
+  rpcName: string,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const { data, error } = await client.rpc(rpcName, params);
+  if (error) throw normalizeRpcError(error, operation);
+  return extractSingleRow(data, operation);
+}
+
+function validatePaymentMethod(paymentMethod: PaymentMethod | null | undefined): PaymentMethod {
+  const method = requireNonEmptyString(paymentMethod, 'РЎРїРѕСЃРѕР± РѕРїР»Р°С‚С‹ РѕР±СЏР·Р°С‚РµР»РµРЅ.') as PaymentMethod;
+  if (!PAYMENT_METHODS.includes(method)) {
+    throw new FinanceRpcClientError({ operation: 'validation', message: 'РќРµРєРѕСЂСЂРµРєС‚РЅС‹Р№ СЃРїРѕСЃРѕР± РѕРїР»Р°С‚С‹.' });
+  }
+  return method;
+}
+
+export class SupabaseFinanceRpcClient implements FinanceRpcClient {
+  private readonly client: SupabaseClient;
+
+  constructor(client: SupabaseClient) {
+    this.client = client;
+  }
+
+  async createInvoice(input: CreateInvoiceInput): Promise<Invoice> {
+    const operation = 'createInvoice';
+    const tenantId = requireTenantId(input.tenantId);
+    const patientId = requireNonEmptyString(input.patientId, 'РџР°С†РёРµРЅС‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const row = await callRpc(this.client, operation, 'create_invoice', {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_currency: input.currency || 'KZT',
+      p_due_date: input.dueDate || null,
+      p_notes: input.notes || null,
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapInvoiceRow(row);
+  }
+
+  async addInvoiceItem(input: AddInvoiceItemInput): Promise<InvoiceItem> {
+    const operation = 'addInvoiceItem';
+    const tenantId = requireTenantId(input.tenantId);
+    const invoiceId = requireNonEmptyString(input.invoiceId, 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const serviceName = requireNonEmptyString(input.serviceName, 'РќР°Р·РІР°РЅРёРµ СѓСЃР»СѓРіРё РѕР±СЏР·Р°С‚РµР»СЊРЅРѕ.');
+    const quantity = input.quantity === undefined ? 1 : requirePositiveNumber(input.quantity, 'РљРѕР»РёС‡РµСЃС‚РІРѕ РґРѕР»Р¶РЅРѕ Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    const unitPrice = input.unitPrice === undefined ? 0 : requireNonNegativeNumber(input.unitPrice, 'Р¦РµРЅР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+    const discountAmount = input.discountAmount === undefined ? 0 : requireNonNegativeNumber(input.discountAmount, 'РЎРєРёРґРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+    const adjustmentAmount = input.adjustmentAmount === undefined ? 0 : requireNonNegativeNumber(input.adjustmentAmount, 'РљРѕСЂСЂРµРєС‚РёСЂРѕРІРєР° РЅРµ РјРѕР¶РµС‚ Р±С‹С‚СЊ РѕС‚СЂРёС†Р°С‚РµР»СЊРЅРѕР№.');
+
+    const row = await callRpc(this.client, operation, 'add_invoice_item', {
+      p_tenant_id: tenantId,
+      p_invoice_id: invoiceId,
+      p_service_name: serviceName,
+      p_quantity: quantity,
+      p_unit_price: unitPrice,
+      p_discount_amount: discountAmount,
+      p_adjustment_amount: adjustmentAmount,
+      p_completed_service_id: input.completedServiceId || null,
+      p_service_code: input.serviceCode || null,
+      p_tooth_number: input.toothNumber || null,
+      p_tooth_surface: input.toothSurface || null,
+      p_notes: input.notes || null,
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapInvoiceItemRow(row);
+  }
+
+  async issueInvoice(input: IssueInvoiceInput): Promise<Invoice> {
+    const operation = 'issueInvoice';
+    const tenantId = requireTenantId(input.tenantId);
+    const invoiceId = requireNonEmptyString(input.invoiceId, 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const row = await callRpc(this.client, operation, 'issue_invoice', {
+      p_tenant_id: tenantId,
+      p_invoice_id: invoiceId,
+    });
+    return mapInvoiceRow(row);
+  }
+
+  async voidInvoice(input: VoidInvoiceInput): Promise<Invoice> {
+    const operation = 'voidInvoice';
+    const tenantId = requireTenantId(input.tenantId);
+    const invoiceId = requireNonEmptyString(input.invoiceId, 'РЎС‡С‘С‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const reason = requireNonEmptyString(input.reason, 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    const row = await callRpc(this.client, operation, 'void_invoice', {
+      p_tenant_id: tenantId,
+      p_invoice_id: invoiceId,
+      p_reason: reason,
+    });
+    return mapInvoiceRow(row);
+  }
+
+  async recordPayment(input: RecordPaymentInput): Promise<Payment> {
+    const operation = 'recordPayment';
+    const tenantId = requireTenantId(input.tenantId);
+    const patientId = requireNonEmptyString(input.patientId, 'РџР°С†РёРµРЅС‚ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const amount = requirePositiveNumber(input.amount, 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    const paymentMethod = validatePaymentMethod(input.paymentMethod);
+    const row = await callRpc(this.client, operation, 'record_payment', {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_amount: amount,
+      p_payment_method: paymentMethod,
+      p_currency: input.currency || 'KZT',
+      p_received_at: input.receivedAt || null,
+      p_external_reference: input.externalReference || null,
+      p_payer_name: input.payerName || null,
+      p_notes: input.notes || null,
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapPaymentRow(row);
+  }
+
+  async allocatePayment(input: AllocatePaymentInput): Promise<PaymentAllocation> {
+    const operation = 'allocatePayment';
+    const tenantId = requireTenantId(input.tenantId);
+    const paymentId = requireNonEmptyString(input.paymentId, 'РџР»Р°С‚С‘Р¶ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const amount = requirePositiveNumber(input.amount, 'РЎСѓРјРјР° РґРѕР»Р¶РЅР° Р±С‹С‚СЊ Р±РѕР»СЊС€Рµ 0.');
+    if (!input.invoiceId && !input.invoiceItemId) {
+      throw new FinanceRpcClientError({ operation: 'validation', message: 'РќСѓР¶РЅРѕ РІС‹Р±СЂР°С‚СЊ СЃС‡С‘С‚ РёР»Рё РїРѕР·РёС†РёСЋ СЃС‡С‘С‚Р°.' });
+    }
+    const row = await callRpc(this.client, operation, 'allocate_payment', {
+      p_tenant_id: tenantId,
+      p_payment_id: paymentId,
+      p_amount: amount,
+      p_invoice_id: input.invoiceId || null,
+      p_invoice_item_id: input.invoiceItemId || null,
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapPaymentAllocationRow(row);
+  }
+
+  async voidPaymentAllocation(input: VoidPaymentAllocationInput): Promise<PaymentAllocation> {
+    const operation = 'voidPaymentAllocation';
+    const tenantId = requireTenantId(input.tenantId);
+    const allocationId = requireNonEmptyString(input.allocationId, 'Р Р°СЃРїСЂРµРґРµР»РµРЅРёРµ РїР»Р°С‚РµР¶Р° РЅРµ РІС‹Р±СЂР°РЅРѕ.');
+    const reason = requireNonEmptyString(input.reason, 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    const row = await callRpc(this.client, operation, 'void_payment_allocation', {
+      p_tenant_id: tenantId,
+      p_allocation_id: allocationId,
+      p_reason: reason,
+    });
+    return mapPaymentAllocationRow(row);
+  }
+
+  async voidPayment(input: VoidPaymentInput): Promise<Payment> {
+    const operation = 'voidPayment';
+    const tenantId = requireTenantId(input.tenantId);
+    const paymentId = requireNonEmptyString(input.paymentId, 'РџР»Р°С‚С‘Р¶ РЅРµ РІС‹Р±СЂР°РЅ.');
+    const reason = requireNonEmptyString(input.reason, 'РџСЂРёС‡РёРЅР° РѕР±СЏР·Р°С‚РµР»СЊРЅР°.');
+    const row = await callRpc(this.client, operation, 'void_payment', {
+      p_tenant_id: tenantId,
+      p_payment_id: paymentId,
+      p_reason: reason,
+    });
+    return mapPaymentRow(row);
+  }
+}
+
+export function createFinanceRpcClient(options: CreateFinanceRpcClientOptions): FinanceRpcClient {
+  if (options.backend === 'local') {
+    throw new Error('Finance RPC client requires Supabase backend.');
+  }
+
+  const client = options.client !== undefined ? options.client : defaultSupabase;
+  if (!client) {
+    throw new Error('Supabase client is not configured for finance RPC access.');
+  }
+
+  return new SupabaseFinanceRpcClient(client as SupabaseClient);
+}
+


### PR DESCRIPTION
﻿## Summary

Adds a typed repository-layer finance RPC client for the controlled SECURITY DEFINER invoice/payment write RPCs introduced in `0017_create_finance_rpc.sql`.

## What changed

- Added `src/data/repositories/FinanceRpcClient.ts`
- Added `src/data/repositories/FinanceRpcClient.test.ts`
- Added implementation report `_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md`

## Client coverage

The client wraps all 8 controlled finance RPCs:

- `createInvoice` -> `create_invoice`
- `addInvoiceItem` -> `add_invoice_item`
- `issueInvoice` -> `issue_invoice`
- `voidInvoice` -> `void_invoice`
- `recordPayment` -> `record_payment`
- `allocatePayment` -> `allocate_payment`
- `voidPaymentAllocation` -> `void_payment_allocation`
- `voidPayment` -> `void_payment`

## Validation and mapping

- validates required frontend inputs before RPC calls
- maps camelCase input fields to exact SQL `p_*` RPC params
- reuses existing `FinanceRepository` row mappers for Invoice, InvoiceItem, Payment, and PaymentAllocation
- normalizes validation and Supabase RPC errors through `FinanceRpcClientError`

## Safety boundaries

- no UI changes
- no hooks
- no migrations or SQL edits
- no Supabase cloud
- no seed changes
- no generated types committed
- no direct `.from(...).insert/update/delete/upsert`
- no service_role usage
- no localStorage usage
- no patients.balance mutation
- no completed_services mutation
- no refunds/write-offs/discount feature work
- no stock/documents/timeline/reports UI
- no HEP-V2 work

## Local validation

- `npx supabase db reset --no-seed`: passed
- migration `0017_create_finance_rpc.sql` applied after `0016_create_finance_model.sql`
- local catalog check confirmed the 8 public finance RPCs exist as SECURITY DEFINER functions with `search_path = public, pg_temp`

## Checks

- `npm run lint`: passed
- `npm run test -- --run src/data/repositories/FinanceRpcClient.test.ts`: passed, 40/40 tests
- `npm run test -- --run`: passed, 61 files / 620 tests
- `npm run build`: passed

Existing unrelated warnings remain:

- React `act(...)` warnings in unrelated UI tests
- Vite chunk-size warning for the main bundle

## Final verdict

PAYMENTS DEBTS RPC CLIENT IMPLEMENTED AND VERIFIED

## Recommended next task

PATIENT-FINANCE-UI-001
