### PR TITLE
COMPLETED-SERVICE-BILLING-GUARD-001: prevent duplicate completed-service billing

### DIFF
--- a/_ai_work/REPORTS/COMPLETED-SERVICE-BILLING-GUARD-001_guard.md
+++ b/_ai_work/REPORTS/COMPLETED-SERVICE-BILLING-GUARD-001_guard.md
@@ -1,4 +1,4 @@
-﻿# COMPLETED-SERVICE-BILLING-GUARD-001
+# COMPLETED-SERVICE-BILLING-GUARD-001
 
 ## 1. Summary
 Implemented a database-authoritative historical billing lock: one `completed_services` row can back at most one `invoice_items` row. Added relationship guards, hardened RPC behavior, a scoped eligibility read model, UI states, SQL/concurrency/unit/browser validation, and no clinical mutations.

--- a/_ai_work/REPORTS/COMPLETED-SERVICE-BILLING-GUARD-001_guard.md
+++ b/_ai_work/REPORTS/COMPLETED-SERVICE-BILLING-GUARD-001_guard.md
@@ -7,10 +7,10 @@ Implemented a database-authoritative historical billing lock: one `completed_ser
 `feature/completed-service-billing-guard-001`, based on verified `origin/main` `6fdfda06f268967941ad3c83bf58489a50ef21b2` containing PR #338.
 
 ## 3. PR URL
-Pending PR creation after the implementation commit.
+https://github.com/NckNA/codex-test/pull/339
 
 ## 4. PR head reviewed before final report update
-Pending. The implementation head will be reviewed before the final report-only update.
+Implementation head `1be4ae881b1f4487f28f4d92ae4ea8436e518c2a` was reviewed after local SQL, concurrency, browser, lint, full test, and build validation, and after fresh GitHub Actions success.
 
 ## 5. Report update commit
 N/A because the final report update commit cannot reference itself before creation.
@@ -97,7 +97,7 @@ All QA data was local-only; Vite processes stopped; final `npx supabase db reset
 `npm run lint`: passed. `npm run test -- --run`: 73 files/754 tests passed. `npm run build`: passed. SQL, concurrency, and repeated clean reset through `0021`: passed. Existing unrelated React `act(...)` warnings and Vite chunk advisory remain non-fatal.
 
 ## 31. GitHub Actions CI
-Pending PR creation and fresh CI on the current PR head.
+Implementation head `1be4ae881b1f4487f28f4d92ae4ea8436e518c2a` passed CI run `29127962215`: ESLint, tests, and build succeeded. The final report-only head must also pass fresh PR CI before final handoff; that final run is recorded in the task delivery.
 
 ## 32. Cloud apply precheck
 No cloud action performed. Before future apply, require empty results for: duplicate non-null `completed_service_id` groups; orphan links; invoice-item/invoice tenant or patient mismatch; completed-service/item tenant or patient mismatch. Migration intentionally fails rather than deleting or choosing a winner.
@@ -109,7 +109,7 @@ Manual semantic duplicates are not detected. Controlled rebilling is deferred. N
 No correction foundation, credit/debit notes, rebill workflow, clinical mutations, payment/refund/write-off/deposit changes, patient-credit foundation, fuzzy matching, cloud apply, seed/generated types, frontend service role, HEP-V2, or broad refactor.
 
 ## 35. Final verdict
-PARTIAL: fresh GitHub Actions CI on the current PR head has not yet been verified.
+COMPLETED SERVICE BILLING GUARD IMPLEMENTED AND VERIFIED
 
 ## 36. Recommended next task
 `PATIENT-CREDIT-DEPOSITS-FOUNDATION-001` because duplicate clinical billing is now blocked and safe prepayment/credit/deposit handling is the next major finance capability. Do not start it in this task.

--- a/_ai_work/REPORTS/COMPLETED-SERVICE-BILLING-GUARD-001_guard.md
+++ b/_ai_work/REPORTS/COMPLETED-SERVICE-BILLING-GUARD-001_guard.md
@@ -1,0 +1,115 @@
+﻿# COMPLETED-SERVICE-BILLING-GUARD-001
+
+## 1. Summary
+Implemented a database-authoritative historical billing lock: one `completed_services` row can back at most one `invoice_items` row. Added relationship guards, hardened RPC behavior, a scoped eligibility read model, UI states, SQL/concurrency/unit/browser validation, and no clinical mutations.
+
+## 2. Branch
+`feature/completed-service-billing-guard-001`, based on verified `origin/main` `6fdfda06f268967941ad3c83bf58489a50ef21b2` containing PR #338.
+
+## 3. PR URL
+Pending PR creation after the implementation commit.
+
+## 4. PR head reviewed before final report update
+Pending. The implementation head will be reviewed before the final report-only update.
+
+## 5. Report update commit
+N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed files
+Migration/test files: `supabase/migrations/0021_prevent_duplicate_completed_service_billing.sql`, `supabase/tests/0021_completed_service_billing_guard_test.sql`, `supabase/tests/0021_completed_service_billing_guard_concurrency.ps1`. App/test files: `FinanceRepository`, `FinanceRpcClient`, `usePatientFinance`, `useFinanceActions`, `PatientFinancePanel`, `InvoiceDetail`, and their related tests. Report: this file.
+
+## 7. Pre-read
+Reviewed required finance reports (`FINANCE-OPERATIONS-RECON-001`, `FINANCE-SUMMARY-CORRECTNESS-001`, `PAYMENTS-DEBTS-SCHEMA/REPOSITORY/RPC/RPC-CLIENT`, `PATIENT-FINANCE-UI-001`), `COMPLETED-SERVICES-UI-001`, encounter/completed-service reports, RLS/security-definer reports, migrations `0014`-`0020`, finance repositories/RPC/hooks/UI, role helpers, and tests.
+
+## 8. Current completed-service billing model
+`completed_services` is the clinical fact. `invoice_items.completed_service_id` is nullable and previously allowed duplicate non-null values. Invoice/item void/archive retained rows. No draft-item removal flow existed. Normal RPC checks were not a concurrency-safe or direct-write invariant, and UI eligibility was not authoritative.
+
+## 9. Duplicate billing risk
+Two sessions could both pass an application check and insert two financial lines for one clinical service, duplicating revenue, totals, and success audit/activity events.
+
+## 10. Active billing definition
+A service is historically billed when any persisted invoice item has that non-null `completed_service_id`. Parent invoice status, item status, payment, refund, or write-off status does not release it. `completed_service_id IS NULL` remains a manual line outside this invariant.
+
+## 11. Void/archive policy
+Invoice void, invoice archive, and item void/archive keep the service locked. Payment void/refund/write-off never unbill it. A non-null source link is immutable. No draft release path was added because no current item-removal workflow exists. Rebilling requires a future explicit correction/reissue workflow.
+
+## 12. Historical precheck
+Migration `0021` fails without deleting data for duplicate source links, orphan links, missing parent invoices, invoice-item versus invoice tenant/patient mismatch, and completed-service versus invoice-item tenant/patient mismatch, including voided/archived history. Clean local reset passed repeatedly.
+
+## 13. Database invariant
+Smallest safe design, no second ledger:
+```sql
+CREATE UNIQUE INDEX uq_invoice_items_completed_service_billed_once
+ON public.invoice_items (completed_service_id)
+WHERE completed_service_id IS NOT NULL;
+```
+The status-independent index intentionally preserves history. A trigger adds cross-row relationship and eligibility enforcement.
+
+## 14. Relationship guards
+For source-backed items: invoice exists; item tenant/patient matches invoice; completed service exists; service tenant/patient matches invoice; status is `completed`; service is not archived; service is not already linked; existing non-null link cannot be cleared or reassigned.
+
+## 15. RPC hardening
+`add_invoice_item` keeps its signature and current role policy. It authenticates, validates membership/role, locks invoice and service, validates scope/finality/archive, inserts under the unique index, updates totals, emits audit/activity, and commits atomically. Only the named unique constraint maps to `Эта выполненная услуга уже включена в другой счёт.` A failed race creates no item, total, or success event.
+
+## 16. Direct-write protection
+`authenticated` has no direct invoice-item INSERT; `anon` has no billing/eligibility RPC execute; privileged inserts still hit trigger/index. No frontend `service_role` and no completed-service write path were added.
+
+## 17. Billing eligibility read model
+Added tenant/patient-scoped `get_completed_service_billing_eligibility`, returning `unbilled|billed|unavailable`, service details, and safe billed metadata: invoice ID, item ID, number, validated status, and billed time. It is not derived from paginated client data.
+
+## 18. Repository/client integration
+Repository/client call the exact scoped RPC, validate billing state and invoice status, and hide raw errors. Browser smoke exposed real Supabase plain-object `PostgrestError` behavior; normalization now supports both `Error` instances and plain structured objects. Unrelated `23505` remains generic.
+
+## 19. UI behavior
+Unbilled services are selectable and populate service fields. Billed/unavailable services are disabled with `Уже включено в счёт №…` or `Недоступно`. Manual line stays explicit. Loading blocks repeat submission. Duplicate response refreshes eligibility and shows `Услуга уже была включена в другой счёт. Данные обновлены.` No fallback to manual or source-ID stripping occurs.
+
+## 20. Manual item limitation
+Manual items with null source remain allowed. The guard prevents duplicate linkage of the same completed-service ID, not a deliberately typed semantically similar manual description. No fuzzy matching was added.
+
+## 21. Role matrix
+Owner/admin/cashier: view and add under existing policy. Doctor/registrar: finance read-only. No-tenant and anon: blocked. Tenant B cannot view or bill tenant A. No role was broadened.
+
+## 22. SQL tests
+Self-contained transactional SQL creates its own tenants/users/memberships/patients/invoices/services. It covers first/duplicate billing, same/other invoice, direct duplicate, two services, manual null, cross-tenant/patient, parent mismatch, orphan, corrected/archived source, roles, no-tenant/anon, stable scoped eligibility, totals, audit/activity atomicity, void/archive lock, link immutability, and side-effect snapshots. Final result: `COMPLETED-SERVICE-BILLING-GUARD-001 SQL validation passed`.
+
+## 23. Concurrency tests
+Separate authenticated PostgreSQL sessions proved same-service race `success=1 rejected=1 items=1 audit=1 activity=1 totals=100.00/0.00`; different services `success=2 items=2 audit=2 activity=2 totals=200.00/300.00`; retry remains non-duplicating. Result: `CONCURRENCY VALIDATION PASSED`.
+
+## 24. TypeScript tests
+Repository/client/hook/UI tests cover exact arguments, mappings, invalid states, safe duplicate mapping for real/plain errors, unrelated unique errors, stale-patient protection, duplicate refresh, disabled labels, invoice number, field population, manual option, loading, no direct writes/service role. Full suite: 73 files, 754 tests passed.
+
+## 25. Browser smoke
+Local-only QA fixtures verified admin normal billing, manual item, billed label, voided-invoice historical lock, unavailable states, cashier add access, doctor/registrar read-only, no-tenant block, and tenant-B isolation. A two-browser stale race produced one success and one expected HTTP 409; after fixing plain-object error normalization, the loser showed the safe refreshed message and billed label. No secrets or raw SQL were shown; no fatal console error occurred.
+
+## 26. DB validation
+Browser DB check: zero duplicate links; draft invoice total/balance 3,450 KZT for 1,500+250+800+900; one manual line; voided invoice retained one link; each successful race had one link; tenant-B service stayed unlinked. Final reset counts: tenants/patients/invoices/items/QA users all zero.
+
+## 27. Audit/activity validation
+Three browser billing successes produced three audit and three activity events, one pair per service; losing race produced none. Standalone concurrency independently verified one success pair and no failed-transaction event.
+
+## 28. Side-effect validation
+`patients.balance`, completed-service facts, appointments, payments, refunds, financial adjustments/write-offs, documents, treatment plans, and clinical history were unchanged. No payment/refund/write-off code changed. Current schema has no stock table to mutate or snapshot.
+
+## 29. Cleanup
+All QA data was local-only; Vite processes stopped; final `npx supabase db reset --no-seed` passed; fixture counts returned zero; no seed/generated types committed; agent prompts/logs excluded.
+
+## 30. Lint/test/build
+`npm run lint`: passed. `npm run test -- --run`: 73 files/754 tests passed. `npm run build`: passed. SQL, concurrency, and repeated clean reset through `0021`: passed. Existing unrelated React `act(...)` warnings and Vite chunk advisory remain non-fatal.
+
+## 31. GitHub Actions CI
+Pending PR creation and fresh CI on the current PR head.
+
+## 32. Cloud apply precheck
+No cloud action performed. Before future apply, require empty results for: duplicate non-null `completed_service_id` groups; orphan links; invoice-item/invoice tenant or patient mismatch; completed-service/item tenant or patient mismatch. Migration intentionally fails rather than deleting or choosing a winner.
+
+## 33. Known limitations
+Manual semantic duplicates are not detected. Controlled rebilling is deferred. No broad invoice-item idempotency foundation was added; this unique guard is authoritative for completed-service linkage. Browser smoke was local-only. The losing race naturally emits network-level 409, converted to safe UI text.
+
+## 34. What was intentionally not implemented
+No correction foundation, credit/debit notes, rebill workflow, clinical mutations, payment/refund/write-off/deposit changes, patient-credit foundation, fuzzy matching, cloud apply, seed/generated types, frontend service role, HEP-V2, or broad refactor.
+
+## 35. Final verdict
+PARTIAL: fresh GitHub Actions CI on the current PR head has not yet been verified.
+
+## 36. Recommended next task
+`PATIENT-CREDIT-DEPOSITS-FOUNDATION-001` because duplicate clinical billing is now blocked and safe prepayment/credit/deposit handling is the next major finance capability. Do not start it in this task.

