### PR TITLE
REFUNDS-WRITEOFFS-FOUNDATION-001: add refund and write-off backend foundation

### DIFF
--- a/_ai_work/REPORTS/REFUNDS-WRITEOFFS-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/REFUNDS-WRITEOFFS-FOUNDATION-001_foundation.md
@@ -1,0 +1,919 @@
+# REFUNDS-WRITEOFFS-FOUNDATION-001 — Refunds and invoice write-offs backend foundation
+
+## 1. Summary
+
+Implemented and locally verified the controlled backend lifecycle for payment refunds and invoice write-offs.
+
+The implementation closes the deliberate gap left by the original finance RPC layer:
+
+- refund request, approval, completion, rejection, and cancellation before completion;
+- invoice write-off request, approval, rejection, and cancellation/reversal;
+- tenant-scoped idempotency;
+- row locking and database guards against duplicate/concurrent over-consumption;
+- payment status recalculation including completed refunds;
+- invoice recalculation including approved write-offs;
+- tenant-scoped repository read models;
+- typed frontend RPC client methods;
+- SQL lifecycle, role, side-effect, and concurrency validation.
+
+The MVP boundary is explicit: a refund may return only currently unallocated payment funds. Existing allocations must first be voided through the existing controlled allocation-void RPC. Refund processing does not silently reopen invoices and does not invent a refund-allocation model that the schema does not possess.
+
+Final verdict: **PASS**
+
+Task acceptance verdict: **REFUNDS WRITEOFFS FOUNDATION IMPLEMENTED AND VERIFIED**
+
+## 2. Branch
+
+- Branch: `feature/refunds-writeoffs-foundation-001`
+- Base branch: `main`
+- Required baseline commit: `69ec4e6044ac082762f4ea20ed7efad4a9d1097d`
+- Baseline validation: PR #332 was merged into `main`, and the task branch was created from that exact current baseline.
+
+## 3. PR URL
+
+- PR: https://github.com/NckNA/codex-test/pull/333
+- PR state before final report update: open, not merged, not draft.
+
+## 4. PR head reviewed before final report update
+
+- Implementation head reviewed: `c48a7afbc878df6ef4db24f743cb66781a7b9657`
+- GitHub Actions CI on implementation head: run `29079751549`, run number `652`, conclusion `success`.
+
+## 5. Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+- Report update commit: N/A (the report commit cannot reference itself; use the finalization receipt).
+
+## 6. Changed files
+
+Implementation files:
+
+- `supabase/migrations/0018_create_refund_writeoff_rpc.sql`
+- `supabase/tests/0018_refund_writeoff_rpc_test.sql`
+- `supabase/tests/0018_refund_writeoff_concurrency.ps1`
+- `src/data/repositories/FinanceRepository.ts`
+- `src/data/repositories/FinanceRepository.test.ts`
+- `src/data/repositories/FinanceRpcClient.ts`
+- `src/data/repositories/FinanceRpcClient.test.ts`
+
+Report file:
+
+- `_ai_work/REPORTS/REFUNDS-WRITEOFFS-FOUNDATION-001_foundation.md`
+
+No UI, React hook, route, cashier component, seed, generated type, document, stock, timeline, appointment, completed-service, or cloud migration file was changed.
+
+## 7. Pre-read
+
+Reviewed before implementation:
+
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-RECON-001_finance_model.md`
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-SCHEMA-001A_schema.md`
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-REPOSITORY-001B_repository.md`
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-001C_rpc.md`
+- `_ai_work/REPORTS/PAYMENTS-DEBTS-RPC-CLIENT-001D_client.md`
+- `_ai_work/REPORTS/PATIENT-FINANCE-UI-001_ui.md`
+- `_ai_work/REPORTS/CASHIER-PAYMENT-FLOW-001_cashier.md`
+- `_ai_work/REPORTS/SECURITY-DEFINER-RPC-RECON-001_security_definer_audit.md`
+- `_ai_work/REPORTS/SECURITY-DEFINER-RPC-HARDENING-001A_rls_helper_grants.md`
+- `supabase/migrations/0016_create_finance_model.sql`
+- `supabase/migrations/0017_create_finance_rpc.sql`
+- later migrations through the current `main` migration head;
+- current `FinanceRepository.ts`, `FinanceRpcClient.ts`, their tests, audit/activity internal helpers, tenant-role helpers, RLS policies, and SECURITY DEFINER conventions.
+
+The two security reports exist under slightly more descriptive filenames than the abbreviated task references. Their contents and conclusions were reviewed.
+
+## 8. Existing schema reconciliation
+
+### Refunds table
+
+Existing `public.refunds` already contained:
+
+- tenant, patient, and payment references;
+- lifecycle status;
+- refund method, amount, currency, and reason;
+- requested, approved, completed, rejected, and void timestamps/actors where supported;
+- external reference and metadata;
+- positive amount, status, method, metadata, void reason/timestamp, tenant ownership, and foreign-key constraints;
+- tenant-scoped read RLS for finance staff;
+- no direct frontend write grants;
+- existing repository row mapping.
+
+Existing statuses were sufficient and were preserved:
+
+- `pending`
+- `approved`
+- `completed`
+- `rejected`
+- `voided`
+- `archived`
+
+Gap closed by this task:
+
+- idempotency key and tenant-scoped unique partial index;
+- additional state-integrity constraints;
+- controlled write lifecycle RPCs;
+- completed-refund payment recalculation;
+- concurrency and legacy-operation guards.
+
+### Financial adjustments table
+
+Existing `public.financial_adjustments` already contained:
+
+- tenant and patient references;
+- optional invoice, invoice-item, and payment references;
+- adjustment type, status, amount, currency, reason, metadata;
+- created, approved, and void actor/timestamp fields;
+- positive amount, type, status, metadata, void, target-reference, tenant ownership, and foreign-key constraints;
+- tenant-scoped read RLS for finance staff;
+- no direct frontend write grants;
+- existing repository row mapping.
+
+Existing adjustment statuses were sufficient and were preserved:
+
+- `active` as requested/pending;
+- `approved` as applied;
+- `rejected`;
+- `voided`;
+- `archived`.
+
+Existing write-off type was preserved: `write_off`.
+
+Gap closed by this task:
+
+- idempotency key and tenant-scoped unique partial index;
+- approved-state integrity;
+- controlled write-off lifecycle RPCs;
+- write-off-aware invoice recalculation;
+- concurrency and legacy-operation guards.
+
+### Existing invoice/payment calculations
+
+Before this task:
+
+- invoice `paid_amount` was derived from active payment allocations;
+- invoice `balance_amount` was derived from total minus active allocations;
+- payment status was derived from active allocation totals;
+- refund and write-off fields existed but the original recalculation helpers intentionally preserved/ignored them;
+- there were no refund or write-off mutation RPCs.
+
+This task reconciles those calculations rather than creating replacement tables.
+
+### Audit/activity rules
+
+The existing project supports finance events through:
+
+- `audit_events` category `payment`;
+- `activity_events` category `payment`;
+- activity visibility `financial`;
+- internal audit/activity functions that derive the actor from `auth.uid()`.
+
+The implementation reuses this convention and adds explicit finance lifecycle event names.
+
+### Role matrix before implementation
+
+The existing finance write helper validates authenticated tenant membership and allowed roles. This task reuses it and applies narrower role arrays per refund/write-off transition.
+
+### Exact schema gaps
+
+The exact gaps were:
+
+- no idempotency key support for refunds/adjustments;
+- no controlled refund/write-off RPCs;
+- no reserved amount calculations;
+- no completed refund status calculation;
+- no approved write-off invoice calculation;
+- no allocation guard aware of reserved refunds/write-offs;
+- no protection against voiding a payment or invoice after refund/write-off facts exist;
+- missing repository eligibility/read models;
+- missing typed client methods and tests.
+
+No replacement finance table was required or created.
+
+## 9. Architecture decisions
+
+1. Refund and write-off remain separate financial concepts.
+2. Refund returns money and is linked to a payment.
+3. Write-off reduces debt and is linked to an invoice.
+4. Refunds do not reverse allocations automatically.
+5. Allocated funds must be released through `void_payment_allocation` first.
+6. Write-offs never change `total_amount` or `paid_amount` and never create payments.
+7. `completed_services` and appointments are outside the finance mutation boundary.
+8. `patients.balance` is neither read nor written as finance truth.
+9. All mutations occur through controlled SECURITY DEFINER RPCs.
+10. Database row locks, partial unique indexes, and capacity triggers defend against retries and races independently of frontend discipline.
+11. Historical read/recalculation support retains both direct invoice write-offs and schema-supported invoice-item-linked write-offs, while the new MVP request RPC creates a direct invoice-linked write-off.
+12. Existing tables, statuses, audit infrastructure, RLS, and repository types were extended rather than replaced.
+
+## 10. Refund domain model
+
+A refund is a return of money previously received in a payment.
+
+It is not:
+
+- a payment void;
+- an invoice void;
+- a treatment cancellation;
+- an appointment cancellation;
+- a completed-service cancellation;
+- an automatic reversal of payment allocation.
+
+A completed refund records a financial fact. It cannot be mutated back to pending, approved, rejected, or voided. A future compensating payment would be a separate financial fact.
+
+## 11. Refund state machine
+
+Supported transitions:
+
+- new request -> `pending`
+- `pending` -> `approved`
+- `approved` -> `completed`
+- `pending` -> `rejected`
+- `pending` -> `voided`
+- `approved` -> `voided`
+
+Idempotent terminal/retry behavior:
+
+- approving an already approved refund returns the current row;
+- approving a completed refund returns the current safe row;
+- completing an already completed refund returns the current row without duplicating the effect;
+- rejecting an already rejected refund returns the current row;
+- voiding an already voided refund returns the current row.
+
+Rejected/archived/completed refunds cannot be moved through invalid transitions. Completed refunds are immutable.
+
+## 12. Refundable amount formula
+
+```text
+refundable amount =
+payment amount
+- active payment allocations
+- completed refunds
+- reserved pending/approved refunds
+```
+
+The request, approval, and completion paths lock the payment row and revalidate capacity.
+
+The migration also adds an allocation-capacity trigger. A later allocation cannot consume money already completed or reserved for refund. This closes the inverse race that would remain if only refund RPCs performed locking.
+
+## 13. Write-off domain model
+
+A write-off is an approved financial adjustment with:
+
+- `adjustment_type = write_off`;
+- direct invoice linkage for new MVP requests;
+- patient and currency derived from the invoice;
+- `active` as requested/pending;
+- `approved` as applied;
+- `rejected`, `voided`, or `archived` as non-applying states.
+
+It reduces invoice debt but does not change:
+
+- invoice `total_amount`;
+- invoice `paid_amount`;
+- payment rows or allocation facts;
+- completed services;
+- treatment or appointment state.
+
+## 14. Write-off state machine
+
+Supported transitions:
+
+- new request -> `active`
+- `active` -> `approved`
+- `active` -> `rejected`
+- `active` -> `voided`
+- `approved` -> `voided`
+
+Approving an already approved write-off returns the current row. Voiding an already voided write-off returns the current row. Rejected/archived write-offs cannot be voided.
+
+Voiding an approved write-off recalculates the invoice and reopens the corresponding debt. No financial fact is hard-deleted.
+
+## 15. Invoice recalculation formula
+
+```text
+subtotal_amount =
+sum(active/adjusted invoice item quantity * unit price)
+
+discount_amount =
+sum(active/adjusted invoice item discount_amount)
+
+adjustment_amount =
+sum(active/adjusted invoice item adjustment_amount)
+
+total_amount =
+sum(active/adjusted invoice item total_amount)
+
+paid_amount =
+sum(active payment allocations linked directly to invoice or to its invoice items)
+
+written_off_amount =
+sum(approved write_off adjustments linked directly to invoice or through a validated invoice item)
+
+balance_amount =
+max(0, total_amount - paid_amount - written_off_amount)
+```
+
+Status rules:
+
+- `draft` remains `draft`;
+- `voided` remains `voided`;
+- `archived` remains `archived`;
+- balance 0 with written-off amount > 0 -> `written_off`;
+- balance 0 with written-off amount = 0 -> `paid`;
+- balance > 0 with paid amount > 0 -> `partially_paid`;
+- otherwise -> `issued`.
+
+The helper rejects an invariant violation where active allocations plus approved write-offs exceed invoice total.
+
+Refund amounts are not subtracted from invoice balance in this MVP.
+
+## 16. Payment recalculation formula
+
+```text
+completed_refund_amount = sum(completed refunds)
+active_allocated_amount = sum(active allocations)
+```
+
+Status priority:
+
+- `voided` remains `voided`;
+- `archived` remains `archived`;
+- completed refunds >= payment amount -> `refunded`;
+- completed refunds > 0 -> `partially_refunded`;
+- active allocations >= payment amount -> `allocated`;
+- active allocations > 0 -> `partially_allocated`;
+- otherwise -> `received`.
+
+The helper rejects an invariant violation where active allocations plus completed refunds exceed payment amount.
+
+## 17. Idempotency design
+
+Added nullable columns:
+
+- `refunds.idempotency_key`
+- `financial_adjustments.idempotency_key`
+
+Added separate partial unique indexes:
+
+- `uq_refunds_tenant_idempotency_key`
+- `uq_financial_adjustments_tenant_idempotency_key`
+
+Both indexes enforce uniqueness on `(tenant_id, idempotency_key)` only when the key is not null.
+
+Behavior:
+
+- the client trims supplied keys and rejects empty keys;
+- the RPC locks the parent payment/invoice first;
+- an existing matching key returns the existing row;
+- reusing a key for materially different request facts is rejected;
+- parallel identical requests with one key create exactly one row and both callers receive success;
+- transition RPCs are idempotent where repeating the same completed transition is safe.
+
+## 18. Concurrency/locking design
+
+Refund paths lock:
+
+- refund row where applicable;
+- parent payment row.
+
+Write-off paths lock:
+
+- adjustment row where applicable;
+- parent invoice row.
+
+Capacity is recalculated after locks are acquired.
+
+Additional database guards:
+
+- `payment_allocations_capacity_guard` prevents active allocations from exceeding payment capacity after completed/reserved refunds and invoice capacity after approved/reserved write-offs;
+- `payments_refund_void_guard` prevents legacy payment void from erasing the meaning of pending, approved, or completed refund facts;
+- `invoices_writeoff_void_guard` prevents legacy invoice void while active/approved direct or invoice-item-linked write-offs exist.
+
+Parallel validation results:
+
+- two concurrent refund requests of 600 against payment 1000: one succeeded, one was rejected, reserved total 600;
+- two concurrent write-off requests of 600 against invoice 1000: one succeeded, one was rejected, reserved total 600;
+- two concurrent identical refund retries with one idempotency key: one row;
+- two concurrent identical write-off retries with one idempotency key: one row.
+
+## 19. Role matrix
+
+| Operation | Owner | Admin | Cashier | Doctor | Registrar | No tenant |
+|---|---:|---:|---:|---:|---:|---:|
+| Request refund | yes | yes | yes | no | no | no |
+| Approve refund | yes | yes | no | no | no | no |
+| Complete refund | yes | yes | yes | no | no | no |
+| Reject refund | yes | yes | no | no | no | no |
+| Void pending/approved refund | yes | yes | no | no | no | no |
+| Request write-off | yes | yes | no | no | no | no |
+| Approve write-off | yes | yes | no | no | no | no |
+| Reject write-off | yes | yes | no | no | no | no |
+| Void active/approved write-off | yes | yes | no | no | no | no |
+
+Cross-tenant identifiers are rejected after role validation and tenant-bound row lookup. Valid UUID format does not bypass tenant ownership.
+
+## 20. RPC list and signatures
+
+Refund RPCs:
+
+```text
+request_refund(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_amount numeric,
+  p_refund_method text,
+  p_reason text,
+  p_idempotency_key text default null,
+  p_metadata jsonb default '{}'
+) returns refunds
+
+approve_refund(p_tenant_id uuid, p_refund_id uuid) returns refunds
+
+complete_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_external_reference text default null,
+  p_metadata jsonb default '{}'
+) returns refunds
+
+reject_refund(p_tenant_id uuid, p_refund_id uuid, p_reason text) returns refunds
+
+void_refund(p_tenant_id uuid, p_refund_id uuid, p_reason text) returns refunds
+```
+
+Write-off RPCs:
+
+```text
+request_invoice_write_off(
+  p_tenant_id uuid,
+  p_invoice_id uuid,
+  p_amount numeric,
+  p_reason text,
+  p_idempotency_key text default null,
+  p_metadata jsonb default '{}'
+) returns financial_adjustments
+
+approve_invoice_write_off(p_tenant_id uuid, p_adjustment_id uuid)
+  returns financial_adjustments
+
+reject_invoice_write_off(
+  p_tenant_id uuid,
+  p_adjustment_id uuid,
+  p_reason text
+) returns financial_adjustments
+
+void_invoice_write_off(
+  p_tenant_id uuid,
+  p_adjustment_id uuid,
+  p_reason text
+) returns financial_adjustments
+```
+
+No RPC accepts a frontend-supplied actor ID, patient ID, or currency where those values can be derived from the payment/invoice.
+
+## 21. Repository read models
+
+Added:
+
+### `getPaymentRefundability({ tenantId, paymentId })`
+
+Returns:
+
+- payment;
+- payment amount;
+- active allocated amount;
+- completed refund amount;
+- reserved refund amount;
+- refundable amount;
+- active-allocation flag;
+- refund count;
+- currency.
+
+### `getInvoiceWriteOffEligibility({ tenantId, invoiceId })`
+
+Returns:
+
+- invoice;
+- invoice total amount;
+- paid amount;
+- approved write-off amount;
+- reserved write-off amount;
+- available write-off amount;
+- eligibility flag;
+- safe ineligibility reason;
+- currency.
+
+Both methods:
+
+- require tenant and record IDs;
+- use tenant-filtered existing repository reads;
+- preserve RLS;
+- perform no write;
+- return null safely when the parent row does not exist;
+- normalize errors with operation context and preserved causes.
+
+Existing `Refund` and `FinancialAdjustment` mappings now preserve nullable `idempotencyKey`.
+
+The patient finance summary counts only approved write-offs as applied debt reduction; active requests are reservations, not completed financial effects.
+
+## 22. Typed client methods
+
+Added to `FinanceRpcClient`:
+
+Refund:
+
+- `requestRefund`
+- `approveRefund`
+- `completeRefund`
+- `rejectRefund`
+- `voidRefund`
+
+Write-off:
+
+- `requestInvoiceWriteOff`
+- `approveInvoiceWriteOff`
+- `rejectInvoiceWriteOff`
+- `voidInvoiceWriteOff`
+
+The client:
+
+- uses camelCase inputs;
+- maps to exact SQL `p_*` names;
+- validates required IDs;
+- validates positive amounts;
+- validates the allowed refund methods;
+- requires non-empty reasons;
+- accepts metadata only as a plain object;
+- trims/rejects empty idempotency keys;
+- maps returned rows to `Refund` and `FinancialAdjustment`;
+- preserves simple safe domain errors;
+- hides structured, multiline, or oversized raw database error dumps;
+- contains no direct table write, localStorage, service-role, React, or UI dependency.
+
+## 23. Audit/activity behavior
+
+Events logged:
+
+Refund:
+
+- `refund_requested`
+- `refund_approved`
+- `refund_completed`
+- `refund_rejected`
+- `refund_voided`
+
+Write-off:
+
+- `write_off_requested`
+- `write_off_approved`
+- `write_off_rejected`
+- `write_off_voided`
+
+Event facts include:
+
+- tenant;
+- patient;
+- payment or invoice reference;
+- refund/adjustment ID;
+- amount and currency;
+- transition states;
+- safe reason where applicable;
+- actor derived from `auth.uid()`.
+
+Idempotent completed retries do not create duplicate financial effects or duplicate completion audit events.
+
+No credentials, service-role keys, payment-card data, or unbounded metadata are stored.
+
+## 24. Security/grants/search_path
+
+Verified on local Supabase:
+
+- all 9 public mutation RPCs exist;
+- all 9 are `SECURITY DEFINER`;
+- all 9 set `search_path = public, pg_temp`;
+- all 9 are executable by `authenticated`;
+- all 9 are not executable by `anon`;
+- all 9 are not executable through `PUBLIC`;
+- internal calculation, sanitizer, capacity, and guard functions are not executable by frontend roles;
+- direct authenticated/anon writes to refunds and financial adjustments remain unavailable;
+- RLS remains enabled;
+- no service-role credential is used by application code;
+- all referenced finance rows are tenant validated;
+- all actor fields derive from `auth.uid()`.
+
+Catalog summary for the 9 public RPCs:
+
+```text
+secured/search_path: 9/9
+anon blocked: true
+authenticated granted: true
+PUBLIC blocked: true
+```
+
+## 25. Local role validation
+
+Guarded local QA users were created temporarily:
+
+- `qa.admin.a@example.local`
+- `qa.cashier.a@example.local`
+- `qa.doctor.a@example.local`
+- `qa.receptionist.a@example.local`
+- `qa.notenant@example.local`
+- `qa.admin.b@example.local`
+
+Validated:
+
+- cashier can request and complete refunds;
+- cashier cannot approve refunds;
+- doctor and registrar cannot request refunds;
+- no-tenant user is blocked;
+- Clinic B admin cannot access Clinic A payment/invoice/refund/write-off data;
+- Clinic A admin can approve/reject/void refund and write-off transitions;
+- cashier, doctor, and registrar cannot request write-offs.
+
+QA users and all smoke facts were removed by the final local reset. No seed file was changed or committed.
+
+## 26. Refund smoke results
+
+Positive smoke:
+
+1. Recorded unallocated payment 1000 KZT.
+2. Cashier requested refund 400.
+3. Admin approved.
+4. Cashier completed.
+5. Payment became `partially_refunded`.
+6. Cashier requested remaining 600.
+7. Admin approved.
+8. Cashier completed.
+9. Payment became `refunded`.
+10. Completion retry returned the same refund without duplicating financial or audit effect.
+
+Allocated-funds negative smoke:
+
+1. Recorded payment 1000.
+2. Allocated all 1000 to an invoice.
+3. Refund request 100 was rejected.
+4. Admin voided the allocation through `void_payment_allocation`.
+5. Refund request became allowed.
+
+Additional validation:
+
+- pending refund reserves capacity;
+- rejection releases capacity;
+- void releases capacity;
+- pending refund cannot be completed;
+- completed refund cannot be voided;
+- a payment with active/completed refunds cannot be voided through the legacy payment-void RPC;
+- invalid method, amount, reason, metadata, role, tenant, and capacity are rejected;
+- audit/activity events and auth-derived actors were verified.
+
+Result: PASS.
+
+## 27. Write-off smoke results
+
+Positive smoke:
+
+1. Created and issued invoice 1000 KZT.
+2. Admin requested write-off 400.
+3. Admin approved.
+4. Invoice became:
+   - total 1000;
+   - paid 0;
+   - written off 400;
+   - balance 600;
+   - status `issued`.
+5. Admin requested and approved remaining 600.
+6. Invoice became:
+   - total 1000;
+   - paid 0;
+   - written off 1000;
+   - balance 0;
+   - status `written_off`.
+7. No payment was created.
+8. Voiding the approved 600 write-off reduced written-off amount to 400, reopened balance to 600, and restored `issued` status.
+
+Negative and reservation validation:
+
+- cashier and doctor request blocked;
+- cross-tenant invoice blocked;
+- draft and paid invoices blocked;
+- invalid amount, reason, and metadata blocked;
+- amount above available balance blocked;
+- active request reserves balance;
+- rejected request does not alter invoice financials;
+- invoice with active/approved write-off cannot be voided through the legacy invoice-void RPC;
+- audit/activity events and auth-derived actors verified.
+
+Result: PASS.
+
+## 28. Cross-tenant results
+
+- Clinic B admin attempting refund against Clinic A payment: rejected as payment not found in this tenant.
+- Clinic B admin attempting write-off against Clinic A invoice: rejected as invoice not found in this tenant.
+- UUID validity did not bypass tenant checks.
+- No Clinic A finance facts were returned through the mutation RPCs to Clinic B.
+
+Result: PASS.
+
+## 29. Side-effect checks
+
+Verified before transaction rollback and cleanup:
+
+- `completed_services` unchanged;
+- appointments unchanged;
+- `patients.balance` unchanged;
+- write-off did not create a payment;
+- write-off did not increase `paid_amount`;
+- refund did not reopen invoice debt;
+- no document or patient-file writes;
+- no stock/material writes;
+- no timeline integration;
+- no treatment, visit, encounter, or clinical mutation;
+- no direct frontend table mutation path was added.
+
+Result: PASS.
+
+## 30. Cleanup
+
+Lifecycle SQL smoke used an explicit transaction and ended with `ROLLBACK`.
+
+Concurrency smoke created local-only rows and was followed by:
+
+```text
+npx supabase db reset --no-seed
+```
+
+Final local database verification after cleanup:
+
+- smoke patient marker: 0;
+- invoices: 0;
+- payments: 0;
+- refunds: 0;
+- financial adjustments: 0;
+- completed services: 0;
+- appointments: 0.
+
+Two baseline patients produced by the normal local migration/fixture baseline remained after reset; no task smoke finance rows remained.
+
+No cloud data was created, changed, or cleaned because cloud was never touched.
+
+## Checks
+
+- Lint: passed.
+- Targeted FinanceRepository tests: 23/23 passed.
+- Targeted FinanceRpcClient tests: 45/45 passed.
+- Full tests: 67 files / 676 tests passed.
+- Build: passed.
+- Local Supabase reset: passed.
+- SQL lifecycle smoke: passed.
+- Concurrency/idempotency smoke: passed.
+- Implementation CI: success on `c48a7afbc878df6ef4db24f743cb66781a7b9657`.
+
+## Browser smoke
+
+- Environment: not run by design.
+- Roles: validated through authenticated local SQL contexts instead of a browser.
+- Database evidence: captured through transactional SQL, catalog assertions, and two-session concurrency tests.
+- Cleanup remaining rows: verified through final local reset.
+- Reason: UI and browser smoke are explicitly forbidden by this backend-only task.
+
+## 31. Tests
+
+Targeted repository tests:
+
+```text
+FinanceRepository.test.ts: 23/23 passed
+```
+
+Targeted RPC client tests:
+
+```text
+FinanceRpcClient.test.ts: 45/45 passed
+```
+
+Full unit/integration suite:
+
+```text
+67 test files passed
+676 tests passed
+```
+
+SQL lifecycle/role/side-effect validation:
+
+```text
+REFUNDS-WRITEOFFS SQL TESTS PASSED
+```
+
+Concurrency validation:
+
+```text
+REFUND_RACE success=1 rejected=1 reserved=600.00
+REFUND_IDEMPOTENCY rows=1
+WRITEOFF_RACE success=1 rejected=1 reserved=600.00
+WRITEOFF_IDEMPOTENCY rows=1
+CONCURRENCY VALIDATION PASSED
+```
+
+Schema assertions:
+
+```text
+28/28 passed
+```
+
+## 32. Lint/build
+
+Local checks:
+
+- `npm run lint`: passed.
+- `npm run test -- --run src/data/repositories/FinanceRepository.test.ts`: passed, 23 tests.
+- `npm run test -- --run src/data/repositories/FinanceRpcClient.test.ts`: passed, 45 tests.
+- full test command through the repository script: passed, 67 files / 676 tests.
+- `npm run build`: passed.
+- `npx supabase db reset --no-seed`: passed after the final migration version and again for cleanup.
+
+Existing non-blocking project warnings:
+
+- unrelated React `act(...)` warnings in visit tests;
+- existing Vite bundle chunk-size warning.
+
+## 33. GitHub Actions CI
+
+Implementation-head CI:
+
+- Workflow: `CI`
+- Run ID: `29079751549`
+- Run number: `652`
+- Status: `completed`
+- Conclusion: `success`
+- Tested commit: `c48a7afbc878df6ef4db24f743cb66781a7b9657`
+- ESLint: success
+- Tests: success
+- Build: success
+
+A fresh CI run on the final report-update head is verified separately after the report commit is pushed; its immutable run/commit pairing is recorded in the finalization receipt and final task response because the report commit cannot contain its own future CI result.
+
+## 34. Issues/warnings
+
+- Existing audit/activity category constraints do not define a separate `finance` category. The established project convention remains category `payment`, financial visibility, and finance-specific event names/metadata.
+- Existing unrelated React `act(...)` warnings remain in visit tests.
+- Existing Vite chunk-size warning remains non-blocking.
+- Browser smoke was intentionally not run because this task explicitly forbids UI/browser work.
+- Cloud Supabase was intentionally not touched.
+- No historical invariant violations were present in the clean local database after reset. The migration does not silently mutate hypothetical unrelated historical rows.
+
+No blocker remains for the backend foundation.
+
+## 35. Known cashier debt from PR #332
+
+The following known concerns from PR #332 were deliberately not fixed in this PR:
+
+- stale finance/result state when switching patients;
+- partial `recordPayment` / `allocatePayment` failure handling;
+- raw read-error normalization in the cashier flow;
+- stale cashier report metadata.
+
+They remain one separate architectural task:
+
+`CASHIER-PAYMENT-FLOW-HARDENING-001`
+
+## 36. What was intentionally not implemented
+
+- no refund/write-off UI;
+- no React hooks or patient finance tab changes;
+- no cashier UI changes;
+- no browser smoke;
+- no cloud migration apply;
+- no payment-provider API;
+- no Kaspi/Halyk integration;
+- no fiscal receipt;
+- no documents/acts;
+- no stock/material integration;
+- no timeline integration;
+- no appointment or clinical mutation;
+- no completed-service mutation;
+- no `patients.balance` truth or write;
+- no direct frontend table writes;
+- no service-role application code;
+- no committed seed changes;
+- no committed generated types;
+- no HEP-V2 work;
+- no unrelated refactor;
+- no merge.
+
+## Final verdict
+
+**PASS**
+
+## 37. Task acceptance verdict
+
+REFUNDS WRITEOFFS FOUNDATION IMPLEMENTED AND VERIFIED
+
+## 38. Recommended next task
+
+Immediate next task:
+
+`CASHIER-PAYMENT-FLOW-HARDENING-001`
+
+After cashier hardening, recommended finance continuation:
+
+`REFUNDS-WRITEOFFS-UI-001`

