### PR TITLE
feat(hep): add local change plan module

### DIFF
--- a/_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md
+++ b/_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md
@@ -1,146 +1,63 @@
-# HERMES-CHANGE-PLAN-001A Report
+﻿# HERMES-CHANGE-PLAN-001A — HEP local change-plan module
 
-## Verdict
+## Summary
+Implemented a repo-local HEP change-plan module for typed plan creation, scope validation, ALLOW/BLOCK simulation, approve/revoke transitions, planned-vs-actual file comparison, and redacted JSON-safe storage records.
 
-PASS
+Final verdict: **PASS**
 
-## Task
+## Branch
+`feature/hermes-change-plan-001a`
 
-HERMES-CHANGE-PLAN-001A: HEP local change-plan module.
+## PR URL
+https://github.com/NckNA/codex-test/pull/330
 
-## What changed
+- PR head reviewed: `c71ba9e64c0290998d5486de429c6623b913d131`
+- Report update commit: N/A (the report commit cannot reference itself; use the finalization receipt).
+- CI run ID: `28197369005`
+- CI run number: `640`
+- Tested commit: `c71ba9e64c0290998d5486de429c6623b913d131`
+- CI conclusion: **SUCCESS**
 
-Implemented a repo-local HEP change-plan module without touching DentalFlow application code.
-
-Changed files:
-
-- `tools/hep/change-plan.ts`
-- `tools/hep/__tests__/change-plan.test.ts`
-- `tools/hep/index.ts`
+## Changed files summary
 - `_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md`
+- `tools/hep/__tests__/change-plan.test.ts`
+- `tools/hep/change-plan.ts`
+- `tools/hep/index.ts`
 
-## What did not change
+## Domain and safety boundaries
+- DentalFlow React UI was not changed.
+- `src/**` was not changed.
+- Supabase migrations were not changed.
+- Generated types were not changed.
+- Seed files were not changed.
+- `package.json` and package lock files were not changed.
+- Cloud Supabase was not touched.
+- Production credentials were not read or printed.
 
-No changes were made to:
+## Checks
+- Targeted test: `npx vitest run tools/hep/__tests__/change-plan.test.ts` — PASS, 12 tests.
+- Tests: `npm test -- --run` — PASS, 62 test files, 632 tests.
+- Lint: `npm run lint` — PASS.
+- Build: `npm run build` — PASS.
+- CLI smoke: `node tools/hep/index.ts change-plan:create ...` — PASS, emitted an active JSON change-plan record.
+- CI: GitHub run `28197369005` / run number `640` — SUCCESS.
 
-- `src/**`
-- React UI
-- DentalFlow pages/components/hooks
-- Supabase migrations
-- generated types
-- seed files
-- package.json
-- package-lock.json
-- cloud Supabase
-- production credentials
-- media files
+## Browser smoke
+- Environment: not applicable.
+- Roles: not applicable.
+- Database evidence: not applicable.
+- Cleanup remaining rows: not applicable.
+- Reason: this task changes local HEP CLI/tooling only and does not alter browser UI.
 
-## Implementation summary
+## Issues / warnings
+- The new module does not yet enforce planned-vs-actual gates before commit or push.
+- External Hermes smoke registries in `D:\hermes\memory\change-plans` and `D:\hermes\memory\changesets` were not modified.
+- CLI commands are intentionally minimal and JSON-oriented.
+- Existing React `act(...)` warnings appeared during the full test run, but did not fail the suite and are unrelated to this HEP tooling task.
+- The `finalize_report_metadata` helper failed with `replaceReportPlaceholders is not defined`; report metadata was corrected manually.
 