--- a/src/components/finance/InvoiceDetail.tsx
+++ b/src/components/finance/InvoiceDetail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type FormEvent } from 'react';
-import type { FinanceRepository, Invoice, InvoiceItem } from '../../data/repositories/FinanceRepository';
+import type { CompletedServiceBillingEligibility, FinanceRepository, Invoice, InvoiceItem } from '../../data/repositories/FinanceRepository';
 import type { FinanceRpcClient } from '../../data/repositories/FinanceRpcClient';
 import type { FinanceActionName } from '../../data/hooks/useFinanceActions';
 import { FinanceStatusBadge } from './FinanceStatusBadge';
@@ -11,6 +11,7 @@ interface InvoiceDetailProps {
   tenantId?: string | null;
   invoice: Invoice | null;
   items: InvoiceItem[];
+  completedServiceBillingEligibility: CompletedServiceBillingEligibility[];
   role?: FinanceUserRole;
   repository?: FinanceRepository;
   rpcClient?: FinanceRpcClient;
@@ -46,7 +47,7 @@ function parseOptionalAmount(value: string) {
   return Number(value);
 }
 
-export function InvoiceDetail({ tenantId, invoice, items, role, repository, rpcClient, canAddItem, actionLoading, onChanged, onAddItem }: InvoiceDetailProps) {
+export function InvoiceDetail({ tenantId, invoice, items, completedServiceBillingEligibility, role, repository, rpcClient, canAddItem, actionLoading, onChanged, onAddItem }: InvoiceDetailProps) {
   const [serviceName, setServiceName] = useState('');
   const [serviceCode, setServiceCode] = useState('');
   const [completedServiceId, setCompletedServiceId] = useState('');
@@ -60,6 +61,7 @@ export function InvoiceDetail({ tenantId, invoice, items, role, repository, rpcC
   const [formError, setFormError] = useState<string | null>(null);
 
   const invoiceItems = useMemo(() => (invoice ? items.filter((item) => item.invoiceId === invoice.id) : []), [invoice, items]);
+  const completedServiceById = useMemo(() => new Map(completedServiceBillingEligibility.map((service) => [service.completedServiceId, service])), [completedServiceBillingEligibility]);
   const canUseForm = Boolean(invoice && canAddItem && ['draft', 'issued'].includes(invoice.status));
   const invoiceCurrency = invoice?.currency ?? 'KZT';
 
@@ -74,6 +76,18 @@ export function InvoiceDetail({ tenantId, invoice, items, role, repository, rpcC
     setDiscountAmount('');
     setAdjustmentAmount('');
     setNotes('');
+  };
+
+  const handleCompletedServiceChange = (nextId: string) => {
+    setCompletedServiceId(nextId);
+    const service = completedServiceById.get(nextId);
+    if (!service || service.billingState !== 'unbilled') return;
+    setServiceName(service.serviceName);
+    setServiceCode(service.serviceCode ?? '');
+    setToothNumber(service.toothNumber ?? '');
+    setToothSurface(service.toothSurface ?? '');
+    setQuantity(String(service.quantity));
+    setUnitPrice(service.unitPrice === null ? '' : String(service.unitPrice));
   };
 
   const handleAddItem = async (event: FormEvent<HTMLFormElement>) => {
@@ -124,10 +138,20 @@ export function InvoiceDetail({ tenantId, invoice, items, role, repository, rpcC
             <label className="text-sm font-medium text-slate-700">Название услуги<input data-testid="finance-item-service-name" value={serviceName} onChange={(event) => setServiceName(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
             <label className="text-sm font-medium text-slate-700">Количество<input data-testid="finance-item-quantity" type="number" min="0" step="0.01" value={quantity} onChange={(event) => setQuantity(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
             <label className="text-sm font-medium text-slate-700">Цена<input data-testid="finance-item-unit-price" type="number" min="0" step="0.01" value={unitPrice} onChange={(event) => setUnitPrice(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Код<input value={serviceCode} onChange={(event) => setServiceCode(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">ID выполненной услуги<input value={completedServiceId} onChange={(event) => setCompletedServiceId(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Зуб<input value={toothNumber} onChange={(event) => setToothNumber(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Поверхность<input value={toothSurface} onChange={(event) => setToothSurface(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
+            <label className="text-sm font-medium text-slate-700">Код<input data-testid="finance-item-service-code" value={serviceCode} onChange={(event) => setServiceCode(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
+            <label className="text-sm font-medium text-slate-700">Выполненная услуга
+              <select data-testid="finance-completed-service-select" value={completedServiceId} onChange={(event) => handleCompletedServiceChange(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                <option value="">Ручная позиция (без выполненной услуги)</option>
+                {completedServiceBillingEligibility.map((service) => {
+                  const billingDetail = service.billingState === 'billed'
+                    ? ` — Уже включено в счёт${service.invoiceNumber ? ` №${service.invoiceNumber}` : ''}`
+                    : service.billingState === 'unavailable' ? ' — Недоступно' : '';
+                  return <option key={service.completedServiceId} value={service.completedServiceId} disabled={service.billingState !== 'unbilled'}>{service.serviceName}{billingDetail}</option>;
+                })}
+              </select>
+            </label>
+            <label className="text-sm font-medium text-slate-700">Зуб<input data-testid="finance-item-tooth-number" value={toothNumber} onChange={(event) => setToothNumber(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
+            <label className="text-sm font-medium text-slate-700">Поверхность<input data-testid="finance-item-tooth-surface" value={toothSurface} onChange={(event) => setToothSurface(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
             <label className="text-sm font-medium text-slate-700">Скидка<input type="number" min="0" step="0.01" value={discountAmount} onChange={(event) => setDiscountAmount(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
             <label className="text-sm font-medium text-slate-700">Корректировка<input type="number" min="0" step="0.01" value={adjustmentAmount} onChange={(event) => setAdjustmentAmount(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
             <label className="text-sm font-medium text-slate-700 md:col-span-3">Примечание<input value={notes} onChange={(event) => setNotes(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>

--- a/src/components/finance/PatientFinancePanel.test.tsx
+++ b/src/components/finance/PatientFinancePanel.test.tsx
@@ -30,6 +30,9 @@ const invoice = { id: 'invoice-1', tenantId, patientId, invoiceNumber: 'INV-1', 
 const invoiceItem = { id: 'item-1', tenantId, patientId, invoiceId: invoice.id, serviceName: 'Smoke finance service', serviceCode: 'SMK', completedServiceId: 'service-1', toothNumber: '16', toothSurface: 'O', quantity: 1, unitPrice: 1000, discountAmount: 0, adjustmentAmount: 0, totalAmount: 1000, status: 'active' } as InvoiceItem;
 const payment = { id: 'payment-1', tenantId, patientId, status: 'received', paymentMethod: 'cash', amount: 1000, currency: 'KZT', receivedAt: '2026-06-21T10:00:00.000Z', payerName: 'Patient', externalReference: 'SMOKE-PATIENT-FINANCE-UI-001', notes: 'Payment note' } as Payment;
 const allocation = { id: 'allocation-1', tenantId, patientId, paymentId: payment.id, invoiceId: invoice.id, invoiceItemId: null, status: 'active', amount: 1000, currency: 'KZT', allocatedAt: '2026-06-21T10:05:00.000Z' } as PaymentAllocation;
+const billedService = { completedServiceId: 'service-1', serviceName: 'Already billed', serviceCode: null, toothNumber: null, toothSurface: null, quantity: 1, unitPrice: 1000, currency: 'KZT', billingState: 'billed', invoiceId: 'invoice-void', invoiceItemId: 'item-void', invoiceNumber: 'INV-VOID', invoiceStatus: 'voided', billedAt: '2026-07-11T00:00:00.000Z' } as const;
+const unbilledService = { completedServiceId: 'service-2', serviceName: 'Selectable service', serviceCode: 'SEL', toothNumber: '16', toothSurface: 'O', quantity: 2, unitPrice: 1500, currency: 'KZT', billingState: 'unbilled', invoiceId: null, invoiceItemId: null, invoiceNumber: null, invoiceStatus: null, billedAt: null } as const;
+const unavailableService = { completedServiceId: 'service-3', serviceName: 'Unavailable service', serviceCode: null, toothNumber: null, toothSurface: null, quantity: 1, unitPrice: 1, currency: 'KZT', billingState: 'unavailable', invoiceId: null, invoiceItemId: null, invoiceNumber: null, invoiceStatus: null, billedAt: null } as const;
 
 function createRepository({ empty = false }: { empty?: boolean } = {}): FinanceRepository {
   return {
@@ -40,6 +43,7 @@ function createRepository({ empty = false }: { empty?: boolean } = {}): FinanceR
     listPaymentAllocations: vi.fn().mockResolvedValue(empty ? [] : [allocation]),
     listRefunds: vi.fn().mockResolvedValue([]),
     listFinancialAdjustments: vi.fn().mockResolvedValue([]),
+    getCompletedServiceBillingEligibility: vi.fn().mockResolvedValue([]),
     getPaymentRefundability: vi.fn().mockResolvedValue({ payment, paymentAmount: 1000, activeAllocatedAmount: 1000, completedRefundAmount: 0, reservedRefundAmount: 0, refundableAmount: 0, hasActiveAllocations: true, refundCount: 0, currency: 'KZT' }),
     getInvoiceWriteOffEligibility: vi.fn().mockResolvedValue({ invoice, invoiceTotalAmount: 1000, paidAmount: 0, approvedWriteOffAmount: 0, reservedWriteOffAmount: 0, availableWriteOffAmount: 0, eligible: false, ineligibilityReason: 'Invoice status draft is not eligible for write-off.', currency: 'KZT' }),
   } as unknown as FinanceRepository;
@@ -175,6 +179,77 @@ describe('PatientFinancePanel', () => {
     await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="finance-add-item-submit"]')?.click(); });
     expect(container.textContent).toContain('Название услуги обязательно.');
     expect(rpcClient.addInvoiceItem).not.toHaveBeenCalled();
+  });
+
+  it('renders billed services disabled with their historical invoice number while keeping manual items available', async () => {
+    const repository = createRepository();
+    vi.mocked(repository.getCompletedServiceBillingEligibility).mockResolvedValue([billedService]);
+    await renderPanel({ repository });
+    const select = container.querySelector<HTMLSelectElement>('[data-testid="finance-completed-service-select"]');
+    expect(select?.options[0]?.text).toContain('Ручная позиция');
+    expect(select?.options[1]?.disabled).toBe(true);
+    expect(select?.options[1]?.text).toContain('Уже включено в счёт');
+    expect(select?.options[1]?.text).toContain('INV-VOID');
+  });
+
+  it('keeps unavailable services disabled and fills a selectable completed service while preserving manual', async () => {
+    const repository = createRepository();
+    vi.mocked(repository.getCompletedServiceBillingEligibility).mockResolvedValue([unbilledService, unavailableService]);
+    await renderPanel({ repository });
+    const select = container.querySelector<HTMLSelectElement>('[data-testid="finance-completed-service-select"]');
+    expect(select?.options[0]?.value).toBe('');
+    expect(select?.options[2]?.disabled).toBe(true);
+    await act(async () => {
+      if (!select) return;
+      select.value = unbilledService.completedServiceId;
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(container.querySelector<HTMLInputElement>('[data-testid="finance-item-service-name"]')?.value).toBe('Selectable service');
+    expect(container.querySelector<HTMLInputElement>('[data-testid="finance-item-service-code"]')?.value).toBe('SEL');
+    expect(container.querySelector<HTMLInputElement>('[data-testid="finance-item-tooth-number"]')?.value).toBe('16');
+    expect(container.querySelector<HTMLInputElement>('[data-testid="finance-item-tooth-surface"]')?.value).toBe('O');
+    expect(container.querySelector<HTMLInputElement>('[data-testid="finance-item-quantity"]')?.value).toBe('2');
+    expect(container.querySelector<HTMLInputElement>('[data-testid="finance-item-unit-price"]')?.value).toBe('1500');
+  });
+
+  it('refreshes and displays the safe duplicate message after the backend rejects a selected service', async () => {
+    const repository = createRepository();
+    const rpcClient = createRpcClient();
+    vi.mocked(repository.getCompletedServiceBillingEligibility).mockResolvedValue([unbilledService]);
+    vi.mocked(rpcClient.addInvoiceItem).mockRejectedValueOnce(new Error('Эта выполненная услуга уже включена в другой счёт.'));
+    await renderPanel({ repository, rpcClient });
+    const select = container.querySelector<HTMLSelectElement>('[data-testid="finance-completed-service-select"]');
+    await act(async () => {
+      if (!select) return;
+      select.value = unbilledService.completedServiceId;
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="finance-add-item-submit"]')?.click(); });
+    expect(rpcClient.addInvoiceItem).toHaveBeenCalledWith(expect.objectContaining({ completedServiceId: unbilledService.completedServiceId }));
+    expect(repository.getPatientFinanceSummary).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('Услуга уже была включена в другой счёт. Данные обновлены.');
+  });
+
+  it('disables a pending item submission so a second click does not repeat the RPC', async () => {
+    const repository = createRepository();
+    const rpcClient = createRpcClient();
+    const pending = deferred<InvoiceItem>();
+    vi.mocked(repository.getCompletedServiceBillingEligibility).mockResolvedValue([unbilledService]);
+    vi.mocked(rpcClient.addInvoiceItem).mockReturnValueOnce(pending.promise);
+    await renderPanel({ repository, rpcClient });
+    const select = container.querySelector<HTMLSelectElement>('[data-testid="finance-completed-service-select"]');
+    await act(async () => {
+      if (!select) return;
+      select.value = unbilledService.completedServiceId;
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="finance-add-item-submit"]')?.click(); });
+    const submit = container.querySelector<HTMLButtonElement>('[data-testid="finance-add-item-submit"]');
+    expect(submit?.disabled).toBe(true);
+    await act(async () => { submit?.click(); });
+    expect(rpcClient.addInvoiceItem).toHaveBeenCalledTimes(1);
+    pending.resolve(invoiceItem);
+    await flush();
   });
 
   it('record payment and allocation forms validate required fields', async () => {

--- a/src/components/finance/PatientFinancePanel.tsx
+++ b/src/components/finance/PatientFinancePanel.tsx
@@ -34,7 +34,13 @@ export function PatientFinancePanel({ tenantId, patientId, role, repository, rpc
   const [createError, setCreateError] = useState<string | null>(null);
   const capabilities = useMemo(() => getFinanceRoleCapabilities(role), [role]);
 
-  const finance = usePatientFinance({ tenantId, patientId, repository, enabled: capabilities.canView });
+  const finance = usePatientFinance({
+    tenantId,
+    patientId,
+    repository,
+    enabled: capabilities.canView,
+    includeCompletedServiceBillingEligibility: capabilities.canAddInvoiceItem,
+  });
   const actions = useFinanceActions({ tenantId, patientId, refresh: finance.refresh, rpcClient });
 
   const selectedInvoice = useMemo(() => {
@@ -101,7 +107,7 @@ export function PatientFinancePanel({ tenantId, patientId, role, repository, rpc
           <PatientFinanceSummaryCard summary={finance.summary} />
           <div className="grid gap-6 xl:grid-cols-2">
             <InvoiceList invoices={finance.invoices} selectedInvoiceId={selectedInvoice?.id ?? null} role={role} actionLoading={actions.actionLoading} onSelectInvoice={setSelectedInvoiceId} onIssueInvoice={actions.issueInvoice} onVoidInvoice={actions.voidInvoice} />
-            <InvoiceDetail tenantId={tenantId} invoice={selectedInvoice} items={finance.invoiceItems} role={role} repository={repository} rpcClient={rpcClient} canAddItem={capabilities.canAddInvoiceItem} actionLoading={actions.actionLoading} onChanged={finance.refresh} onAddItem={actions.addInvoiceItem} />
+            <InvoiceDetail tenantId={tenantId} invoice={selectedInvoice} items={finance.invoiceItems} completedServiceBillingEligibility={finance.completedServiceBillingEligibility} role={role} repository={repository} rpcClient={rpcClient} canAddItem={capabilities.canAddInvoiceItem} actionLoading={actions.actionLoading} onChanged={finance.refresh} onAddItem={actions.addInvoiceItem} />
           </div>
           <PaymentList tenantId={tenantId} payments={finance.payments} role={role} repository={repository} rpcClient={rpcClient} actionLoading={actions.actionLoading} onRecordPayment={actions.recordPayment} onVoidPayment={actions.voidPayment} onChanged={finance.refresh} />
           <AllocationActions invoices={finance.invoices} invoiceItems={finance.invoiceItems} payments={finance.payments} allocations={finance.paymentAllocations} role={role} actionLoading={actions.actionLoading} onAllocatePayment={actions.allocatePayment} onVoidAllocation={actions.voidPaymentAllocation} />

--- a/src/data/hooks/useFinanceActions.test.tsx
+++ b/src/data/hooks/useFinanceActions.test.tsx
@@ -67,6 +67,18 @@ describe('useFinanceActions', () => {
     expect(rpcClient.addInvoiceItem).toHaveBeenCalledWith(expect.objectContaining({ tenantId, invoiceId: 'invoice-1', serviceName: 'Service', quantity: 1, unitPrice: 1000 }));
   });
 
+  it('refreshes and shows the safe race message after a completed-service duplicate', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.addInvoiceItem).mockRejectedValueOnce(new Error('Эта выполненная услуга уже включена в другой счёт.'));
+    await renderHook(rpcClient);
+    let thrown: unknown;
+    await act(async () => {
+      try { await latest?.addInvoiceItem({ invoiceId: 'invoice-1', serviceName: 'Service', quantity: 1, unitPrice: 1000, completedServiceId: 'service-1' }); } catch (error) { thrown = error; }
+    });
+    expect((thrown as Error).message).toBe('Услуга уже была включена в другой счёт. Данные обновлены.');
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
   it('calls issueInvoice', async () => {
     const rpcClient = await renderHook();
     await act(async () => { await latest?.issueInvoice('invoice-1'); });

--- a/src/data/hooks/useFinanceActions.ts
+++ b/src/data/hooks/useFinanceActions.ts
@@ -66,6 +66,8 @@ export interface UseFinanceActionsResult {
 }
 
 const ACTION_METADATA = { source: 'patient_finance_ui' };
+const COMPLETED_SERVICE_ALREADY_BILLED_ERROR = 'Эта выполненная услуга уже включена в другой счёт.';
+const COMPLETED_SERVICE_ALREADY_BILLED_REFRESHED_ERROR = 'Услуга уже была включена в другой счёт. Данные обновлены.';
 
 function normalizeOptionalText(value?: string | null) {
   const trimmed = value?.trim();
@@ -84,6 +86,10 @@ function safeFinanceError(error: unknown): Error {
     }
   }
   return new Error('Не удалось выполнить финансовую операцию.');
+}
+
+function isCompletedServiceDuplicate(error: unknown) {
+  return error instanceof Error && error.message.toLowerCase().includes(COMPLETED_SERVICE_ALREADY_BILLED_ERROR.toLowerCase());
 }
 
 export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: UseFinanceActionsOptions): UseFinanceActionsResult {
@@ -109,7 +115,10 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
       await action();
       await refresh?.();
     } catch (err) {
-      const parsed = safeFinanceError(err);
+      const parsed = isCompletedServiceDuplicate(err)
+        ? new Error(COMPLETED_SERVICE_ALREADY_BILLED_REFRESHED_ERROR)
+        : safeFinanceError(err);
+      if (isCompletedServiceDuplicate(err)) await refresh?.();
       setActionError(parsed);
       throw parsed;
     } finally {
@@ -225,3 +234,5 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
     clearError: () => setActionError(null),
   };
 }
+
+export { COMPLETED_SERVICE_ALREADY_BILLED_ERROR, COMPLETED_SERVICE_ALREADY_BILLED_REFRESHED_ERROR };

--- a/src/data/hooks/usePatientFinance.test.tsx
+++ b/src/data/hooks/usePatientFinance.test.tsx
@@ -38,11 +38,18 @@ function createRepository(): FinanceRepository {
     listPaymentAllocations: vi.fn().mockResolvedValue([allocation]),
     listRefunds: vi.fn().mockResolvedValue([]),
     listFinancialAdjustments: vi.fn().mockResolvedValue([]),
+    getCompletedServiceBillingEligibility: vi.fn().mockResolvedValue([]),
   } as unknown as FinanceRepository;
 }
 
 async function flush() {
   await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolver) => { resolve = resolver; });
+  return { promise, resolve };
 }
 
 describe('usePatientFinance', () => {
@@ -100,6 +107,23 @@ describe('usePatientFinance', () => {
     await flush();
     await act(async () => { await latest?.refresh(); });
     expect(repository.getPatientFinanceSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a stale patient response after the patient context changes', async () => {
+    const repository = createRepository();
+    const slowPatientA = deferred<PatientFinanceSummary>();
+    const patientB = 'patient-2';
+    const summaryB = { ...summary, patientId: patientB };
+    vi.mocked(repository.getPatientFinanceSummary).mockImplementation(({ patientId: requestedPatientId }) => (
+      requestedPatientId === patientId ? slowPatientA.promise : Promise.resolve(summaryB)
+    ));
+    await act(async () => { root.render(<Probe repository={repository} />); });
+    await act(async () => { root.render(<Probe patient={patientB} repository={repository} />); });
+    await flush();
+    expect(latest?.summary?.patientId).toBe(patientB);
+    slowPatientA.resolve(summary);
+    await flush();
+    expect(latest?.summary?.patientId).toBe(patientB);
   });
 
   it('surfaces repository errors safely', async () => {

--- a/src/data/hooks/usePatientFinance.ts
+++ b/src/data/hooks/usePatientFinance.ts
@@ -4,6 +4,7 @@ import {
   createFinanceRepository,
   type FinanceRepository,
   type FinancialAdjustment,
+  type CompletedServiceBillingEligibility,
   type Invoice,
   type InvoiceItem,
   type PatientFinanceSummary,
@@ -18,6 +19,7 @@ export interface UsePatientFinanceOptions {
   patientId?: string | null;
   repository?: FinanceRepository;
   enabled?: boolean;
+  includeCompletedServiceBillingEligibility?: boolean;
 }
 
 export interface PatientFinanceState {
@@ -28,6 +30,7 @@ export interface PatientFinanceState {
   paymentAllocations: PaymentAllocation[];
   refunds: Refund[];
   financialAdjustments: FinancialAdjustment[];
+  completedServiceBillingEligibility: CompletedServiceBillingEligibility[];
 }
 
 export interface UsePatientFinanceResult extends PatientFinanceState {
@@ -46,11 +49,12 @@ const EMPTY_FINANCE_STATE: PatientFinanceState = {
   paymentAllocations: [],
   refunds: [],
   financialAdjustments: [],
+  completedServiceBillingEligibility: [],
 };
 
 const UNAVAILABLE_ERROR = 'Supabase client is not configured for finance access.';
 
-export function usePatientFinance({ tenantId, patientId, repository, enabled = true }: UsePatientFinanceOptions): UsePatientFinanceResult {
+export function usePatientFinance({ tenantId, patientId, repository, enabled = true, includeCompletedServiceBillingEligibility = true }: UsePatientFinanceOptions): UsePatientFinanceResult {
   const canFetch = Boolean(tenantId && patientId) && enabled;
 
   const financeRepository = useMemo(() => {
@@ -63,7 +67,7 @@ export function usePatientFinance({ tenantId, patientId, repository, enabled = t
     if (!tenantId || !patientId) return EMPTY_FINANCE_STATE;
     if (!financeRepository) throw new Error(UNAVAILABLE_ERROR);
 
-    const [summary, invoices, invoiceItems, payments, paymentAllocations, refunds, financialAdjustments] = await Promise.all([
+    const [summary, invoices, invoiceItems, payments, paymentAllocations, refunds, financialAdjustments, completedServiceBillingEligibility] = await Promise.all([
       financeRepository.getPatientFinanceSummary({ tenantId, patientId }),
       financeRepository.listInvoices({ tenantId, patientId, includeArchived: true, limit: 100 }),
       financeRepository.listInvoiceItems({ tenantId, patientId, includeArchived: true, limit: 200 }),
@@ -71,15 +75,19 @@ export function usePatientFinance({ tenantId, patientId, repository, enabled = t
       financeRepository.listPaymentAllocations({ tenantId, patientId, includeVoided: true, limit: 200 }),
       financeRepository.listRefunds({ tenantId, patientId, includeArchived: true, limit: 50 }),
       financeRepository.listFinancialAdjustments({ tenantId, patientId, includeArchived: true, limit: 50 }),
+      includeCompletedServiceBillingEligibility
+        ? financeRepository.getCompletedServiceBillingEligibility({ tenantId, patientId })
+        : Promise.resolve([]),
     ]);
 
-    return { summary, invoices, invoiceItems, payments, paymentAllocations, refunds, financialAdjustments };
-  }, [financeRepository, patientId, tenantId]);
+    return { summary, invoices, invoiceItems, payments, paymentAllocations, refunds, financialAdjustments, completedServiceBillingEligibility };
+  }, [financeRepository, includeCompletedServiceBillingEligibility, patientId, tenantId]);
 
   const { data, isLoading, isError, error, refetch } = useAsyncQuery<PatientFinanceState>({
     queryFn,
     initialData: EMPTY_FINANCE_STATE,
     enabled: canFetch,
+    queryKey: `${tenantId ?? ''}:${patientId ?? ''}:${canFetch}`,
   });
 
   return {

--- a/src/data/repositories/FinanceRepository.test.ts
+++ b/src/data/repositories/FinanceRepository.test.ts
@@ -7,6 +7,7 @@ import {
   SupabaseFinanceRepository,
   createFinanceRepository,
   mapFinancialAdjustmentRow,
+  mapCompletedServiceBillingEligibilityRow,
   mapInvoiceItemRow,
   mapInvoiceRow,
   mapPaymentAllocationRow,
@@ -292,6 +293,38 @@ describe('FinanceRepository', () => {
 
     await expect(repository.getPatientFinanceFacts({ tenantId, patientId: '' })).rejects.toThrow(PATIENT_REQUIRED_FOR_FINANCE_ERROR);
     await expect(repository.getPatientFinanceSummary({ tenantId, patientId: '' })).rejects.toThrow(PATIENT_REQUIRED_FOR_FINANCE_ERROR);
+  });
+
+  it('reads authoritative completed-service billing eligibility through its tenant-scoped RPC', async () => {
+    const { repository, client } = createRepository();
+    client.rpc.mockResolvedValueOnce({ data: [{
+      completed_service_id: completedServiceId, service_name: 'Consultation', service_code: 'CONS',
+      tooth_number: '16', tooth_surface: 'O', quantity: '1', unit_price: '1000', currency: 'KZT',
+      billing_state: 'billed', invoice_id: invoiceId, invoice_item_id: invoiceItemId,
+      invoice_number: 'INV-1', invoice_status: 'voided', billed_at: '2026-07-11T10:00:00Z',
+    }], error: null });
+
+    await expect(repository.getCompletedServiceBillingEligibility({ tenantId, patientId })).resolves.toEqual([expect.objectContaining({
+      completedServiceId, billingState: 'billed', invoiceId, invoiceItemId, invoiceNumber: 'INV-1', invoiceStatus: 'voided', billedAt: '2026-07-11T10:00:00Z',
+    })]);
+    expect(client.rpc).toHaveBeenCalledWith('get_completed_service_billing_eligibility', { p_tenant_id: tenantId, p_patient_id: patientId });
+    expect(client.insert).not.toHaveBeenCalled();
+    expect(client.update).not.toHaveBeenCalled();
+    expect(client.delete).not.toHaveBeenCalled();
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown billing eligibility state instead of treating it as selectable', () => {
+    expect(() => mapCompletedServiceBillingEligibilityRow({
+      completed_service_id: completedServiceId, service_name: 'Consultation', quantity: 1, currency: 'KZT', billing_state: 'unknown',
+    })).toThrow('invalid billing_state');
+  });
+
+  it('rejects an invalid eligibility invoice status instead of blindly casting it', () => {
+    expect(() => mapCompletedServiceBillingEligibilityRow({
+      completed_service_id: completedServiceId, service_name: 'Consultation', quantity: 1, currency: 'KZT',
+      billing_state: 'billed', invoice_status: 'invented',
+    })).toThrow('invalid invoice_status');
   });
 
   it('requires ids for get methods', async () => {

--- a/src/data/repositories/FinanceRepository.ts
+++ b/src/data/repositories/FinanceRepository.ts
@@ -67,6 +67,25 @@ export interface InvoiceItem {
   updatedAt: string;
 }
 
+export type CompletedServiceBillingState = 'unbilled' | 'billed' | 'unavailable';
+
+export interface CompletedServiceBillingEligibility {
+  completedServiceId: string;
+  serviceName: string;
+  serviceCode: string | null;
+  toothNumber: string | null;
+  toothSurface: string | null;
+  quantity: number;
+  unitPrice: number | null;
+  currency: string;
+  billingState: CompletedServiceBillingState;
+  invoiceId: string | null;
+  invoiceItemId: string | null;
+  invoiceNumber: string | null;
+  invoiceStatus: InvoiceStatus | null;
+  billedAt: string | null;
+}
+
 export interface Payment {
   id: string;
   tenantId: string;
@@ -331,6 +350,11 @@ export interface PatientFinanceOptions {
   patientId: string;
 }
 
+export interface GetCompletedServiceBillingEligibilityOptions {
+  tenantId: string;
+  patientId: string;
+}
+
 export interface FinanceRepository {
   listInvoices(options: ListInvoicesOptions): Promise<Invoice[]>;
   getInvoiceById(options: GetInvoiceByIdOptions): Promise<Invoice | null>;
@@ -342,6 +366,7 @@ export interface FinanceRepository {
   listFinancialAdjustments(options: ListFinancialAdjustmentsOptions): Promise<FinancialAdjustment[]>;
   getPaymentRefundability(options: GetPaymentRefundabilityOptions): Promise<PaymentRefundability | null>;
   getInvoiceWriteOffEligibility(options: GetInvoiceWriteOffEligibilityOptions): Promise<InvoiceWriteOffEligibility | null>;
+  getCompletedServiceBillingEligibility(options: GetCompletedServiceBillingEligibilityOptions): Promise<CompletedServiceBillingEligibility[]>;
   getPatientFinanceFacts(options: PatientFinanceOptions): Promise<PatientFinanceFacts>;
   getPatientFinanceSummary(options: PatientFinanceOptions): Promise<PatientFinanceSummary>;
 }
@@ -474,6 +499,33 @@ export function mapInvoiceItemRow(row: Record<string, unknown>): InvoiceItem {
     archivedAt: nullableString(row.archived_at),
     createdAt: requiredString(row.created_at, 'created_at'),
     updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+export function mapCompletedServiceBillingEligibilityRow(row: Record<string, unknown>): CompletedServiceBillingEligibility {
+  const billingState = requiredString(row.billing_state, 'billing_state') as CompletedServiceBillingState;
+  if (!['unbilled', 'billed', 'unavailable'].includes(billingState)) {
+    throw new Error('Finance billing eligibility row has invalid billing_state');
+  }
+  const invoiceStatus = nullableString(row.invoice_status);
+  if (invoiceStatus !== null && !['draft', 'issued', 'partially_paid', 'paid', 'voided', 'written_off', 'archived'].includes(invoiceStatus)) {
+    throw new Error('Finance billing eligibility row has invalid invoice_status');
+  }
+  return {
+    completedServiceId: requiredString(row.completed_service_id, 'completed_service_id'),
+    serviceName: requiredString(row.service_name, 'service_name'),
+    serviceCode: nullableString(row.service_code),
+    toothNumber: nullableString(row.tooth_number),
+    toothSurface: nullableString(row.tooth_surface),
+    quantity: requiredNumber(row.quantity, 'quantity'),
+    unitPrice: row.unit_price === null || row.unit_price === undefined ? null : requiredNumber(row.unit_price, 'unit_price'),
+    currency: requiredString(row.currency, 'currency'),
+    billingState,
+    invoiceId: nullableString(row.invoice_id),
+    invoiceItemId: nullableString(row.invoice_item_id),
+    invoiceNumber: nullableString(row.invoice_number),
+    invoiceStatus: invoiceStatus as InvoiceStatus | null,
+    billedAt: nullableString(row.billed_at),
   };
 }
 
@@ -724,6 +776,17 @@ export class SupabaseFinanceRepository implements FinanceRepository {
     const { data, error } = await query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
     if (error) throw error;
     return ((data ?? []) as Record<string, unknown>[]).map(mapInvoiceItemRow);
+  }
+
+  async getCompletedServiceBillingEligibility(options: GetCompletedServiceBillingEligibilityOptions): Promise<CompletedServiceBillingEligibility[]> {
+    const tenantId = requireTenantId(options.tenantId);
+    const patientId = requirePatientId(options.patientId);
+    const { data, error } = await this.client.rpc('get_completed_service_billing_eligibility', {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+    });
+    if (error) throw error;
+    return ((data ?? []) as Record<string, unknown>[]).map(mapCompletedServiceBillingEligibilityRow);
   }
 
   async listPayments(options: ListPaymentsOptions): Promise<Payment[]> {

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -314,6 +314,58 @@ describe('FinanceRpcClient RPC mapping', () => {
     } });
   });
 
+  it('maps the completed-service duplicate conflict to the safe message', async () => {
+    const error = Object.assign(new Error('Эта выполненная услуга уже включена в другой счёт.'), { code: '23505' });
+    const { rpcClient } = createClientMock({ data: null, error });
+    await expect(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Filling', completedServiceId })).rejects.toMatchObject({
+      category: 'duplicate_conflict',
+      message: 'Эта выполненная услуга уже включена в другой счёт.',
+    });
+  });
+
+  it('maps the plain PostgREST duplicate response used by Supabase in the browser', async () => {
+    const error = {
+      code: '23505',
+      message: 'Эта выполненная услуга уже включена в другой счёт.',
+      details: null,
+      hint: null,
+    } as unknown as Error;
+    const { rpcClient } = createClientMock({ data: null, error });
+    await expect(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Filling', completedServiceId })).rejects.toMatchObject({
+      category: 'duplicate_conflict',
+      message: 'Эта выполненная услуга уже включена в другой счёт.',
+    });
+  });
+
+  it('does not mislabel an unrelated 23505 as a completed-service billing conflict', async () => {
+    const error = Object.assign(new Error('duplicate key value violates unique constraint "some_other_unique"'), { code: '23505', constraint: 'some_other_unique' });
+    const { rpcClient } = createClientMock({ data: null, error });
+    await expect(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Filling', completedServiceId })).rejects.toMatchObject({
+      category: undefined,
+      message: 'Не удалось выполнить финансовую операцию.',
+    });
+  });
+
+  it('maps the known unique index conflict safely without exposing raw SQL detail', async () => {
+    const error = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505', constraint: 'uq_invoice_items_completed_service_billed_once' });
+    const { rpcClient } = createClientMock({ data: null, error });
+    await expect(rpcClient.addInvoiceItem({ tenantId, invoiceId, serviceName: 'Filling', completedServiceId })).rejects.toMatchObject({
+      category: 'duplicate_conflict',
+      message: 'Эта выполненная услуга уже включена в другой счёт.',
+    });
+  });
+
+  it('gets completed-service billing eligibility only through the RPC', async () => {
+    const { rpcClient, rpcCalls, client } = createClientMock({ data: [{
+      completed_service_id: completedServiceId, service_name: 'Consultation', service_code: null,
+      tooth_number: null, tooth_surface: null, quantity: 1, unit_price: 1000, currency: 'KZT',
+      billing_state: 'unbilled', invoice_id: null, invoice_item_id: null, invoice_number: null, invoice_status: null, billed_at: null,
+    }], error: null });
+    await expect(rpcClient.getCompletedServiceBillingEligibility({ tenantId, patientId })).resolves.toEqual([expect.objectContaining({ completedServiceId, billingState: 'unbilled' })]);
+    expect(rpcCalls).toEqual([{ rpcName: 'get_completed_service_billing_eligibility', params: { p_tenant_id: tenantId, p_patient_id: patientId } }]);
+    expectNoDirectWriteCalls(client);
+  });
+
   it('issueInvoice calls issue_invoice', async () => {
     const { rpcClient, rpcCalls } = createClientMock({ data: invoiceRow, error: null });
     await rpcClient.issueInvoice({ tenantId, invoiceId });
@@ -618,6 +670,7 @@ describe('FinanceRpcClient safety boundaries', () => {
     expect(methods).toEqual(expect.arrayContaining([
       'createInvoice',
       'addInvoiceItem',
+      'getCompletedServiceBillingEligibility',
       'issueInvoice',
       'voidInvoice',
       'recordPayment',

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -7,6 +7,8 @@ import {
   mapPaymentRow,
   mapRefundRow,
   mapFinancialAdjustmentRow,
+  mapCompletedServiceBillingEligibilityRow,
+  type CompletedServiceBillingEligibility,
   type Invoice,
   type InvoiceItem,
   type Payment,
@@ -71,6 +73,11 @@ export interface AddInvoiceItemInput {
   toothSurface?: string | null;
   notes?: string | null;
   metadata?: Record<string, unknown>;
+}
+
+export interface GetCompletedServiceBillingEligibilityInput {
+  tenantId: string;
+  patientId: string;
 }
 
 export interface IssueInvoiceInput {
@@ -189,6 +196,7 @@ export interface VoidInvoiceWriteOffInput { tenantId: string; adjustmentId: stri
 export interface FinanceRpcClient {
   createInvoice(input: CreateInvoiceInput): Promise<Invoice>;
   addInvoiceItem(input: AddInvoiceItemInput): Promise<InvoiceItem>;
+  getCompletedServiceBillingEligibility(input: GetCompletedServiceBillingEligibilityInput): Promise<CompletedServiceBillingEligibility[]>;
   issueInvoice(input: IssueInvoiceInput): Promise<Invoice>;
   voidInvoice(input: VoidInvoiceInput): Promise<Invoice>;
   recordPayment(input: RecordPaymentInput): Promise<Payment>;
@@ -282,22 +290,53 @@ function extractSingleRow(data: unknown, operation: string): Record<string, unkn
   return row;
 }
 
-function safeRpcErrorDetail(error: Error): string {
-  const raw = error.message.trim();
+function getRpcErrorField(error: unknown, field: 'message' | 'code' | 'constraint' | 'details'): string | undefined {
+  if (error instanceof Error && field === 'message') return error.message;
+  if (error instanceof Error || isPlainObject(error)) {
+    const value = (error as unknown as Record<string, unknown>)[field];
+    return typeof value === 'string' ? value : undefined;
+  }
+  return undefined;
+}
+
+function safeRpcErrorDetail(error: unknown): string {
+  const raw = getRpcErrorField(error, 'message')?.trim() ?? '';
   if (!raw || raw.length > 240 || /[\r\n{}]/.test(raw) || raw.includes('[') || raw.includes(']')) return '';
   return raw.replace(/\s+/g, ' ');
 }
 
+function isCompletedServiceBillingConstraint(error: unknown, code?: string): boolean {
+  if (code !== '23505') return false;
+  const values = ['constraint', 'details', 'message']
+    .map((field) => getRpcErrorField(error, field as 'constraint' | 'details' | 'message'))
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+  return values.includes('uq_invoice_items_completed_service_billed_once');
+}
+
 function normalizeRpcError(error: unknown, operation: string): FinanceRpcClientError {
   if (error instanceof FinanceRpcClientError) return error;
-  if (error instanceof Error) {
-    const errorWithCode = error as unknown as { code?: unknown };
-    const code = typeof errorWithCode.code === 'string' ? errorWithCode.code : undefined;
+  if (error instanceof Error || isPlainObject(error)) {
+    const code = getRpcErrorField(error, 'code');
     const detail = safeRpcErrorDetail(error);
+    if (operation === 'addInvoiceItem' && (
+      detail.toLowerCase().includes('эта выполненная услуга уже включена')
+      || isCompletedServiceBillingConstraint(error, code)
+    )) {
+      return new FinanceRpcClientError({
+        operation,
+        code,
+        category: 'duplicate_conflict',
+        message: 'Эта выполненная услуга уже включена в другой счёт.',
+      });
+    }
     return new FinanceRpcClientError({
       operation,
       code,
-      message: detail
+      message: operation === 'addInvoiceItem'
+        ? FINANCE_RPC_OPERATION_FAILED_MESSAGE
+        : detail
         ? `${FINANCE_RPC_OPERATION_FAILED_MESSAGE} ${detail}`
         : FINANCE_RPC_OPERATION_FAILED_MESSAGE,
     });
@@ -315,6 +354,22 @@ async function callRpc(
     const { data, error } = await client.rpc(rpcName, params);
     if (error) throw normalizeRpcError(error, operation);
     return extractSingleRow(data, operation);
+  } catch (error) {
+    throw normalizeRpcError(error, operation);
+  }
+}
+
+async function callRpcRows(
+  client: SupabaseClient,
+  operation: string,
+  rpcName: string,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>[]> {
+  try {
+    const { data, error } = await client.rpc(rpcName, params);
+    if (error) throw normalizeRpcError(error, operation);
+    if (!Array.isArray(data)) throw new FinanceRpcClientError({ operation, category: 'read_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+    return data.filter(isPlainObject);
   } catch (error) {
     throw normalizeRpcError(error, operation);
   }
@@ -505,6 +560,15 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
       p_metadata: normalizeMetadata(input.metadata),
     });
     return mapInvoiceItemRow(row);
+  }
+
+  async getCompletedServiceBillingEligibility(input: GetCompletedServiceBillingEligibilityInput): Promise<CompletedServiceBillingEligibility[]> {
+    const operation = 'getCompletedServiceBillingEligibility';
+    const rows = await callRpcRows(this.client, operation, 'get_completed_service_billing_eligibility', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_patient_id: requireNonEmptyString(input.patientId, 'Пациент не выбран.'),
+    });
+    return rows.map(mapCompletedServiceBillingEligibilityRow);
   }
 
   async issueInvoice(input: IssueInvoiceInput): Promise<Invoice> {

--- a/supabase/migrations/0021_prevent_duplicate_completed_service_billing.sql
+++ b/supabase/migrations/0021_prevent_duplicate_completed_service_billing.sql
@@ -1,0 +1,280 @@
+-- COMPLETED-SERVICE-BILLING-GUARD-001
+-- A completed clinical service is a historical clinical fact.  One non-null
+-- invoice_items.completed_service_id is therefore retained for its entire
+-- financial history, including voided and archived invoice/item states.
+
+-- Do not silently repair historical finance data.  These checks intentionally
+-- inspect every item state, because a void/archive does not release a service.
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM (
+    SELECT completed_service_id
+    FROM public.invoice_items
+    WHERE completed_service_id IS NOT NULL
+    GROUP BY completed_service_id
+    HAVING count(*) > 1
+  ) duplicates;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install completed-service billing guard: % duplicate completed_service_id link(s) exist (including voided/archived rows). Resolve historical duplicates first.', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.invoice_items ii
+  LEFT JOIN public.completed_services cs ON cs.id = ii.completed_service_id
+  WHERE ii.completed_service_id IS NOT NULL AND cs.id IS NULL;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install completed-service billing guard: % orphan completed_service_id link(s) exist (including voided/archived rows). Resolve historical links first.', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.invoice_items ii
+  LEFT JOIN public.invoices i ON i.id = ii.invoice_id
+  WHERE i.id IS NULL OR ii.tenant_id <> i.tenant_id OR ii.patient_id <> i.patient_id;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install completed-service billing guard: % invoice-item/invoice tenant or patient mismatch(es) exist (including voided/archived rows). Resolve historical rows first.', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.invoice_items ii
+  JOIN public.completed_services cs ON cs.id = ii.completed_service_id
+  WHERE ii.completed_service_id IS NOT NULL
+    AND (ii.tenant_id <> cs.tenant_id OR ii.patient_id <> cs.patient_id);
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install completed-service billing guard: % cross-tenant or cross-patient completed-service link(s) exist (including voided/archived rows). Resolve historical links first.', v_count;
+  END IF;
+
+END;
+$$;
+
+-- PostgreSQL partial-index predicates cannot refer to invoice state.  A plain
+-- non-null unique key is deliberately stronger: financial void/archive never
+-- frees a completed service for a second bill.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_invoice_items_completed_service_billed_once
+  ON public.invoice_items (completed_service_id)
+  WHERE completed_service_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.enforce_invoice_item_completed_service_billing_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_invoice public.invoices;
+  v_completed_service public.completed_services;
+BEGIN
+  -- A historical clinical link is a financial fact, not an editable selector.
+  -- There is no supported item-removal flow; allowing a privileged UPDATE to
+  -- clear or replace this value would silently release or reassign the lock.
+  IF TG_OP = 'UPDATE'
+     AND OLD.completed_service_id IS NOT NULL
+     AND NEW.completed_service_id IS DISTINCT FROM OLD.completed_service_id THEN
+    RAISE EXCEPTION 'A billed completed service link is immutable';
+  END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = NEW.invoice_id
+  FOR KEY SHARE;
+
+  IF v_invoice.id IS NULL THEN
+    RAISE EXCEPTION 'Invoice item invoice does not exist';
+  END IF;
+  IF NEW.tenant_id <> v_invoice.tenant_id OR NEW.patient_id <> v_invoice.patient_id THEN
+    RAISE EXCEPTION 'Invoice item tenant and patient must match its invoice';
+  END IF;
+
+  -- Manual items remain valid and do not participate in the clinical lock.
+  IF NEW.completed_service_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO v_completed_service
+  FROM public.completed_services
+  WHERE id = NEW.completed_service_id
+  FOR KEY SHARE;
+
+  IF v_completed_service.id IS NULL THEN
+    RAISE EXCEPTION 'Completed service not found';
+  END IF;
+  IF v_completed_service.tenant_id <> NEW.tenant_id
+     OR v_completed_service.patient_id <> NEW.patient_id THEN
+    RAISE EXCEPTION 'Completed service does not belong to this invoice patient/tenant';
+  END IF;
+  IF v_completed_service.status <> 'completed' OR v_completed_service.archived_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Completed service is not available for billing';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS invoice_items_completed_service_billing_guard ON public.invoice_items;
+CREATE TRIGGER invoice_items_completed_service_billing_guard
+BEFORE INSERT OR UPDATE OF tenant_id, invoice_id, patient_id, completed_service_id
+ON public.invoice_items
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_invoice_item_completed_service_billing_guard();
+
+-- This is the only actual invoice-item creation RPC.  It retains the original
+-- role set, derives the actor from auth.uid(), locks the source service, and
+-- commits item, invoice totals, and success audit as one transaction.
+CREATE OR REPLACE FUNCTION public.add_invoice_item(
+  p_tenant_id uuid,
+  p_invoice_id uuid,
+  p_service_name text,
+  p_quantity numeric DEFAULT 1,
+  p_unit_price numeric DEFAULT 0,
+  p_discount_amount numeric DEFAULT 0,
+  p_adjustment_amount numeric DEFAULT 0,
+  p_completed_service_id uuid DEFAULT NULL,
+  p_service_code text DEFAULT NULL,
+  p_tooth_number text DEFAULT NULL,
+  p_tooth_surface text DEFAULT NULL,
+  p_notes text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.invoice_items
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_metadata jsonb := COALESCE(p_metadata, '{}'::jsonb);
+  v_invoice public.invoices;
+  v_completed_service public.completed_services;
+  v_item public.invoice_items;
+  v_total numeric(12,2);
+  v_constraint_name text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  IF p_invoice_id IS NULL THEN RAISE EXCEPTION 'Invoice ID is required'; END IF;
+  IF p_service_name IS NULL OR length(btrim(p_service_name)) = 0 THEN RAISE EXCEPTION 'Service name is required'; END IF;
+  IF COALESCE(p_quantity, 0) <= 0 THEN RAISE EXCEPTION 'Quantity must be positive'; END IF;
+  IF COALESCE(p_unit_price, 0) < 0 OR COALESCE(p_discount_amount, 0) < 0 OR COALESCE(p_adjustment_amount, 0) < 0 THEN RAISE EXCEPTION 'Amounts must be non-negative'; END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN RAISE EXCEPTION 'Metadata must be a JSON object'; END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = p_invoice_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+  IF v_invoice.id IS NULL THEN RAISE EXCEPTION 'Invoice not found in this tenant'; END IF;
+  IF v_invoice.status NOT IN ('draft', 'issued') THEN RAISE EXCEPTION 'Cannot add invoice item to invoice with status %', v_invoice.status; END IF;
+
+  IF p_completed_service_id IS NOT NULL THEN
+    SELECT * INTO v_completed_service
+    FROM public.completed_services
+    WHERE id = p_completed_service_id
+    FOR UPDATE;
+
+    IF v_completed_service.id IS NULL
+       OR v_completed_service.tenant_id <> p_tenant_id
+       OR v_completed_service.patient_id <> v_invoice.patient_id
+       OR v_completed_service.status <> 'completed'
+       OR v_completed_service.archived_at IS NOT NULL THEN
+      RAISE EXCEPTION 'Completed service is not available for this invoice';
+    END IF;
+    IF EXISTS (SELECT 1 FROM public.invoice_items WHERE completed_service_id = p_completed_service_id) THEN
+      RAISE EXCEPTION USING ERRCODE = '23505', MESSAGE = 'Эта выполненная услуга уже включена в другой счёт.';
+    END IF;
+  END IF;
+
+  v_total := GREATEST(0, COALESCE(p_quantity, 1) * COALESCE(p_unit_price, 0) - COALESCE(p_discount_amount, 0) + COALESCE(p_adjustment_amount, 0))::numeric(12,2);
+  BEGIN
+    INSERT INTO public.invoice_items (
+      tenant_id, invoice_id, patient_id, completed_service_id, service_name, service_code,
+      tooth_number, tooth_surface, quantity, unit_price, discount_amount, adjustment_amount,
+      total_amount, status, notes, metadata, created_by
+    ) VALUES (
+      p_tenant_id, p_invoice_id, v_invoice.patient_id, p_completed_service_id, btrim(p_service_name),
+      p_service_code, p_tooth_number, p_tooth_surface, p_quantity, p_unit_price, p_discount_amount,
+      p_adjustment_amount, v_total, 'active', p_notes, v_metadata, auth.uid()
+    ) RETURNING * INTO v_item;
+  EXCEPTION WHEN unique_violation THEN
+    -- The pre-check is user-friendly, while the unique index is the race-safe
+    -- backstop.  Inspect the actual constraint: a broad "row exists" check
+    -- could mislabel a future, unrelated invoice_items unique violation.
+    GET STACKED DIAGNOSTICS v_constraint_name = CONSTRAINT_NAME;
+    IF p_completed_service_id IS NOT NULL
+       AND v_constraint_name = 'uq_invoice_items_completed_service_billed_once' THEN
+      RAISE EXCEPTION USING ERRCODE = '23505', MESSAGE = 'Эта выполненная услуга уже включена в другой счёт.';
+    END IF;
+    RAISE;
+  END;
+
+  PERFORM public.recalculate_invoice_financials_internal(p_invoice_id);
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'invoice_item_added', 'invoice_item', v_item.id, v_invoice.patient_id,
+    p_metadata => jsonb_strip_nulls(jsonb_build_object(
+      'invoiceId', p_invoice_id, 'invoiceItemId', v_item.id,
+      'completedServiceId', p_completed_service_id, 'amount', v_total
+    ))
+  );
+  RETURN v_item;
+END;
+$$;
+
+-- A server-side, unpaginated eligibility read is necessary for race-safe UI.
+-- It exposes invoice metadata only to the same existing finance-writer roles.
+CREATE OR REPLACE FUNCTION public.get_completed_service_billing_eligibility(
+  p_tenant_id uuid,
+  p_patient_id uuid
+) RETURNS TABLE (
+  completed_service_id uuid,
+  service_name text,
+  service_code text,
+  tooth_number text,
+  tooth_surface text,
+  quantity numeric,
+  unit_price numeric,
+  currency text,
+  billing_state text,
+  invoice_id uuid,
+  invoice_item_id uuid,
+  invoice_number text,
+  invoice_status text,
+  billed_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  IF p_patient_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.patients WHERE tenant_id = p_tenant_id AND id = p_patient_id
+  ) THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  RETURN QUERY
+  SELECT cs.id, cs.service_name, cs.service_code, cs.tooth_number, cs.tooth_surface,
+    cs.quantity, cs.unit_price, cs.currency,
+    CASE WHEN ii.id IS NOT NULL THEN 'billed'
+         WHEN cs.status = 'completed' AND cs.archived_at IS NULL THEN 'unbilled'
+         ELSE 'unavailable' END,
+    ii.invoice_id, ii.id, i.invoice_number, i.status, ii.created_at
+  FROM public.completed_services cs
+  LEFT JOIN public.invoice_items ii ON ii.completed_service_id = cs.id
+  LEFT JOIN public.invoices i ON i.id = ii.invoice_id
+  WHERE cs.tenant_id = p_tenant_id AND cs.patient_id = p_patient_id
+  ORDER BY cs.performed_at DESC, cs.id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enforce_invoice_item_completed_service_billing_guard() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.add_invoice_item(uuid, uuid, text, numeric, numeric, numeric, numeric, uuid, text, text, text, text, jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_completed_service_billing_eligibility(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.add_invoice_item(uuid, uuid, text, numeric, numeric, numeric, numeric, uuid, text, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_completed_service_billing_eligibility(uuid, uuid) TO authenticated;
+
+COMMENT ON INDEX public.uq_invoice_items_completed_service_billed_once IS
+  'Historical billing lock: one completed clinical service backs at most one invoice item, including voided or archived finance records.';

--- a/supabase/tests/0021_completed_service_billing_guard_concurrency.ps1
+++ b/supabase/tests/0021_completed_service_billing_guard_concurrency.ps1
@@ -1,0 +1,125 @@
+$ErrorActionPreference = 'Stop'
+
+# Local-only validation. The UUID namespace is reserved for this script and the
+# finally block removes the tenant (cascading its task-scoped clinical/finance data).
+$container = 'supabase_db_codex-test-supabase'
+$tenant = 'd3100000-0000-4000-8000-000000000001'
+$patient = 'd3110000-0000-4000-8000-000000000001'
+$admin = 'd3120000-0000-4000-8000-000000000001'
+$invoiceA = 'd3130000-0000-4000-8000-000000000001'
+$invoiceB = 'd3130000-0000-4000-8000-000000000002'
+$invoiceC = 'd3130000-0000-4000-8000-000000000003'
+$invoiceD = 'd3130000-0000-4000-8000-000000000004'
+$serviceRace = 'd3140000-0000-4000-8000-000000000001'
+$serviceC = 'd3140000-0000-4000-8000-000000000002'
+$serviceD = 'd3140000-0000-4000-8000-000000000003'
+
+function Invoke-Sql([string]$sql) {
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+  if ($LASTEXITCODE -ne 0) { throw ($output -join "`n") }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $output = & docker exec $container psql -U postgres -d postgres -At -v ON_ERROR_STOP=1 -c $sql 2>&1
+  if ($LASTEXITCODE -ne 0) { throw ($output -join "`n") }
+  return ($output | Select-Object -Last 1).ToString().Trim()
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id='$tenant'::uuid;
+DELETE FROM auth.users WHERE id='$admin'::uuid;
+"@
+
+$setup = @"
+BEGIN;
+INSERT INTO public.tenants(id,name) VALUES ('$tenant'::uuid,'CSBG concurrency tenant');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at)
+VALUES ('$admin'::uuid,'00000000-0000-0000-0000-000000000000','authenticated','authenticated','csbg-concurrency@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$admin'::uuid);
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES ('$tenant'::uuid,'$admin'::uuid,'clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,balance) VALUES ('$patient'::uuid,'$tenant'::uuid,'CSBG concurrency patient','+77003110001','phone',91);
+INSERT INTO public.invoices(id,tenant_id,patient_id,invoice_number,status,currency,subtotal_amount,total_amount,balance_amount) VALUES
+ ('$invoiceA'::uuid,'$tenant'::uuid,'$patient'::uuid,'CSBG-RACE-A','draft','KZT',0,0,0),
+ ('$invoiceB'::uuid,'$tenant'::uuid,'$patient'::uuid,'CSBG-RACE-B','draft','KZT',0,0,0),
+ ('$invoiceC'::uuid,'$tenant'::uuid,'$patient'::uuid,'CSBG-DIFF-C','draft','KZT',0,0,0),
+ ('$invoiceD'::uuid,'$tenant'::uuid,'$patient'::uuid,'CSBG-DIFF-D','draft','KZT',0,0,0);
+INSERT INTO public.completed_services(id,tenant_id,patient_id,service_name,quantity,unit_price,total_amount,currency,status,created_by) VALUES
+ ('$serviceRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'race service',1,100,100,'KZT','completed','$admin'::uuid),
+ ('$serviceC'::uuid,'$tenant'::uuid,'$patient'::uuid,'different service C',1,200,200,'KZT','completed','$admin'::uuid),
+ ('$serviceD'::uuid,'$tenant'::uuid,'$patient'::uuid,'different service D',1,300,300,'KZT','completed','$admin'::uuid);
+COMMIT;
+"@
+
+$authContext = "BEGIN; SET LOCAL ROLE authenticated; SELECT set_config('request.jwt.claim.sub','$admin',true);"
+
+try {
+  Invoke-Sql $cleanup | Out-Null
+  Invoke-Sql $setup | Out-Null
+
+  $race = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.add_invoice_item('$tenant','$invoiceA','race A',1,100,0,0,'$serviceRace'); COMMIT;") `
+    ($authContext + " SELECT public.add_invoice_item('$tenant','$invoiceB','race B',1,100,0,0,'$serviceRace'); COMMIT;"))
+  $raceSuccess = @($race | Where-Object { $_.Code -eq 0 }).Count
+  $raceRejected = @($race | Where-Object { $_.Code -ne 0 }).Count
+  $linkedItems = [int](Invoke-Scalar "select count(*) from public.invoice_items where completed_service_id='$serviceRace'::uuid")
+  $successAudit = [int](Invoke-Scalar "select count(*) from public.audit_events where action='invoice_item_added' and metadata->>'completedServiceId'='$serviceRace'")
+  $successActivity = [int](Invoke-Scalar "select count(*) from public.activity_events where type='invoice_item_added' and metadata->>'completedServiceId'='$serviceRace'")
+  $totalA = [decimal](Invoke-Scalar "select total_amount from public.invoices where id='$invoiceA'::uuid")
+  $totalB = [decimal](Invoke-Scalar "select total_amount from public.invoices where id='$invoiceB'::uuid")
+  if ($raceSuccess -ne 1 -or $raceRejected -ne 1 -or $linkedItems -ne 1 -or $successAudit -ne 1 -or $successActivity -ne 1 -or (($totalA -eq 100 -and $totalB -eq 0) -or ($totalA -eq 0 -and $totalB -eq 100)) -ne $true) {
+    throw "Same-service race invariant failed: success=$raceSuccess rejected=$raceRejected items=$linkedItems audit=$successAudit activity=$successActivity totals=$totalA/$totalB"
+  }
+
+  $retry = $authContext + " SELECT public.add_invoice_item('$tenant','$invoiceA','retry',1,100,0,0,'$serviceRace'); COMMIT;"
+  $retryExit = 0
+  try {
+    $retryOutput = $retry | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    $retryExit = $LASTEXITCODE
+  } catch {
+    # An expected rejected retry is a nonzero native command under Stop mode.
+    $retryOutput = $_
+    $retryExit = $LASTEXITCODE
+  }
+  if ($retryExit -eq 0) { throw 'Retry unexpectedly succeeded.' }
+  if ([int](Invoke-Scalar "select count(*) from public.invoice_items where completed_service_id='$serviceRace'::uuid") -ne 1) { throw 'Retry created a duplicate item.' }
+
+  $different = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.add_invoice_item('$tenant','$invoiceC','different C',1,200,0,0,'$serviceC'); COMMIT;") `
+    ($authContext + " SELECT public.add_invoice_item('$tenant','$invoiceD','different D',1,300,0,0,'$serviceD'); COMMIT;"))
+  if (@($different | Where-Object { $_.Code -eq 0 }).Count -ne 2) { throw 'Different completed services should both bill concurrently.' }
+  $differentItems = [int](Invoke-Scalar "select count(*) from public.invoice_items where completed_service_id in ('$serviceC'::uuid,'$serviceD'::uuid)")
+  $differentAudit = [int](Invoke-Scalar "select count(*) from public.audit_events where action='invoice_item_added' and metadata->>'completedServiceId' in ('$serviceC','$serviceD')")
+  $differentActivity = [int](Invoke-Scalar "select count(*) from public.activity_events where type='invoice_item_added' and metadata->>'completedServiceId' in ('$serviceC','$serviceD')")
+  $totalC = [decimal](Invoke-Scalar "select total_amount from public.invoices where id='$invoiceC'::uuid")
+  $totalD = [decimal](Invoke-Scalar "select total_amount from public.invoices where id='$invoiceD'::uuid")
+  if ($differentItems -ne 2 -or $differentAudit -ne 2 -or $differentActivity -ne 2 -or $totalC -ne 200 -or $totalD -ne 300) {
+    throw "Different-service concurrency invariant failed: items=$differentItems audit=$differentAudit activity=$differentActivity totals=$totalC/$totalD"
+  }
+
+  Write-Output "SAME_SERVICE_RACE success=$raceSuccess rejected=$raceRejected items=$linkedItems audit=$successAudit activity=$successActivity totals=$totalA/$totalB"
+  Write-Output "DIFFERENT_SERVICE_RACE success=2 items=$differentItems audit=$differentAudit activity=$differentActivity totals=$totalC/$totalD"
+  Write-Output 'COMPLETED-SERVICE-BILLING-GUARD-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remaining = [int](Invoke-Scalar "select count(*) from public.tenants where id='$tenant'::uuid")
+  if ($remaining -ne 0) { throw "Concurrency cleanup failed: remaining tenants=$remaining" }
+}

--- a/supabase/tests/0021_completed_service_billing_guard_test.sql
+++ b/supabase/tests/0021_completed_service_billing_guard_test.sql
@@ -1,0 +1,207 @@
+\set ON_ERROR_STOP on
+\echo 'COMPLETED-SERVICE-BILLING-GUARD-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+-- All identities and domain rows are scoped to this transaction.  This test
+-- intentionally does not depend on the optional local QA-user seed.
+\set tenant_a 'a9210000-0000-4000-8000-000000000001'
+\set tenant_b 'b9210000-0000-4000-8000-000000000001'
+\set patient_a 'a9220000-0000-4000-8000-000000000001'
+\set patient_a2 'a9220000-0000-4000-8000-000000000002'
+\set patient_b 'b9220000-0000-4000-8000-000000000001'
+\set owner_a 'a9230000-0000-4000-8000-000000000001'
+\set admin_a 'a9230000-0000-4000-8000-000000000002'
+\set cashier_a 'a9230000-0000-4000-8000-000000000003'
+\set doctor_a 'a9230000-0000-4000-8000-000000000004'
+\set registrar_a 'a9230000-0000-4000-8000-000000000005'
+\set notenant 'a9230000-0000-4000-8000-000000000006'
+\set admin_b 'b9230000-0000-4000-8000-000000000001'
+\set invoice_a1 'a9240000-0000-4000-8000-000000000001'
+\set invoice_a2 'a9240000-0000-4000-8000-000000000002'
+\set invoice_a_patient2 'a9240000-0000-4000-8000-000000000003'
+\set invoice_b 'b9240000-0000-4000-8000-000000000001'
+\set service_a1 'a9250000-0000-4000-8000-000000000001'
+\set service_a2 'a9250000-0000-4000-8000-000000000002'
+\set service_corrected 'a9250000-0000-4000-8000-000000000003'
+\set service_archived 'a9250000-0000-4000-8000-000000000004'
+\set service_owner 'a9250000-0000-4000-8000-000000000005'
+\set service_admin 'a9250000-0000-4000-8000-000000000006'
+\set service_cashier 'a9250000-0000-4000-8000-000000000007'
+
+INSERT INTO public.tenants(id, name) VALUES
+  (:'tenant_a', 'Completed service billing guard A'),
+  (:'tenant_b', 'Completed service billing guard B');
+INSERT INTO auth.users(id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+VALUES
+  (:'owner_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-owner@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'admin_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-admin@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'cashier_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-cashier@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'doctor_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-doctor@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'registrar_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-registrar@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'notenant', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-notenant@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'admin_b', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'csg-admin-b@example.local', 'not-a-secret', now(), '{"provider":"email"}', '{}', now(), now());
+INSERT INTO public.profiles(id) VALUES
+  (:'owner_a'), (:'admin_a'), (:'cashier_a'), (:'doctor_a'), (:'registrar_a'), (:'notenant'), (:'admin_b');
+INSERT INTO public.tenant_users(tenant_id, user_id, role) VALUES
+  (:'tenant_a', :'owner_a', 'clinic_owner'),
+  (:'tenant_a', :'admin_a', 'clinic_admin'),
+  (:'tenant_a', :'cashier_a', 'cashier'),
+  (:'tenant_a', :'doctor_a', 'doctor'),
+  (:'tenant_a', :'registrar_a', 'registrar'),
+  (:'tenant_b', :'admin_b', 'clinic_admin');
+
+INSERT INTO public.patients(id, tenant_id, full_name, phone, source, balance) VALUES
+  (:'patient_a', :'tenant_a', 'Billing Guard Patient A', '+77009220001', 'phone', 777),
+  (:'patient_a2', :'tenant_a', 'Billing Guard Patient A2', '+77009220002', 'phone', 0),
+  (:'patient_b', :'tenant_b', 'Billing Guard Patient B', '+77009220003', 'phone', 0);
+INSERT INTO public.appointments(tenant_id, patient_id, service, status, start_time, end_time)
+VALUES (:'tenant_a', :'patient_a', 'No billing side effect fixture', 'completed', now() - interval '1 hour', now());
+INSERT INTO public.invoices(id, tenant_id, patient_id, invoice_number, status, currency, subtotal_amount, total_amount, balance_amount, created_by, metadata) VALUES
+  (:'invoice_a1', :'tenant_a', :'patient_a', 'CSBG-A1', 'draft', 'KZT', 0, 0, 0, :'admin_a', '{}'),
+  (:'invoice_a2', :'tenant_a', :'patient_a', 'CSBG-A2', 'draft', 'KZT', 0, 0, 0, :'admin_a', '{}'),
+  (:'invoice_a_patient2', :'tenant_a', :'patient_a2', 'CSBG-A-P2', 'draft', 'KZT', 0, 0, 0, :'admin_a', '{}'),
+  (:'invoice_b', :'tenant_b', :'patient_b', 'CSBG-B1', 'draft', 'KZT', 0, 0, 0, :'admin_b', '{}');
+INSERT INTO public.completed_services(id, tenant_id, patient_id, service_name, service_code, tooth_number, tooth_surface, quantity, unit_price, total_amount, currency, status, correction_reason, archived_at, created_by, metadata) VALUES
+  (:'service_a1', :'tenant_a', :'patient_a', 'Guard service one', 'CS-1', '11', 'O', 1, 1000, 1000, 'KZT', 'completed', NULL, NULL, :'admin_a', '{}'),
+  (:'service_a2', :'tenant_a', :'patient_a', 'Guard service two', 'CS-2', '12', 'M', 1, 2000, 2000, 'KZT', 'completed', NULL, NULL, :'admin_a', '{}'),
+  (:'service_corrected', :'tenant_a', :'patient_a', 'Corrected service', NULL, NULL, NULL, 1, 10, 10, 'KZT', 'corrected', 'fixture correction', NULL, :'admin_a', '{}'),
+  (:'service_archived', :'tenant_a', :'patient_a', 'Archived service', NULL, NULL, NULL, 1, 10, 10, 'KZT', 'archived', NULL, now(), :'admin_a', '{}'),
+  (:'service_owner', :'tenant_a', :'patient_a', 'Owner service', NULL, NULL, NULL, 1, 50, 50, 'KZT', 'completed', NULL, NULL, :'admin_a', '{}'),
+  (:'service_admin', :'tenant_a', :'patient_a', 'Admin service', NULL, NULL, NULL, 1, 60, 60, 'KZT', 'completed', NULL, NULL, :'admin_a', '{}'),
+  (:'service_cashier', :'tenant_a', :'patient_a', 'Cashier service', NULL, NULL, NULL, 1, 70, 70, 'KZT', 'completed', NULL, NULL, :'admin_a', '{}');
+
+-- The schema deliberately has no "incomplete" completed-service state. It
+-- rejects that invalid lifecycle value; valid non-final/archived rows below
+-- are separately proven unavailable to the billing RPC.
+SELECT pg_temp.expect_error(format('insert into public.completed_services(tenant_id,patient_id,service_name,status) values(%L::uuid,%L::uuid,''invalid incomplete'',''incomplete'')', :'tenant_a', :'patient_a'), 'completed_services_status_check');
+
+SELECT balance::text AS balance_before FROM public.patients WHERE id = :'patient_a' \gset
+SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(cs) ORDER BY id)::text, '[]'), 'sha256'), 'hex') AS services_before FROM public.completed_services cs WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS appointments_before FROM public.appointments WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS payments_before FROM public.payments WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS documents_before FROM public.documents WHERE patient_id = :'patient_a' \gset
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+
+-- First bill succeeds and produces exactly one financial audit/activity pair.
+SELECT (public.add_invoice_item(:'tenant_a', :'invoice_a1', 'Guard service one', 1, 1000, 0, 0, :'service_a1')).id::text AS item_a1 \gset
+SELECT pg_temp.assert_true((SELECT total_amount FROM public.invoices WHERE id = :'invoice_a1') = 1000, 'first completed-service bill updates total');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoice_items WHERE completed_service_id = :'service_a1') = 1, 'first completed-service bill creates one item');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'invoice_item_added' AND metadata->>'completedServiceId' = :'service_a1') = 1, 'first bill creates one audit event');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type = 'invoice_item_added' AND metadata->>'completedServiceId' = :'service_a1') = 1, 'first bill creates one activity event');
+
+-- Duplicate via either invoice is safe and has no item, total, or success event side effect.
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,1000,0,0,%L::uuid)', :'tenant_a', :'invoice_a1', 'same invoice retry', :'service_a1'), 'Эта выполненная услуга уже включена');
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,1000,0,0,%L::uuid)', :'tenant_a', :'invoice_a2', 'other invoice retry', :'service_a1'), 'Эта выполненная услуга уже включена');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoice_items WHERE completed_service_id = :'service_a1') = 1, 'duplicate RPC creates no second item');
+SELECT pg_temp.assert_true((SELECT total_amount FROM public.invoices WHERE id = :'invoice_a1') = 1000 AND (SELECT total_amount FROM public.invoices WHERE id = :'invoice_a2') = 0, 'duplicate RPC changes no totals');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action = 'invoice_item_added' AND metadata->>'completedServiceId' = :'service_a1') = 1, 'duplicate RPC creates no second audit');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type = 'invoice_item_added' AND metadata->>'completedServiceId' = :'service_a1') = 1, 'duplicate RPC creates no second activity');
+
+-- The scoped eligibility read is stable and has all three modeled states.
+SELECT pg_temp.assert_true((SELECT billing_state = 'billed' AND invoice_id = :'invoice_a1'::uuid AND invoice_item_id IS NOT NULL AND invoice_number = 'CSBG-A1' AND invoice_status = 'draft' AND billed_at IS NOT NULL FROM public.get_completed_service_billing_eligibility(:'tenant_a', :'patient_a') WHERE completed_service_id = :'service_a1'), 'billed eligibility exposes only scoped historic invoice metadata');
+SELECT pg_temp.assert_true((SELECT billing_state = 'unbilled' FROM public.get_completed_service_billing_eligibility(:'tenant_a', :'patient_a') WHERE completed_service_id = :'service_a2'), 'completed unbilled service is selectable');
+SELECT pg_temp.assert_true((SELECT billing_state = 'unavailable' FROM public.get_completed_service_billing_eligibility(:'tenant_a', :'patient_a') WHERE completed_service_id = :'service_corrected'), 'non-completed service is unavailable');
+SELECT pg_temp.assert_true((SELECT billing_state = 'unavailable' FROM public.get_completed_service_billing_eligibility(:'tenant_a', :'patient_a') WHERE completed_service_id = :'service_archived'), 'archived service is unavailable');
+SELECT jsonb_agg(to_jsonb(e) ORDER BY e.completed_service_id)::text AS eligibility_once FROM public.get_completed_service_billing_eligibility(:'tenant_a', :'patient_a') e \gset
+SELECT pg_temp.assert_true(:'eligibility_once' = (SELECT jsonb_agg(to_jsonb(e) ORDER BY e.completed_service_id)::text FROM public.get_completed_service_billing_eligibility(:'tenant_a', :'patient_a') e), 'repeated eligibility reads are stable');
+
+SELECT public.add_invoice_item(:'tenant_a', :'invoice_a2', 'Guard service two', 1, 2000, 0, 0, :'service_a2');
+SELECT public.add_invoice_item(:'tenant_a', :'invoice_a2', 'Manual item', 1, 300, 0, 0, NULL);
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoice_items WHERE invoice_id = :'invoice_a2' AND completed_service_id = :'service_a2') = 1, 'two different completed services can be billed');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoice_items WHERE invoice_id = :'invoice_a2' AND completed_service_id IS NULL) = 1, 'manual NULL completed_service item remains allowed');
+SELECT pg_temp.assert_true((SELECT total_amount FROM public.invoices WHERE id = :'invoice_a2') = 2300, 'successful totals are correct');
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,10,0,0,%L::uuid)', :'tenant_a', :'invoice_a2', 'corrected', :'service_corrected'), 'not available');
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,10,0,0,%L::uuid)', :'tenant_a', :'invoice_a2', 'archived', :'service_archived'), 'not available');
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,10,0,0,%L::uuid)', :'tenant_a', :'invoice_a_patient2', 'cross patient', :'service_a1'), 'not available');
+SELECT set_config('request.jwt.claim.sub', :'admin_b', true);
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,10,0,0,%L::uuid)', :'tenant_b', :'invoice_b', 'cross tenant', :'service_a1'), 'not available');
+SELECT pg_temp.expect_error(format('select public.get_completed_service_billing_eligibility(%L::uuid,%L::uuid)', :'tenant_a', :'patient_a'), 'Insufficient finance permissions');
+
+-- Existing add_invoice_item writers remain the exact allowed matrix.
+SELECT set_config('request.jwt.claim.sub', :'owner_a', true);
+SELECT public.add_invoice_item(:'tenant_a', :'invoice_a2', 'Owner service', 1, 50, 0, 0, :'service_owner');
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.add_invoice_item(:'tenant_a', :'invoice_a2', 'Admin service', 1, 60, 0, 0, :'service_admin');
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT public.add_invoice_item(:'tenant_a', :'invoice_a2', 'Cashier service', 1, 70, 0, 0, :'service_cashier');
+SELECT set_config('request.jwt.claim.sub', :'doctor_a', true);
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L)', :'tenant_a', :'invoice_a2', 'doctor denied'), 'Insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'registrar_a', true);
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L)', :'tenant_a', :'invoice_a2', 'registrar denied'), 'Insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'notenant', true);
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L)', :'tenant_a', :'invoice_a2', 'no tenant denied'), 'Insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+
+RESET ROLE;
+-- Privileged fixture attempts exercise the guard itself; authenticated writers
+-- never receive direct INSERT permission.
+SELECT pg_temp.expect_error(format('insert into public.invoice_items(tenant_id,invoice_id,patient_id,completed_service_id,service_name,quantity,unit_price,total_amount,status,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,1,1000,1000,%L,%L::jsonb)', :'tenant_a', :'invoice_a2', :'patient_a', :'service_a1', 'direct duplicate', 'active', '{}'), 'uq_invoice_items_completed_service_billed_once');
+SELECT pg_temp.expect_error(format('insert into public.invoice_items(tenant_id,invoice_id,patient_id,completed_service_id,service_name,quantity,unit_price,total_amount,status,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,1,1,1,%L,%L::jsonb)', :'tenant_a', :'invoice_a_patient2', :'patient_a2', :'service_a1', 'cross patient direct', 'active', '{}'), 'does not belong');
+SELECT pg_temp.expect_error(format('insert into public.invoice_items(tenant_id,invoice_id,patient_id,completed_service_id,service_name,quantity,unit_price,total_amount,status,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,1,1,1,%L,%L::jsonb)', :'tenant_b', :'invoice_b', :'patient_b', :'service_a1', 'cross tenant direct', 'active', '{}'), 'does not belong');
+SELECT pg_temp.expect_error(format('insert into public.invoice_items(tenant_id,invoice_id,patient_id,service_name,quantity,unit_price,total_amount,status,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L,1,1,1,%L,%L::jsonb)', :'tenant_a', :'invoice_b', :'patient_a', 'invoice mismatch', 'active', '{}'), 'must match its invoice');
+SELECT pg_temp.expect_error(format('insert into public.invoice_items(tenant_id,invoice_id,patient_id,completed_service_id,service_name,quantity,unit_price,total_amount,status,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,1,1,1,%L,%L::jsonb)', :'tenant_a', :'invoice_a2', :'patient_a', 'a9250000-0000-4000-8000-000000000099', 'orphan', 'active', '{}'), 'Completed service not found');
+SELECT pg_temp.expect_error(format('update public.invoice_items set completed_service_id = null where id = %L::uuid', :'item_a1'), 'immutable');
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(format('insert into public.invoice_items(tenant_id,invoice_id,patient_id,service_name,quantity,unit_price,total_amount,status,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L,1,1,1,%L,%L::jsonb)', :'tenant_a', :'invoice_a2', :'patient_a', 'direct authenticated', 'active', '{}'), 'permission denied');
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L)', :'tenant_a', :'invoice_a2', 'anon denied'), 'permission denied');
+SELECT pg_temp.assert_true(NOT has_function_privilege('anon', 'public.add_invoice_item(uuid,uuid,text,numeric,numeric,numeric,numeric,uuid,text,text,text,text,jsonb)', 'EXECUTE'), 'anon has no add_invoice_item execute');
+RESET ROLE;
+
+-- Voiding then archiving does not release the historical unique lock.  Item
+-- archiving likewise cannot make a previously billed service selectable.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.void_invoice(:'tenant_a', :'invoice_a1', 'historical lock fixture');
+RESET ROLE;
+UPDATE public.invoices SET status = 'archived', archived_at = now() WHERE id = :'invoice_a1';
+UPDATE public.invoice_items SET status = 'archived', archived_at = now() WHERE id = :'item_a1';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(format('select public.add_invoice_item(%L::uuid,%L::uuid,%L,1,1000,0,0,%L::uuid)', :'tenant_a', :'invoice_a2', 'after void and archive', :'service_a1'), 'Эта выполненная услуга уже включена');
+RESET ROLE;
+
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id = :'patient_a') = :'balance_before'::numeric, 'patients.balance is unchanged');
+SELECT pg_temp.assert_true((SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(cs) ORDER BY id)::text, '[]'), 'sha256'), 'hex') FROM public.completed_services cs WHERE patient_id = :'patient_a') = :'services_before', 'completed_services rows and fields are unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE patient_id = :'patient_a') = :'appointments_before'::integer, 'appointments are unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments WHERE patient_id = :'patient_a') = :'payments_before'::integer, 'payments are unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.refunds WHERE patient_id = :'patient_a') = :'refunds_before'::integer, 'refunds are unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.financial_adjustments WHERE patient_id = :'patient_a') = :'adjustments_before'::integer, 'write-offs and adjustments are unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.documents WHERE patient_id = :'patient_a') = :'documents_before'::integer, 'documents are unchanged');
+
+ROLLBACK;
+\echo 'COMPLETED-SERVICE-BILLING-GUARD-001 SQL validation passed'


### PR DESCRIPTION
## Summary
- enforce one historical invoice-item link per completed service in PostgreSQL
- harden tenant/patient/finality guards and add authoritative billing eligibility RPC
- update patient finance UI with billed/unavailable states and safe stale-race refresh
- add SQL, concurrency, repository/client, hook, UI, and local browser validation

## Validation
- Supabase clean reset through migration 0021
- SQL billing guard test passed
- concurrency validation passed
- npm run lint passed
- 73 test files / 754 tests passed
- npm run build passed
- local multi-role browser smoke passed, including stale two-browser race

## Policy
Completed-service links are historical locks. Invoice/item void or archive, payment void/refund, and write-off do not make the service ordinarily billable again. Manual invoice items with a null completed_service_id remain allowed.

## Safety
No cloud migration applied. No seed or generated types changed. Do not merge until review and fresh CI are complete.