--- a/_ai_work/REPORTS/REFUNDS-WRITEOFFS-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/REFUNDS-WRITEOFFS-FOUNDATION-001_foundation.md
@@ -850,7 +850,40 @@ Implementation-head CI:
 - Tests: success
 - Build: success
 
-A fresh CI run on the final report-update head is verified separately after the report commit is pushed; its immutable run/commit pairing is recorded in the finalization receipt and final task response because the report commit cannot contain its own future CI result.
+## Finalization
+
+Final PR head before report-only update:
+
+`108a4d04626dc2e0c184d509d5b1f73b76b72515`
+
+GitHub Actions CI #653 / run `29080027605`:
+
+- conclusion: `success`;
+- tested commit: `108a4d04626dc2e0c184d509d5b1f73b76b72515`;
+- tested commit matched the PR head before this report-only update.
+
+Report update commit:
+
+N/A because the final report update commit cannot reference itself before creation.
+
+Hermes finalizer note:
+
+Hermes finalizer failed with `replaceReportPlaceholders is not defined`.
+The failure did not modify repository files or implementation results.
+
+Final verdict:
+
+REFUNDS WRITEOFFS FOUNDATION IMPLEMENTED AND VERIFIED
+
+Recommended next task:
+
+`CASHIER-PAYMENT-FLOW-HARDENING-001`
+
+After that:
+
+`REFUNDS-WRITEOFFS-UI-001`
+
+A fresh CI run on the report-only commit is verified after push. Its final run ID, run number, conclusion, and tested commit are reported separately because this report cannot contain its own future commit SHA or CI result.
 
 ## 34. Issues/warnings
 

--- a/src/data/repositories/FinanceRepository.test.ts
+++ b/src/data/repositories/FinanceRepository.test.ts
@@ -542,3 +542,87 @@ describe('FinanceRepository', () => {
     expect(() => createFinanceRepository({ backend: 'local' })).toThrow('Finance repository requires Supabase backend.');
   });
 });