-Added `tools/hep/change-plan.ts` with typed local HEP change-plan primitives:
-
-- `createChangePlan`
-- `validateChangePlanInput`
-- `validatePlanAgainstScope`
-- `simulateChangePlan`
-- `approveChangePlan`
-- `revokeChangePlan`
-- `comparePlannedToActual`
-- `toStorageRecord`
-- `normalizePlanPath`
-
-The module supports:
-
-- safe task ID and actor validation;
-- safe relative path normalization;
-- absolute path and traversal rejection;
-- allowlist/prefix scope validation;
-- planned-vs-actual changed file comparison;
-- owner-review blocking for high/critical risk plans;
-- approve/revoke state transitions;
-- secret redaction through existing HEP redaction behavior.
-
-Extended `tools/hep/index.ts` with minimal local CLI commands:
-
-- `change-plan:create`
-- `change-plan:simulate`
-- `change-plan:approve`
-- `change-plan:revoke`
-- `change-plan:diff-check`
-
-Created `tools/hep/__tests__/change-plan.test.ts` with coverage for:
-
-- valid plan creation;
-- unsafe task ID rejection;
-- safe path normalization;
-- traversal/absolute path rejection;
-- allowlist pass/block;
-- unplanned file detection;
-- missing planned file detection;
-- low/medium ALLOW simulation;
-- high-risk owner-review BLOCK simulation;
-- approved high-risk ALLOW simulation;
-- revoke transition and revoked BLOCK simulation;
-- redaction in storage records.
-
-## Validation
-
-Targeted test:
-
-```bash
-npx vitest run tools/hep/__tests__/change-plan.test.ts
-```
-
-Result:
-
-- PASS
-- 1 test file passed
-- 12 tests passed
-
-Full quality run:
-
-```bash
-npm test -- --run
-npm run lint
-npm run build
-```
-
-Result:
-
-- PASS: test
-- PASS: lint
-- PASS: build
-- 62 test files passed
-- 632 tests passed
-
-CLI smoke:
-
-```bash
-node tools/hep/index.ts change-plan:create --taskId HERMES-CHANGE-PLAN-001A --actor maintenance.autopilot --action modify --target tools/hep/change-plan.ts --riskLevel medium --summary "Smoke local change-plan CLI" --plannedFiles tools/hep/change-plan.ts,tools/hep/index.ts --createdBy Nick --rollbackRef feature/hermes-change-plan-001a
-```
-
-Result:
-
-- PASS: emitted a redacted JSON change-plan record with active status.
-
-Report validation:
-
-- `report_validate` was attempted before opening a PR.
-- It failed because no pull request exists yet for `feature/hermes-change-plan-001a`, not because of report content.
-
-Notes:
-
-- Existing React test warnings about `act(...)` appeared in stderr during the full test run.
-- They did not fail the suite and are unrelated to this HEP tooling task.
-
-## Risk / limitations
-
-- The module is local tooling only. It does not yet enforce gates automatically before `git commit` or `git push`.
-- Existing external smoke registries in `D:\hermes\memory\change-plans` and `D:\hermes\memory\changesets` were not modified.
-- CLI commands are intentionally minimal and JSON-oriented; no interactive UX was added.
+## Final verdict
+**PASS**
 
 ## Recommended next task
-
-HERMES-CHANGESET-GATE-001A
-
-Purpose: enforce planned-vs-actual file gates before commit/push using the new local change-plan module.
+**HERMES-CHANGESET-GATE-001A**

--- a/_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md
+++ b/_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md
@@ -1,0 +1,146 @@
+# HERMES-CHANGE-PLAN-001A Report
+
+## Verdict
+
+PASS
+
+## Task
+
+HERMES-CHANGE-PLAN-001A: HEP local change-plan module.
+
+## What changed
+
+Implemented a repo-local HEP change-plan module without touching DentalFlow application code.
+
+Changed files:
+
+- `tools/hep/change-plan.ts`
+- `tools/hep/__tests__/change-plan.test.ts`
+- `tools/hep/index.ts`
+- `_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md`
+
+## What did not change
+
+No changes were made to:
+
+- `src/**`
+- React UI
+- DentalFlow pages/components/hooks
+- Supabase migrations
+- generated types
+- seed files
+- package.json
+- package-lock.json
+- cloud Supabase
+- production credentials
+- media files
+
+## Implementation summary
+
+Added `tools/hep/change-plan.ts` with typed local HEP change-plan primitives:
+
+- `createChangePlan`
+- `validateChangePlanInput`
+- `validatePlanAgainstScope`
+- `simulateChangePlan`
+- `approveChangePlan`
+- `revokeChangePlan`
+- `comparePlannedToActual`
+- `toStorageRecord`
+- `normalizePlanPath`
+
+The module supports:
+
+- safe task ID and actor validation;
+- safe relative path normalization;
+- absolute path and traversal rejection;
+- allowlist/prefix scope validation;
+- planned-vs-actual changed file comparison;
+- owner-review blocking for high/critical risk plans;
+- approve/revoke state transitions;
+- secret redaction through existing HEP redaction behavior.
+
+Extended `tools/hep/index.ts` with minimal local CLI commands:
+
+- `change-plan:create`
+- `change-plan:simulate`
+- `change-plan:approve`
+- `change-plan:revoke`
+- `change-plan:diff-check`
+
+Created `tools/hep/__tests__/change-plan.test.ts` with coverage for:
+
+- valid plan creation;
+- unsafe task ID rejection;
+- safe path normalization;
+- traversal/absolute path rejection;
+- allowlist pass/block;
+- unplanned file detection;
+- missing planned file detection;
+- low/medium ALLOW simulation;
+- high-risk owner-review BLOCK simulation;
+- approved high-risk ALLOW simulation;
+- revoke transition and revoked BLOCK simulation;
+- redaction in storage records.
+
+## Validation
+
+Targeted test:
+
+```bash
+npx vitest run tools/hep/__tests__/change-plan.test.ts
+```
+
+Result:
+
+- PASS
+- 1 test file passed
+- 12 tests passed
+
+Full quality run:
+
+```bash
+npm test -- --run
+npm run lint
+npm run build
+```
+
+Result:
+
+- PASS: test
+- PASS: lint
+- PASS: build
+- 62 test files passed
+- 632 tests passed
+
+CLI smoke:
+
+```bash
+node tools/hep/index.ts change-plan:create --taskId HERMES-CHANGE-PLAN-001A --actor maintenance.autopilot --action modify --target tools/hep/change-plan.ts --riskLevel medium --summary "Smoke local change-plan CLI" --plannedFiles tools/hep/change-plan.ts,tools/hep/index.ts --createdBy Nick --rollbackRef feature/hermes-change-plan-001a
+```
+
+Result:
+
+- PASS: emitted a redacted JSON change-plan record with active status.
+
+Report validation:
+
+- `report_validate` was attempted before opening a PR.
+- It failed because no pull request exists yet for `feature/hermes-change-plan-001a`, not because of report content.
+
+Notes:
+
+- Existing React test warnings about `act(...)` appeared in stderr during the full test run.
+- They did not fail the suite and are unrelated to this HEP tooling task.
+
+## Risk / limitations
+
+- The module is local tooling only. It does not yet enforce gates automatically before `git commit` or `git push`.
+- Existing external smoke registries in `D:\hermes\memory\change-plans` and `D:\hermes\memory\changesets` were not modified.
+- CLI commands are intentionally minimal and JSON-oriented; no interactive UX was added.
+
+## Recommended next task
+
+HERMES-CHANGESET-GATE-001A
+
+Purpose: enforce planned-vs-actual file gates before commit/push using the new local change-plan module.