+
+
+describe('FinanceRepository refundability and write-off eligibility', () => {
+  it('maps payment refundability from tenant-scoped payment, allocations, and refunds', async () => {
+    const pendingRefund = { ...refundRow, id: 'pending-refund', status: 'pending', amount: '100.00', idempotency_key: 'pending-1' };
+    const { repository, calls, client } = createRepository(
+      {
+        payment_allocations: { data: [allocationRow], error: null },
+        refunds: { data: [refundRow, pendingRefund], error: null },
+      },
+      { payments: { data: paymentRow, error: null } },
+    );
+
+    await expect(repository.getPaymentRefundability({ tenantId, paymentId })).resolves.toMatchObject({
+      paymentAmount: 5000,
+      activeAllocatedAmount: 4000,
+      completedRefundAmount: 500,
+      reservedRefundAmount: 100,
+      refundableAmount: 400,
+      hasActiveAllocations: true,
+      refundCount: 2,
+      currency: 'KZT',
+    });
+    expectCall(calls, 'payments', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'payment_allocations', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'payment_allocations', 'eq', 'payment_id', paymentId);
+    expectCall(calls, 'refunds', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'refunds', 'eq', 'payment_id', paymentId);
+    expectNoWriteCalls(client);
+  });
+
+  it('returns null safely when payment or invoice does not exist', async () => {
+    const { repository } = createRepository({}, {
+      payments: { data: null, error: null },
+      invoices: { data: null, error: null },
+    });
+    await expect(repository.getPaymentRefundability({ tenantId, paymentId })).resolves.toBeNull();
+    await expect(repository.getInvoiceWriteOffEligibility({ tenantId, invoiceId })).resolves.toBeNull();
+  });
+
+  it('maps invoice write-off eligibility and reserves active requests', async () => {
+    const approved = { ...adjustmentRow, invoice_item_id: null, amount: '1000.00', status: 'approved', idempotency_key: 'approved-1' };
+    const reserved = { ...adjustmentRow, id: 'reserved-adjustment', invoice_item_id: null, amount: '500.00', status: 'active', idempotency_key: 'active-1' };
+    const { repository, calls, client } = createRepository(
+      { financial_adjustments: { data: [approved, reserved], error: null } },
+      { invoices: { data: invoiceRow, error: null } },
+    );
+
+    await expect(repository.getInvoiceWriteOffEligibility({ tenantId, invoiceId })).resolves.toMatchObject({
+      invoiceTotalAmount: 11000,
+      paidAmount: 4000,
+      approvedWriteOffAmount: 1000,
+      reservedWriteOffAmount: 500,
+      availableWriteOffAmount: 5500,
+      eligible: true,
+      ineligibilityReason: null,
+      currency: 'KZT',
+    });
+    expectCall(calls, 'financial_adjustments', 'eq', 'tenant_id', tenantId);
+    expectCall(calls, 'financial_adjustments', 'eq', 'invoice_id', invoiceId);
+    expectCall(calls, 'financial_adjustments', 'in', 'adjustment_type', ['write_off']);
+    expectNoWriteCalls(client);
+  });
+
+  it('reports ineligible invoice status and normalizes read errors', async () => {
+    const paid = { ...invoiceRow, status: 'paid', balance_amount: '0.00' };
+    const ineligible = createRepository(
+      { financial_adjustments: { data: [], error: null } },
+      { invoices: { data: paid, error: null } },
+    );
+    await expect(ineligible.repository.getInvoiceWriteOffEligibility({ tenantId, invoiceId })).resolves.toMatchObject({
+      eligible: false,
+      availableWriteOffAmount: 7000,
+      ineligibilityReason: 'Invoice status paid is not eligible for write-off.',
+    });
+
+    const failed = createRepository(
+      { refunds: { data: null, error: new Error('read failed') } },
+      { payments: { data: paymentRow, error: null } },
+    );
+    await expect(failed.repository.getPaymentRefundability({ tenantId, paymentId }))
+      .rejects.toThrow('Finance refundability read failed: read failed');
+  });
+});

--- a/src/data/repositories/FinanceRepository.ts
+++ b/src/data/repositories/FinanceRepository.ts
@@ -130,6 +130,7 @@ export interface Refund {
   voidedBy: string | null;
   voidReason: string | null;
   externalReference: string | null;
+  idempotencyKey: string | null;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -153,6 +154,7 @@ export interface FinancialAdjustment {
   approvedAt: string | null;
   voidedAt: string | null;
   voidReason: string | null;
+  idempotencyKey: string | null;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -183,6 +185,40 @@ export interface PatientFinanceSummary {
   unpaidInvoiceCount: number;
   partiallyPaidInvoiceCount: number;
   lastPaymentAt: string | null;
+}
+
+export interface PaymentRefundability {
+  payment: Payment;
+  paymentAmount: number;
+  activeAllocatedAmount: number;
+  completedRefundAmount: number;
+  reservedRefundAmount: number;
+  refundableAmount: number;
+  hasActiveAllocations: boolean;
+  refundCount: number;
+  currency: string;
+}
+
+export interface InvoiceWriteOffEligibility {
+  invoice: Invoice;
+  invoiceTotalAmount: number;
+  paidAmount: number;
+  approvedWriteOffAmount: number;
+  reservedWriteOffAmount: number;
+  availableWriteOffAmount: number;
+  eligible: boolean;
+  ineligibilityReason: string | null;
+  currency: string;
+}
+
+export interface GetPaymentRefundabilityOptions {
+  tenantId: string;
+  paymentId: string;
+}
+
+export interface GetInvoiceWriteOffEligibilityOptions {
+  tenantId: string;
+  invoiceId: string;
 }
 
 export interface ListInvoicesOptions {
@@ -273,6 +309,8 @@ export interface FinanceRepository {
   listPaymentAllocations(options: ListPaymentAllocationsOptions): Promise<PaymentAllocation[]>;
   listRefunds(options: ListRefundsOptions): Promise<Refund[]>;
   listFinancialAdjustments(options: ListFinancialAdjustmentsOptions): Promise<FinancialAdjustment[]>;
+  getPaymentRefundability(options: GetPaymentRefundabilityOptions): Promise<PaymentRefundability | null>;
+  getInvoiceWriteOffEligibility(options: GetInvoiceWriteOffEligibilityOptions): Promise<InvoiceWriteOffEligibility | null>;
   getPatientFinanceFacts(options: PatientFinanceOptions): Promise<PatientFinanceFacts>;
   getPatientFinanceSummary(options: PatientFinanceOptions): Promise<PatientFinanceSummary>;
 }
@@ -476,6 +514,7 @@ export function mapRefundRow(row: Record<string, unknown>): Refund {
     voidedBy: nullableString(row.voided_by),
     voidReason: nullableString(row.void_reason),
     externalReference: nullableString(row.external_reference),
+    idempotencyKey: nullableString(row.idempotency_key),
     metadata: metadataObject(row.metadata),
     createdAt: requiredString(row.created_at, 'created_at'),
     updatedAt: requiredString(row.updated_at, 'updated_at'),
@@ -501,6 +540,7 @@ export function mapFinancialAdjustmentRow(row: Record<string, unknown>): Financi
     approvedAt: nullableString(row.approved_at),
     voidedAt: nullableString(row.voided_at),
     voidReason: nullableString(row.void_reason),
+    idempotencyKey: nullableString(row.idempotency_key),
     metadata: metadataObject(row.metadata),
     createdAt: requiredString(row.created_at, 'created_at'),
     updatedAt: requiredString(row.updated_at, 'updated_at'),
@@ -537,7 +577,10 @@ export function computePatientFinanceSummary(
   const allocatedPaymentAmount = sumBy(activeAllocations, (allocation) => allocation.amount);
   const refundedAmount = sumBy(completedRefunds, (refund) => refund.amount);
   const discountAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'discount'), (adjustment) => adjustment.amount);
-  const writeOffAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'write_off'), (adjustment) => adjustment.amount);
+  const writeOffAmount = sumBy(
+    activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'write_off' && adjustment.status === 'approved'),
+    (adjustment) => adjustment.amount,
+  );
   const surchargeAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'surcharge'), (adjustment) => adjustment.amount);
   const correctionAmount = sumBy(activeAdjustments.filter((adjustment) => adjustment.adjustmentType === 'correction'), (adjustment) => adjustment.amount);
   const adjustmentAmount = Number((surchargeAmount + correctionAmount - discountAmount - writeOffAmount).toFixed(2));