--- a/tools/hep/__tests__/change-plan.test.ts
+++ b/tools/hep/__tests__/change-plan.test.ts
@@ -1,0 +1,178 @@
+﻿import { describe, expect, it } from "vitest";
+import {
+  approveChangePlan,
+  comparePlannedToActual,
+  createChangePlan,
+  normalizePlanPath,
+  revokeChangePlan,
+  simulateChangePlan,
+  toStorageRecord,
+  validatePlanAgainstScope,
+  type ChangePlanInput,
+  type ChangePlanScope
+} from "../change-plan.ts";
+
+function validInput(overrides: Partial<ChangePlanInput> = {}): ChangePlanInput {
+  return {
+    taskId: "HERMES-CHANGE-PLAN-001A",
+    actor: "maintenance.autopilot",
+    action: "modify",
+    target: "tools/hep/index.ts",
+    riskLevel: "medium",
+    createdBy: "Nick",
+    reason: "Implement local HEP change-plan module",
+    summary: "Add typed change-plan simulation and planned-vs-actual checks",
+    expectedFiles: [
+      {
+        path: "tools/hep/change-plan.ts",
+        reason: "add local change-plan model and validators",
+        changeType: "create"
+      },
+      {
+        path: "tools/hep/index.ts",
+        reason: "wire local change-plan CLI commands",
+        changeType: "modify"
+      }
+    ],
+    checks: [
+      {
+        command: "npm test -- --run",
+        required: true,
+        expectedResult: "tests pass"
+      }
+    ],
+    rollbackRef: "feature/hermes-change-plan-001a",
+    requiresOwnerReview: false,
+    notes: [],
+    planId: "change-plan.hermes-change-plan-001a.test",
+    createdAt: "2026-06-25T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+const hepScope: ChangePlanScope = {
+  allowedFiles: [
+    "tools/hep/change-plan.ts",
+    "tools/hep/__tests__/change-plan.test.ts",
+    "tools/hep/index.ts",
+    "_ai_work/REPORTS/HERMES-CHANGE-PLAN-001A.md"
+  ],
+  forbiddenPrefixes: ["src", "supabase/migrations"]
+};
+
+describe("HEP local change-plan module", () => {
+  it("creates a valid redacted active plan", () => {
+    const plan = createChangePlan(validInput({ notes: ["API_KEY = top-secret"] }));
+
+    expect(plan.planId).toBe("change-plan.hermes-change-plan-001a.test");
+    expect(plan.status).toBe("active");
+    expect(plan.expectedFiles[0]?.path).toBe("tools/hep/change-plan.ts");
+    expect(plan.notes?.[0]).toContain("API_KEY = [REDACTED]");
+  });
+
+  it("rejects unsafe task IDs", () => {
+    expect(() => createChangePlan(validInput({ taskId: "../bad" }))).toThrow(/Unsafe taskId/);
+  });
+
+  it("normalizes safe paths and rejects traversal", () => {
+    expect(normalizePlanPath("tools\\hep\\index.ts")).toBe("tools/hep/index.ts");
+    expect(() => normalizePlanPath("tools/../src/App.tsx")).toThrow(/path traversal/i);
+    expect(() => normalizePlanPath("C:/tmp/file.ts")).toThrow(/absolute path/i);
+  });
+
+  it("passes planned file allowlist validation", () => {
+    const plan = createChangePlan(validInput());
+    expect(validatePlanAgainstScope(plan, hepScope)).toEqual([]);
+  });
+
+  it("blocks planned files outside the allowlist", () => {
+    const plan = createChangePlan(
+      validInput({
+        expectedFiles: [
+          {
+            path: "src/App.tsx",
+            reason: "not allowed for this HEP tooling task",
+            changeType: "modify"
+          }
+        ]
+      })
+    );
+
+    expect(validatePlanAgainstScope(plan, hepScope)).toEqual(["src/App.tsx"]);
+    const simulation = simulateChangePlan(plan, hepScope);
+    expect(simulation.decision).toBe("BLOCK");
+    expect(simulation.matchedRules).toContain("BLOCK_SCOPE_VIOLATION");
+  });
+
+  it("detects unplanned actual files", () => {
+    const plan = createChangePlan(validInput());
+    const diff = comparePlannedToActual(plan, ["tools/hep/change-plan.ts", "src/App.tsx"]);
+
+    expect(diff.unplannedFiles.map((file) => file.path)).toEqual(["src/App.tsx"]);
+  });
+
+  it("detects missing planned files", () => {
+    const plan = createChangePlan(validInput());
+    const diff = comparePlannedToActual(plan, ["tools/hep/change-plan.ts"]);
+
+    expect(diff.missingPlannedFiles).toEqual(["tools/hep/index.ts"]);
+  });
+
+  it("allows low and medium risk plans inside scope", () => {
+    const plan = createChangePlan(validInput({ riskLevel: "low" }));
+    const simulation = simulateChangePlan(plan, hepScope);
+
+    expect(simulation.decision).toBe("ALLOW");
+    expect(simulation.matchedRules).toContain("ALLOW_SCOPE_AND_RISK_OK");
+  });
+
+  it("blocks high-risk plans until owner approval", () => {
+    const plan = createChangePlan(validInput({ riskLevel: "high", requiresOwnerReview: true }));
+    const simulation = simulateChangePlan(plan, hepScope);
+
+    expect(simulation.decision).toBe("BLOCK");
+    expect(simulation.matchedRules).toContain("BLOCK_OWNER_REVIEW_REQUIRED");
+  });
+
+  it("allows approved high-risk plans inside scope", () => {
+    const plan = createChangePlan(validInput({ riskLevel: "high", requiresOwnerReview: true }));
+    const approved = approveChangePlan(plan, "Nick", "2026-06-25T00:10:00.000Z");
+    const simulation = simulateChangePlan(approved, hepScope);
+
+    expect(approved.status).toBe("approved");
+    expect(simulation.decision).toBe("ALLOW");
+  });
+
+  it("revokes plans and blocks revoked execution", () => {
+    const plan = createChangePlan(validInput());
+    const revoked = revokeChangePlan(plan, "Nick", "2026-06-25T00:20:00.000Z");
+    const simulation = simulateChangePlan(revoked, hepScope);
+
+    expect(revoked.status).toBe("revoked");
+    expect(simulation.decision).toBe("BLOCK");
+    expect(simulation.matchedRules).toContain("BLOCK_REVOKED");
+  });
+
+  it("redacts sensitive strings in storage records", () => {
+    const plan = createChangePlan(
+      validInput({
+        summary: "Use DB_PASSWORD=secret-value in notes only",
+        checks: [
+          {
+            command: "echo API_KEY=hidden-value",
+            required: true,
+            expectedResult: "password: 'hidden' is never printed"
+          }
+        ]
+      })
+    );
+    const storage = toStorageRecord(plan);
+
+    expect(storage.summary).toContain("DB_PASSWORD=[REDACTED]");
+    expect(storage.checks[0]?.command).toContain("API_KEY=[REDACTED]");
+    expect(storage.checks[0]?.expectedResult).toContain("[REDACTED]");
+    expect(storage.checks[0]?.expectedResult).not.toContain("hidden");
+  });
+});
+
+

--- a/tools/hep/change-plan.ts
+++ b/tools/hep/change-plan.ts
@@ -1,0 +1,322 @@
+import { randomUUID } from "node:crypto";
+import { redactSecrets } from "./task-memory.ts";
+
+export type ChangePlanAction = "create" | "modify" | "delete" | "inspect";
+export type ChangePlanRiskLevel = "low" | "medium" | "high" | "critical";
+export type ChangePlanStatus = "draft" | "active" | "approved" | "revoked";
+export type ChangePlanDecision = "ALLOW" | "BLOCK";
+
+export interface ChangePlanFile {
+  path: string;
+  reason: string;
+  changeType: ChangePlanAction;
+}
+
+export interface ChangePlanCheck {
+  command: string;
+  required: boolean;
+  expectedResult: string;
+}
+
+export interface ChangePlanInput {
+  taskId: string;
+  actor: string;
+  action: ChangePlanAction;
+  target: string;
+  riskLevel: ChangePlanRiskLevel;
+  createdBy: string;
+  reason: string;
+  summary: string;
+  expectedFiles: ChangePlanFile[];
+  checks: ChangePlanCheck[];
+  rollbackRef: string;
+  requiresOwnerReview?: boolean;
+  notes?: string[];
+  planId?: string;
+  createdAt?: string;
+}
+
+export interface ChangePlanRecord extends ChangePlanInput {
+  planId: string;
+  status: ChangePlanStatus;
+  createdAt: string;
+  updatedAt: string;
+  requiresOwnerReview: boolean;
+  approvedBy?: string;
+  approvedAt?: string;
+  revokedBy?: string;
+  revokedAt?: string;
+}
+
+export interface ChangePlanScope {
+  allowedFiles?: string[];
+  allowedPrefixes?: string[];
+  forbiddenPrefixes?: string[];
+}
+
+export interface ChangePlanSimulation {
+  decision: ChangePlanDecision;
+  reasons: string[];
+  matchedRules: string[];
+}
+
+export interface ActualChangedFile {
+  path: string;
+  status?: string;
+  additions?: number;
+  deletions?: number;
+}
+
+export interface PlannedDiffResult {
+  plannedFiles: string[];
+  actualFiles: ActualChangedFile[];
+  unplannedFiles: ActualChangedFile[];
+  missingPlannedFiles: string[];
+}
+
+const TASK_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{1,119}$/;
+const ACTOR_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{1,159}$/;
+const SAFE_REF_RE = /^[a-zA-Z0-9][a-zA-Z0-9._/-]{1,199}$/;
+const VALID_ACTIONS: ChangePlanAction[] = ["create", "modify", "delete", "inspect"];
+const VALID_RISK_LEVELS: ChangePlanRiskLevel[] = ["low", "medium", "high", "critical"];
+
+export function normalizePlanPath(input: string): string {
+  const normalized = input.trim().replace(/\\/g, "/").replace(/\/+/g, "/");
+  if (!normalized) {
+    throw new Error("Path must not be empty.");
+  }
+  if (normalized.startsWith("/") || /^[a-zA-Z]:\//.test(normalized)) {
+    throw new Error(`Unsafe absolute path: ${input}`);
+  }
+  const parts = normalized.split("/");
+  if (parts.includes("..") || parts.includes(".")) {
+    throw new Error(`Unsafe path traversal segment in: ${input}`);
+  }
+  return normalized;
+}
+
+function assertNonEmpty(value: string, fieldName: string): void {
+  if (!value || value.trim().length === 0) {
+    throw new Error(`${fieldName} is required.`);
+  }
+}
+
+function assertTaskId(taskId: string): void {
+  if (!TASK_ID_RE.test(taskId)) {
+    throw new Error(`Unsafe taskId "${taskId}".`);
+  }
+}
+
+function assertActor(actor: string): void {
+  if (!ACTOR_RE.test(actor)) {
+    throw new Error(`Unsafe actor "${actor}".`);
+  }
+}
+
+function assertSafeRef(value: string, fieldName: string): void {
+  if (!SAFE_REF_RE.test(value)) {
+    throw new Error(`Unsafe ${fieldName} "${value}".`);
+  }
+}
+
+function normalizeFile(file: ChangePlanFile): ChangePlanFile {
+  assertNonEmpty(file.reason, "file.reason");
+  if (!VALID_ACTIONS.includes(file.changeType)) {
+    throw new Error(`Invalid file changeType "${file.changeType}".`);
+  }
+  return {
+    path: normalizePlanPath(file.path),
+    reason: redactSecrets(file.reason),
+    changeType: file.changeType
+  };
+}
+
+function normalizeCheck(check: ChangePlanCheck): ChangePlanCheck {
+  assertNonEmpty(check.command, "check.command");
+  assertNonEmpty(check.expectedResult, "check.expectedResult");
+  return {
+    command: redactSecrets(check.command),
+    required: check.required,
+    expectedResult: redactSecrets(check.expectedResult)
+  };
+}
+
+function normalizeNotes(notes: string[] | undefined): string[] {
+  return (notes ?? []).map((note) => redactSecrets(note));
+}
+
+export function validateChangePlanInput(input: ChangePlanInput): void {
+  assertTaskId(input.taskId);
+  assertActor(input.actor);
+  assertNonEmpty(input.createdBy, "createdBy");
+  assertNonEmpty(input.reason, "reason");
+  assertNonEmpty(input.summary, "summary");
+  assertSafeRef(input.rollbackRef, "rollbackRef");
+  if (!VALID_ACTIONS.includes(input.action)) {
+    throw new Error(`Invalid action "${input.action}".`);
+  }
+  if (!VALID_RISK_LEVELS.includes(input.riskLevel)) {
+    throw new Error(`Invalid riskLevel "${input.riskLevel}".`);
+  }
+  normalizePlanPath(input.target);
+  if (input.expectedFiles.length === 0) {
+    throw new Error("expectedFiles must contain at least one file.");
+  }
+  if (input.checks.length === 0) {
+    throw new Error("checks must contain at least one check.");
+  }
+  input.expectedFiles.forEach(normalizeFile);
+  input.checks.forEach(normalizeCheck);
+}
+
+export function createChangePlan(input: ChangePlanInput): ChangePlanRecord {
+  validateChangePlanInput(input);
+  const now = input.createdAt ?? new Date().toISOString();
+  const expectedFiles = input.expectedFiles.map(normalizeFile);
+  const checks = input.checks.map(normalizeCheck);
+  const requiresOwnerReview = input.requiresOwnerReview ?? (input.riskLevel === "high" || input.riskLevel === "critical");
+
+  return {
+    ...input,
+    planId: input.planId ?? `change-plan.${input.taskId.toLowerCase()}.${randomUUID()}`,
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+    target: normalizePlanPath(input.target),
+    reason: redactSecrets(input.reason),
+    summary: redactSecrets(input.summary),
+    expectedFiles,
+    checks,
+    requiresOwnerReview,
+    notes: normalizeNotes(input.notes)
+  };
+}
+
+function matchesPrefix(filePath: string, prefix: string): boolean {
+  const cleanPrefix = normalizePlanPath(prefix).replace(/\*\*$/u, "").replace(/\*$/u, "").replace(/\/$/u, "");
+  return filePath === cleanPrefix || filePath.startsWith(`${cleanPrefix}/`);
+}
+
+function isFileAllowed(filePath: string, scope: ChangePlanScope): boolean {
+  const normalized = normalizePlanPath(filePath);
+  const forbiddenPrefixes = scope.forbiddenPrefixes ?? [];
+  if (forbiddenPrefixes.some((prefix) => matchesPrefix(normalized, prefix))) {
+    return false;
+  }
+
+  const allowedFiles = (scope.allowedFiles ?? []).map((path) => normalizePlanPath(path));
+  const allowedPrefixes = scope.allowedPrefixes ?? [];
+  if (allowedFiles.length === 0 && allowedPrefixes.length === 0) {
+    return true;
+  }
+  return allowedFiles.includes(normalized) || allowedPrefixes.some((prefix) => matchesPrefix(normalized, prefix));
+}
+
+export function validatePlanAgainstScope(plan: ChangePlanRecord, scope: ChangePlanScope): string[] {
+  const blocked: string[] = [];
+  for (const file of plan.expectedFiles) {
+    if (!isFileAllowed(file.path, scope)) {
+      blocked.push(file.path);
+    }
+  }
+  return blocked;
+}
+
+export function simulateChangePlan(plan: ChangePlanRecord, scope: ChangePlanScope = {}): ChangePlanSimulation {
+  const reasons: string[] = [];
+  const matchedRules: string[] = [];
+
+  if (plan.status === "revoked") {
+    reasons.push("Plan is revoked.");
+    matchedRules.push("BLOCK_REVOKED");
+  }
+
+  if ((plan.riskLevel === "high" || plan.riskLevel === "critical") && !plan.requiresOwnerReview) {
+    reasons.push("High or critical risk plans must require owner review.");
+    matchedRules.push("BLOCK_HIGH_RISK_WITHOUT_OWNER_REVIEW_FLAG");
+  }
+
+  if (plan.requiresOwnerReview && plan.status !== "approved") {
+    reasons.push("Plan requires owner review before execution.");
+    matchedRules.push("BLOCK_OWNER_REVIEW_REQUIRED");
+  }
+
+  const blockedFiles = validatePlanAgainstScope(plan, scope);
+  if (blockedFiles.length > 0) {
+    reasons.push(`Planned files outside allowed scope: ${blockedFiles.join(", ")}`);
+    matchedRules.push("BLOCK_SCOPE_VIOLATION");
+  }
+
+  if (reasons.length > 0) {
+    return { decision: "BLOCK", reasons, matchedRules };
+  }
+
+  return {
+    decision: "ALLOW",
+    reasons: ["Plan is within scope and does not require additional owner review."],
+    matchedRules: ["ALLOW_SCOPE_AND_RISK_OK"]
+  };
+}
+
+export function approveChangePlan(plan: ChangePlanRecord, approvedBy: string, approvedAt: string = new Date().toISOString()): ChangePlanRecord {
+  assertNonEmpty(approvedBy, "approvedBy");
+  if (plan.status === "revoked") {
+    throw new Error("Cannot approve a revoked change plan.");
+  }
+  return {
+    ...plan,
+    status: "approved",
+    approvedBy: redactSecrets(approvedBy),
+    approvedAt,
+    updatedAt: approvedAt
+  };
+}
+
+export function revokeChangePlan(plan: ChangePlanRecord, revokedBy: string, revokedAt: string = new Date().toISOString()): ChangePlanRecord {
+  assertNonEmpty(revokedBy, "revokedBy");
+  return {
+    ...plan,
+    status: "revoked",
+    revokedBy: redactSecrets(revokedBy),
+    revokedAt,
+    updatedAt: revokedAt,
+    notes: [...(plan.notes ?? []), `revoked by ${redactSecrets(revokedBy)}`]
+  };
+}
+
+function normalizeActualFile(file: string | ActualChangedFile): ActualChangedFile {
+  if (typeof file === "string") {
+    return { path: normalizePlanPath(file) };
+  }
+  return {
+    ...file,
+    path: normalizePlanPath(file.path)
+  };
+}
+
+export function comparePlannedToActual(plan: ChangePlanRecord, actualFiles: Array<string | ActualChangedFile>): PlannedDiffResult {
+  const plannedFiles = plan.expectedFiles.map((file) => normalizePlanPath(file.path));
+  const actual = actualFiles.map(normalizeActualFile);
+  const plannedSet = new Set(plannedFiles);
+  const actualSet = new Set(actual.map((file) => file.path));
+
+  return {
+    plannedFiles,
+    actualFiles: actual,
+    unplannedFiles: actual.filter((file) => !plannedSet.has(file.path)),
+    missingPlannedFiles: plannedFiles.filter((file) => !actualSet.has(file))
+  };
+}
+
+export function toStorageRecord(plan: ChangePlanRecord): ChangePlanRecord {
+  return {
+    ...plan,
+    createdBy: redactSecrets(plan.createdBy),
+    reason: redactSecrets(plan.reason),
+    summary: redactSecrets(plan.summary),
+    rollbackRef: redactSecrets(plan.rollbackRef),
+    notes: normalizeNotes(plan.notes),
+    expectedFiles: plan.expectedFiles.map(normalizeFile),
+    checks: plan.checks.map(normalizeCheck)
+  };
+}

--- a/tools/hep/index.ts
+++ b/tools/hep/index.ts
@@ -13,6 +13,11 @@ Commands:
   clean-task          Clean/remove a task worktree.
   test-db             Run connection test on SQLite database.
   finalize-report     Finalize metadata in a task report file using Git/GitHub CLI.
+  change-plan:create  Create a local HEP change-plan record from CLI options.
+  change-plan:simulate Simulate ALLOW/BLOCK for a change-plan JSON file.
+  change-plan:approve Approve a change-plan JSON file.
+  change-plan:revoke Revoke a change-plan JSON file.
+  change-plan:diff-check Compare planned files with actual changed files.
 
 Options:
   --taskId <id>       ID of the task (e.g. HEP-V1-WORKTREE-MEMORY-001)
@@ -26,6 +31,10 @@ Options:
   --report <path>     Path to the report file (default: auto-detect latest modified report)
   --verdict <str>     Optional final verdict text to update in report
   --next-task <str>   Optional next task ID to update in report
+  --plan <path>       Path to a change-plan JSON file
+  --scope <path>      Optional path to a scope JSON file
+  --actualFiles <csv> Comma-separated actual changed files for diff-check
+  --out <path>        Optional output JSON path for change-plan commands
 `);
 }
 
@@ -83,8 +92,28 @@ async function main(): Promise<void> {
   const report = (options.report as string) || (options["report"] as string);
   const nextTask = (options.nextTask as string) || (options["next-task"] as string);
   const verdict = options.verdict as string;
+  const planPath = (options.plan as string) || (options["plan"] as string);
+  const scopePath = (options.scope as string) || (options["scope"] as string);
+  const outPath = (options.out as string) || (options["out"] as string);
+  const actualFilesCsv = (options.actualFiles as string) || (options["actual-files"] as string);
 
   const manager = new WorktreeManager(repositoryPath, worktreeRoot);
+
+  async function readJsonFile(filePath: string): Promise<unknown> {
+    const fs = await import("node:fs");
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  }
+
+  async function writeJsonOrPrint(value: unknown): Promise<void> {
+    const serialized = `${JSON.stringify(value, null, 2)}\n`;
+    if (outPath) {
+      const fs = await import("node:fs");
+      fs.writeFileSync(outPath, serialized, "utf8");
+      console.log(`Wrote ${outPath}`);
+      return;
+    }
+    console.log(serialized);
+  }
 
   try {
     switch (command) {
@@ -135,6 +164,73 @@ async function main(): Promise<void> {
           verdict,
           nextTask
         });
+        break;
+      }
+      case "change-plan:create": {
+        const { createChangePlan } = await import("./change-plan.ts");
+        if (!taskId) throw new Error("Missing required option: --taskId");
+        const actor = (options.actor as string) || "maintenance.autopilot";
+        const action = ((options.action as string) || "modify") as "create" | "modify" | "delete" | "inspect";
+        const target = (options.target as string) || "tools/hep/index.ts";
+        const riskLevel = ((options.riskLevel as string) || (options["risk-level"] as string) || "medium") as "low" | "medium" | "high" | "critical";
+        const summary = (options.summary as string) || "HEP local change-plan";
+        const reason = (options.reason as string) || summary;
+        const createdBy = (options.createdBy as string) || (options["created-by"] as string) || actor;
+        const rollbackRef = (options.rollbackRef as string) || (options["rollback-ref"] as string) || branchName || "local.rollback.ref";
+        const plannedFilesCsv = (options.plannedFiles as string) || (options["planned-files"] as string) || target;
+        const expectedFiles = plannedFilesCsv.split(",").map((filePath) => ({
+          path: filePath.trim(),
+          reason: "planned by CLI",
+          changeType: action
+        }));
+        const plan = createChangePlan({
+          taskId,
+          actor,
+          action,
+          target,
+          riskLevel,
+          createdBy,
+          reason,
+          summary,
+          expectedFiles,
+          checks: [{ command: "npm test -- --run", required: true, expectedResult: "tests pass" }],
+          rollbackRef,
+          requiresOwnerReview: riskLevel === "high" || riskLevel === "critical"
+        });
+        await writeJsonOrPrint(plan);
+        break;
+      }
+      case "change-plan:simulate": {
+        const { simulateChangePlan } = await import("./change-plan.ts");
+        if (!planPath) throw new Error("Missing required option: --plan");
+        const plan = await readJsonFile(planPath);
+        const scope = scopePath ? await readJsonFile(scopePath) : {};
+        await writeJsonOrPrint(simulateChangePlan(plan as Parameters<typeof simulateChangePlan>[0], scope as Parameters<typeof simulateChangePlan>[1]));
+        break;
+      }
+      case "change-plan:approve": {
+        const { approveChangePlan } = await import("./change-plan.ts");
+        if (!planPath) throw new Error("Missing required option: --plan");
+        const approvedBy = (options.approvedBy as string) || (options["approved-by"] as string) || "owner";
+        const plan = await readJsonFile(planPath);
+        await writeJsonOrPrint(approveChangePlan(plan as Parameters<typeof approveChangePlan>[0], approvedBy));
+        break;
+      }
+      case "change-plan:revoke": {
+        const { revokeChangePlan } = await import("./change-plan.ts");
+        if (!planPath) throw new Error("Missing required option: --plan");
+        const revokedBy = (options.revokedBy as string) || (options["revoked-by"] as string) || "owner";
+        const plan = await readJsonFile(planPath);
+        await writeJsonOrPrint(revokeChangePlan(plan as Parameters<typeof revokeChangePlan>[0], revokedBy));
+        break;
+      }
+      case "change-plan:diff-check": {
+        const { comparePlannedToActual } = await import("./change-plan.ts");
+        if (!planPath) throw new Error("Missing required option: --plan");
+        if (!actualFilesCsv) throw new Error("Missing required option: --actualFiles");
+        const plan = await readJsonFile(planPath);
+        const actualFiles = actualFilesCsv.split(",").map((filePath) => filePath.trim()).filter(Boolean);
+        await writeJsonOrPrint(comparePlannedToActual(plan as Parameters<typeof comparePlannedToActual>[0], actualFiles));
         break;
       }
       default: {


### PR DESCRIPTION
## Summary

Adds a repo-local HEP change-plan module for typed plan creation, scope validation, ALLOW/BLOCK simulation, approve/revoke transitions, planned-vs-actual file comparison, and redacted storage records.

This is HEP tooling only. It does not touch DentalFlow React UI, app pages, Supabase migrations, generated types, seeds, package files, or cloud Supabase.

Final PR state: ready for review, merge state CLEAN, latest CI success on head eb2d95dc4a10f9b1536901fe6156297a64277a35.

## Checks

- npx vitest run tools/hep/__tests__/change-plan.test.ts: PASS, 12 tests
- npm test -- --run: PASS, 62 files / 632 tests
- npm run lint: PASS
- npm run build: PASS
- CLI smoke change-plan:create: PASS
- GitHub CI run 28197610666 / #641: SUCCESS

## Limitations

- Does not yet enforce planned-vs-actual gates before commit/push.
- External D:\hermes smoke registries were not modified.
- CLI is intentionally minimal and JSON-oriented.
- finalize_report_metadata helper failed with replaceReportPlaceholders is not defined, so report structure was corrected manually.