@@ -704,6 +747,76 @@ export class SupabaseFinanceRepository implements FinanceRepository {
     const { data, error } = await query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
     if (error) throw error;
     return ((data ?? []) as Record<string, unknown>[]).map(mapFinancialAdjustmentRow);
+  }
+
+  async getPaymentRefundability(options: GetPaymentRefundabilityOptions): Promise<PaymentRefundability | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const paymentId = requireRecordId(options.paymentId);
+    try {
+      const payment = await this.getPaymentById({ tenantId, paymentId });
+      if (!payment) return null;
+      const [allocations, refunds] = await Promise.all([
+        this.listPaymentAllocations({ tenantId, paymentId, includeVoided: true, limit: MAX_FINANCE_LIMIT }),
+        this.listRefunds({ tenantId, paymentId, includeArchived: true, limit: MAX_FINANCE_LIMIT }),
+      ]);
+      const activeAllocatedAmount = sumBy(allocations.filter((row) => row.status === 'active'), (row) => row.amount);
+      const completedRefundAmount = sumBy(refunds.filter((row) => row.status === 'completed'), (row) => row.amount);
+      const reservedRefundAmount = sumBy(refunds.filter((row) => row.status === 'pending' || row.status === 'approved'), (row) => row.amount);
+      return {
+        payment,
+        paymentAmount: payment.amount,
+        activeAllocatedAmount,
+        completedRefundAmount,
+        reservedRefundAmount,
+        refundableAmount: Math.max(0, Number((payment.amount - activeAllocatedAmount - completedRefundAmount - reservedRefundAmount).toFixed(2))),
+        hasActiveAllocations: activeAllocatedAmount > 0,
+        refundCount: refunds.length,
+        currency: payment.currency,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown finance read failure';
+      throw new Error(`Finance refundability read failed: ${message}`, { cause: error });
+    }
+  }
+
+  async getInvoiceWriteOffEligibility(options: GetInvoiceWriteOffEligibilityOptions): Promise<InvoiceWriteOffEligibility | null> {
+    const tenantId = requireTenantId(options.tenantId);
+    const invoiceId = requireRecordId(options.invoiceId);
+    try {
+      const invoice = await this.getInvoiceById({ tenantId, invoiceId });
+      if (!invoice) return null;
+      const adjustments = await this.listFinancialAdjustments({
+        tenantId,
+        invoiceId,
+        adjustmentType: 'write_off',
+        includeArchived: true,
+        limit: MAX_FINANCE_LIMIT,
+      });
+      const approvedWriteOffAmount = sumBy(adjustments.filter((row) => row.status === 'approved'), (row) => row.amount);
+      const reservedWriteOffAmount = sumBy(adjustments.filter((row) => row.status === 'active'), (row) => row.amount);
+      const availableWriteOffAmount = Math.max(0, Number((invoice.totalAmount - invoice.paidAmount - approvedWriteOffAmount - reservedWriteOffAmount).toFixed(2)));
+      const eligibleStatuses: InvoiceStatus[] = ['issued', 'partially_paid'];
+      const eligible = eligibleStatuses.includes(invoice.status) && availableWriteOffAmount > 0;
+      const ineligibilityReason = eligible
+        ? null
+        : !eligibleStatuses.includes(invoice.status)
+          ? `Invoice status ${invoice.status} is not eligible for write-off.`
+          : 'Invoice has no available balance for write-off.';
+      return {
+        invoice,
+        invoiceTotalAmount: invoice.totalAmount,
+        paidAmount: invoice.paidAmount,
+        approvedWriteOffAmount,
+        reservedWriteOffAmount,
+        availableWriteOffAmount,
+        eligible,
+        ineligibilityReason,
+        currency: invoice.currency,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown finance read failure';
+      throw new Error(`Finance write-off eligibility read failed: ${message}`, { cause: error });
+    }
   }
 
   async getPatientFinanceFacts(options: PatientFinanceOptions): Promise<PatientFinanceFacts> {

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
 import {
   createFinanceRpcClient,
@@ -168,6 +168,59 @@ const paymentAllocationRow = {
   voided_at: null,
   created_at: '2026-06-21T03:00:01Z',
   updated_at: '2026-06-21T03:00:02Z',
+};
+
+const refundId = '88888888-8888-8888-8888-888888888888';
+const adjustmentId = '99999999-9999-9999-9999-999999999999';
+const refundRow = {
+  id: refundId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  payment_id: paymentId,
+  status: 'pending',
+  refund_method: 'cash',
+  amount: '400.00',
+  currency: 'KZT',
+  reason: 'Overpayment',
+  requested_by: 'cashier-1',
+  approved_by: null,
+  completed_by: null,
+  requested_at: '2026-06-21T04:00:00Z',
+  approved_at: null,
+  completed_at: null,
+  rejected_at: null,
+  voided_at: null,
+  voided_by: null,
+  void_reason: null,
+  external_reference: null,
+  idempotency_key: 'refund-1',
+  metadata: { source: 'refund' },
+  created_at: '2026-06-21T04:00:01Z',
+  updated_at: '2026-06-21T04:00:02Z',
+};
+
+const adjustmentRow = {
+  id: adjustmentId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  invoice_id: invoiceId,
+  invoice_item_id: null,
+  payment_id: null,
+  adjustment_type: 'write_off',
+  status: 'active',
+  amount: '400.00',
+  currency: 'KZT',
+  reason: 'Bad debt',
+  approved_by: null,
+  created_by: 'admin-1',
+  voided_by: null,
+  approved_at: null,
+  voided_at: null,
+  void_reason: null,
+  idempotency_key: 'writeoff-1',
+  metadata: { source: 'writeoff' },
+  created_at: '2026-06-21T05:00:01Z',
+  updated_at: '2026-06-21T05:00:02Z',
 };
 
 function sourceText() {
@@ -494,6 +547,17 @@ describe('FinanceRpcClient error behavior', () => {
     });
   });
 
+  it('hides raw structured Supabase error dumps', async () => {
+    const error = Object.assign(new Error('{"message":"denied","details":{"secret":"hidden"}}'), { code: '42501' });
+    const { rpcClient } = createClientMock({ data: null, error });
+    await expect(rpcClient.createInvoice({ tenantId, patientId })).rejects.toMatchObject({
+      name: 'FinanceRpcClientError',
+      operation: 'createInvoice',
+      code: '42501',
+      message: 'Не удалось выполнить финансовую операцию.',
+    });
+  });
+
   it('null data with no error is handled safely', async () => {
     const { rpcClient } = createClientMock({ data: null, error: null });
     await expect(rpcClient.createInvoice({ tenantId, patientId })).rejects.toMatchObject({
@@ -549,7 +613,7 @@ describe('FinanceRpcClient safety boundaries', () => {
     expect(source).not.toContain('balance =');
   });
 
-  it('client exposes only controlled invoice/payment RPC methods', () => {
+  it('client exposes controlled invoice, payment, refund, and write-off RPC methods', () => {
     const methods = Object.getOwnPropertyNames(SupabaseFinanceRpcClient.prototype);
     expect(methods).toEqual(expect.arrayContaining([
       'createInvoice',
@@ -560,9 +624,92 @@ describe('FinanceRpcClient safety boundaries', () => {
       'allocatePayment',
       'voidPaymentAllocation',
       'voidPayment',
+      'requestRefund',
+      'approveRefund',
+      'completeRefund',
+      'rejectRefund',
+      'voidRefund',
+      'requestInvoiceWriteOff',
+      'approveInvoiceWriteOff',
+      'rejectInvoiceWriteOff',
+      'voidInvoiceWriteOff',
     ]));
-    expect(methods.some((method) => method.toLowerCase().includes('refund'))).toBe(false);
-    expect(methods.some((method) => method.toLowerCase().includes('writeoff'))).toBe(false);
   });
 });
 
+
+
+describe('FinanceRpcClient refund and write-off lifecycle', () => {
+  it('maps all refund RPC names and exact p_* arguments', async () => {
+    const request = createClientMock({ data: [refundRow], error: null });
+    await request.rpcClient.requestRefund({ tenantId, paymentId, amount: 400, refundMethod: 'cash', reason: 'Overpayment', idempotencyKey: ' refund-1 ', metadata: { source: 'ui' } });
+    expect(request.rpcCalls).toEqual([{ rpcName: 'request_refund', params: {
+      p_tenant_id: tenantId, p_payment_id: paymentId, p_amount: 400, p_refund_method: 'cash',
+      p_reason: 'Overpayment', p_idempotency_key: 'refund-1', p_metadata: { source: 'ui' },
+    } }]);
+
+    const approve = createClientMock({ data: [refundRow], error: null });
+    await approve.rpcClient.approveRefund({ tenantId, refundId });
+    expect(approve.rpcCalls[0]).toEqual({ rpcName: 'approve_refund', params: { p_tenant_id: tenantId, p_refund_id: refundId } });
+
+    const complete = createClientMock({ data: [refundRow], error: null });
+    await complete.rpcClient.completeRefund({ tenantId, refundId, externalReference: 'EXT-1', metadata: { provider: false } });
+    expect(complete.rpcCalls[0]).toEqual({ rpcName: 'complete_refund', params: {
+      p_tenant_id: tenantId, p_refund_id: refundId, p_external_reference: 'EXT-1', p_metadata: { provider: false },
+    } });
+
+    const reject = createClientMock({ data: [refundRow], error: null });
+    await reject.rpcClient.rejectRefund({ tenantId, refundId, reason: 'Not approved' });
+    expect(reject.rpcCalls[0]).toEqual({ rpcName: 'reject_refund', params: { p_tenant_id: tenantId, p_refund_id: refundId, p_reason: 'Not approved' } });
+
+    const voided = createClientMock({ data: [refundRow], error: null });
+    await voided.rpcClient.voidRefund({ tenantId, refundId, reason: 'Cancelled' });
+    expect(voided.rpcCalls[0]).toEqual({ rpcName: 'void_refund', params: { p_tenant_id: tenantId, p_refund_id: refundId, p_reason: 'Cancelled' } });
+  });
+
+  it('maps all write-off RPC names and exact p_* arguments', async () => {
+    const request = createClientMock({ data: [adjustmentRow], error: null });
+    await request.rpcClient.requestInvoiceWriteOff({ tenantId, invoiceId, amount: 400, reason: 'Bad debt', idempotencyKey: ' writeoff-1 ', metadata: { source: 'ui' } });
+    expect(request.rpcCalls[0]).toEqual({ rpcName: 'request_invoice_write_off', params: {
+      p_tenant_id: tenantId, p_invoice_id: invoiceId, p_amount: 400, p_reason: 'Bad debt',
+      p_idempotency_key: 'writeoff-1', p_metadata: { source: 'ui' },
+    } });
+
+    const approve = createClientMock({ data: [adjustmentRow], error: null });
+    await approve.rpcClient.approveInvoiceWriteOff({ tenantId, adjustmentId });
+    expect(approve.rpcCalls[0]).toEqual({ rpcName: 'approve_invoice_write_off', params: { p_tenant_id: tenantId, p_adjustment_id: adjustmentId } });
+
+    const reject = createClientMock({ data: [adjustmentRow], error: null });
+    await reject.rpcClient.rejectInvoiceWriteOff({ tenantId, adjustmentId, reason: 'No evidence' });
+    expect(reject.rpcCalls[0]).toEqual({ rpcName: 'reject_invoice_write_off', params: { p_tenant_id: tenantId, p_adjustment_id: adjustmentId, p_reason: 'No evidence' } });
+
+    const voided = createClientMock({ data: [adjustmentRow], error: null });
+    await voided.rpcClient.voidInvoiceWriteOff({ tenantId, adjustmentId, reason: 'Reversed' });
+    expect(voided.rpcCalls[0]).toEqual({ rpcName: 'void_invoice_write_off', params: { p_tenant_id: tenantId, p_adjustment_id: adjustmentId, p_reason: 'Reversed' } });
+  });
+
+  it('maps refund and write-off results including idempotency keys', async () => {
+    const refund = createClientMock({ data: [refundRow], error: null });
+    await expect(refund.rpcClient.requestRefund({ tenantId, paymentId, amount: 400, refundMethod: 'cash', reason: 'Overpayment' }))
+      .resolves.toMatchObject({ id: refundId, paymentId, amount: 400, idempotencyKey: 'refund-1' });
+    const adjustment = createClientMock({ data: [adjustmentRow], error: null });
+    await expect(adjustment.rpcClient.requestInvoiceWriteOff({ tenantId, invoiceId, amount: 400, reason: 'Bad debt' }))
+      .resolves.toMatchObject({ id: adjustmentId, invoiceId, amount: 400, idempotencyKey: 'writeoff-1' });
+  });
+
+  it('validates refund and write-off IDs, amounts, methods, reasons, metadata, and idempotency keys', async () => {
+    const refund = createClientMock({ data: [refundRow], error: null }).rpcClient;
+    await expectFinanceClientError(refund.requestRefund({ tenantId, paymentId, amount: 0, refundMethod: 'cash', reason: 'x' }), 'Сумма возврата должна быть больше 0.');
+    await expectFinanceClientError(refund.requestRefund({ tenantId, paymentId, amount: 1, refundMethod: 'crypto' as never, reason: 'x' }), 'Некорректный способ возврата.');
+    await expectFinanceClientError(refund.requestRefund({ tenantId, paymentId, amount: 1, refundMethod: 'cash', reason: ' ' }), 'Причина возврата обязательна.');
+    await expectFinanceClientError(refund.requestRefund({ tenantId, paymentId, amount: 1, refundMethod: 'cash', reason: 'x', idempotencyKey: ' ' }), 'Ключ идемпотентности не должен быть пустым.');
+    await expectFinanceClientError(refund.completeRefund({ tenantId, refundId, metadata: [] as never }), 'Метаданные должны быть объектом.');
+    await expectFinanceClientError(refund.approveRefund({ tenantId, refundId: '' }), 'Возврат не выбран.');
+
+    const writeOff = createClientMock({ data: [adjustmentRow], error: null }).rpcClient;
+    await expectFinanceClientError(writeOff.requestInvoiceWriteOff({ tenantId, invoiceId, amount: -1, reason: 'x' }), 'Сумма списания должна быть больше 0.');
+    await expectFinanceClientError(writeOff.requestInvoiceWriteOff({ tenantId, invoiceId, amount: 1, reason: '' }), 'Причина списания обязательна.');
+    await expectFinanceClientError(writeOff.requestInvoiceWriteOff({ tenantId, invoiceId, amount: 1, reason: 'x', metadata: null as never }), 'Метаданные должны быть объектом.');
+    await expectFinanceClientError(writeOff.approveInvoiceWriteOff({ tenantId, adjustmentId: '' }), 'Списание не выбрано.');
+  });
+});

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -1,15 +1,20 @@
-﻿import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { supabase as defaultSupabase } from '../../lib/supabaseClient';
 import {
   mapInvoiceItemRow,
   mapInvoiceRow,
   mapPaymentAllocationRow,
   mapPaymentRow,
+  mapRefundRow,
+  mapFinancialAdjustmentRow,
   type Invoice,
   type InvoiceItem,
   type Payment,
   type PaymentAllocation,
   type PaymentMethod,
+  type Refund,
+  type RefundMethod,
+  type FinancialAdjustment,
 } from './FinanceRepository';
 
 export interface FinanceRpcClientErrorDetails {
@@ -100,6 +105,38 @@ export interface VoidPaymentInput {
   reason: string;
 }
 
+export interface RequestRefundInput {
+  tenantId: string;
+  paymentId: string;
+  amount: number;
+  refundMethod: RefundMethod;
+  reason: string;
+  idempotencyKey?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ApproveRefundInput { tenantId: string; refundId: string; }
+export interface CompleteRefundInput {
+  tenantId: string;
+  refundId: string;
+  externalReference?: string | null;
+  metadata?: Record<string, unknown>;
+}
+export interface RejectRefundInput { tenantId: string; refundId: string; reason: string; }
+export interface VoidRefundInput { tenantId: string; refundId: string; reason: string; }
+
+export interface RequestInvoiceWriteOffInput {
+  tenantId: string;
+  invoiceId: string;
+  amount: number;
+  reason: string;
+  idempotencyKey?: string | null;
+  metadata?: Record<string, unknown>;
+}
+export interface ApproveInvoiceWriteOffInput { tenantId: string; adjustmentId: string; }
+export interface RejectInvoiceWriteOffInput { tenantId: string; adjustmentId: string; reason: string; }
+export interface VoidInvoiceWriteOffInput { tenantId: string; adjustmentId: string; reason: string; }
+
 export interface FinanceRpcClient {
   createInvoice(input: CreateInvoiceInput): Promise<Invoice>;
   addInvoiceItem(input: AddInvoiceItemInput): Promise<InvoiceItem>;
@@ -109,6 +146,15 @@ export interface FinanceRpcClient {
   allocatePayment(input: AllocatePaymentInput): Promise<PaymentAllocation>;
   voidPaymentAllocation(input: VoidPaymentAllocationInput): Promise<PaymentAllocation>;
   voidPayment(input: VoidPaymentInput): Promise<Payment>;
+  requestRefund(input: RequestRefundInput): Promise<Refund>;
+  approveRefund(input: ApproveRefundInput): Promise<Refund>;
+  completeRefund(input: CompleteRefundInput): Promise<Refund>;
+  rejectRefund(input: RejectRefundInput): Promise<Refund>;
+  voidRefund(input: VoidRefundInput): Promise<Refund>;
+  requestInvoiceWriteOff(input: RequestInvoiceWriteOffInput): Promise<FinancialAdjustment>;
+  approveInvoiceWriteOff(input: ApproveInvoiceWriteOffInput): Promise<FinancialAdjustment>;
+  rejectInvoiceWriteOff(input: RejectInvoiceWriteOffInput): Promise<FinancialAdjustment>;
+  voidInvoiceWriteOff(input: VoidInvoiceWriteOffInput): Promise<FinancialAdjustment>;
 }
 
 export type FinanceRpcClientBackend = 'supabase' | 'local';
@@ -129,6 +175,9 @@ const PAYMENT_METHODS: readonly PaymentMethod[] = [
   'osms',
   'mixed',
   'other',
+];
+const REFUND_METHODS: readonly RefundMethod[] = [
+  'cash', 'kaspi', 'halyk_terminal', 'card', 'bank_transfer', 'other',
 ];
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -182,15 +231,24 @@ function extractSingleRow(data: unknown, operation: string): Record<string, unkn
   return row;
 }
 
+function safeRpcErrorDetail(error: Error): string {
+  const raw = error.message.trim();
+  if (!raw || raw.length > 240 || /[\r\n{}]/.test(raw) || raw.includes('[') || raw.includes(']')) return '';
+  return raw.replace(/\s+/g, ' ');
+}
+
 function normalizeRpcError(error: unknown, operation: string): FinanceRpcClientError {
   if (error instanceof FinanceRpcClientError) return error;
   if (error instanceof Error) {
     const errorWithCode = error as unknown as { code?: unknown };
     const code = typeof errorWithCode.code === 'string' ? errorWithCode.code : undefined;
+    const detail = safeRpcErrorDetail(error);
     return new FinanceRpcClientError({
       operation,
       code,
-      message: `${FINANCE_RPC_OPERATION_FAILED_MESSAGE} ${error.message}`.trim(),
+      message: detail
+        ? `${FINANCE_RPC_OPERATION_FAILED_MESSAGE} ${detail}`
+        : FINANCE_RPC_OPERATION_FAILED_MESSAGE,
     });
   }
   return new FinanceRpcClientError({ operation, message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
@@ -213,6 +271,23 @@ function validatePaymentMethod(paymentMethod: PaymentMethod | null | undefined):
     throw new FinanceRpcClientError({ operation: 'validation', message: 'Некорректный способ оплаты.' });
   }
   return method;
+}
+
+function validateRefundMethod(refundMethod: RefundMethod | null | undefined): RefundMethod {
+  const method = requireNonEmptyString(refundMethod, 'Способ возврата обязателен.') as RefundMethod;
+  if (!REFUND_METHODS.includes(method)) {
+    throw new FinanceRpcClientError({ operation: 'validation', message: 'Некорректный способ возврата.' });
+  }
+  return method;
+}
+
+function normalizeIdempotencyKey(value?: string | null): string | null {
+  if (value === undefined || value === null) return null;
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new FinanceRpcClientError({ operation: 'validation', message: 'Ключ идемпотентности не должен быть пустым.' });
+  }
+  return normalized;
 }
 
 export class SupabaseFinanceRpcClient implements FinanceRpcClient {
@@ -353,6 +428,102 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
       p_reason: reason,
     });
     return mapPaymentRow(row);
+  }
+
+  async requestRefund(input: RequestRefundInput): Promise<Refund> {
+    const operation = 'requestRefund';
+    const row = await callRpc(this.client, operation, 'request_refund', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_payment_id: requireNonEmptyString(input.paymentId, 'Платёж не выбран.'),
+      p_amount: requirePositiveNumber(input.amount, 'Сумма возврата должна быть больше 0.'),
+      p_refund_method: validateRefundMethod(input.refundMethod),
+      p_reason: requireNonEmptyString(input.reason, 'Причина возврата обязательна.'),
+      p_idempotency_key: normalizeIdempotencyKey(input.idempotencyKey),
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapRefundRow(row);
+  }
+
+  async approveRefund(input: ApproveRefundInput): Promise<Refund> {
+    const operation = 'approveRefund';
+    const row = await callRpc(this.client, operation, 'approve_refund', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_refund_id: requireNonEmptyString(input.refundId, 'Возврат не выбран.'),
+    });
+    return mapRefundRow(row);
+  }
+
+  async completeRefund(input: CompleteRefundInput): Promise<Refund> {
+    const operation = 'completeRefund';
+    const row = await callRpc(this.client, operation, 'complete_refund', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_refund_id: requireNonEmptyString(input.refundId, 'Возврат не выбран.'),
+      p_external_reference: input.externalReference || null,
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapRefundRow(row);
+  }
+
+  async rejectRefund(input: RejectRefundInput): Promise<Refund> {
+    const operation = 'rejectRefund';
+    const row = await callRpc(this.client, operation, 'reject_refund', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_refund_id: requireNonEmptyString(input.refundId, 'Возврат не выбран.'),
+      p_reason: requireNonEmptyString(input.reason, 'Причина отказа обязательна.'),
+    });
+    return mapRefundRow(row);
+  }
+
+  async voidRefund(input: VoidRefundInput): Promise<Refund> {
+    const operation = 'voidRefund';
+    const row = await callRpc(this.client, operation, 'void_refund', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_refund_id: requireNonEmptyString(input.refundId, 'Возврат не выбран.'),
+      p_reason: requireNonEmptyString(input.reason, 'Причина отмены обязательна.'),
+    });
+    return mapRefundRow(row);
+  }
+
+  async requestInvoiceWriteOff(input: RequestInvoiceWriteOffInput): Promise<FinancialAdjustment> {
+    const operation = 'requestInvoiceWriteOff';
+    const row = await callRpc(this.client, operation, 'request_invoice_write_off', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_invoice_id: requireNonEmptyString(input.invoiceId, 'Счёт не выбран.'),
+      p_amount: requirePositiveNumber(input.amount, 'Сумма списания должна быть больше 0.'),
+      p_reason: requireNonEmptyString(input.reason, 'Причина списания обязательна.'),
+      p_idempotency_key: normalizeIdempotencyKey(input.idempotencyKey),
+      p_metadata: normalizeMetadata(input.metadata),
+    });
+    return mapFinancialAdjustmentRow(row);
+  }
+
+  async approveInvoiceWriteOff(input: ApproveInvoiceWriteOffInput): Promise<FinancialAdjustment> {
+    const operation = 'approveInvoiceWriteOff';
+    const row = await callRpc(this.client, operation, 'approve_invoice_write_off', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_adjustment_id: requireNonEmptyString(input.adjustmentId, 'Списание не выбрано.'),
+    });
+    return mapFinancialAdjustmentRow(row);
+  }
+
+  async rejectInvoiceWriteOff(input: RejectInvoiceWriteOffInput): Promise<FinancialAdjustment> {
+    const operation = 'rejectInvoiceWriteOff';
+    const row = await callRpc(this.client, operation, 'reject_invoice_write_off', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_adjustment_id: requireNonEmptyString(input.adjustmentId, 'Списание не выбрано.'),
+      p_reason: requireNonEmptyString(input.reason, 'Причина отказа обязательна.'),
+    });
+    return mapFinancialAdjustmentRow(row);
+  }
+
+  async voidInvoiceWriteOff(input: VoidInvoiceWriteOffInput): Promise<FinancialAdjustment> {
+    const operation = 'voidInvoiceWriteOff';
+    const row = await callRpc(this.client, operation, 'void_invoice_write_off', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_adjustment_id: requireNonEmptyString(input.adjustmentId, 'Списание не выбрано.'),
+      p_reason: requireNonEmptyString(input.reason, 'Причина отмены обязательна.'),
+    });
+    return mapFinancialAdjustmentRow(row);
   }
 }
 

--- a/supabase/migrations/0018_create_refund_writeoff_rpc.sql
+++ b/supabase/migrations/0018_create_refund_writeoff_rpc.sql
@@ -1,0 +1,1187 @@
+-- 0018_create_refund_writeoff_rpc.sql
+-- Controlled backend lifecycle for refunds and invoice write-offs.
+-- Refunds return only currently unallocated payment funds.
+-- Write-offs reduce invoice debt without creating or changing payment facts.
+
+ALTER TABLE public.refunds
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+ALTER TABLE public.financial_adjustments
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_refunds_tenant_idempotency_key
+  ON public.refunds (tenant_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_financial_adjustments_tenant_idempotency_key
+  ON public.financial_adjustments (tenant_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+ALTER TABLE public.refunds
+  DROP CONSTRAINT IF EXISTS refunds_idempotency_key_non_empty_check;
+ALTER TABLE public.refunds
+  ADD CONSTRAINT refunds_idempotency_key_non_empty_check
+  CHECK (idempotency_key IS NULL OR length(btrim(idempotency_key)) > 0);
+
+ALTER TABLE public.financial_adjustments
+  DROP CONSTRAINT IF EXISTS financial_adjustments_idempotency_key_non_empty_check;
+ALTER TABLE public.financial_adjustments
+  ADD CONSTRAINT financial_adjustments_idempotency_key_non_empty_check
+  CHECK (idempotency_key IS NULL OR length(btrim(idempotency_key)) > 0);
+
+ALTER TABLE public.refunds
+  DROP CONSTRAINT IF EXISTS refunds_approved_state_check;
+ALTER TABLE public.refunds
+  ADD CONSTRAINT refunds_approved_state_check
+  CHECK (
+    status NOT IN ('approved', 'completed')
+    OR (approved_at IS NOT NULL AND approved_by IS NOT NULL)
+  );
+
+ALTER TABLE public.refunds
+  DROP CONSTRAINT IF EXISTS refunds_completed_actor_check;
+ALTER TABLE public.refunds
+  ADD CONSTRAINT refunds_completed_actor_check
+  CHECK (status <> 'completed' OR completed_by IS NOT NULL);
+
+ALTER TABLE public.refunds
+  DROP CONSTRAINT IF EXISTS refunds_rejected_at_check;
+ALTER TABLE public.refunds
+  ADD CONSTRAINT refunds_rejected_at_check
+  CHECK (status <> 'rejected' OR rejected_at IS NOT NULL);
+
+ALTER TABLE public.financial_adjustments
+  DROP CONSTRAINT IF EXISTS financial_adjustments_approved_state_check;
+ALTER TABLE public.financial_adjustments
+  ADD CONSTRAINT financial_adjustments_approved_state_check
+  CHECK (
+    status <> 'approved'
+    OR (approved_at IS NOT NULL AND approved_by IS NOT NULL)
+  );
+
+CREATE OR REPLACE FUNCTION public.sanitize_finance_metadata_internal(
+  p_metadata jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_metadata jsonb := COALESCE(p_metadata, '{}'::jsonb);
+BEGIN
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
+  IF octet_length(v_metadata::text) > 16384 THEN
+    RAISE EXCEPTION 'Metadata is too large';
+  END IF;
+
+  RETURN jsonb_strip_nulls(v_metadata);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.payment_active_allocation_total_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_allocation_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(sum(amount), 0)::numeric(12,2)
+  FROM public.payment_allocations
+  WHERE tenant_id = p_tenant_id
+    AND payment_id = p_payment_id
+    AND status = 'active'
+    AND (p_exclude_allocation_id IS NULL OR id <> p_exclude_allocation_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.payment_completed_refund_total_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_refund_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(sum(amount), 0)::numeric(12,2)
+  FROM public.refunds
+  WHERE tenant_id = p_tenant_id
+    AND payment_id = p_payment_id
+    AND status = 'completed'
+    AND (p_exclude_refund_id IS NULL OR id <> p_exclude_refund_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.payment_reserved_refund_total_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_refund_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(sum(amount), 0)::numeric(12,2)
+  FROM public.refunds
+  WHERE tenant_id = p_tenant_id
+    AND payment_id = p_payment_id
+    AND status IN ('pending', 'approved')
+    AND (p_exclude_refund_id IS NULL OR id <> p_exclude_refund_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.payment_refundable_amount_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_refund_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_amount numeric(12,2);
+  v_allocated numeric(12,2);
+  v_completed numeric(12,2);
+  v_reserved numeric(12,2);
+BEGIN
+  SELECT amount INTO v_amount
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = p_payment_id;
+
+  IF v_amount IS NULL THEN
+    RAISE EXCEPTION 'Payment not found in this tenant';
+  END IF;
+
+  v_allocated := public.payment_active_allocation_total_internal(p_tenant_id, p_payment_id);
+  v_completed := public.payment_completed_refund_total_internal(p_tenant_id, p_payment_id, p_exclude_refund_id);
+  v_reserved := public.payment_reserved_refund_total_internal(p_tenant_id, p_payment_id, p_exclude_refund_id);
+
+  RETURN GREATEST(0, v_amount - v_allocated - v_completed - v_reserved)::numeric(12,2);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.invoice_approved_writeoff_total_internal(
+  p_tenant_id uuid,
+  p_invoice_id uuid,
+  p_exclude_adjustment_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(sum(fa.amount), 0)::numeric(12,2)
+  FROM public.financial_adjustments fa
+  LEFT JOIN public.invoice_items ii
+    ON ii.id = fa.invoice_item_id
+   AND ii.tenant_id = fa.tenant_id
+  WHERE fa.tenant_id = p_tenant_id
+    AND fa.adjustment_type = 'write_off'
+    AND fa.status = 'approved'
+    AND (fa.invoice_id = p_invoice_id OR ii.invoice_id = p_invoice_id)
+    AND (p_exclude_adjustment_id IS NULL OR fa.id <> p_exclude_adjustment_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.invoice_reserved_writeoff_total_internal(
+  p_tenant_id uuid,
+  p_invoice_id uuid,
+  p_exclude_adjustment_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(sum(fa.amount), 0)::numeric(12,2)
+  FROM public.financial_adjustments fa
+  LEFT JOIN public.invoice_items ii
+    ON ii.id = fa.invoice_item_id
+   AND ii.tenant_id = fa.tenant_id
+  WHERE fa.tenant_id = p_tenant_id
+    AND fa.adjustment_type = 'write_off'
+    AND fa.status = 'active'
+    AND (fa.invoice_id = p_invoice_id OR ii.invoice_id = p_invoice_id)
+    AND (p_exclude_adjustment_id IS NULL OR fa.id <> p_exclude_adjustment_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.invoice_available_writeoff_amount_internal(
+  p_tenant_id uuid,
+  p_invoice_id uuid,
+  p_exclude_adjustment_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_total numeric(12,2);
+  v_paid numeric(12,2);
+  v_approved numeric(12,2);
+  v_reserved numeric(12,2);
+BEGIN
+  SELECT total_amount INTO v_total
+  FROM public.invoices
+  WHERE tenant_id = p_tenant_id AND id = p_invoice_id;
+
+  IF v_total IS NULL THEN
+    RAISE EXCEPTION 'Invoice not found in this tenant';
+  END IF;
+
+  SELECT COALESCE(sum(pa.amount), 0)::numeric(12,2)
+  INTO v_paid
+  FROM public.payment_allocations pa
+  LEFT JOIN public.invoice_items ii
+    ON ii.id = pa.invoice_item_id
+   AND ii.tenant_id = pa.tenant_id
+  WHERE pa.tenant_id = p_tenant_id
+    AND pa.status = 'active'
+    AND (pa.invoice_id = p_invoice_id OR ii.invoice_id = p_invoice_id);
+
+  v_approved := public.invoice_approved_writeoff_total_internal(
+    p_tenant_id, p_invoice_id, p_exclude_adjustment_id
+  );
+  v_reserved := public.invoice_reserved_writeoff_total_internal(
+    p_tenant_id, p_invoice_id, p_exclude_adjustment_id
+  );
+
+  RETURN GREATEST(0, v_total - v_paid - v_approved - v_reserved)::numeric(12,2);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.recalculate_invoice_financials_internal(
+  p_invoice_id uuid
+) RETURNS public.invoices
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invoice public.invoices;
+  v_subtotal numeric(12,2) := 0;
+  v_discount numeric(12,2) := 0;
+  v_adjustment numeric(12,2) := 0;
+  v_total numeric(12,2) := 0;
+  v_paid numeric(12,2) := 0;
+  v_written_off numeric(12,2) := 0;
+  v_balance numeric(12,2) := 0;
+  v_next_status text;
+BEGIN
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = p_invoice_id
+  FOR UPDATE;
+
+  IF v_invoice.id IS NULL THEN
+    RAISE EXCEPTION 'Invoice not found';
+  END IF;
+
+  SELECT
+    COALESCE(sum(quantity * unit_price), 0)::numeric(12,2),
+    COALESCE(sum(discount_amount), 0)::numeric(12,2),
+    COALESCE(sum(adjustment_amount), 0)::numeric(12,2),
+    COALESCE(sum(total_amount), 0)::numeric(12,2)
+  INTO v_subtotal, v_discount, v_adjustment, v_total
+  FROM public.invoice_items
+  WHERE tenant_id = v_invoice.tenant_id
+    AND invoice_id = p_invoice_id
+    AND status IN ('active', 'adjusted');
+
+  SELECT COALESCE(sum(pa.amount), 0)::numeric(12,2)
+  INTO v_paid
+  FROM public.payment_allocations pa
+  LEFT JOIN public.invoice_items ii
+    ON ii.id = pa.invoice_item_id
+   AND ii.tenant_id = pa.tenant_id
+  WHERE pa.tenant_id = v_invoice.tenant_id
+    AND pa.status = 'active'
+    AND (pa.invoice_id = p_invoice_id OR ii.invoice_id = p_invoice_id);
+
+  v_written_off := public.invoice_approved_writeoff_total_internal(
+    v_invoice.tenant_id, p_invoice_id
+  );
+
+  IF v_paid + v_written_off > v_total THEN
+    RAISE EXCEPTION 'Invoice financial invariant violated: payments plus write-offs exceed total amount';
+  END IF;
+
+  v_balance := GREATEST(0, v_total - v_paid - v_written_off)::numeric(12,2);
+  v_next_status := v_invoice.status;
+
+  IF v_invoice.status NOT IN ('draft', 'voided', 'archived') THEN
+    IF v_balance = 0 AND v_written_off > 0 THEN
+      v_next_status := 'written_off';
+    ELSIF v_balance = 0 AND v_written_off = 0 THEN
+      v_next_status := 'paid';
+    ELSIF v_balance > 0 AND v_paid > 0 THEN
+      v_next_status := 'partially_paid';
+    ELSE
+      v_next_status := 'issued';
+    END IF;
+  END IF;
+
+  UPDATE public.invoices
+  SET subtotal_amount = v_subtotal,
+      discount_amount = v_discount,
+      adjustment_amount = v_adjustment,
+      total_amount = v_total,
+      paid_amount = v_paid,
+      refunded_amount = COALESCE(refunded_amount, 0),
+      written_off_amount = v_written_off,
+      balance_amount = v_balance,
+      status = v_next_status
+  WHERE id = p_invoice_id
+  RETURNING * INTO v_invoice;
+
+  RETURN v_invoice;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.recalculate_payment_status_internal(
+  p_payment_id uuid
+) RETURNS public.payments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_allocated numeric(12,2) := 0;
+  v_refunded numeric(12,2) := 0;
+  v_next_status text;
+BEGIN
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE id = p_payment_id
+  FOR UPDATE;
+
+  IF v_payment.id IS NULL THEN
+    RAISE EXCEPTION 'Payment not found';
+  END IF;
+
+  v_allocated := public.payment_active_allocation_total_internal(
+    v_payment.tenant_id, p_payment_id
+  );
+  v_refunded := public.payment_completed_refund_total_internal(
+    v_payment.tenant_id, p_payment_id
+  );
+
+  IF v_allocated + v_refunded > v_payment.amount THEN
+    RAISE EXCEPTION 'Payment financial invariant violated: allocations plus completed refunds exceed payment amount';
+  END IF;
+
+  v_next_status := v_payment.status;
+
+  IF v_payment.status NOT IN ('voided', 'archived') THEN
+    IF v_refunded >= v_payment.amount THEN
+      v_next_status := 'refunded';
+    ELSIF v_refunded > 0 THEN
+      v_next_status := 'partially_refunded';
+    ELSIF v_allocated >= v_payment.amount THEN
+      v_next_status := 'allocated';
+    ELSIF v_allocated > 0 THEN
+      v_next_status := 'partially_allocated';
+    ELSE
+      v_next_status := 'received';
+    END IF;
+  END IF;
+
+  UPDATE public.payments
+  SET status = v_next_status
+  WHERE id = p_payment_id
+  RETURNING * INTO v_payment;
+
+  RETURN v_payment;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_payment_allocation_capacity_internal()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_allocated numeric(12,2);
+  v_completed numeric(12,2);
+  v_reserved numeric(12,2);
+  v_invoice_id uuid;
+  v_invoice_total numeric(12,2);
+  v_invoice_allocated numeric(12,2);
+  v_writeoffs numeric(12,2);
+  v_writeoff_reserved numeric(12,2);
+BEGIN
+  IF NEW.status <> 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = NEW.tenant_id AND id = NEW.payment_id
+  FOR UPDATE;
+
+  IF v_payment.id IS NULL THEN
+    RAISE EXCEPTION 'Payment not found in this tenant';
+  END IF;
+
+  v_allocated := public.payment_active_allocation_total_internal(
+    NEW.tenant_id, NEW.payment_id, NEW.id
+  );
+  v_completed := public.payment_completed_refund_total_internal(
+    NEW.tenant_id, NEW.payment_id
+  );
+  v_reserved := public.payment_reserved_refund_total_internal(
+    NEW.tenant_id, NEW.payment_id
+  );
+
+  IF v_allocated + NEW.amount + v_completed + v_reserved > v_payment.amount THEN
+    RAISE EXCEPTION 'Allocation amount exceeds payment capacity after refunds and reserved refunds';
+  END IF;
+
+  IF NEW.invoice_id IS NOT NULL THEN
+    v_invoice_id := NEW.invoice_id;
+  ELSE
+    SELECT invoice_id INTO v_invoice_id
+    FROM public.invoice_items
+    WHERE tenant_id = NEW.tenant_id AND id = NEW.invoice_item_id;
+  END IF;
+
+  IF v_invoice_id IS NOT NULL THEN
+    SELECT total_amount INTO v_invoice_total
+    FROM public.invoices
+    WHERE tenant_id = NEW.tenant_id AND id = v_invoice_id
+    FOR UPDATE;
+
+    SELECT COALESCE(sum(pa.amount), 0)::numeric(12,2)
+    INTO v_invoice_allocated
+    FROM public.payment_allocations pa
+    LEFT JOIN public.invoice_items ii
+      ON ii.id = pa.invoice_item_id
+     AND ii.tenant_id = pa.tenant_id
+    WHERE pa.tenant_id = NEW.tenant_id
+      AND pa.status = 'active'
+      AND pa.id <> NEW.id
+      AND (pa.invoice_id = v_invoice_id OR ii.invoice_id = v_invoice_id);
+
+    v_writeoffs := public.invoice_approved_writeoff_total_internal(
+      NEW.tenant_id, v_invoice_id
+    );
+    v_writeoff_reserved := public.invoice_reserved_writeoff_total_internal(
+      NEW.tenant_id, v_invoice_id
+    );
+
+    IF v_invoice_allocated + NEW.amount + v_writeoffs + v_writeoff_reserved > v_invoice_total THEN
+      RAISE EXCEPTION 'Allocation amount exceeds invoice capacity after write-offs and reserved write-offs';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS payment_allocations_capacity_guard ON public.payment_allocations;
+CREATE TRIGGER payment_allocations_capacity_guard
+BEFORE INSERT OR UPDATE OF amount, status, payment_id, invoice_id, invoice_item_id
+ON public.payment_allocations
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_payment_allocation_capacity_internal();
+
+CREATE OR REPLACE FUNCTION public.enforce_payment_refund_void_guard_internal()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $payment_refund_guard$
+BEGIN
+  IF NEW.status = 'voided' AND OLD.status <> 'voided' AND EXISTS (
+    SELECT 1
+    FROM public.refunds
+    WHERE tenant_id = NEW.tenant_id
+      AND payment_id = NEW.id
+      AND status IN ('pending', 'approved', 'completed')
+  ) THEN
+    RAISE EXCEPTION 'Payment with active or completed refunds cannot be voided';
+  END IF;
+
+  RETURN NEW;
+END;
+$payment_refund_guard$;
+
+DROP TRIGGER IF EXISTS payments_refund_void_guard ON public.payments;
+CREATE TRIGGER payments_refund_void_guard
+BEFORE UPDATE OF status ON public.payments
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_payment_refund_void_guard_internal();
+
+CREATE OR REPLACE FUNCTION public.enforce_invoice_writeoff_void_guard_internal()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $invoice_writeoff_guard$
+BEGIN
+  IF NEW.status = 'voided' AND OLD.status <> 'voided' AND EXISTS (
+    SELECT 1
+    FROM public.financial_adjustments fa
+    LEFT JOIN public.invoice_items ii
+      ON ii.tenant_id = fa.tenant_id
+     AND ii.id = fa.invoice_item_id
+    WHERE fa.tenant_id = NEW.tenant_id
+      AND fa.adjustment_type = 'write_off'
+      AND fa.status IN ('active', 'approved')
+      AND (fa.invoice_id = NEW.id OR ii.invoice_id = NEW.id)
+  ) THEN
+    RAISE EXCEPTION 'Invoice with active or approved write-offs cannot be voided';
+  END IF;
+
+  RETURN NEW;
+END;
+$invoice_writeoff_guard$;
+
+DROP TRIGGER IF EXISTS invoices_writeoff_void_guard ON public.invoices;
+CREATE TRIGGER invoices_writeoff_void_guard
+BEFORE UPDATE OF status ON public.invoices
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_invoice_writeoff_void_guard_internal();
+
+CREATE OR REPLACE FUNCTION public.request_refund(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_amount numeric,
+  p_refund_method text,
+  p_reason text,
+  p_idempotency_key text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.refunds
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_refund public.refunds;
+  v_metadata jsonb;
+  v_idempotency_key text := NULLIF(btrim(p_idempotency_key), '');
+  v_refundable numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+
+  IF p_payment_id IS NULL THEN RAISE EXCEPTION 'Payment ID is required'; END IF;
+  IF COALESCE(p_amount, 0) <= 0 THEN RAISE EXCEPTION 'Refund amount must be positive'; END IF;
+  IF p_refund_method IS NULL OR p_refund_method NOT IN ('cash', 'kaspi', 'halyk_terminal', 'card', 'bank_transfer', 'other') THEN
+    RAISE EXCEPTION 'Unsupported refund method: %', p_refund_method;
+  END IF;
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN RAISE EXCEPTION 'Refund reason is required'; END IF;
+  IF p_idempotency_key IS NOT NULL AND v_idempotency_key IS NULL THEN RAISE EXCEPTION 'Idempotency key must not be empty'; END IF;
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = p_payment_id
+  FOR UPDATE;
+
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  IF v_payment.status IN ('voided', 'archived') THEN
+    RAISE EXCEPTION 'Cannot refund payment with status %', v_payment.status;
+  END IF;
+
+  IF v_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_refund
+    FROM public.refunds
+    WHERE tenant_id = p_tenant_id AND idempotency_key = v_idempotency_key;
+
+    IF v_refund.id IS NOT NULL THEN
+      IF v_refund.payment_id <> p_payment_id
+         OR v_refund.amount <> p_amount::numeric(12,2)
+         OR v_refund.refund_method <> p_refund_method THEN
+        RAISE EXCEPTION 'Idempotency key is already used for a different refund request';
+      END IF;
+      RETURN v_refund;
+    END IF;
+  END IF;
+
+  v_refundable := public.payment_refundable_amount_internal(p_tenant_id, p_payment_id);
+  IF p_amount > v_refundable THEN
+    RAISE EXCEPTION 'Refund amount exceeds currently unallocated refundable amount';
+  END IF;
+
+  INSERT INTO public.refunds (
+    tenant_id, patient_id, payment_id, status, refund_method, amount, currency,
+    reason, requested_by, requested_at, metadata, idempotency_key
+  ) VALUES (
+    p_tenant_id, v_payment.patient_id, v_payment.id, 'pending', p_refund_method,
+    p_amount, v_payment.currency, btrim(p_reason), auth.uid(), now(), v_metadata, v_idempotency_key
+  ) RETURNING * INTO v_refund;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'refund_requested', 'refund', v_refund.id,
+    v_refund.patient_id, v_refund.payment_id, v_refund.reason,
+    jsonb_build_object(
+      'refundId', v_refund.id, 'paymentId', v_refund.payment_id,
+      'amount', v_refund.amount, 'currency', v_refund.currency,
+      'fromStatus', NULL, 'toStatus', 'pending'
+    )
+  );
+
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.approve_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid
+) RETURNS public.refunds
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_refund public.refunds;
+  v_payment public.payments;
+  v_refundable numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+
+  SELECT * INTO v_refund
+  FROM public.refunds
+  WHERE tenant_id = p_tenant_id AND id = p_refund_id
+  FOR UPDATE;
+
+  IF v_refund.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  IF v_refund.status IN ('approved', 'completed') THEN RETURN v_refund; END IF;
+  IF v_refund.status <> 'pending' THEN RAISE EXCEPTION 'Only pending refunds can be approved'; END IF;
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = v_refund.payment_id
+  FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  IF v_payment.status IN ('voided', 'archived') THEN RAISE EXCEPTION 'Cannot approve refund for payment with status %', v_payment.status; END IF;
+
+  v_refundable := public.payment_refundable_amount_internal(p_tenant_id, v_payment.id, v_refund.id);
+  IF v_refund.amount > v_refundable THEN RAISE EXCEPTION 'Refund amount exceeds currently refundable amount'; END IF;
+
+  UPDATE public.refunds
+  SET status = 'approved', approved_by = auth.uid(), approved_at = now()
+  WHERE id = v_refund.id
+  RETURNING * INTO v_refund;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'refund_approved', 'refund', v_refund.id,
+    v_refund.patient_id, v_refund.payment_id,
+    p_metadata => jsonb_build_object(
+      'refundId', v_refund.id, 'paymentId', v_refund.payment_id,
+      'amount', v_refund.amount, 'currency', v_refund.currency,
+      'fromStatus', 'pending', 'toStatus', 'approved'
+    )
+  );
+
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_external_reference text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.refunds
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_refund public.refunds;
+  v_payment public.payments;
+  v_metadata jsonb;
+  v_refundable numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+
+  SELECT * INTO v_refund
+  FROM public.refunds
+  WHERE tenant_id = p_tenant_id AND id = p_refund_id
+  FOR UPDATE;
+
+  IF v_refund.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  IF v_refund.status = 'completed' THEN RETURN v_refund; END IF;
+  IF v_refund.status <> 'approved' THEN RAISE EXCEPTION 'Only approved refunds can be completed'; END IF;
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = v_refund.payment_id
+  FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  IF v_payment.status IN ('voided', 'archived') THEN RAISE EXCEPTION 'Cannot complete refund for payment with status %', v_payment.status; END IF;
+
+  v_refundable := public.payment_refundable_amount_internal(p_tenant_id, v_payment.id, v_refund.id);
+  IF v_refund.amount > v_refundable THEN RAISE EXCEPTION 'Refund amount exceeds currently refundable amount'; END IF;
+
+  UPDATE public.refunds
+  SET status = 'completed',
+      completed_by = auth.uid(),
+      completed_at = now(),
+      external_reference = COALESCE(NULLIF(btrim(p_external_reference), ''), external_reference),
+      metadata = public.sanitize_finance_metadata_internal(metadata || v_metadata)
+  WHERE id = v_refund.id
+  RETURNING * INTO v_refund;
+
+  PERFORM public.recalculate_payment_status_internal(v_payment.id);
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'refund_completed', 'refund', v_refund.id,
+    v_refund.patient_id, v_refund.payment_id,
+    p_metadata => jsonb_build_object(
+      'refundId', v_refund.id, 'paymentId', v_refund.payment_id,
+      'amount', v_refund.amount, 'currency', v_refund.currency,
+      'fromStatus', 'approved', 'toStatus', 'completed',
+      'externalReference', v_refund.external_reference
+    )
+  );
+
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reject_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_reason text
+) RETURNS public.refunds
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_refund public.refunds;
+  v_reason text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+  v_reason := NULLIF(btrim(p_reason), '');
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'Rejection reason is required'; END IF;
+
+  SELECT * INTO v_refund
+  FROM public.refunds
+  WHERE tenant_id = p_tenant_id AND id = p_refund_id
+  FOR UPDATE;
+
+  IF v_refund.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  IF v_refund.status = 'rejected' THEN RETURN v_refund; END IF;
+  IF v_refund.status <> 'pending' THEN RAISE EXCEPTION 'Only pending refunds can be rejected'; END IF;
+
+  UPDATE public.refunds
+  SET status = 'rejected',
+      rejected_at = now(),
+      metadata = public.sanitize_finance_metadata_internal(
+        metadata || jsonb_build_object(
+          'rejectionReason', v_reason,
+          'rejectedBy', auth.uid(),
+          'rejectedAt', now()
+        )
+      )
+  WHERE id = v_refund.id
+  RETURNING * INTO v_refund;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'refund_rejected', 'refund', v_refund.id,
+    v_refund.patient_id, v_refund.payment_id, v_reason,
+    jsonb_build_object(
+      'refundId', v_refund.id, 'paymentId', v_refund.payment_id,
+      'amount', v_refund.amount, 'currency', v_refund.currency,
+      'fromStatus', 'pending', 'toStatus', 'rejected'
+    )
+  );
+
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.void_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_reason text
+) RETURNS public.refunds
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_refund public.refunds;
+  v_reason text;
+  v_from_status text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+  v_reason := NULLIF(btrim(p_reason), '');
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'Void reason is required'; END IF;
+
+  SELECT * INTO v_refund
+  FROM public.refunds
+  WHERE tenant_id = p_tenant_id AND id = p_refund_id
+  FOR UPDATE;
+
+  IF v_refund.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  IF v_refund.status = 'voided' THEN RETURN v_refund; END IF;
+  IF v_refund.status = 'completed' THEN RAISE EXCEPTION 'Completed refunds are immutable and cannot be voided'; END IF;
+  IF v_refund.status NOT IN ('pending', 'approved') THEN RAISE EXCEPTION 'Only pending or approved refunds can be voided'; END IF;
+
+  v_from_status := v_refund.status;
+  UPDATE public.refunds
+  SET status = 'voided', voided_by = auth.uid(), voided_at = now(), void_reason = v_reason
+  WHERE id = v_refund.id
+  RETURNING * INTO v_refund;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'refund_voided', 'refund', v_refund.id,
+    v_refund.patient_id, v_refund.payment_id, v_reason,
+    jsonb_build_object(
+      'refundId', v_refund.id, 'paymentId', v_refund.payment_id,
+      'amount', v_refund.amount, 'currency', v_refund.currency,
+      'fromStatus', v_from_status, 'toStatus', 'voided'
+    )
+  );
+
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.request_invoice_write_off(
+  p_tenant_id uuid,
+  p_invoice_id uuid,
+  p_amount numeric,
+  p_reason text,
+  p_idempotency_key text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.financial_adjustments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invoice public.invoices;
+  v_adjustment public.financial_adjustments;
+  v_metadata jsonb;
+  v_idempotency_key text := NULLIF(btrim(p_idempotency_key), '');
+  v_available numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+
+  IF p_invoice_id IS NULL THEN RAISE EXCEPTION 'Invoice ID is required'; END IF;
+  IF COALESCE(p_amount, 0) <= 0 THEN RAISE EXCEPTION 'Write-off amount must be positive'; END IF;
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN RAISE EXCEPTION 'Write-off reason is required'; END IF;
+  IF p_idempotency_key IS NOT NULL AND v_idempotency_key IS NULL THEN RAISE EXCEPTION 'Idempotency key must not be empty'; END IF;
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE tenant_id = p_tenant_id AND id = p_invoice_id
+  FOR UPDATE;
+
+  IF v_invoice.id IS NULL THEN RAISE EXCEPTION 'Invoice not found in this tenant'; END IF;
+  IF v_invoice.status NOT IN ('issued', 'partially_paid') THEN
+    RAISE EXCEPTION 'Cannot write off invoice with status %', v_invoice.status;
+  END IF;
+
+  v_invoice := public.recalculate_invoice_financials_internal(v_invoice.id);
+  IF v_invoice.status NOT IN ('issued', 'partially_paid') THEN
+    RAISE EXCEPTION 'Cannot write off invoice with status %', v_invoice.status;
+  END IF;
+
+  IF v_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_adjustment
+    FROM public.financial_adjustments
+    WHERE tenant_id = p_tenant_id AND idempotency_key = v_idempotency_key;
+
+    IF v_adjustment.id IS NOT NULL THEN
+      IF v_adjustment.adjustment_type <> 'write_off'
+         OR v_adjustment.invoice_id <> p_invoice_id
+         OR v_adjustment.amount <> p_amount::numeric(12,2) THEN
+        RAISE EXCEPTION 'Idempotency key is already used for a different adjustment request';
+      END IF;
+      RETURN v_adjustment;
+    END IF;
+  END IF;
+
+  v_available := public.invoice_available_writeoff_amount_internal(p_tenant_id, p_invoice_id);
+  IF p_amount > v_available THEN
+    RAISE EXCEPTION 'Write-off amount exceeds available invoice balance';
+  END IF;
+
+  INSERT INTO public.financial_adjustments (
+    tenant_id, patient_id, invoice_id, adjustment_type, status, amount,
+    currency, reason, created_by, metadata, idempotency_key
+  ) VALUES (
+    p_tenant_id, v_invoice.patient_id, v_invoice.id, 'write_off', 'active',
+    p_amount, v_invoice.currency, btrim(p_reason), auth.uid(), v_metadata, v_idempotency_key
+  ) RETURNING * INTO v_adjustment;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'write_off_requested', 'financial_adjustment', v_adjustment.id,
+    v_adjustment.patient_id, p_reason => v_adjustment.reason,
+    p_metadata => jsonb_build_object(
+      'adjustmentId', v_adjustment.id, 'invoiceId', v_adjustment.invoice_id,
+      'amount', v_adjustment.amount, 'currency', v_adjustment.currency,
+      'fromStatus', NULL, 'toStatus', 'active'
+    )
+  );
+
+  RETURN v_adjustment;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.approve_invoice_write_off(
+  p_tenant_id uuid,
+  p_adjustment_id uuid
+) RETURNS public.financial_adjustments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_adjustment public.financial_adjustments;
+  v_invoice public.invoices;
+  v_available numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+
+  SELECT * INTO v_adjustment
+  FROM public.financial_adjustments
+  WHERE tenant_id = p_tenant_id AND id = p_adjustment_id
+  FOR UPDATE;
+
+  IF v_adjustment.id IS NULL THEN RAISE EXCEPTION 'Financial adjustment not found in this tenant'; END IF;
+  IF v_adjustment.adjustment_type <> 'write_off' THEN RAISE EXCEPTION 'Adjustment is not an invoice write-off'; END IF;
+  IF v_adjustment.status = 'approved' THEN RETURN v_adjustment; END IF;
+  IF v_adjustment.status <> 'active' THEN RAISE EXCEPTION 'Only active write-offs can be approved'; END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE tenant_id = p_tenant_id AND id = v_adjustment.invoice_id
+  FOR UPDATE;
+  IF v_invoice.id IS NULL THEN RAISE EXCEPTION 'Invoice not found in this tenant'; END IF;
+  IF v_invoice.status NOT IN ('issued', 'partially_paid') THEN RAISE EXCEPTION 'Cannot approve write-off for invoice with status %', v_invoice.status; END IF;
+
+  v_available := public.invoice_available_writeoff_amount_internal(
+    p_tenant_id, v_invoice.id, v_adjustment.id
+  );
+  IF v_adjustment.amount > v_available THEN RAISE EXCEPTION 'Write-off amount exceeds available invoice balance'; END IF;
+
+  UPDATE public.financial_adjustments
+  SET status = 'approved', approved_by = auth.uid(), approved_at = now()
+  WHERE id = v_adjustment.id
+  RETURNING * INTO v_adjustment;
+
+  PERFORM public.recalculate_invoice_financials_internal(v_invoice.id);
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'write_off_approved', 'financial_adjustment', v_adjustment.id,
+    v_adjustment.patient_id,
+    p_metadata => jsonb_build_object(
+      'adjustmentId', v_adjustment.id, 'invoiceId', v_adjustment.invoice_id,
+      'amount', v_adjustment.amount, 'currency', v_adjustment.currency,
+      'fromStatus', 'active', 'toStatus', 'approved'
+    )
+  );
+
+  RETURN v_adjustment;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reject_invoice_write_off(
+  p_tenant_id uuid,
+  p_adjustment_id uuid,
+  p_reason text
+) RETURNS public.financial_adjustments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_adjustment public.financial_adjustments;
+  v_reason text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+  v_reason := NULLIF(btrim(p_reason), '');
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'Rejection reason is required'; END IF;
+
+  SELECT * INTO v_adjustment
+  FROM public.financial_adjustments
+  WHERE tenant_id = p_tenant_id AND id = p_adjustment_id
+  FOR UPDATE;
+
+  IF v_adjustment.id IS NULL THEN RAISE EXCEPTION 'Financial adjustment not found in this tenant'; END IF;
+  IF v_adjustment.adjustment_type <> 'write_off' THEN RAISE EXCEPTION 'Adjustment is not an invoice write-off'; END IF;
+  IF v_adjustment.status = 'rejected' THEN RETURN v_adjustment; END IF;
+  IF v_adjustment.status <> 'active' THEN RAISE EXCEPTION 'Only active write-offs can be rejected'; END IF;
+
+  UPDATE public.financial_adjustments
+  SET status = 'rejected',
+      metadata = public.sanitize_finance_metadata_internal(
+        metadata || jsonb_build_object(
+          'rejectionReason', v_reason,
+          'rejectedBy', auth.uid(),
+          'rejectedAt', now()
+        )
+      )
+  WHERE id = v_adjustment.id
+  RETURNING * INTO v_adjustment;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'write_off_rejected', 'financial_adjustment', v_adjustment.id,
+    v_adjustment.patient_id, p_reason => v_reason,
+    p_metadata => jsonb_build_object(
+      'adjustmentId', v_adjustment.id, 'invoiceId', v_adjustment.invoice_id,
+      'amount', v_adjustment.amount, 'currency', v_adjustment.currency,
+      'fromStatus', 'active', 'toStatus', 'rejected'
+    )
+  );
+
+  RETURN v_adjustment;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.void_invoice_write_off(
+  p_tenant_id uuid,
+  p_adjustment_id uuid,
+  p_reason text
+) RETURNS public.financial_adjustments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_adjustment public.financial_adjustments;
+  v_reason text;
+  v_from_status text;
+  v_recalculate boolean;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+  v_reason := NULLIF(btrim(p_reason), '');
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'Void reason is required'; END IF;
+
+  SELECT * INTO v_adjustment
+  FROM public.financial_adjustments
+  WHERE tenant_id = p_tenant_id AND id = p_adjustment_id
+  FOR UPDATE;
+
+  IF v_adjustment.id IS NULL THEN RAISE EXCEPTION 'Financial adjustment not found in this tenant'; END IF;
+  IF v_adjustment.adjustment_type <> 'write_off' THEN RAISE EXCEPTION 'Adjustment is not an invoice write-off'; END IF;
+  IF v_adjustment.status = 'voided' THEN RETURN v_adjustment; END IF;
+  IF v_adjustment.status NOT IN ('active', 'approved') THEN RAISE EXCEPTION 'Only active or approved write-offs can be voided'; END IF;
+
+  PERFORM 1 FROM public.invoices
+  WHERE tenant_id = p_tenant_id AND id = v_adjustment.invoice_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Invoice not found in this tenant'; END IF;
+
+  v_from_status := v_adjustment.status;
+  v_recalculate := v_adjustment.status = 'approved';
+
+  UPDATE public.financial_adjustments
+  SET status = 'voided', voided_by = auth.uid(), voided_at = now(), void_reason = v_reason
+  WHERE id = v_adjustment.id
+  RETURNING * INTO v_adjustment;
+
+  IF v_recalculate THEN
+    PERFORM public.recalculate_invoice_financials_internal(v_adjustment.invoice_id);
+  END IF;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'write_off_voided', 'financial_adjustment', v_adjustment.id,
+    v_adjustment.patient_id, p_reason => v_reason,
+    p_metadata => jsonb_build_object(
+      'adjustmentId', v_adjustment.id, 'invoiceId', v_adjustment.invoice_id,
+      'amount', v_adjustment.amount, 'currency', v_adjustment.currency,
+      'fromStatus', v_from_status, 'toStatus', 'voided'
+    )
+  );
+
+  RETURN v_adjustment;
+END;
+$$;
+
+COMMENT ON FUNCTION public.request_refund(uuid, uuid, numeric, text, text, text, jsonb)
+  IS 'Request return of currently unallocated payment funds. Does not reverse invoice allocations.';
+COMMENT ON FUNCTION public.approve_refund(uuid, uuid)
+  IS 'Owner/admin approval of a pending refund request.';
+COMMENT ON FUNCTION public.complete_refund(uuid, uuid, text, jsonb)
+  IS 'Record completion of an approved refund; no provider API call is performed.';
+COMMENT ON FUNCTION public.reject_refund(uuid, uuid, text)
+  IS 'Reject a pending refund request and release reserved payment capacity.';
+COMMENT ON FUNCTION public.void_refund(uuid, uuid, text)
+  IS 'Cancel a pending or approved refund. Completed refunds are immutable.';
+COMMENT ON FUNCTION public.request_invoice_write_off(uuid, uuid, numeric, text, text, jsonb)
+  IS 'Request debt reduction for an issued or partially paid invoice.';
+COMMENT ON FUNCTION public.approve_invoice_write_off(uuid, uuid)
+  IS 'Approve and apply an invoice write-off without changing payment facts.';
+COMMENT ON FUNCTION public.reject_invoice_write_off(uuid, uuid, text)
+  IS 'Reject an active invoice write-off request.';
+COMMENT ON FUNCTION public.void_invoice_write_off(uuid, uuid, text)
+  IS 'Void active or approved invoice write-off; approved reversal reopens debt.';
+
+REVOKE ALL ON FUNCTION public.sanitize_finance_metadata_internal(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.payment_active_allocation_total_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.payment_completed_refund_total_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.payment_reserved_refund_total_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.payment_refundable_amount_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.invoice_approved_writeoff_total_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.invoice_reserved_writeoff_total_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.invoice_available_writeoff_amount_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_payment_allocation_capacity_internal() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_payment_refund_void_guard_internal() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_invoice_writeoff_void_guard_internal() FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.request_refund(uuid, uuid, numeric, text, text, text, jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.approve_refund(uuid, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.complete_refund(uuid, uuid, text, jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.reject_refund(uuid, uuid, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.void_refund(uuid, uuid, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.request_invoice_write_off(uuid, uuid, numeric, text, text, jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.approve_invoice_write_off(uuid, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.reject_invoice_write_off(uuid, uuid, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.void_invoice_write_off(uuid, uuid, text) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.request_refund(uuid, uuid, numeric, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.approve_refund(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_refund(uuid, uuid, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reject_refund(uuid, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.void_refund(uuid, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.request_invoice_write_off(uuid, uuid, numeric, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.approve_invoice_write_off(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reject_invoice_write_off(uuid, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.void_invoice_write_off(uuid, uuid, text) TO authenticated;

--- a/supabase/tests/0018_refund_writeoff_concurrency.ps1
+++ b/supabase/tests/0018_refund_writeoff_concurrency.ps1
@@ -1,0 +1,110 @@
+$ErrorActionPreference = 'Stop'
+
+$container = 'supabase_db_codex-test-supabase'
+$tenant = '11111111-1111-1111-1111-111111111111'
+$patient = 'c1000000-0000-4000-8000-000000000001'
+$paymentRace = 'c2000000-0000-4000-8000-000000000001'
+$paymentIdempotency = 'c2000000-0000-4000-8000-000000000002'
+$invoiceRace = 'c3000000-0000-4000-8000-000000000001'
+$invoiceIdempotency = 'c3000000-0000-4000-8000-000000000002'
+$itemRace = 'c4000000-0000-4000-8000-000000000001'
+$itemIdempotency = 'c4000000-0000-4000-8000-000000000002'
+
+function Invoke-Scalar([string]$sql) {
+  return (& docker exec $container psql -U postgres -d postgres -Atc $sql).Trim()
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+$admin = Invoke-Scalar "select id from auth.users where email='qa.admin.a@example.local'"
+$cashier = Invoke-Scalar "select id from auth.users where email='qa.cashier.a@example.local'"
+if (-not $admin -or -not $cashier) {
+  throw 'Local QA users are missing. Run the guarded QA user seed first.'
+}
+
+$setup = @"
+BEGIN;
+DELETE FROM public.patients WHERE id='$patient'::uuid;
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,balance)
+VALUES ('$patient','$tenant','Concurrency Smoke','+77000000999','phone',0);
+INSERT INTO public.payments(id,tenant_id,patient_id,status,payment_method,amount,currency,received_by)
+VALUES
+  ('$paymentRace','$tenant','$patient','received','cash',1000,'KZT','$cashier'),
+  ('$paymentIdempotency','$tenant','$patient','received','cash',1000,'KZT','$cashier');
+INSERT INTO public.invoices(id,tenant_id,patient_id,status,currency,issue_date,issued_at,subtotal_amount,total_amount,balance_amount,created_by,issued_by)
+VALUES
+  ('$invoiceRace','$tenant','$patient','issued','KZT',now(),now(),1000,1000,1000,'$admin','$admin'),
+  ('$invoiceIdempotency','$tenant','$patient','issued','KZT',now(),now(),1000,1000,1000,'$admin','$admin');
+INSERT INTO public.invoice_items(id,tenant_id,invoice_id,patient_id,service_name,quantity,unit_price,total_amount,status,created_by)
+VALUES
+  ('$itemRace','$tenant','$invoiceRace','$patient','Race write-off',1,1000,1000,'active','$admin'),
+  ('$itemIdempotency','$tenant','$invoiceIdempotency','$patient','Idempotent write-off',1,1000,1000,'active','$admin');
+COMMIT;
+"@
+$setup | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 | Out-Null
+
+$refundContext = "BEGIN; SET LOCAL ROLE authenticated; SELECT set_config('request.jwt.claim.sub','$cashier',true);"
+$refundRace = @(Invoke-ConcurrentPair `
+  ($refundContext + " SELECT (public.request_refund('$tenant','$paymentRace',600,'cash','race A','refund-race-a','{}')).id; COMMIT;") `
+  ($refundContext + " SELECT (public.request_refund('$tenant','$paymentRace',600,'cash','race B','refund-race-b','{}')).id; COMMIT;"))
+$refundSuccess = @($refundRace | Where-Object { $_.Code -eq 0 }).Count
+$refundRejected = @($refundRace | Where-Object { $_.Code -ne 0 }).Count
+$refundReserved = [decimal](Invoke-Scalar "select coalesce(sum(amount),0) from public.refunds where payment_id='$paymentRace' and status in ('pending','approved')")
+if ($refundSuccess -ne 1 -or $refundRejected -ne 1 -or $refundReserved -ne 600) {
+  throw "Refund race failed: success=$refundSuccess rejected=$refundRejected reserved=$refundReserved"
+}
+
+$refundIdempotencyRace = @(Invoke-ConcurrentPair `
+  ($refundContext + " SELECT (public.request_refund('$tenant','$paymentIdempotency',400,'cash','same retry','refund-race-same','{}')).id; COMMIT;") `
+  ($refundContext + " SELECT (public.request_refund('$tenant','$paymentIdempotency',400,'cash','same retry','refund-race-same','{}')).id; COMMIT;"))
+if (@($refundIdempotencyRace | Where-Object { $_.Code -ne 0 }).Count -ne 0) {
+  throw 'Concurrent refund idempotency call failed.'
+}
+$refundIdempotencyRows = [int](Invoke-Scalar "select count(*) from public.refunds where payment_id='$paymentIdempotency' and idempotency_key='refund-race-same'")
+if ($refundIdempotencyRows -ne 1) {
+  throw "Concurrent refund idempotency created $refundIdempotencyRows rows."
+}
+
+$writeOffContext = "BEGIN; SET LOCAL ROLE authenticated; SELECT set_config('request.jwt.claim.sub','$admin',true);"
+$writeOffRace = @(Invoke-ConcurrentPair `
+  ($writeOffContext + " SELECT (public.request_invoice_write_off('$tenant','$invoiceRace',600,'race A','writeoff-race-a','{}')).id; COMMIT;") `
+  ($writeOffContext + " SELECT (public.request_invoice_write_off('$tenant','$invoiceRace',600,'race B','writeoff-race-b','{}')).id; COMMIT;"))
+$writeOffSuccess = @($writeOffRace | Where-Object { $_.Code -eq 0 }).Count
+$writeOffRejected = @($writeOffRace | Where-Object { $_.Code -ne 0 }).Count
+$writeOffReserved = [decimal](Invoke-Scalar "select coalesce(sum(amount),0) from public.financial_adjustments where invoice_id='$invoiceRace' and adjustment_type='write_off' and status='active'")
+if ($writeOffSuccess -ne 1 -or $writeOffRejected -ne 1 -or $writeOffReserved -ne 600) {
+  throw "Write-off race failed: success=$writeOffSuccess rejected=$writeOffRejected reserved=$writeOffReserved"
+}
+
+$writeOffIdempotencyRace = @(Invoke-ConcurrentPair `
+  ($writeOffContext + " SELECT (public.request_invoice_write_off('$tenant','$invoiceIdempotency',400,'same retry','writeoff-race-same','{}')).id; COMMIT;") `
+  ($writeOffContext + " SELECT (public.request_invoice_write_off('$tenant','$invoiceIdempotency',400,'same retry','writeoff-race-same','{}')).id; COMMIT;"))
+if (@($writeOffIdempotencyRace | Where-Object { $_.Code -ne 0 }).Count -ne 0) {
+  throw 'Concurrent write-off idempotency call failed.'
+}
+$writeOffIdempotencyRows = [int](Invoke-Scalar "select count(*) from public.financial_adjustments where invoice_id='$invoiceIdempotency' and idempotency_key='writeoff-race-same'")
+if ($writeOffIdempotencyRows -ne 1) {
+  throw "Concurrent write-off idempotency created $writeOffIdempotencyRows rows."
+}
+
+Write-Output "REFUND_RACE success=$refundSuccess rejected=$refundRejected reserved=$refundReserved"
+Write-Output "REFUND_IDEMPOTENCY rows=$refundIdempotencyRows"
+Write-Output "WRITEOFF_RACE success=$writeOffSuccess rejected=$writeOffRejected reserved=$writeOffReserved"
+Write-Output "WRITEOFF_IDEMPOTENCY rows=$writeOffIdempotencyRows"
+Write-Output 'CONCURRENCY VALIDATION PASSED'

--- a/supabase/tests/0018_refund_writeoff_rpc_test.sql
+++ b/supabase/tests/0018_refund_writeoff_rpc_test.sql
@@ -1,0 +1,306 @@
+\set ON_ERROR_STOP on
+\echo 'REFUNDS-WRITEOFFS-FOUNDATION-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION
+    WHEN OTHERS THEN
+      v_message := SQLERRM;
+      IF v_message LIKE 'ASSERTION FAILED:%' THEN
+        RAISE;
+      END IF;
+      IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+        RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%", got "%"', p_expected, v_message;
+      END IF;
+  END;
+END;
+$$;
+
+SELECT id::text AS admin_a FROM auth.users WHERE email = 'qa.admin.a@example.local' \gset
+SELECT id::text AS cashier_a FROM auth.users WHERE email = 'qa.cashier.a@example.local' \gset
+SELECT id::text AS doctor_a FROM auth.users WHERE email = 'qa.doctor.a@example.local' \gset
+SELECT id::text AS registrar_a FROM auth.users WHERE email = 'qa.receptionist.a@example.local' \gset
+SELECT id::text AS notenant FROM auth.users WHERE email = 'qa.notenant@example.local' \gset
+SELECT id::text AS admin_b FROM auth.users WHERE email = 'qa.admin.b@example.local' \gset
+
+\set tenant_a '11111111-1111-1111-1111-111111111111'
+\set tenant_b '22222222-2222-2222-2222-222222222222'
+\set patient_a 'a1000000-0000-4000-8000-000000000001'
+\set patient_b 'b1000000-0000-4000-8000-000000000001'
+
+INSERT INTO public.patients (id, tenant_id, full_name, phone, source, balance)
+VALUES
+  (:'patient_a'::uuid, :'tenant_a'::uuid, 'Refund Writeoff Smoke A', '+77000000001', 'phone', 0),
+  (:'patient_b'::uuid, :'tenant_b'::uuid, 'Refund Writeoff Smoke B', '+77000000002', 'phone', 0);
+
+SELECT count(*)::text AS completed_before FROM public.completed_services WHERE patient_id = :'patient_a'::uuid \gset
+SELECT count(*)::text AS appointments_before FROM public.appointments WHERE patient_id = :'patient_a'::uuid \gset
+SELECT balance::text AS balance_before FROM public.patients WHERE id = :'patient_a'::uuid \gset
+
+SET LOCAL ROLE authenticated;
+
+-- REFUND ROLE AND VALIDATION MATRIX
+SELECT set_config('request.jwt.claim.sub', :'doctor_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,100,''cash'',''doctor attempt'',null,''{}''::jsonb)', :'tenant_a', '00000000-0000-4000-8000-000000000099'),
+  'Insufficient finance permissions'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'registrar_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,100,''cash'',''registrar attempt'',null,''{}''::jsonb)', :'tenant_a', '00000000-0000-4000-8000-000000000099'),
+  'Insufficient finance permissions'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'notenant', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,100,''cash'',''no tenant attempt'',null,''{}''::jsonb)', :'tenant_a', '00000000-0000-4000-8000-000000000099'),
+  'Insufficient finance permissions'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 1000, 'cash')).id::text AS refund_payment \gset
+
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,0,''cash'',''bad amount'',null,''{}''::jsonb)', :'tenant_a', :'refund_payment'),
+  'must be positive'
+);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,1,''crypto'',''bad method'',null,''{}''::jsonb)', :'tenant_a', :'refund_payment'),
+  'Unsupported refund method'
+);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,1,''cash'','' '',null,''{}''::jsonb)', :'tenant_a', :'refund_payment'),
+  'reason is required'
+);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,1,''cash'',''bad metadata'',null,''[]''::jsonb)', :'tenant_a', :'refund_payment'),
+  'Metadata must be a JSON object'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'admin_b', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,100,''cash'',''cross tenant'',null,''{}''::jsonb)', :'tenant_b', :'refund_payment'),
+  'Payment not found in this tenant'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.request_refund(:'tenant_a'::uuid, :'refund_payment'::uuid, 400, 'cash', 'Return overpayment', 'refund-idempotency-1', '{"source":"sql-smoke"}'::jsonb)).id::text AS refund_400 \gset
+SELECT (public.request_refund(:'tenant_a'::uuid, :'refund_payment'::uuid, 400, 'cash', 'Return overpayment', 'refund-idempotency-1', '{"source":"retry"}'::jsonb)).id::text AS refund_400_retry \gset
+SELECT pg_temp.assert_true(:'refund_400' = :'refund_400_retry', 'refund idempotency retry must return same row');
+SELECT pg_temp.assert_true((SELECT COALESCE(sum(amount), 0) FROM public.refunds WHERE tenant_id = :'tenant_a'::uuid AND payment_id = :'refund_payment'::uuid AND status IN ('pending','approved')) = 400, 'pending refund must reserve 400');
+SELECT pg_temp.assert_true((SELECT p.amount - COALESCE((SELECT sum(pa.amount) FROM public.payment_allocations pa WHERE pa.tenant_id=p.tenant_id AND pa.payment_id=p.id AND pa.status='active'),0) - COALESCE((SELECT sum(r.amount) FROM public.refunds r WHERE r.tenant_id=p.tenant_id AND r.payment_id=p.id AND r.status='completed'),0) - COALESCE((SELECT sum(r.amount) FROM public.refunds r WHERE r.tenant_id=p.tenant_id AND r.payment_id=p.id AND r.status IN ('pending','approved')),0) FROM public.payments p WHERE p.id=:'refund_payment'::uuid) = 600, 'refundable amount after reservation must be 600');
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,601,''cash'',''over reserved capacity'',null,''{}''::jsonb)', :'tenant_a', :'refund_payment'),
+  'exceeds currently unallocated refundable amount'
+);
+
+SELECT pg_temp.expect_error(
+  format('select public.approve_refund(%L::uuid,%L::uuid)', :'tenant_a', :'refund_400'),
+  'Insufficient finance permissions'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT (public.approve_refund(:'tenant_a'::uuid, :'refund_400'::uuid)).status AS approved_status \gset
+SELECT pg_temp.assert_true(:'approved_status' = 'approved', 'admin must approve pending refund');
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.complete_refund(:'tenant_a'::uuid, :'refund_400'::uuid, 'LOCAL-REFUND-400', '{"recorded":true}'::jsonb)).status AS completed_status \gset
+SELECT pg_temp.assert_true(:'completed_status' = 'completed', 'cashier must complete approved refund');
+SELECT (public.complete_refund(:'tenant_a'::uuid, :'refund_400'::uuid, 'LOCAL-REFUND-400', '{}'::jsonb)).id::text AS completed_retry \gset
+SELECT pg_temp.assert_true(:'completed_retry' = :'refund_400', 'completed refund retry must return same row');
+SELECT pg_temp.assert_true((SELECT status FROM public.payments WHERE id = :'refund_payment'::uuid) = 'partially_refunded', 'payment must become partially_refunded');
+
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.void_refund(%L::uuid,%L::uuid,''illegal reversal'')', :'tenant_a', :'refund_400'),
+  'Completed refunds are immutable'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.request_refund(:'tenant_a'::uuid, :'refund_payment'::uuid, 600, 'cash', 'Return remainder', 'refund-idempotency-2', '{}'::jsonb)).id::text AS refund_600 \gset
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.approve_refund(:'tenant_a'::uuid, :'refund_600'::uuid);
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT public.complete_refund(:'tenant_a'::uuid, :'refund_600'::uuid, 'LOCAL-REFUND-600', '{}'::jsonb);
+SELECT pg_temp.assert_true((SELECT status FROM public.payments WHERE id = :'refund_payment'::uuid) = 'refunded', 'payment must become refunded after full return');
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.void_payment(%L::uuid,%L::uuid,''cannot void refunded payment'')', :'tenant_a', :'refund_payment'),
+  'Payment with active or completed refunds cannot be voided'
+);
+
+-- Pending cannot complete, pending/approved can void, rejection releases reserve.
+SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 500, 'cash')).id::text AS reserve_payment \gset
+SELECT (public.request_refund(:'tenant_a'::uuid, :'reserve_payment'::uuid, 400, 'cash', 'Pending flow', 'refund-pending-flow', '{}'::jsonb)).id::text AS pending_refund \gset
+SELECT pg_temp.expect_error(
+  format('select public.complete_refund(%L::uuid,%L::uuid,null,''{}''::jsonb)', :'tenant_a', :'pending_refund'),
+  'Only approved refunds can be completed'
+);
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.reject_refund(:'tenant_a'::uuid, :'pending_refund'::uuid, 'Rejected in smoke');
+SELECT pg_temp.assert_true((SELECT p.amount - COALESCE((SELECT sum(r.amount) FROM public.refunds r WHERE r.tenant_id=p.tenant_id AND r.payment_id=p.id AND r.status IN ('pending','approved','completed')),0) FROM public.payments p WHERE p.id=:'reserve_payment'::uuid) = 500, 'rejection must release reservation');
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.request_refund(:'tenant_a'::uuid, :'reserve_payment'::uuid, 500, 'cash', 'Replacement request', 'refund-replacement', '{}'::jsonb)).id::text AS replacement_refund \gset
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.void_refund(:'tenant_a'::uuid, :'replacement_refund'::uuid, 'Cancelled before approval');
+SELECT pg_temp.assert_true((SELECT p.amount - COALESCE((SELECT sum(r.amount) FROM public.refunds r WHERE r.tenant_id=p.tenant_id AND r.payment_id=p.id AND r.status IN ('pending','approved','completed')),0) FROM public.payments p WHERE p.id=:'reserve_payment'::uuid) = 500, 'void must release reservation');
+
+-- Allocated funds cannot be refunded until controlled allocation void.
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT (public.create_invoice(:'tenant_a'::uuid, :'patient_a'::uuid)).id::text AS allocated_invoice \gset
+SELECT public.add_invoice_item(:'tenant_a'::uuid, :'allocated_invoice'::uuid, 'Allocated refund test', 1, 1000);
+SELECT public.issue_invoice(:'tenant_a'::uuid, :'allocated_invoice'::uuid);
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 1000, 'cash')).id::text AS allocated_payment \gset
+SELECT (public.allocate_payment(:'tenant_a'::uuid, :'allocated_payment'::uuid, 1000, :'allocated_invoice'::uuid)).id::text AS allocation_id \gset
+SELECT pg_temp.expect_error(
+  format('select public.request_refund(%L::uuid,%L::uuid,100,''cash'',''allocated money'',null,''{}''::jsonb)', :'tenant_a', :'allocated_payment'),
+  'exceeds currently unallocated refundable amount'
+);
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.void_payment_allocation(:'tenant_a'::uuid, :'allocation_id'::uuid, 'Release allocation for refund');
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.request_refund(:'tenant_a'::uuid, :'allocated_payment'::uuid, 100, 'cash', 'Now refundable', 'refund-after-allocation-void', '{}'::jsonb)).id::text AS after_void_refund \gset
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.void_refund(:'tenant_a'::uuid, :'after_void_refund'::uuid, 'Smoke cleanup transition');
+
+-- WRITE-OFF ROLE AND VALIDATION MATRIX
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT (public.create_invoice(:'tenant_a'::uuid, :'patient_a'::uuid)).id::text AS writeoff_invoice \gset
+SELECT public.add_invoice_item(:'tenant_a'::uuid, :'writeoff_invoice'::uuid, 'Write-off test', 1, 1000);
+SELECT public.issue_invoice(:'tenant_a'::uuid, :'writeoff_invoice'::uuid);
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,100,''cashier attempt'',null,''{}''::jsonb)', :'tenant_a', :'writeoff_invoice'),
+  'Insufficient finance permissions'
+);
+SELECT set_config('request.jwt.claim.sub', :'doctor_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,100,''doctor attempt'',null,''{}''::jsonb)', :'tenant_a', :'writeoff_invoice'),
+  'Insufficient finance permissions'
+);
+SELECT set_config('request.jwt.claim.sub', :'admin_b', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,100,''cross tenant'',null,''{}''::jsonb)', :'tenant_b', :'writeoff_invoice'),
+  'Invoice not found in this tenant'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,0,''bad amount'',null,''{}''::jsonb)', :'tenant_a', :'writeoff_invoice'),
+  'must be positive'
+);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,1,'' '',null,''{}''::jsonb)', :'tenant_a', :'writeoff_invoice'),
+  'reason is required'
+);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,1,''bad metadata'',null,''[]''::jsonb)', :'tenant_a', :'writeoff_invoice'),
+  'Metadata must be a JSON object'
+);
+
+SELECT (public.create_invoice(:'tenant_a'::uuid, :'patient_a'::uuid)).id::text AS draft_invoice \gset
+SELECT public.add_invoice_item(:'tenant_a'::uuid, :'draft_invoice'::uuid, 'Draft writeoff negative', 1, 100);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,10,''draft not eligible'',null,''{}''::jsonb)', :'tenant_a', :'draft_invoice'),
+  'Cannot write off invoice with status draft'
+);
+
+SELECT (public.create_invoice(:'tenant_a'::uuid, :'patient_a'::uuid)).id::text AS paid_invoice \gset
+SELECT public.add_invoice_item(:'tenant_a'::uuid, :'paid_invoice'::uuid, 'Paid writeoff negative', 1, 100);
+SELECT public.issue_invoice(:'tenant_a'::uuid, :'paid_invoice'::uuid);
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 100, 'cash')).id::text AS paid_invoice_payment \gset
+SELECT public.allocate_payment(:'tenant_a'::uuid, :'paid_invoice_payment'::uuid, 100, :'paid_invoice'::uuid);
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,1,''paid not eligible'',null,''{}''::jsonb)', :'tenant_a', :'paid_invoice'),
+  'Cannot write off invoice with status paid'
+);
+
+SELECT count(*)::text AS writeoff_payment_count_before FROM public.payments WHERE patient_id = :'patient_a'::uuid \gset
+SELECT (public.request_invoice_write_off(:'tenant_a'::uuid, :'writeoff_invoice'::uuid, 400, 'Bad debt partial', 'writeoff-idempotency-1', '{"source":"sql-smoke"}'::jsonb)).id::text AS writeoff_400 \gset
+SELECT (public.request_invoice_write_off(:'tenant_a'::uuid, :'writeoff_invoice'::uuid, 400, 'Bad debt partial', 'writeoff-idempotency-1', '{"source":"retry"}'::jsonb)).id::text AS writeoff_400_retry \gset
+SELECT pg_temp.assert_true(:'writeoff_400' = :'writeoff_400_retry', 'write-off idempotency retry must return same row');
+SELECT pg_temp.assert_true((SELECT COALESCE(sum(amount),0) FROM public.financial_adjustments WHERE tenant_id=:'tenant_a'::uuid AND invoice_id=:'writeoff_invoice'::uuid AND adjustment_type='write_off' AND status='active') = 400, 'active write-off must reserve 400');
+SELECT pg_temp.assert_true((SELECT i.total_amount - i.paid_amount - COALESCE((SELECT sum(fa.amount) FROM public.financial_adjustments fa WHERE fa.tenant_id=i.tenant_id AND fa.invoice_id=i.id AND fa.adjustment_type='write_off' AND fa.status IN ('active','approved')),0) FROM public.invoices i WHERE i.id=:'writeoff_invoice'::uuid) = 600, 'available write-off amount must be 600');
+SELECT pg_temp.expect_error(
+  format('select public.request_invoice_write_off(%L::uuid,%L::uuid,601,''over reserve'',null,''{}''::jsonb)', :'tenant_a', :'writeoff_invoice'),
+  'exceeds available invoice balance'
+);
+
+SELECT (public.approve_invoice_write_off(:'tenant_a'::uuid, :'writeoff_400'::uuid)).status AS writeoff_400_status \gset
+SELECT pg_temp.assert_true(:'writeoff_400_status' = 'approved', 'admin must approve active write-off');
+SELECT pg_temp.assert_true((SELECT written_off_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 400, 'partial write-off must increment written_off_amount');
+SELECT pg_temp.assert_true((SELECT balance_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 600, 'partial write-off must leave 600 balance');
+SELECT pg_temp.assert_true((SELECT paid_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 0, 'write-off must not increase paid_amount');
+SELECT pg_temp.assert_true((SELECT status FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 'issued', 'partial write-off without payment remains issued');
+SELECT pg_temp.expect_error(
+  format('select public.void_invoice(%L::uuid,%L::uuid,''cannot void invoice with write-off'')', :'tenant_a', :'writeoff_invoice'),
+  'Invoice with active or approved write-offs cannot be voided'
+);
+
+SELECT (public.request_invoice_write_off(:'tenant_a'::uuid, :'writeoff_invoice'::uuid, 600, 'Bad debt remainder', 'writeoff-idempotency-2', '{}'::jsonb)).id::text AS writeoff_600 \gset
+SELECT public.approve_invoice_write_off(:'tenant_a'::uuid, :'writeoff_600'::uuid);
+SELECT pg_temp.assert_true((SELECT written_off_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 1000, 'full write-off must total 1000');
+SELECT pg_temp.assert_true((SELECT balance_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 0, 'full write-off must zero balance');
+SELECT pg_temp.assert_true((SELECT status FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 'written_off', 'full write-off must set written_off status');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments WHERE patient_id = :'patient_a'::uuid) = :'writeoff_payment_count_before'::integer, 'write-off must not create payment');
+
+SELECT public.void_invoice_write_off(:'tenant_a'::uuid, :'writeoff_600'::uuid, 'Reverse second write-off');
+SELECT pg_temp.assert_true((SELECT written_off_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 400, 'void approved write-off must reduce written_off_amount');
+SELECT pg_temp.assert_true((SELECT balance_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 600, 'void approved write-off must reopen debt');
+SELECT pg_temp.assert_true((SELECT status FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 'issued', 'reopened debt must restore issued status');
+
+SELECT (public.request_invoice_write_off(:'tenant_a'::uuid, :'writeoff_invoice'::uuid, 100, 'Reject flow', 'writeoff-reject-flow', '{}'::jsonb)).id::text AS rejected_writeoff \gset
+SELECT public.reject_invoice_write_off(:'tenant_a'::uuid, :'rejected_writeoff'::uuid, 'Rejected in smoke');
+SELECT pg_temp.assert_true((SELECT balance_amount FROM public.invoices WHERE id = :'writeoff_invoice'::uuid) = 600, 'rejected write-off must not change invoice balance');
+
+-- ACTOR, AUDIT, ACTIVITY, AND SIDE-EFFECT ASSERTIONS
+SELECT pg_temp.assert_true((SELECT requested_by FROM public.refunds WHERE id = :'refund_400'::uuid) = :'cashier_a'::uuid, 'refund requested_by must come from auth.uid()');
+SELECT pg_temp.assert_true((SELECT approved_by FROM public.refunds WHERE id = :'refund_400'::uuid) = :'admin_a'::uuid, 'refund approved_by must come from auth.uid()');
+SELECT pg_temp.assert_true((SELECT completed_by FROM public.refunds WHERE id = :'refund_400'::uuid) = :'cashier_a'::uuid, 'refund completed_by must come from auth.uid()');
+SELECT pg_temp.assert_true((SELECT created_by FROM public.financial_adjustments WHERE id = :'writeoff_400'::uuid) = :'admin_a'::uuid, 'write-off created_by must come from auth.uid()');
+SELECT pg_temp.assert_true((SELECT approved_by FROM public.financial_adjustments WHERE id = :'writeoff_400'::uuid) = :'admin_a'::uuid, 'write-off approved_by must come from auth.uid()');
+
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'refund_requested' AND tenant_id = :'tenant_a'::uuid) >= 4, 'refund_requested audit events must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'refund_approved' AND tenant_id = :'tenant_a'::uuid) >= 2, 'refund_approved audit events must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'refund_completed' AND tenant_id = :'tenant_a'::uuid) = 2, 'refund_completed audit events must be idempotent');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'refund_rejected' AND tenant_id = :'tenant_a'::uuid) = 1, 'refund_rejected audit event must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'refund_voided' AND tenant_id = :'tenant_a'::uuid) >= 2, 'refund_voided audit events must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'write_off_requested' AND tenant_id = :'tenant_a'::uuid) >= 3, 'write_off_requested audit events must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'write_off_approved' AND tenant_id = :'tenant_a'::uuid) = 2, 'write_off_approved audit events must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'write_off_rejected' AND tenant_id = :'tenant_a'::uuid) = 1, 'write_off_rejected audit event must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'write_off_voided' AND tenant_id = :'tenant_a'::uuid) = 1, 'write_off_voided audit event must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type IN ('refund_requested','refund_approved','refund_completed','refund_rejected','refund_voided') AND tenant_id = :'tenant_a'::uuid) >= 11, 'refund activity events must exist');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type IN ('write_off_requested','write_off_approved','write_off_rejected','write_off_voided') AND tenant_id = :'tenant_a'::uuid) >= 7, 'write-off activity events must exist');
+
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.completed_services WHERE patient_id = :'patient_a'::uuid) = :'completed_before'::integer, 'completed_services must remain unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE patient_id = :'patient_a'::uuid) = :'appointments_before'::integer, 'appointments must remain unchanged');
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id = :'patient_a'::uuid) = :'balance_before'::numeric, 'patients.balance must remain unchanged');
+
+\echo 'REFUNDS-WRITEOFFS SQL TESTS PASSED'
+ROLLBACK;


### PR DESCRIPTION
## Current implementation

- refund request/approve/complete/reject/void RPC lifecycle;
- invoice write-off request/approve/reject/void lifecycle;
- tenant-scoped idempotency;
- concurrency and capacity guards;
- repository eligibility/read models;
- typed `FinanceRpcClient` methods;
- no UI, cloud apply, seed changes, generated types, or clinical mutations.

## Validation

- SQL lifecycle/role/side-effect smoke: passed;
- concurrency/idempotency validation: passed;
- `FinanceRepository` tests: 23/23;
- `FinanceRpcClient` tests: 45/45;
- full suite: 67 files / 676 tests;
- ESLint: passed;
- build: passed;
- Supabase reset: passed;
- GitHub Actions CI #653 / run `29080027605`: success on `108a4d04626dc2e0c184d509d5b1f73b76b72515` before the report-only update;
- GitHub Actions CI #654 / run `29080769055`: success on final PR head `7711adda7ee94360de736dddf8ee1cc39bf4060c`.

## Finalization

Final PR head before the report-only update:

`108a4d04626dc2e0c184d509d5b1f73b76b72515`

Report-only update commit and current PR head:

`7711adda7ee94360de736dddf8ee1cc39bf4060c`

Hermes finalizer failed with `replaceReportPlaceholders is not defined`. The failure did not modify repository files or implementation results.

The final CI tested commit equals the current PR head.

## Final verdict

**REFUNDS WRITEOFFS FOUNDATION IMPLEMENTED AND VERIFIED**

## Recommended next task

`CASHIER-PAYMENT-FLOW-HARDENING-001`

After that:

`REFUNDS-WRITEOFFS-UI-001`

Do not merge as part of this task.
