### PR TITLE
feat(finance): patient credit deposit foundation

### DIFF
--- a/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-FOUNDATION-001_foundation.md
@@ -1,0 +1,120 @@
+# PATIENT-CREDIT-DEPOSITS-FOUNDATION-001
+
+## Verdict
+
+**PASS — локальный foundation депозитов пациента реализован и проверен.**
+
+## Scope
+
+Реализована серверная основа резервирования уже полученных денег пациента без второго денежного реестра. Источником денег остаётся `payments`; депозит хранит только блокировку свободной ёмкости конкретного платежа.
+
+Формула доступной ёмкости учитывает:
+
+- активные распределения платежа;
+- завершённые возвраты;
+- pending/approved возвраты;
+- оставшийся активный резерв депозита.
+
+## Implemented
+
+- Таблица `patient_fund_reservations` с tenant/patient/payment/currency scope, purpose, lifecycle, идемпотентностью и архивным состоянием.
+- RPC чтения capacity и резервов пациента.
+- RPC создания резерва, освобождения резерва и распределения зарезервированного кредита на счёт.
+- Единый порядок блокировок payment → refund rows → reservation rows.
+- Generic allocation, refund и payment void учитывают активные резервы.
+- Reservation-backed allocation атомарно уменьшает резерв и создаёт allocation.
+- Одноразовая внутренняя авторизация mutations хранится в закрытой схеме и не подделывается одним GUC.
+- Финансовая идентичность reservation/allocation/refund (`tenant_id`, `patient_id`, `payment_id`, `currency` и исходные суммы/ключи) защищена от прямого переноса или изменения.
+- Обновлён patient finance summary: gross unallocated, reserved deposit и available credit выводятся отдельно по валютам.
+- Добавлены типизированные Repository/RPC client модели и безопасная нормализация ошибок.
+- В существующих финансовых карточках добавлено пояснение, что свободный кредит уже уменьшен на резервы.
+
+## Permissions
+
+- `clinic_owner`, `clinic_admin`, `cashier`: создание и controlled consume резерва.
+- `clinic_owner`, `clinic_admin`: release резерва.
+- `doctor`, `registrar`, пользователь без tenant и пользователь другого tenant: mutation запрещена.
+- `anon`: execute новых mutation RPC не предоставлен.
+- Прямые записи authenticated запрещены RLS/grants; поддельные service-role mutation contexts проверены отрицательными SQL-тестами.
+
+## Verification
+
+### Clean database application
+
+- Выполнен `supabase db reset --no-seed` после последних изменений миграции.
+- Все миграции `0001`–`0022` применились с нуля.
+- `0022_patient_credit_deposits_foundation_test.sql` прошёл полностью.
+
+SQL-набор проверяет capacity, tenant/patient/currency isolation, роли, idempotency, audit/activity events, release/consume/archive, generic allocation/refund/void guards, forged service-role contexts и отсутствие побочных изменений в клинических данных и `patients.balance`.
+
+### Concurrency
+
+`0022_patient_credit_deposits_concurrency.ps1` прошёл полностью:
+
+- reservation ↔ reservation;
+- reservation ↔ request refund;
+- reservation ↔ allocation;
+- release ↔ allocation;
+- consume ↔ consume;
+- одинаковые и конфликтующие idempotency keys;
+- reservation ↔ approve refund;
+- reservation ↔ complete refund;
+- reservation ↔ reject refund;
+- reservation ↔ void refund.
+
+Результат: deadlock не обнаружен, отрицательная ёмкость не возникла, один и тот же остаток не был использован дважды.
+
+### TypeScript quality gates
+
+- ESLint: PASS.
+- Vitest: **73 files, 767 tests passed**.
+- TypeScript/Vite production build: PASS.
+
+Существующие React `act(...)` warnings и предупреждение Vite о размере bundle не связаны с этой задачей и не приводят к падению проверок.
+
+### Browser smoke
+
+На локальном Supabase Auth проверены сценарии A–F:
+
+- 1000 received → reserve 300 → available 700;
+- generic allocation сверх available блокируется, allocation 700 разрешён;
+- refund сверх available блокируется, refund 700 разрешён;
+- release возвращает available credit;
+- partial consume корректно меняет remaining/status;
+- full consume даёт `fully_used`, reserved = 0.
+
+Ролевая матрица в изолированных браузерных контекстах:
+
+- owner/admin/cashier: разрешённые операции проходят;
+- doctor/registrar/другой tenant: безопасный отказ;
+- no-tenant: доступ к smoke-странице отсутствует.
+
+Ожидаемые HTTP 400 возникали только на намеренно запрещённых операциях; пользовательские assertions прошли, SQL/секреты в UI не раскрывались.
+
+## Security review history
+
+В ходе независимых read-only reviews были найдены и исправлены:
+
+1. подделываемая GUC-only авторизация privileged writes;
+2. противоположный порядок refund/payment locks, создававший deadlock;
+3. возможность прямого изменения tenant/patient/currency у allocation/refund;
+4. недостаточное покрытие forged service-role и refund-transition races.
+
+После исправлений выполнены чистый reset, полный SQL-набор, concurrency suite и TypeScript quality gates.
+
+Финальный дополнительный запуск внешнего Codex review не состоялся, поскольку исполняемый файл Codex отсутствовал в текущей desktop-сессии. Это не заменено выдуманным verdict: финальная проверка выполнена воспроизводимыми локальными тестами и статическими guard-проверками.
+
+## Boundaries
+
+- Cloud Supabase не изменялся.
+- Полноценный UI управления депозитами не создавался.
+- Expiry automation, forfeiture и correction/void flow для reservation-backed allocations не входят в foundation.
+- `patients.balance`, клинические факты, документы и склад не используются как источник или побочный объект депозитных операций.
+
+## Pull Request
+
+PR URL и CI metadata будут внесены после публикации ветки. Слияние не выполняется.
+
+## Recommended next task
+
+`PATIENT-CREDIT-DEPOSITS-UI-001` — создать пользовательский интерфейс просмотра, создания, освобождения и controlled consume депозитов поверх готовых scoped RPC.

--- a/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-FOUNDATION-001_foundation.md
@@ -113,7 +113,13 @@ SQL-набор проверяет capacity, tenant/patient/currency isolation, �
 
 ## Pull Request
 
-PR URL и CI metadata будут внесены после публикации ветки. Слияние не выполняется.
+- PR: https://github.com/NckNA/codex-test/pull/340
+- Implementation commit: `1d72c2f8cc5da1abfb342c34f5bf19220f0eafd0`
+- CI run: `29132986607` / run #677
+- CI result on implementation commit: **success**
+- PR state: open; слияние не выполнялось.
+
+После этого отчёт обновляется отдельным report-only коммитом; итоговый HEAD дополнительно проверяется свежим PR CI.
 
 ## Recommended next task
 

--- a/src/components/cashier/CashierPatientFinanceSummary.tsx
+++ b/src/components/cashier/CashierPatientFinanceSummary.tsx
@@ -8,6 +8,7 @@ interface Props { patient: Patient | null; summary: PatientFinanceSummary | null
 const warningLabels: Record<FinanceSummaryWarningCode, string> = {
   PAYMENT_OVERCONSUMED: 'Платёж использован сверх доступной суммы',
   REFUND_RESERVATION_EXCEEDS_CAPACITY: 'Резерв возврата превышает остаток платежа',
+  DEPOSIT_RESERVATION_EXCEEDS_CAPACITY: 'Депозит зарезервирован сверх доступного кредита',
   INVOICE_NEGATIVE_BALANCE: 'У счёта отрицательный остаток',
   INVOICE_PAID_MISMATCH: 'Сумма оплаты счёта требует проверки',
   INVOICE_WRITEOFF_MISMATCH: 'Сумма списания счёта требует проверки',

--- a/src/components/finance/PatientFinanceSummaryCard.tsx
+++ b/src/components/finance/PatientFinanceSummaryCard.tsx
@@ -9,6 +9,7 @@ interface PatientFinanceSummaryCardProps {
 const warningLabels: Record<FinanceSummaryWarningCode, string> = {
   PAYMENT_OVERCONSUMED: 'Платёж использован сверх доступной суммы',
   REFUND_RESERVATION_EXCEEDS_CAPACITY: 'Возврат зарезервирован сверх доступной суммы',
+  DEPOSIT_RESERVATION_EXCEEDS_CAPACITY: 'Депозит зарезервирован сверх доступного кредита',
   INVOICE_NEGATIVE_BALANCE: 'У счёта отрицательный остаток',
   INVOICE_PAID_MISMATCH: 'Оплаченная сумма счёта не совпадает с распределениями',
   INVOICE_WRITEOFF_MISMATCH: 'Списание счёта не совпадает с подтверждёнными решениями',

--- a/src/data/repositories/FinanceRepository.test.ts
+++ b/src/data/repositories/FinanceRepository.test.ts
@@ -13,6 +13,8 @@ import {
   mapPaymentAllocationRow,
   mapPaymentRow,
   mapPatientFinanceSummaryPayload,
+  mapPatientFundReservationRow,
+  mapPaymentFundCapacityRow,
   mapRefundRow,
   normalizeFinanceLimit,
   normalizeFinanceOffset,
@@ -627,5 +629,131 @@ describe('FinanceRepository refundability and write-off eligibility', () => {
     );
     await expect(failed.repository.getPaymentRefundability({ tenantId, paymentId }))
       .rejects.toThrow('Finance refundability read failed: read failed');
+  });
+});
+
+
+describe('FinanceRepository patient fund reservations', () => {
+  const reservationRow = {
+    id: 'reservation-1',
+    tenant_id: tenantId,
+    patient_id: patientId,
+    payment_id: paymentId,
+    currency: 'KZT',
+    purpose_type: 'appointment',
+    purpose_label: 'Visit deposit',
+    appointment_id: 'appointment-1',
+    treatment_plan_id: null,
+    original_amount: '300.00',
+    consumed_amount: '100.00',
+    released_amount: '0.00',
+    remaining_amount: '200.00',
+    status: 'partially_used',
+    expires_at: null,
+    notes: 'Reserved',
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:01:00Z',
+    released_at: null,
+    archived_at: null,
+  };
+
+  const capacityRow = {
+    payment_id: paymentId,
+    patient_id: patientId,
+    currency: 'kzt',
+    payment_amount: '1000.00',
+    active_allocated_amount: '100.00',
+    completed_refund_amount: '50.00',
+    refund_reserved_amount: '100.00',
+    reserved_deposit_amount: '200.00',
+    gross_unallocated_amount: '850.00',
+    available_credit_amount: '550.00',
+  };
+
+  it('maps reservation status, purpose, amounts and nullable fields', () => {
+    expect(mapPatientFundReservationRow(reservationRow)).toEqual({
+      id: 'reservation-1', tenantId, patientId, paymentId, currency: 'KZT',
+      purposeType: 'appointment', purposeLabel: 'Visit deposit', appointmentId: 'appointment-1',
+      treatmentPlanId: null, originalAmount: 300, consumedAmount: 100, releasedAmount: 0,
+      remainingAmount: 200, status: 'partially_used', expiresAt: null, notes: 'Reserved',
+      createdAt: '2026-07-11T00:00:00Z', updatedAt: '2026-07-11T00:01:00Z',
+      releasedAt: null, archivedAt: null,
+    });
+    expect(() => mapPatientFundReservationRow({ ...reservationRow, status: 'expired' })).toThrow('invalid status');
+    expect(() => mapPatientFundReservationRow({ ...reservationRow, purpose_type: 'insurance' })).toThrow('invalid purpose_type');
+  });
+
+  it('maps payment capacity with the authoritative formula fields', () => {
+    expect(mapPaymentFundCapacityRow(capacityRow)).toEqual({
+      paymentId, patientId, currency: 'KZT', paymentAmount: 1000,
+      activeAllocatedAmount: 100, completedRefundAmount: 50, refundReservedAmount: 100,
+      reservedDepositAmount: 200, grossUnallocatedAmount: 850, availableCreditAmount: 550,
+    });
+  });
+
+  it('reads reservations only through the tenant and patient scoped RPC', async () => {
+    const { repository, client, calls } = createRepository();
+    client.rpc.mockResolvedValueOnce({ data: [reservationRow], error: null });
+    await expect(repository.getPatientFundReservations({ tenantId, patientId, paymentId }))
+      .resolves.toEqual([expect.objectContaining({ id: 'reservation-1', remainingAmount: 200 })]);
+    expect(client.rpc).toHaveBeenCalledWith('get_patient_fund_reservations', {
+      p_tenant_id: tenantId, p_patient_id: patientId, p_payment_id: paymentId,
+    });
+    expect(calls).toEqual([]);
+    expect(client.from).not.toHaveBeenCalled();
+    expect(client.insert).not.toHaveBeenCalled();
+    expect(client.update).not.toHaveBeenCalled();
+    expect(client.delete).not.toHaveBeenCalled();
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it('reads payment capacity only through the scoped RPC and maps an empty result to null', async () => {
+    const { repository, client, calls } = createRepository();
+    client.rpc.mockResolvedValueOnce({ data: [capacityRow], error: null });
+    await expect(repository.getPaymentFundCapacity({ tenantId, patientId, paymentId }))
+      .resolves.toMatchObject({ paymentAmount: 1000, reservedDepositAmount: 200, availableCreditAmount: 550 });
+    expect(client.rpc).toHaveBeenCalledWith('get_payment_fund_capacity', {
+      p_tenant_id: tenantId, p_patient_id: patientId, p_payment_id: paymentId,
+    });
+    client.rpc.mockResolvedValueOnce({ data: [], error: null });
+    await expect(repository.getPaymentFundCapacity({ tenantId, patientId, paymentId })).resolves.toBeNull();
+    expect(calls).toEqual([]);
+    expect(client.from).not.toHaveBeenCalled();
+    expect(client.insert).not.toHaveBeenCalled();
+    expect(client.update).not.toHaveBeenCalled();
+    expect(client.delete).not.toHaveBeenCalled();
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it('keeps gross unallocated visible while mapping reserved and available credit across currencies', () => {
+    const mapped = mapPatientFinanceSummaryPayload({
+      tenantId, patientId, asOf: '2026-07-11T00:00:00Z', modelVersion: 'finance-summary-v2',
+      currencies: [
+        { currency: 'KZT', totalInvoiced: 0, activeAllocatedAmount: 0, cashReceived: 1000,
+          completedRefundAmount: 0, approvedWriteOffAmount: 0, currentDebt: 0,
+          grossUnallocatedAmount: 1000, refundReservedAmount: 0, reservedDepositAmount: 300,
+          availableCreditAmount: 700, netPositionAmount: 700, openInvoiceCount: 0,
+          unpaidInvoiceCount: 0, partiallyPaidInvoiceCount: 0, lastPaymentAt: null },
+        { currency: 'USD', totalInvoiced: 0, activeAllocatedAmount: 0, cashReceived: 200,
+          completedRefundAmount: 0, approvedWriteOffAmount: 0, currentDebt: 0,
+          grossUnallocatedAmount: 200, refundReservedAmount: 0, reservedDepositAmount: 50,
+          availableCreditAmount: 150, netPositionAmount: 150, openInvoiceCount: 0,
+          unpaidInvoiceCount: 0, partiallyPaidInvoiceCount: 0, lastPaymentAt: null },
+      ], factComplete: true,
+      warnings: [{ code: 'DEPOSIT_RESERVATION_EXCEEDS_CAPACITY', currency: 'KZT', entityType: 'payment', entityId: paymentId, details: { reservedDepositAmount: 1200 } }],
+    });
+    expect(mapped.currencies).toEqual([
+      expect.objectContaining({ currency: 'KZT', grossUnallocatedAmount: 1000, reservedDepositAmount: 300, availableCreditAmount: 700 }),
+      expect.objectContaining({ currency: 'USD', grossUnallocatedAmount: 200, reservedDepositAmount: 50, availableCreditAmount: 150 }),
+    ]);
+    expect(mapped.warnings[0]?.code).toBe('DEPOSIT_RESERVATION_EXCEEDS_CAPACITY');
+  });
+
+  it('hides raw backend details in reservation and capacity read failures', async () => {
+    const { repository, client } = createRepository();
+    client.rpc.mockResolvedValueOnce({ data: null, error: new Error('sensitive reservation SQL') });
+    await expect(repository.getPatientFundReservations({ tenantId, patientId })).rejects.toThrow('Finance reservation read failed.');
+    client.rpc.mockResolvedValueOnce({ data: null, error: new Error('sensitive capacity SQL') });
+    await expect(repository.getPaymentFundCapacity({ tenantId, patientId, paymentId })).rejects.toThrow('Finance payment capacity read failed.');
   });
 });

--- a/src/data/repositories/FinanceRepository.ts
+++ b/src/data/repositories/FinanceRepository.ts
@@ -9,6 +9,44 @@ export type RefundStatus = 'pending' | 'approved' | 'completed' | 'rejected' | '
 export type RefundMethod = 'cash' | 'kaspi' | 'halyk_terminal' | 'card' | 'bank_transfer' | 'other';
 export type FinancialAdjustmentType = 'discount' | 'correction' | 'write_off' | 'surcharge' | 'void';
 export type FinancialAdjustmentStatus = 'active' | 'approved' | 'rejected' | 'voided' | 'archived';
+export type PatientFundReservationStatus = 'active' | 'partially_used' | 'fully_used' | 'released' | 'refunded' | 'archived';
+export type PatientFundReservationPurpose = 'general' | 'appointment' | 'treatment_plan' | 'service' | 'other';
+
+export interface PatientFundReservation {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  paymentId: string;
+  currency: string;
+  purposeType: PatientFundReservationPurpose;
+  purposeLabel: string | null;
+  appointmentId: string | null;
+  treatmentPlanId: string | null;
+  originalAmount: number;
+  consumedAmount: number;
+  releasedAmount: number;
+  remainingAmount: number;
+  status: PatientFundReservationStatus;
+  expiresAt: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+  releasedAt: string | null;
+  archivedAt: string | null;
+}
+
+export interface PaymentFundCapacity {
+  paymentId: string;
+  patientId: string;
+  currency: string;
+  paymentAmount: number;
+  activeAllocatedAmount: number;
+  completedRefundAmount: number;
+  refundReservedAmount: number;
+  reservedDepositAmount: number;
+  grossUnallocatedAmount: number;
+  availableCreditAmount: number;
+}
 
 export interface Invoice {
   id: string;
@@ -128,6 +166,8 @@ export interface PaymentAllocation {
   voidedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  patientFundReservationId: string | null;
+  reservationOperationKey: string | null;
 }
 
 export interface Refund {
@@ -193,6 +233,7 @@ export interface PatientFinanceFacts {
 export type FinanceSummaryWarningCode =
   | 'PAYMENT_OVERCONSUMED'
   | 'REFUND_RESERVATION_EXCEEDS_CAPACITY'
+  | 'DEPOSIT_RESERVATION_EXCEEDS_CAPACITY'
   | 'INVOICE_NEGATIVE_BALANCE'
   | 'INVOICE_PAID_MISMATCH'
   | 'INVOICE_WRITEOFF_MISMATCH'
@@ -349,6 +390,13 @@ export interface PatientFinanceOptions {
   tenantId: string;
   patientId: string;
 }
+export interface GetPatientFundReservationsOptions extends PatientFinanceOptions {
+  paymentId?: string;
+}
+
+export interface GetPaymentFundCapacityOptions extends PatientFinanceOptions {
+  paymentId: string;
+}
 
 export interface GetCompletedServiceBillingEligibilityOptions {
   tenantId: string;
@@ -369,6 +417,8 @@ export interface FinanceRepository {
   getCompletedServiceBillingEligibility(options: GetCompletedServiceBillingEligibilityOptions): Promise<CompletedServiceBillingEligibility[]>;
   getPatientFinanceFacts(options: PatientFinanceOptions): Promise<PatientFinanceFacts>;
   getPatientFinanceSummary(options: PatientFinanceOptions): Promise<PatientFinanceSummary>;
+  getPatientFundReservations(options: GetPatientFundReservationsOptions): Promise<PatientFundReservation[]>;
+  getPaymentFundCapacity(options: GetPaymentFundCapacityOptions): Promise<PaymentFundCapacity | null>;
 }
 
 export type FinanceRepositoryBackend = 'supabase' | 'local';
@@ -574,6 +624,8 @@ export function mapPaymentAllocationRow(row: Record<string, unknown>): PaymentAl
     voidedAt: nullableString(row.voided_at),
     createdAt: requiredString(row.created_at, 'created_at'),
     updatedAt: requiredString(row.updated_at, 'updated_at'),
+    patientFundReservationId: nullableString(row.patient_fund_reservation_id),
+    reservationOperationKey: nullableString(row.reservation_operation_key),
   };
 }
 
@@ -603,6 +655,61 @@ export function mapRefundRow(row: Record<string, unknown>): Refund {
     metadata: metadataObject(row.metadata),
     createdAt: requiredString(row.created_at, 'created_at'),
     updatedAt: requiredString(row.updated_at, 'updated_at'),
+  };
+}
+
+const PATIENT_FUND_RESERVATION_STATUSES: PatientFundReservationStatus[] = [
+  'active', 'partially_used', 'fully_used', 'released', 'refunded', 'archived',
+];
+const PATIENT_FUND_RESERVATION_PURPOSES: PatientFundReservationPurpose[] = [
+  'general', 'appointment', 'treatment_plan', 'service', 'other',
+];
+
+export function mapPatientFundReservationRow(row: Record<string, unknown>): PatientFundReservation {
+  const status = requiredString(row.status, 'status') as PatientFundReservationStatus;
+  if (!PATIENT_FUND_RESERVATION_STATUSES.includes(status)) {
+    throw new Error('Finance reservation row has invalid status');
+  }
+  const purposeType = requiredString(row.purpose_type, 'purpose_type') as PatientFundReservationPurpose;
+  if (!PATIENT_FUND_RESERVATION_PURPOSES.includes(purposeType)) {
+    throw new Error('Finance reservation row has invalid purpose_type');
+  }
+  return {
+    id: requiredString(row.id, 'id'),
+    tenantId: requiredString(row.tenant_id, 'tenant_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    paymentId: requiredString(row.payment_id, 'payment_id'),
+    currency: requiredString(row.currency, 'currency'),
+    purposeType,
+    purposeLabel: nullableString(row.purpose_label),
+    appointmentId: nullableString(row.appointment_id),
+    treatmentPlanId: nullableString(row.treatment_plan_id),
+    originalAmount: requiredNumber(row.original_amount, 'original_amount'),
+    consumedAmount: requiredNumber(row.consumed_amount, 'consumed_amount'),
+    releasedAmount: requiredNumber(row.released_amount, 'released_amount'),
+    remainingAmount: requiredNumber(row.remaining_amount, 'remaining_amount'),
+    status,
+    expiresAt: nullableString(row.expires_at),
+    notes: nullableString(row.notes),
+    createdAt: requiredString(row.created_at, 'created_at'),
+    updatedAt: nullableString(row.updated_at),
+    releasedAt: nullableString(row.released_at),
+    archivedAt: nullableString(row.archived_at),
+  };
+}
+
+export function mapPaymentFundCapacityRow(row: Record<string, unknown>): PaymentFundCapacity {
+  return {
+    paymentId: requiredString(row.payment_id, 'payment_id'),
+    patientId: requiredString(row.patient_id, 'patient_id'),
+    currency: normalizeCurrency(requiredString(row.currency, 'currency')),
+    paymentAmount: requiredNumber(row.payment_amount, 'payment_amount'),
+    activeAllocatedAmount: requiredNumber(row.active_allocated_amount, 'active_allocated_amount'),
+    completedRefundAmount: requiredNumber(row.completed_refund_amount, 'completed_refund_amount'),
+    refundReservedAmount: requiredNumber(row.refund_reserved_amount, 'refund_reserved_amount'),
+    reservedDepositAmount: requiredNumber(row.reserved_deposit_amount, 'reserved_deposit_amount'),
+    grossUnallocatedAmount: requiredNumber(row.gross_unallocated_amount, 'gross_unallocated_amount'),
+    availableCreditAmount: requiredNumber(row.available_credit_amount, 'available_credit_amount'),
   };
 }
 
@@ -684,7 +791,7 @@ export function mapPatientFinanceSummaryPayload(payload: unknown): PatientFinanc
   });
 
   const allowedCodes: FinanceSummaryWarningCode[] = [
-    'PAYMENT_OVERCONSUMED', 'REFUND_RESERVATION_EXCEEDS_CAPACITY', 'INVOICE_NEGATIVE_BALANCE',
+    'PAYMENT_OVERCONSUMED', 'REFUND_RESERVATION_EXCEEDS_CAPACITY', 'DEPOSIT_RESERVATION_EXCEEDS_CAPACITY', 'INVOICE_NEGATIVE_BALANCE',
     'INVOICE_PAID_MISMATCH', 'INVOICE_WRITEOFF_MISMATCH', 'INVOICE_STATUS_MISMATCH',
     'PAYMENT_STATUS_MISMATCH', 'MULTIPLE_CURRENCIES',
   ];
@@ -974,6 +1081,30 @@ export class SupabaseFinanceRepository implements FinanceRepository {
     } catch (error) {
       throw new Error('Finance summary read failed.', { cause: error });
     }
+  }
+
+
+  async getPatientFundReservations(options: GetPatientFundReservationsOptions): Promise<PatientFundReservation[]> {
+    const { data, error } = await this.client.rpc('get_patient_fund_reservations', {
+      p_tenant_id: requireTenantId(options.tenantId),
+      p_patient_id: requirePatientId(options.patientId),
+      p_payment_id: options.paymentId ? requireRecordId(options.paymentId) : null,
+    });
+    if (error) throw new Error('Finance reservation read failed.', { cause: error });
+    if (!Array.isArray(data)) throw new Error('Finance reservation RPC returned an invalid payload.');
+    return data.filter(isRecord).map(mapPatientFundReservationRow);
+  }
+
+  async getPaymentFundCapacity(options: GetPaymentFundCapacityOptions): Promise<PaymentFundCapacity | null> {
+    const { data, error } = await this.client.rpc('get_payment_fund_capacity', {
+      p_tenant_id: requireTenantId(options.tenantId),
+      p_patient_id: requirePatientId(options.patientId),
+      p_payment_id: requireRecordId(options.paymentId),
+    });
+    if (error) throw new Error('Finance payment capacity read failed.', { cause: error });
+    if (!Array.isArray(data)) throw new Error('Finance payment capacity RPC returned an invalid payload.');
+    const row = data.find(isRecord);
+    return row ? mapPaymentFundCapacityRow(row) : null;
   }
 }
 

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -885,3 +885,176 @@ describe('FinanceRpcClient atomic cashier payment operation', () => {
     });
   });
 });
+
+
+describe('FinanceRpcClient patient fund reservation operations', () => {
+  const reservationId = '88888888-8888-8888-8888-888888888888';
+  const reservationRow = {
+    id: reservationId,
+    tenant_id: tenantId,
+    patient_id: patientId,
+    payment_id: paymentId,
+    currency: 'KZT',
+    purpose_type: 'appointment',
+    purpose_label: 'Visit deposit',
+    appointment_id: '99999999-9999-9999-9999-999999999999',
+    treatment_plan_id: null,
+    original_amount: '300.00',
+    consumed_amount: '100.00',
+    released_amount: '0.00',
+    remaining_amount: '200.00',
+    status: 'partially_used',
+    expires_at: null,
+    notes: null,
+    created_at: '2026-07-11T00:00:00Z',
+    updated_at: '2026-07-11T00:01:00Z',
+    released_at: null,
+    archived_at: null,
+  };
+  const capacity = {
+    paymentId,
+    patientId,
+    currency: 'KZT',
+    paymentAmount: '1000.00',
+    activeAllocatedAmount: '100.00',
+    completedRefundAmount: '50.00',
+    refundReservedAmount: '100.00',
+    reservedDepositAmount: '200.00',
+    grossUnallocatedAmount: '850.00',
+    availableCreditAmount: '550.00',
+  };
+  const operationResult = {
+    status: 'completed',
+    reservation: reservationRow,
+    allocation: null,
+    capacity,
+  };
+
+  it('calls create_patient_fund_reservation with exact parameters and preserves the idempotency key', async () => {
+    const { rpcClient, rpcCalls, client } = createClientMock({ data: operationResult, error: null });
+    const result = await rpcClient.createPatientFundReservation({
+      tenantId,
+      patientId,
+      paymentId,
+      amount: 300,
+      purposeType: 'appointment',
+      purposeLabel: ' Visit deposit ',
+      appointmentId: '99999999-9999-9999-9999-999999999999',
+      treatmentPlanId: null,
+      expiresAt: null,
+      notes: ' Reserve for visit ',
+      metadata: { source: 'test' },
+      idempotencyKey: ' create-reservation-1 ',
+    });
+    expect(rpcCalls).toEqual([{ rpcName: 'create_patient_fund_reservation', params: {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_payment_id: paymentId,
+      p_amount: 300,
+      p_purpose_type: 'appointment',
+      p_purpose_label: 'Visit deposit',
+      p_appointment_id: '99999999-9999-9999-9999-999999999999',
+      p_treatment_plan_id: null,
+      p_expires_at: null,
+      p_notes: 'Reserve for visit',
+      p_metadata: { source: 'test' },
+      p_idempotency_key: 'create-reservation-1',
+    } }]);
+    expect(result).toMatchObject({
+      status: 'completed',
+      reservation: { id: reservationId, purposeType: 'appointment', originalAmount: 300, remainingAmount: 200 },
+      allocation: null,
+      capacity: { paymentAmount: 1000, reservedDepositAmount: 200, availableCreditAmount: 550 },
+    });
+    expectNoDirectWriteCalls(client);
+  });
+
+  it('calls release_patient_fund_reservation with exact parameters', async () => {
+    const released = {
+      ...operationResult,
+      reservation: { ...reservationRow, status: 'released', consumed_amount: '0.00', released_amount: '300.00', remaining_amount: '0.00', released_at: '2026-07-11T01:00:00Z' },
+    };
+    const { rpcClient, rpcCalls } = createClientMock({ data: released, error: null });
+    await expect(rpcClient.releasePatientFundReservation({
+      tenantId, reservationId, amount: null, reason: ' Patient changed mind ', idempotencyKey: ' release-1 ',
+    })).resolves.toMatchObject({ reservation: { status: 'released', releasedAmount: 300, remainingAmount: 0 } });
+    expect(rpcCalls).toEqual([{ rpcName: 'release_patient_fund_reservation', params: {
+      p_tenant_id: tenantId,
+      p_reservation_id: reservationId,
+      p_amount: null,
+      p_reason: 'Patient changed mind',
+      p_idempotency_key: 'release-1',
+    } }]);
+  });
+
+  it('calls allocate_reserved_credit and maps the allocation, reservation and capacity', async () => {
+    const allocationResult = {
+      ...operationResult,
+      status: 'already_completed',
+      allocation: { ...paymentAllocationRow, patient_fund_reservation_id: reservationId, reservation_operation_key: 'consume-1' },
+    };
+    const { rpcClient, rpcCalls, client } = createClientMock({ data: allocationResult, error: null });
+    const result = await rpcClient.allocateReservedCredit({
+      tenantId, patientId, reservationId, invoiceId, amount: 100, idempotencyKey: ' consume-1 ',
+    });
+    expect(rpcCalls).toEqual([{ rpcName: 'allocate_reserved_credit', params: {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_reservation_id: reservationId,
+      p_invoice_id: invoiceId,
+      p_amount: 100,
+      p_idempotency_key: 'consume-1',
+    } }]);
+    expect(result).toMatchObject({
+      status: 'already_completed',
+      allocation: { id: allocationId, patientFundReservationId: reservationId, reservationOperationKey: 'consume-1' },
+      reservation: { id: reservationId, remainingAmount: 200 },
+    });
+    expectNoDirectWriteCalls(client);
+  });
+
+  it('validates amounts, IDs, metadata and idempotency keys before calling RPC', async () => {
+    const rpcClient = createClientMock({ data: operationResult, error: null }).rpcClient;
+    await expect(rpcClient.createPatientFundReservation({ tenantId, patientId, paymentId, amount: 0, purposeType: 'general', idempotencyKey: 'x' })).rejects.toThrow();
+    await expect(rpcClient.createPatientFundReservation({ tenantId, patientId, paymentId, amount: 1, purposeType: 'general', metadata: [] as never, idempotencyKey: 'x' })).rejects.toThrow();
+    await expect(rpcClient.createPatientFundReservation({ tenantId, patientId, paymentId, amount: 1, purposeType: 'general', idempotencyKey: ' ' })).rejects.toThrow();
+    await expect(rpcClient.releasePatientFundReservation({ tenantId, reservationId: '', reason: 'x', idempotencyKey: 'x' })).rejects.toThrow();
+    await expect(rpcClient.allocateReservedCredit({ tenantId, patientId, reservationId, invoiceId, amount: -1, idempotencyKey: 'x' })).rejects.toThrow();
+  });
+
+  it('maps safe reservation errors and hides raw database details', async () => {
+    const insufficient = createClientMock({ data: null, error: { code: 'P0001', message: 'Недостаточно доступного кредита для создания депозита.', details: null, hint: null } as unknown as PostgrestError });
+    await expect(insufficient.rpcClient.createPatientFundReservation({ tenantId, patientId, paymentId, amount: 900, purposeType: 'general', idempotencyKey: 'x' }))
+      .rejects.toMatchObject({ category: 'validation', message: 'Недостаточно доступного кредита для создания депозита.' });
+
+    const conflict = createClientMock({ data: null, error: { code: 'P0001', message: 'Release idempotency key is already used with different details', details: 'sensitive SQL', hint: null } as unknown as PostgrestError });
+    await expect(conflict.rpcClient.releasePatientFundReservation({ tenantId, reservationId, reason: 'x', idempotencyKey: 'same' }))
+      .rejects.toMatchObject({ category: 'duplicate_conflict', message: 'Ключ операции уже использован с другими параметрами.' });
+
+    const raw = createClientMock({ data: null, error: { code: 'XX000', message: 'duplicate key on private_index with table details', details: 'secret', hint: null } as unknown as PostgrestError });
+    await raw.rpcClient.allocateReservedCredit({ tenantId, patientId, reservationId, invoiceId, amount: 1, idempotencyKey: 'x' }).catch((error: Error) => {
+      expect(error.message).toBe('Не удалось выполнить финансовую операцию.');
+      expect(error.message).not.toContain('private_index');
+    });
+  });
+
+  it('maps reserved-deposit allocation, refund, and payment-void failures to exact safe messages', async () => {
+    const depositError = { code: 'P0001', message: 'Часть средств зарезервирована как депозит. Сначала освободите резерв.', details: null, hint: null } as unknown as PostgrestError;
+    const allocation = createClientMock({ data: null, error: depositError }).rpcClient;
+    await expect(allocation.allocatePayment({ tenantId, paymentId, invoiceId, amount: 1 }))
+      .rejects.toMatchObject({ category: 'validation', message: 'Часть средств зарезервирована как депозит. Сначала освободите резерв.' });
+    const refund = createClientMock({ data: null, error: depositError }).rpcClient;
+    await expect(refund.requestRefund({ tenantId, paymentId, amount: 1, refundMethod: 'cash', reason: 'x' }))
+      .rejects.toMatchObject({ category: 'validation', message: 'Часть средств зарезервирована как депозит. Сначала освободите резерв.' });
+    const voided = createClientMock({ data: null, error: { code: 'P0001', message: 'Нельзя аннулировать платёж с активным депозитом.', details: null, hint: null } as unknown as PostgrestError }).rpcClient;
+    await expect(voided.voidPayment({ tenantId, paymentId, reason: 'x' }))
+      .rejects.toMatchObject({ category: 'validation', message: 'Нельзя аннулировать платёж с активным депозитом.' });
+  });
+
+  it('does not expose direct table writes, service_role, or patients.balance in reservation client code', () => {
+    const source = SupabaseFinanceRpcClient.toString();
+    expect(source).not.toContain("from('patient_fund_reservations')");
+    expect(source).not.toContain('service_role');
+    expect(source).not.toContain('patients.balance');
+  });
+});

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -17,6 +17,11 @@ import {
   type Refund,
   type RefundMethod,
   type FinancialAdjustment,
+  type PatientFundReservation,
+  type PatientFundReservationPurpose,
+  type PaymentFundCapacity,
+  mapPatientFundReservationRow,
+  mapPaymentFundCapacityRow,
 } from './FinanceRepository';
 
 export type FinanceRpcErrorCategory =
@@ -160,6 +165,44 @@ export interface VoidPaymentInput {
   paymentId: string;
   reason: string;
 }
+export interface CreatePatientFundReservationInput {
+  tenantId: string;
+  patientId: string;
+  paymentId: string;
+  amount: number;
+  purposeType: PatientFundReservationPurpose;
+  purposeLabel?: string | null;
+  appointmentId?: string | null;
+  treatmentPlanId?: string | null;
+  expiresAt?: string | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown>;
+  idempotencyKey: string;
+}
+
+export interface ReleasePatientFundReservationInput {
+  tenantId: string;
+  reservationId: string;
+  amount?: number | null;
+  reason: string;
+  idempotencyKey: string;
+}
+
+export interface AllocateReservedCreditInput {
+  tenantId: string;
+  patientId: string;
+  reservationId: string;
+  invoiceId: string;
+  amount: number;
+  idempotencyKey: string;
+}
+
+export interface PatientFundReservationOperationResult {
+  status: 'completed' | 'already_completed';
+  reservation: PatientFundReservation;
+  allocation: PaymentAllocation | null;
+  capacity: PaymentFundCapacity;
+}
 
 export interface RequestRefundInput {
   tenantId: string;
@@ -205,6 +248,9 @@ export interface FinanceRpcClient {
   allocatePayment(input: AllocatePaymentInput): Promise<PaymentAllocation>;
   voidPaymentAllocation(input: VoidPaymentAllocationInput): Promise<PaymentAllocation>;
   voidPayment(input: VoidPaymentInput): Promise<Payment>;
+  createPatientFundReservation(input: CreatePatientFundReservationInput): Promise<PatientFundReservationOperationResult>;
+  releasePatientFundReservation(input: ReleasePatientFundReservationInput): Promise<PatientFundReservationOperationResult>;
+  allocateReservedCredit(input: AllocateReservedCreditInput): Promise<PatientFundReservationOperationResult>;
   requestRefund(input: RequestRefundInput): Promise<Refund>;
   approveRefund(input: ApproveRefundInput): Promise<Refund>;
   completeRefund(input: CompleteRefundInput): Promise<Refund>;
@@ -320,6 +366,38 @@ function normalizeRpcError(error: unknown, operation: string): FinanceRpcClientE
   if (error instanceof Error || isPlainObject(error)) {
     const code = getRpcErrorField(error, 'code');
     const detail = safeRpcErrorDetail(error);
+    const normalizedDetail = detail.toLowerCase();
+    if (normalizedDetail.includes('часть средств зарезервирована как депозит')) {
+      return new FinanceRpcClientError({
+        operation,
+        code,
+        category: 'validation',
+        message: 'Часть средств зарезервирована как депозит. Сначала освободите резерв.',
+      });
+    }
+    if (normalizedDetail.includes('нельзя аннулировать платёж с активным депозитом')) {
+      return new FinanceRpcClientError({
+        operation,
+        code,
+        category: 'validation',
+        message: 'Нельзя аннулировать платёж с активным депозитом.',
+      });
+    }
+    if (['createPatientFundReservation', 'releasePatientFundReservation', 'allocateReservedCredit'].includes(operation)) {
+      if (normalizedDetail.includes('недостаточно доступного кредита')) {
+        return new FinanceRpcClientError({ operation, code, category: 'validation', message: 'Недостаточно доступного кредита для создания депозита.' });
+      }
+      if (normalizedDetail.includes('платёж недоступен') || normalizedDetail.includes('payment is not available')) {
+        return new FinanceRpcClientError({ operation, code, category: 'validation', message: 'Платёж недоступен для резервирования.' });
+      }
+      if (normalizedDetail.includes('already') || normalizedDetail.includes('idempotency') || normalizedDetail.includes('уже создан')) {
+        return new FinanceRpcClientError({ operation, code, category: 'duplicate_conflict', message: 'Ключ операции уже использован с другими параметрами.' });
+      }
+      if (normalizedDetail.includes('insufficient finance permissions') || normalizedDetail.includes('access denied') || code === '42501') {
+        return new FinanceRpcClientError({ operation, code, category: 'permission', message: 'Недостаточно прав для операции с депозитом.' });
+      }
+      return new FinanceRpcClientError({ operation, code, category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+    }
     if (operation === 'addInvoiceItem' && (
       detail.toLowerCase().includes('эта выполненная услуга уже включена')
       || isCompletedServiceBillingConstraint(error, code)
@@ -432,6 +510,45 @@ function requiredResultString(value: unknown, field: string): string {
     throw new FinanceRpcClientError({ operation: 'mapCashierPaymentOperation', category: 'operation_failed', message: `Некорректное поле результата: ${field}.` });
   }
   return value;
+}
+
+function mapOperationCapacity(value: unknown): PaymentFundCapacity {
+  if (!isPlainObject(value)) {
+    throw new FinanceRpcClientError({ operation: 'mapPatientFundReservationOperation', category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+  }
+  return mapPaymentFundCapacityRow({
+    payment_id: value.paymentId,
+    patient_id: value.patientId,
+    currency: value.currency,
+    payment_amount: value.paymentAmount,
+    active_allocated_amount: value.activeAllocatedAmount,
+    completed_refund_amount: value.completedRefundAmount,
+    refund_reserved_amount: value.refundReservedAmount,
+    reserved_deposit_amount: value.reservedDepositAmount,
+    gross_unallocated_amount: value.grossUnallocatedAmount,
+    available_credit_amount: value.availableCreditAmount,
+  });
+}
+
+function mapPatientFundReservationOperationRow(row: Record<string, unknown>): PatientFundReservationOperationResult {
+  const status = requiredResultString(row.status, 'status') as PatientFundReservationOperationResult['status'];
+  if (!['completed', 'already_completed'].includes(status)) {
+    throw new FinanceRpcClientError({ operation: 'mapPatientFundReservationOperation', category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+  }
+  if (!isPlainObject(row.reservation)) {
+    throw new FinanceRpcClientError({ operation: 'mapPatientFundReservationOperation', category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
+  }
+  const allocation = row.allocation == null
+    ? null
+    : isPlainObject(row.allocation)
+      ? mapPaymentAllocationRow(row.allocation)
+      : (() => { throw new FinanceRpcClientError({ operation: 'mapPatientFundReservationOperation', category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE }); })();
+  return {
+    status,
+    reservation: mapPatientFundReservationRow(row.reservation),
+    allocation,
+    capacity: mapOperationCapacity(row.capacity),
+  };
 }
 
 function mapCashierPaymentOperationRow(row: Record<string, unknown>): CashierPaymentOperationResult {
@@ -691,6 +808,48 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
       p_reason: reason,
     });
     return mapPaymentRow(row);
+  }
+
+
+  async createPatientFundReservation(input: CreatePatientFundReservationInput): Promise<PatientFundReservationOperationResult> {
+    const row = await callRpc(this.client, 'createPatientFundReservation', 'create_patient_fund_reservation', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_patient_id: requireNonEmptyString(input.patientId, 'Пациент не выбран.'),
+      p_payment_id: requireNonEmptyString(input.paymentId, 'Платёж не выбран.'),
+      p_amount: requirePositiveNumber(input.amount, 'Сумма должна быть больше 0.'),
+      p_purpose_type: requireNonEmptyString(input.purposeType, 'Назначение депозита обязательно.'),
+      p_purpose_label: input.purposeLabel?.trim() || null,
+      p_appointment_id: input.appointmentId?.trim() || null,
+      p_treatment_plan_id: input.treatmentPlanId?.trim() || null,
+      p_expires_at: input.expiresAt?.trim() || null,
+      p_notes: input.notes?.trim() || null,
+      p_metadata: normalizeMetadata(input.metadata),
+      p_idempotency_key: requireNonEmptyString(input.idempotencyKey, 'Нужен ключ идемпотентности.').trim(),
+    });
+    return mapPatientFundReservationOperationRow(row);
+  }
+
+  async releasePatientFundReservation(input: ReleasePatientFundReservationInput): Promise<PatientFundReservationOperationResult> {
+    const row = await callRpc(this.client, 'releasePatientFundReservation', 'release_patient_fund_reservation', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_reservation_id: requireNonEmptyString(input.reservationId, 'Резерв не выбран.'),
+      p_amount: input.amount == null ? null : requirePositiveNumber(input.amount, 'Сумма должна быть больше 0.'),
+      p_reason: requireNonEmptyString(input.reason, 'Укажите причину.').trim(),
+      p_idempotency_key: requireNonEmptyString(input.idempotencyKey, 'Нужен ключ идемпотентности.').trim(),
+    });
+    return mapPatientFundReservationOperationRow(row);
+  }
+
+  async allocateReservedCredit(input: AllocateReservedCreditInput): Promise<PatientFundReservationOperationResult> {
+    const row = await callRpc(this.client, 'allocateReservedCredit', 'allocate_reserved_credit', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_patient_id: requireNonEmptyString(input.patientId, 'Пациент не выбран.'),
+      p_reservation_id: requireNonEmptyString(input.reservationId, 'Резерв не выбран.'),
+      p_invoice_id: requireNonEmptyString(input.invoiceId, 'Счёт не выбран.'),
+      p_amount: requirePositiveNumber(input.amount, 'Сумма должна быть больше 0.'),
+      p_idempotency_key: requireNonEmptyString(input.idempotencyKey, 'Нужен ключ идемпотентности.').trim(),
+    });
+    return mapPatientFundReservationOperationRow(row);
   }
 
   async requestRefund(input: RequestRefundInput): Promise<Refund> {

--- a/supabase/migrations/0022_create_patient_fund_reservations.sql
+++ b/supabase/migrations/0022_create_patient_fund_reservations.sql
@@ -1,0 +1,1894 @@
+-- 0022_create_patient_fund_reservations.sql
+-- Patient credit remains a derived view over payments, allocations, refunds,
+-- and payment-linked reservations. This migration creates no second money ledger.
+--
+-- Capacity lock order for all mutation RPCs in this migration:
+--   1. payment row;
+--   2. refund rows for the payment, ordered by id;
+--   3. active/partially-used reservation rows, ordered by id;
+--   4. target reservation row;
+--   5. target invoice row when reserved credit is consumed.
+--
+-- The public app has no direct reservation/allocation/refund writes. Triggers are
+-- still authoritative backstops for privileged or future write paths.
+
+DO $precheck$
+DECLARE
+  v_count bigint;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM public.payment_allocations pa
+  LEFT JOIN public.payments p ON p.id = pa.payment_id
+  WHERE p.id IS NULL
+     OR pa.tenant_id <> p.tenant_id
+     OR pa.patient_id <> p.patient_id
+     OR upper(btrim(pa.currency)) <> upper(btrim(p.currency));
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install patient fund reservations: % orphan or mismatched payment allocation row(s) exist.', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.refunds r
+  LEFT JOIN public.payments p ON p.id = r.payment_id
+  WHERE p.id IS NULL
+     OR r.tenant_id <> p.tenant_id
+     OR r.patient_id <> p.patient_id
+     OR upper(btrim(r.currency)) <> upper(btrim(p.currency));
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install patient fund reservations: % orphan or mismatched refund row(s) exist.', v_count;
+  END IF;
+
+  WITH capacity AS (
+    SELECT p.id, p.amount,
+      COALESCE((SELECT sum(pa.amount) FROM public.payment_allocations pa WHERE pa.payment_id = p.id AND pa.status = 'active'), 0) AS allocated,
+      COALESCE((SELECT sum(r.amount) FROM public.refunds r WHERE r.payment_id = p.id AND r.status = 'completed'), 0) AS completed_refunds,
+      COALESCE((SELECT sum(r.amount) FROM public.refunds r WHERE r.payment_id = p.id AND r.status IN ('pending', 'approved')), 0) AS reserved_refunds
+    FROM public.payments p
+  )
+  SELECT count(*) INTO v_count
+  FROM capacity
+  WHERE allocated + completed_refunds + reserved_refunds > amount;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'Cannot install patient fund reservations: % payment(s) already exceed authoritative capacity. Resolve finance history first.', v_count;
+  END IF;
+END;
+$precheck$;
+
+CREATE SCHEMA IF NOT EXISTS private_finance;
+REVOKE ALL ON SCHEMA private_finance FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE TABLE private_finance.mutation_authorizations (
+  token uuid PRIMARY KEY,
+  action text NOT NULL,
+  target_id uuid NOT NULL,
+  transaction_id bigint NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+REVOKE ALL ON TABLE private_finance.mutation_authorizations FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.issue_finance_mutation_authorization_internal(
+  p_action text,
+  p_target_id uuid
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = private_finance, public, pg_temp
+AS $$
+DECLARE
+  v_token uuid := gen_random_uuid();
+BEGIN
+  IF length(btrim(COALESCE(p_action, ''))) = 0 OR p_target_id IS NULL THEN
+    RAISE EXCEPTION 'Mutation authorization action and target are required';
+  END IF;
+  INSERT INTO private_finance.mutation_authorizations(token, action, target_id, transaction_id)
+  VALUES (v_token, p_action, p_target_id, txid_current());
+  PERFORM set_config('app.finance_mutation_token', v_token::text, true);
+  RETURN v_token;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.consume_finance_mutation_authorization_internal(
+  p_action text,
+  p_target_id uuid
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = private_finance, public, pg_temp
+AS $$
+DECLARE
+  v_token uuid;
+  v_deleted uuid;
+BEGIN
+  BEGIN
+    v_token := NULLIF(current_setting('app.finance_mutation_token', true), '')::uuid;
+  EXCEPTION WHEN invalid_text_representation THEN
+    RETURN false;
+  END;
+  IF v_token IS NULL THEN RETURN false; END IF;
+
+  DELETE FROM private_finance.mutation_authorizations
+  WHERE token = v_token
+    AND action = p_action
+    AND target_id = p_target_id
+    AND transaction_id = txid_current()
+  RETURNING token INTO v_deleted;
+  PERFORM set_config('app.finance_mutation_token', '', true);
+  RETURN v_deleted IS NOT NULL;
+END;
+$$;
+
+CREATE TABLE public.patient_fund_reservations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  payment_id uuid NOT NULL REFERENCES public.payments(id) ON DELETE RESTRICT,
+  currency text NOT NULL,
+  purpose_type text NOT NULL,
+  purpose_label text,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE RESTRICT,
+  treatment_plan_id uuid REFERENCES public.treatment_plans(id) ON DELETE RESTRICT,
+  original_amount numeric(12,2) NOT NULL,
+  consumed_amount numeric(12,2) NOT NULL DEFAULT 0,
+  released_amount numeric(12,2) NOT NULL DEFAULT 0,
+  remaining_amount numeric(12,2) GENERATED ALWAYS AS (
+    original_amount - consumed_amount - released_amount
+  ) STORED,
+  status text NOT NULL DEFAULT 'active',
+  expires_at timestamptz,
+  notes text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key text NOT NULL,
+  operation_fingerprint text NOT NULL,
+  release_idempotency_key text,
+  release_operation_fingerprint text,
+  created_by uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  released_by uuid REFERENCES auth.users(id) ON DELETE RESTRICT,
+  released_at timestamptz,
+  release_reason text,
+  archived_by uuid REFERENCES auth.users(id) ON DELETE RESTRICT,
+  archived_at timestamptz,
+  archived_from_status text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT patient_fund_reservations_patient_fk
+    FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT patient_fund_reservations_currency_check
+    CHECK (length(btrim(currency)) > 0),
+  CONSTRAINT patient_fund_reservations_purpose_check
+    CHECK (purpose_type IN ('general', 'appointment', 'treatment_plan', 'service', 'other')),
+  CONSTRAINT patient_fund_reservations_other_label_check
+    CHECK (purpose_type <> 'other' OR length(btrim(COALESCE(purpose_label, ''))) > 0),
+  CONSTRAINT patient_fund_reservations_reference_check
+    CHECK (
+      (appointment_id IS NULL OR purpose_type = 'appointment')
+      AND (treatment_plan_id IS NULL OR purpose_type = 'treatment_plan')
+    ),
+  CONSTRAINT patient_fund_reservations_status_check
+    CHECK (status IN ('active', 'partially_used', 'fully_used', 'released', 'refunded', 'archived')),
+  CONSTRAINT patient_fund_reservations_amounts_check
+    CHECK (
+      original_amount > 0
+      AND consumed_amount >= 0
+      AND released_amount >= 0
+      AND consumed_amount + released_amount <= original_amount
+    ),
+  CONSTRAINT patient_fund_reservations_metadata_check
+    CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT patient_fund_reservations_idempotency_check
+    CHECK (
+      length(btrim(idempotency_key)) BETWEEN 1 AND 240
+      AND length(btrim(operation_fingerprint)) > 0
+      AND (
+        (release_idempotency_key IS NULL AND release_operation_fingerprint IS NULL)
+        OR (
+          length(btrim(release_idempotency_key)) BETWEEN 1 AND 240
+          AND length(btrim(release_operation_fingerprint)) > 0
+        )
+      )
+    ),
+  CONSTRAINT patient_fund_reservations_lifecycle_check
+    CHECK (
+      (status = 'active' AND consumed_amount = 0 AND released_amount = 0 AND released_at IS NULL AND released_by IS NULL)
+      OR (status = 'partially_used' AND consumed_amount > 0 AND remaining_amount > 0 AND released_amount = 0 AND released_at IS NULL AND released_by IS NULL)
+      OR (status = 'fully_used' AND consumed_amount = original_amount AND released_amount = 0 AND remaining_amount = 0)
+      OR (status = 'released' AND remaining_amount = 0 AND released_amount > 0 AND released_at IS NOT NULL AND released_by IS NOT NULL AND length(btrim(COALESCE(release_reason, ''))) > 0)
+      OR (status = 'refunded' AND remaining_amount = 0)
+      OR (status = 'archived' AND remaining_amount = 0 AND archived_at IS NOT NULL AND archived_by IS NOT NULL AND archived_from_status IN ('fully_used', 'released', 'refunded'))
+    )
+);
+
+CREATE UNIQUE INDEX uq_patient_fund_reservations_tenant_create_key
+  ON public.patient_fund_reservations (tenant_id, idempotency_key);
+CREATE UNIQUE INDEX uq_patient_fund_reservations_tenant_release_key
+  ON public.patient_fund_reservations (tenant_id, release_idempotency_key)
+  WHERE release_idempotency_key IS NOT NULL;
+CREATE INDEX idx_patient_fund_reservations_payment_active
+  ON public.patient_fund_reservations (tenant_id, payment_id, id)
+  WHERE status IN ('active', 'partially_used');
+CREATE INDEX idx_patient_fund_reservations_patient_created
+  ON public.patient_fund_reservations (tenant_id, patient_id, created_at DESC);
+
+ALTER TABLE public.payment_allocations
+  ADD COLUMN patient_fund_reservation_id uuid REFERENCES public.patient_fund_reservations(id) ON DELETE RESTRICT,
+  ADD COLUMN reservation_operation_key text,
+  ADD COLUMN reservation_operation_fingerprint text;
+
+ALTER TABLE public.payment_allocations
+  ADD CONSTRAINT payment_allocations_reservation_operation_check
+  CHECK (
+    (patient_fund_reservation_id IS NULL AND reservation_operation_key IS NULL AND reservation_operation_fingerprint IS NULL)
+    OR (
+      patient_fund_reservation_id IS NOT NULL
+      AND length(btrim(reservation_operation_key)) BETWEEN 1 AND 240
+      AND length(btrim(reservation_operation_fingerprint)) > 0
+    )
+  );
+
+CREATE UNIQUE INDEX uq_payment_allocations_tenant_reservation_operation_key
+  ON public.payment_allocations (tenant_id, reservation_operation_key)
+  WHERE reservation_operation_key IS NOT NULL;
+CREATE INDEX idx_payment_allocations_reservation
+  ON public.payment_allocations (tenant_id, patient_fund_reservation_id)
+  WHERE patient_fund_reservation_id IS NOT NULL;
+
+DROP TRIGGER IF EXISTS patient_fund_reservations_set_updated_at ON public.patient_fund_reservations;
+CREATE TRIGGER patient_fund_reservations_set_updated_at
+BEFORE UPDATE ON public.patient_fund_reservations
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.patient_fund_reservations ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Finance operators can read patient fund reservations" ON public.patient_fund_reservations;
+CREATE POLICY "Finance operators can read patient fund reservations"
+ON public.patient_fund_reservations FOR SELECT TO authenticated
+USING (
+  public.has_tenant_role(
+    tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  )
+);
+
+GRANT SELECT ON public.patient_fund_reservations TO authenticated, service_role;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON public.patient_fund_reservations FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.payment_active_deposit_reserved_total_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_reservation_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(sum(remaining_amount), 0)::numeric(12,2)
+  FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id
+    AND payment_id = p_payment_id
+    AND status IN ('active', 'partially_used')
+    AND (p_exclude_reservation_id IS NULL OR id <> p_exclude_reservation_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.lock_payment_capacity_rows_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  PERFORM id FROM public.refunds
+  WHERE tenant_id = p_tenant_id
+    AND payment_id = p_payment_id
+    AND status IN ('pending', 'approved', 'completed')
+  ORDER BY id FOR UPDATE;
+
+  PERFORM id FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id
+    AND payment_id = p_payment_id
+    AND status IN ('active', 'partially_used')
+  ORDER BY id FOR UPDATE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_payment_fund_capacity_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_refund_id uuid DEFAULT NULL,
+  p_exclude_reservation_id uuid DEFAULT NULL
+) RETURNS TABLE (
+  payment_amount numeric(12,2),
+  active_allocated_amount numeric(12,2),
+  completed_refund_amount numeric(12,2),
+  refund_reserved_amount numeric(12,2),
+  reserved_deposit_amount numeric(12,2),
+  gross_unallocated_amount numeric(12,2),
+  available_credit_amount numeric(12,2)
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_amount numeric(12,2);
+  v_allocated numeric(12,2);
+  v_completed numeric(12,2);
+  v_refund_reserved numeric(12,2);
+  v_deposit_reserved numeric(12,2);
+BEGIN
+  SELECT amount INTO v_amount
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = p_payment_id;
+  IF v_amount IS NULL THEN
+    RAISE EXCEPTION 'Payment not found in this tenant';
+  END IF;
+
+  v_allocated := public.payment_active_allocation_total_internal(p_tenant_id, p_payment_id);
+  v_completed := public.payment_completed_refund_total_internal(p_tenant_id, p_payment_id, p_exclude_refund_id);
+  v_refund_reserved := public.payment_reserved_refund_total_internal(p_tenant_id, p_payment_id, p_exclude_refund_id);
+  v_deposit_reserved := public.payment_active_deposit_reserved_total_internal(p_tenant_id, p_payment_id, p_exclude_reservation_id);
+
+  RETURN QUERY SELECT
+    v_amount,
+    v_allocated,
+    v_completed,
+    v_refund_reserved,
+    v_deposit_reserved,
+    GREATEST(0, v_amount - v_allocated - v_completed)::numeric(12,2),
+    GREATEST(0, v_amount - v_allocated - v_completed - v_refund_reserved - v_deposit_reserved)::numeric(12,2);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.payment_refundable_amount_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_exclude_refund_id uuid DEFAULT NULL
+) RETURNS numeric(12,2)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_capacity record;
+BEGIN
+  SELECT * INTO v_capacity
+  FROM public.get_payment_fund_capacity_internal(
+    p_tenant_id, p_payment_id, p_exclude_refund_id, NULL
+  );
+  RETURN v_capacity.available_credit_amount;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_payment_fund_capacity(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_payment_id uuid
+) RETURNS TABLE (
+  payment_id uuid,
+  patient_id uuid,
+  currency text,
+  payment_amount numeric(12,2),
+  active_allocated_amount numeric(12,2),
+  completed_refund_amount numeric(12,2),
+  refund_reserved_amount numeric(12,2),
+  reserved_deposit_amount numeric(12,2),
+  gross_unallocated_amount numeric(12,2),
+  available_credit_amount numeric(12,2)
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_capacity record;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  SELECT * INTO v_payment FROM public.payments p
+  WHERE p.tenant_id = p_tenant_id AND p.patient_id = p_patient_id AND p.id = p_payment_id;
+  IF v_payment.id IS NULL THEN
+    RAISE EXCEPTION 'Payment not found for this patient and tenant';
+  END IF;
+  SELECT * INTO v_capacity FROM public.get_payment_fund_capacity_internal(p_tenant_id, p_payment_id);
+  RETURN QUERY SELECT v_payment.id, v_payment.patient_id, v_payment.currency,
+    v_capacity.payment_amount, v_capacity.active_allocated_amount,
+    v_capacity.completed_refund_amount, v_capacity.refund_reserved_amount,
+    v_capacity.reserved_deposit_amount, v_capacity.gross_unallocated_amount,
+    v_capacity.available_credit_amount;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_patient_fund_reservations(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_payment_id uuid DEFAULT NULL
+) RETURNS TABLE (
+  id uuid,
+  tenant_id uuid,
+  patient_id uuid,
+  payment_id uuid,
+  currency text,
+  purpose_type text,
+  purpose_label text,
+  appointment_id uuid,
+  treatment_plan_id uuid,
+  original_amount numeric(12,2),
+  consumed_amount numeric(12,2),
+  released_amount numeric(12,2),
+  remaining_amount numeric(12,2),
+  status text,
+  expires_at timestamptz,
+  notes text,
+  created_at timestamptz,
+  released_at timestamptz,
+  archived_at timestamptz
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  IF NOT EXISTS (SELECT 1 FROM public.patients p WHERE p.tenant_id = p_tenant_id AND p.id = p_patient_id) THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+  RETURN QUERY
+  SELECT r.id, r.tenant_id, r.patient_id, r.payment_id, r.currency, r.purpose_type, r.purpose_label,
+    r.appointment_id, r.treatment_plan_id, r.original_amount, r.consumed_amount,
+    r.released_amount, r.remaining_amount, r.status, r.expires_at, r.notes,
+    r.created_at, r.released_at, r.archived_at
+  FROM public.patient_fund_reservations r
+  WHERE r.tenant_id = p_tenant_id
+    AND r.patient_id = p_patient_id
+    AND (p_payment_id IS NULL OR r.payment_id = p_payment_id)
+  ORDER BY r.created_at DESC, r.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.patient_fund_reservation_result_internal(
+  p_reservation_id uuid,
+  p_status text,
+  p_allocation_id uuid DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_reservation public.patient_fund_reservations;
+  v_allocation public.payment_allocations;
+  v_capacity record;
+BEGIN
+  SELECT * INTO v_reservation FROM public.patient_fund_reservations WHERE id = p_reservation_id;
+  IF v_reservation.id IS NULL THEN RAISE EXCEPTION 'Reservation not found'; END IF;
+  IF p_allocation_id IS NOT NULL THEN
+    SELECT * INTO v_allocation FROM public.payment_allocations WHERE id = p_allocation_id;
+  END IF;
+  SELECT * INTO v_capacity FROM public.get_payment_fund_capacity_internal(v_reservation.tenant_id, v_reservation.payment_id);
+  RETURN jsonb_build_object(
+    'status', p_status,
+    'reservation', to_jsonb(v_reservation) - 'metadata' - 'operation_fingerprint' - 'release_operation_fingerprint',
+    'allocation', CASE WHEN v_allocation.id IS NULL THEN NULL ELSE to_jsonb(v_allocation) - 'metadata' - 'reservation_operation_fingerprint' END,
+    'capacity', jsonb_build_object(
+      'paymentId', v_reservation.payment_id,
+      'patientId', v_reservation.patient_id,
+      'currency', v_reservation.currency,
+      'paymentAmount', v_capacity.payment_amount,
+      'activeAllocatedAmount', v_capacity.active_allocated_amount,
+      'completedRefundAmount', v_capacity.completed_refund_amount,
+      'refundReservedAmount', v_capacity.refund_reserved_amount,
+      'reservedDepositAmount', v_capacity.reserved_deposit_amount,
+      'grossUnallocatedAmount', v_capacity.gross_unallocated_amount,
+      'availableCreditAmount', v_capacity.available_credit_amount
+    )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_patient_fund_reservation_internal()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, private_finance, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_capacity record;
+  v_appointment public.appointments;
+  v_plan public.treatment_plans;
+  v_authorized boolean := false;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_authorized := public.consume_finance_mutation_authorization_internal('reservation_create', NEW.id);
+    IF NOT v_authorized THEN
+      RAISE EXCEPTION 'Reservation creation requires create_patient_fund_reservation';
+    END IF;
+    IF NEW.status <> 'active' OR NEW.consumed_amount <> 0 OR NEW.released_amount <> 0 THEN
+      RAISE EXCEPTION 'New reservation must start active and unused';
+    END IF;
+  ELSE
+    IF OLD.status = 'archived' THEN RAISE EXCEPTION 'Archived reservation cannot be mutated'; END IF;
+    IF NEW.consumed_amount IS DISTINCT FROM OLD.consumed_amount THEN
+      v_authorized := public.consume_finance_mutation_authorization_internal('reservation_consume', NEW.id);
+      IF NOT v_authorized THEN RAISE EXCEPTION 'Reservation consumption requires allocate_reserved_credit'; END IF;
+    ELSIF NEW.released_amount IS DISTINCT FROM OLD.released_amount THEN
+      v_authorized := public.consume_finance_mutation_authorization_internal('reservation_release', NEW.id);
+      IF NOT v_authorized THEN RAISE EXCEPTION 'Reservation release requires release_patient_fund_reservation'; END IF;
+    ELSIF NEW.status = 'archived' AND OLD.status IN ('fully_used', 'released', 'refunded') THEN
+      v_authorized := public.consume_finance_mutation_authorization_internal('reservation_archive', NEW.id);
+      IF NOT v_authorized THEN RAISE EXCEPTION 'Reservation archive requires an authorized archive operation'; END IF;
+    ELSE
+      RAISE EXCEPTION 'Reservation updates require an authoritative reservation operation';
+    END IF;
+
+    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       OR NEW.patient_id IS DISTINCT FROM OLD.patient_id
+       OR NEW.payment_id IS DISTINCT FROM OLD.payment_id
+       OR NEW.currency IS DISTINCT FROM OLD.currency
+       OR NEW.original_amount IS DISTINCT FROM OLD.original_amount
+       OR NEW.purpose_type IS DISTINCT FROM OLD.purpose_type
+       OR NEW.purpose_label IS DISTINCT FROM OLD.purpose_label
+       OR NEW.appointment_id IS DISTINCT FROM OLD.appointment_id
+       OR NEW.treatment_plan_id IS DISTINCT FROM OLD.treatment_plan_id
+       OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+       OR NEW.operation_fingerprint IS DISTINCT FROM OLD.operation_fingerprint
+       OR NEW.created_by IS DISTINCT FROM OLD.created_by
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+      RAISE EXCEPTION 'Reservation identity and original financial facts are immutable';
+    END IF;
+    IF OLD.status IN ('released', 'refunded') AND NEW.status <> 'archived' THEN
+      RAISE EXCEPTION 'Terminal reservation can only be archived';
+    END IF;
+    IF OLD.status = 'fully_used' AND NEW.status <> 'archived' THEN
+      RAISE EXCEPTION 'Fully used reservation can only be archived';
+    END IF;
+    IF OLD.status = 'active' AND NEW.status NOT IN ('active', 'partially_used', 'fully_used', 'released') THEN
+      RAISE EXCEPTION 'Invalid reservation status transition';
+    END IF;
+    IF OLD.status = 'partially_used' AND NEW.status NOT IN ('partially_used', 'fully_used', 'released') THEN
+      RAISE EXCEPTION 'Invalid reservation status transition';
+    END IF;
+  END IF;
+
+  SELECT * INTO v_payment FROM public.payments
+  WHERE id = NEW.payment_id AND tenant_id = NEW.tenant_id FOR UPDATE;
+  IF v_payment.id IS NULL
+     OR v_payment.patient_id <> NEW.patient_id
+     OR upper(btrim(v_payment.currency)) <> upper(btrim(NEW.currency)) THEN
+    RAISE EXCEPTION 'Reservation tenant, patient, currency, and payment must match';
+  END IF;
+  IF v_payment.status IN ('voided', 'archived', 'refunded') THEN
+    RAISE EXCEPTION 'Платёж недоступен для резервирования.';
+  END IF;
+
+  IF NEW.appointment_id IS NOT NULL THEN
+    SELECT * INTO v_appointment FROM public.appointments WHERE id = NEW.appointment_id;
+    IF v_appointment.id IS NULL OR v_appointment.tenant_id <> NEW.tenant_id OR v_appointment.patient_id <> NEW.patient_id THEN
+      RAISE EXCEPTION 'Appointment purpose does not belong to this patient and tenant';
+    END IF;
+  END IF;
+  IF NEW.treatment_plan_id IS NOT NULL THEN
+    SELECT * INTO v_plan FROM public.treatment_plans WHERE id = NEW.treatment_plan_id;
+    IF v_plan.id IS NULL OR v_plan.tenant_id <> NEW.tenant_id OR v_plan.patient_id <> NEW.patient_id THEN
+      RAISE EXCEPTION 'Treatment plan purpose does not belong to this patient and tenant';
+    END IF;
+  END IF;
+
+  PERFORM public.lock_payment_capacity_rows_internal(NEW.tenant_id, NEW.payment_id);
+  IF NEW.status IN ('active', 'partially_used') THEN
+    SELECT * INTO v_capacity FROM public.get_payment_fund_capacity_internal(
+      NEW.tenant_id, NEW.payment_id, NULL, CASE WHEN TG_OP = 'UPDATE' THEN NEW.id ELSE NULL END
+    );
+    IF v_capacity.active_allocated_amount + v_capacity.completed_refund_amount
+       + v_capacity.refund_reserved_amount + v_capacity.reserved_deposit_amount
+       + NEW.remaining_amount > v_capacity.payment_amount THEN
+      RAISE EXCEPTION 'Недостаточно доступного кредита для создания депозита.';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS patient_fund_reservations_guard ON public.patient_fund_reservations;
+CREATE TRIGGER patient_fund_reservations_guard
+BEFORE INSERT OR UPDATE ON public.patient_fund_reservations
+FOR EACH ROW EXECUTE FUNCTION public.enforce_patient_fund_reservation_internal();
+
+CREATE OR REPLACE FUNCTION public.create_patient_fund_reservation(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_payment_id uuid,
+  p_amount numeric,
+  p_purpose_type text,
+  p_purpose_label text DEFAULT NULL,
+  p_appointment_id uuid DEFAULT NULL,
+  p_treatment_plan_id uuid DEFAULT NULL,
+  p_expires_at timestamptz DEFAULT NULL,
+  p_notes text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_reservation public.patient_fund_reservations;
+  v_capacity record;
+  v_amount numeric(12,2);
+  v_key text;
+  v_metadata jsonb;
+  v_fingerprint text;
+  v_reservation_id uuid := gen_random_uuid();
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  v_amount := round(COALESCE(p_amount, 0)::numeric, 2)::numeric(12,2);
+  IF v_amount <= 0 THEN RAISE EXCEPTION 'Некорректная сумма депозита.'; END IF;
+  v_key := btrim(COALESCE(p_idempotency_key, ''));
+  IF length(v_key) = 0 OR length(v_key) > 240 THEN RAISE EXCEPTION 'Deposit idempotency key is required'; END IF;
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+  IF p_purpose_type NOT IN ('general', 'appointment', 'treatment_plan', 'service', 'other') THEN
+    RAISE EXCEPTION 'Unsupported deposit purpose';
+  END IF;
+  IF p_purpose_type = 'other' AND length(btrim(COALESCE(p_purpose_label, ''))) = 0 THEN
+    RAISE EXCEPTION 'Purpose label is required for other deposit purpose';
+  END IF;
+
+  v_fingerprint := md5(jsonb_build_object(
+    'tenantId', p_tenant_id, 'patientId', p_patient_id, 'paymentId', p_payment_id,
+    'amount', v_amount, 'purposeType', p_purpose_type,
+    'purposeLabel', nullif(btrim(COALESCE(p_purpose_label, '')), ''),
+    'appointmentId', p_appointment_id, 'treatmentPlanId', p_treatment_plan_id,
+    'expiresAt', p_expires_at, 'notes', nullif(btrim(COALESCE(p_notes, '')), ''),
+    'metadata', v_metadata
+  )::text);
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('fund-reservation:create:' || p_tenant_id::text || ':' || v_key, 0));
+  SELECT * INTO v_reservation FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id AND idempotency_key = v_key;
+  IF v_reservation.id IS NOT NULL THEN
+    IF v_reservation.operation_fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Депозит уже создан с другими параметрами.';
+    END IF;
+    RETURN public.patient_fund_reservation_result_internal(v_reservation.id, 'already_completed');
+  END IF;
+
+  SELECT * INTO v_payment FROM public.payments
+  WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id AND id = p_payment_id
+  FOR UPDATE;
+  IF v_payment.id IS NULL OR v_payment.status IN ('voided', 'archived', 'refunded') THEN
+    RAISE EXCEPTION 'Платёж недоступен для резервирования.';
+  END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id, p_payment_id);
+  SELECT * INTO v_capacity FROM public.get_payment_fund_capacity_internal(p_tenant_id, p_payment_id);
+  IF v_amount > v_capacity.available_credit_amount THEN
+    RAISE EXCEPTION 'Недостаточно доступного кредита для создания депозита.';
+  END IF;
+
+  PERFORM public.issue_finance_mutation_authorization_internal('reservation_create', v_reservation_id);
+  INSERT INTO public.patient_fund_reservations (
+    id, tenant_id, patient_id, payment_id, currency, purpose_type, purpose_label,
+    appointment_id, treatment_plan_id, original_amount, expires_at, notes,
+    metadata, idempotency_key, operation_fingerprint, created_by
+  ) VALUES (
+    v_reservation_id, p_tenant_id, p_patient_id, p_payment_id, v_payment.currency, p_purpose_type,
+    nullif(btrim(COALESCE(p_purpose_label, '')), ''), p_appointment_id, p_treatment_plan_id,
+    v_amount, p_expires_at, nullif(btrim(COALESCE(p_notes, '')), ''), v_metadata,
+    v_key, v_fingerprint, auth.uid()
+  ) RETURNING * INTO v_reservation;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'patient_fund_reservation_created', 'patient_fund_reservation', v_reservation.id,
+    p_patient_id, p_payment_id,
+    p_metadata => jsonb_build_object(
+      'reservationId', v_reservation.id, 'paymentId', p_payment_id,
+      'amount', v_amount, 'remainingAmount', v_reservation.remaining_amount,
+      'purposeType', v_reservation.purpose_type, 'operationRef', md5(v_key)
+    )
+  );
+  RETURN public.patient_fund_reservation_result_internal(v_reservation.id, 'completed');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.release_patient_fund_reservation(
+  p_tenant_id uuid,
+  p_reservation_id uuid,
+  p_amount numeric DEFAULT NULL,
+  p_reason text DEFAULT NULL,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_probe public.patient_fund_reservations;
+  v_reservation public.patient_fund_reservations;
+  v_payment public.payments;
+  v_key text;
+  v_reason text;
+  v_fingerprint text;
+  v_before numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+  v_key := btrim(COALESCE(p_idempotency_key, ''));
+  v_reason := btrim(COALESCE(p_reason, ''));
+  IF length(v_key) = 0 OR length(v_key) > 240 THEN RAISE EXCEPTION 'Release idempotency key is required'; END IF;
+  IF length(v_reason) = 0 THEN RAISE EXCEPTION 'Release reason is required'; END IF;
+  IF p_amount IS NOT NULL AND p_amount <= 0 THEN RAISE EXCEPTION 'Release amount must be positive'; END IF;
+  v_fingerprint := md5(jsonb_build_object(
+    'tenantId', p_tenant_id, 'reservationId', p_reservation_id,
+    'amount', p_amount, 'reason', v_reason
+  )::text);
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('fund-reservation:release:' || p_tenant_id::text || ':' || v_key, 0));
+  SELECT * INTO v_reservation FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id AND release_idempotency_key = v_key;
+  IF v_reservation.id IS NOT NULL THEN
+    IF v_reservation.id <> p_reservation_id OR v_reservation.release_operation_fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Release idempotency key is already used with different details';
+    END IF;
+    RETURN public.patient_fund_reservation_result_internal(v_reservation.id, 'already_completed');
+  END IF;
+
+  SELECT * INTO v_probe FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id AND id = p_reservation_id;
+  IF v_probe.id IS NULL THEN RAISE EXCEPTION 'Reservation not found in this tenant'; END IF;
+  SELECT * INTO v_payment FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = v_probe.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id, v_payment.id);
+  SELECT * INTO v_reservation FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id AND id = p_reservation_id FOR UPDATE;
+  IF v_reservation.status NOT IN ('active', 'partially_used') OR v_reservation.remaining_amount <= 0 THEN
+    RAISE EXCEPTION 'Reservation cannot be released';
+  END IF;
+  IF p_amount IS NOT NULL AND round(p_amount::numeric, 2)::numeric(12,2) <> v_reservation.remaining_amount THEN
+    RAISE EXCEPTION 'Only full remaining reservation release is supported';
+  END IF;
+  v_before := v_reservation.remaining_amount;
+  PERFORM public.issue_finance_mutation_authorization_internal('reservation_release', v_reservation.id);
+
+  UPDATE public.patient_fund_reservations
+  SET released_amount = released_amount + remaining_amount,
+      status = 'released',
+      released_by = auth.uid(), released_at = now(), release_reason = v_reason,
+      release_idempotency_key = v_key,
+      release_operation_fingerprint = v_fingerprint
+  WHERE id = v_reservation.id
+  RETURNING * INTO v_reservation;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'patient_fund_reservation_released', 'patient_fund_reservation', v_reservation.id,
+    v_reservation.patient_id, v_reservation.payment_id, v_reason,
+    jsonb_build_object(
+      'reservationId', v_reservation.id, 'paymentId', v_reservation.payment_id,
+      'amount', v_before, 'beforeRemainingAmount', v_before,
+      'afterRemainingAmount', v_reservation.remaining_amount,
+      'purposeType', v_reservation.purpose_type, 'operationRef', md5(v_key)
+    )
+  );
+  RETURN public.patient_fund_reservation_result_internal(v_reservation.id, 'completed');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.allocate_reserved_credit(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_reservation_id uuid,
+  p_invoice_id uuid,
+  p_amount numeric,
+  p_idempotency_key text
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_probe public.patient_fund_reservations;
+  v_reservation public.patient_fund_reservations;
+  v_payment public.payments;
+  v_invoice public.invoices;
+  v_allocation public.payment_allocations;
+  v_amount numeric(12,2);
+  v_key text;
+  v_fingerprint text;
+  v_before numeric(12,2);
+  v_event text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+  v_amount := round(COALESCE(p_amount, 0)::numeric, 2)::numeric(12,2);
+  IF v_amount <= 0 THEN RAISE EXCEPTION 'Allocation amount must be positive'; END IF;
+  v_key := btrim(COALESCE(p_idempotency_key, ''));
+  IF length(v_key) = 0 OR length(v_key) > 240 THEN RAISE EXCEPTION 'Reservation allocation idempotency key is required'; END IF;
+  v_fingerprint := md5(jsonb_build_object(
+    'tenantId', p_tenant_id, 'patientId', p_patient_id,
+    'reservationId', p_reservation_id, 'invoiceId', p_invoice_id, 'amount', v_amount
+  )::text);
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('fund-reservation:consume:' || p_tenant_id::text || ':' || v_key, 0));
+  SELECT * INTO v_allocation FROM public.payment_allocations
+  WHERE tenant_id = p_tenant_id AND reservation_operation_key = v_key;
+  IF v_allocation.id IS NOT NULL THEN
+    IF v_allocation.patient_fund_reservation_id <> p_reservation_id
+       OR v_allocation.invoice_id <> p_invoice_id
+       OR v_allocation.amount <> v_amount
+       OR v_allocation.reservation_operation_fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Reservation allocation idempotency key is already used with different details';
+    END IF;
+    RETURN public.patient_fund_reservation_result_internal(p_reservation_id, 'already_completed', v_allocation.id);
+  END IF;
+
+  SELECT * INTO v_probe FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id AND id = p_reservation_id;
+  IF v_probe.id IS NULL THEN RAISE EXCEPTION 'Reservation not found for this patient and tenant'; END IF;
+  SELECT * INTO v_payment FROM public.payments
+  WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id AND id = v_probe.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL OR v_payment.status IN ('voided', 'archived', 'refunded') THEN
+    RAISE EXCEPTION 'Payment is not available for reserved allocation';
+  END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id, v_payment.id);
+  SELECT * INTO v_reservation FROM public.patient_fund_reservations
+  WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id AND id = p_reservation_id FOR UPDATE;
+  IF v_reservation.status NOT IN ('active', 'partially_used') OR v_amount > v_reservation.remaining_amount THEN
+    RAISE EXCEPTION 'Reserved allocation amount exceeds reservation remainder';
+  END IF;
+  SELECT * INTO v_invoice FROM public.invoices
+  WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id AND id = p_invoice_id FOR UPDATE;
+  IF v_invoice.id IS NULL THEN RAISE EXCEPTION 'Invoice not found for this patient and tenant'; END IF;
+  IF v_invoice.status NOT IN ('issued', 'partially_paid') THEN RAISE EXCEPTION 'Invoice is not available for reserved allocation'; END IF;
+  IF upper(btrim(v_invoice.currency)) <> upper(btrim(v_payment.currency)) THEN RAISE EXCEPTION 'Payment and invoice currency mismatch'; END IF;
+  v_invoice := public.recalculate_invoice_financials_internal(v_invoice.id);
+  IF v_amount > v_invoice.balance_amount THEN RAISE EXCEPTION 'Reserved allocation amount exceeds remaining invoice balance'; END IF;
+  v_before := v_reservation.remaining_amount;
+  PERFORM public.issue_finance_mutation_authorization_internal('reserved_allocation_insert', v_reservation.id);
+
+  INSERT INTO public.payment_allocations (
+    tenant_id, patient_id, payment_id, invoice_id, amount, currency, status,
+    metadata, created_by, patient_fund_reservation_id,
+    reservation_operation_key, reservation_operation_fingerprint
+  ) VALUES (
+    p_tenant_id, p_patient_id, v_payment.id, v_invoice.id, v_amount, v_payment.currency, 'active',
+    jsonb_build_object('source', 'reserved_credit_allocation', 'patientFundReservationId', v_reservation.id),
+    auth.uid(), v_reservation.id, v_key, v_fingerprint
+  ) RETURNING * INTO v_allocation;
+
+  PERFORM public.issue_finance_mutation_authorization_internal('reservation_consume', v_reservation.id);
+  UPDATE public.patient_fund_reservations
+  SET consumed_amount = consumed_amount + v_amount,
+      status = CASE WHEN remaining_amount - v_amount = 0 THEN 'fully_used' ELSE 'partially_used' END
+  WHERE id = v_reservation.id
+  RETURNING * INTO v_reservation;
+
+  PERFORM public.recalculate_payment_status_internal(v_payment.id);
+  PERFORM public.recalculate_invoice_financials_internal(v_invoice.id);
+  v_event := CASE WHEN v_reservation.status = 'fully_used'
+    THEN 'patient_fund_reservation_fully_used'
+    ELSE 'patient_fund_reservation_partially_used' END;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, v_event, 'patient_fund_reservation', v_reservation.id,
+    p_patient_id, v_payment.id,
+    p_metadata => jsonb_build_object(
+      'reservationId', v_reservation.id, 'paymentId', v_payment.id,
+      'invoiceId', v_invoice.id, 'allocationId', v_allocation.id,
+      'amount', v_amount, 'beforeRemainingAmount', v_before,
+      'afterRemainingAmount', v_reservation.remaining_amount,
+      'purposeType', v_reservation.purpose_type, 'operationRef', md5(v_key)
+    )
+  );
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'reserved_credit_allocated', 'payment_allocation', v_allocation.id,
+    p_patient_id, v_payment.id,
+    p_metadata => jsonb_build_object(
+      'reservationId', v_reservation.id, 'paymentId', v_payment.id,
+      'invoiceId', v_invoice.id, 'allocationId', v_allocation.id,
+      'amount', v_amount, 'remainingAmount', v_reservation.remaining_amount,
+      'purposeType', v_reservation.purpose_type, 'operationRef', md5(v_key)
+    )
+  );
+  RETURN public.patient_fund_reservation_result_internal(v_reservation.id, 'completed', v_allocation.id);
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.enforce_payment_allocation_capacity_internal()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_reservation public.patient_fund_reservations;
+  v_allocated numeric(12,2);
+  v_completed numeric(12,2);
+  v_refund_reserved numeric(12,2);
+  v_deposit_reserved numeric(12,2);
+  v_invoice_id uuid;
+  v_invoice_total numeric(12,2);
+  v_invoice_allocated numeric(12,2);
+  v_writeoffs numeric(12,2);
+  v_writeoff_reserved numeric(12,2);
+BEGIN
+  IF TG_OP = 'UPDATE' AND (
+       NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       OR NEW.patient_id IS DISTINCT FROM OLD.patient_id
+       OR NEW.payment_id IS DISTINCT FROM OLD.payment_id
+       OR NEW.invoice_id IS DISTINCT FROM OLD.invoice_id
+       OR NEW.invoice_item_id IS DISTINCT FROM OLD.invoice_item_id
+       OR NEW.amount IS DISTINCT FROM OLD.amount
+       OR NEW.currency IS DISTINCT FROM OLD.currency
+       OR NEW.patient_fund_reservation_id IS DISTINCT FROM OLD.patient_fund_reservation_id
+       OR NEW.reservation_operation_key IS DISTINCT FROM OLD.reservation_operation_key
+       OR NEW.reservation_operation_fingerprint IS DISTINCT FROM OLD.reservation_operation_fingerprint
+     ) THEN
+    RAISE EXCEPTION 'Payment allocation financial identity is immutable';
+  END IF;
+  IF TG_OP = 'UPDATE'
+     AND OLD.patient_fund_reservation_id IS NOT NULL
+     AND NEW.status IS DISTINCT FROM OLD.status THEN
+    RAISE EXCEPTION 'Reservation-backed allocations are immutable; use a future controlled correction flow';
+  END IF;
+  IF NEW.status <> 'active' THEN RETURN NEW; END IF;
+
+  SELECT * INTO v_payment FROM public.payments
+  WHERE tenant_id = NEW.tenant_id AND id = NEW.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL
+     OR v_payment.patient_id <> NEW.patient_id
+     OR upper(btrim(v_payment.currency)) <> upper(btrim(NEW.currency)) THEN
+    RAISE EXCEPTION 'Payment allocation tenant, patient, and currency must match payment';
+  END IF;
+  IF v_payment.status IN ('voided', 'archived', 'refunded') THEN
+    RAISE EXCEPTION 'Payment is not available for allocation';
+  END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(NEW.tenant_id, NEW.payment_id);
+
+  v_allocated := public.payment_active_allocation_total_internal(NEW.tenant_id, NEW.payment_id, NEW.id);
+  v_completed := public.payment_completed_refund_total_internal(NEW.tenant_id, NEW.payment_id);
+  v_refund_reserved := public.payment_reserved_refund_total_internal(NEW.tenant_id, NEW.payment_id);
+
+  IF NEW.patient_fund_reservation_id IS NULL THEN
+    v_deposit_reserved := public.payment_active_deposit_reserved_total_internal(NEW.tenant_id, NEW.payment_id);
+  ELSE
+    IF NOT public.consume_finance_mutation_authorization_internal('reserved_allocation_insert', NEW.patient_fund_reservation_id) THEN
+      RAISE EXCEPTION 'Reservation-backed allocation requires allocate_reserved_credit';
+    END IF;
+    SELECT * INTO v_reservation FROM public.patient_fund_reservations
+    WHERE tenant_id = NEW.tenant_id AND id = NEW.patient_fund_reservation_id FOR UPDATE;
+    IF v_reservation.id IS NULL
+       OR v_reservation.patient_id <> NEW.patient_id
+       OR v_reservation.payment_id <> NEW.payment_id
+       OR upper(btrim(v_reservation.currency)) <> upper(btrim(NEW.currency))
+       OR v_reservation.status NOT IN ('active', 'partially_used')
+       OR NEW.amount > v_reservation.remaining_amount THEN
+      RAISE EXCEPTION 'Reservation-backed allocation does not match an available reservation';
+    END IF;
+    v_deposit_reserved := public.payment_active_deposit_reserved_total_internal(
+      NEW.tenant_id, NEW.payment_id, v_reservation.id
+    ) + (v_reservation.remaining_amount - NEW.amount);
+  END IF;
+
+  IF v_allocated + NEW.amount + v_completed + v_refund_reserved + v_deposit_reserved > v_payment.amount THEN
+    RAISE EXCEPTION 'Allocation amount exceeds payment capacity after refunds and reservations';
+  END IF;
+
+  IF NEW.invoice_id IS NOT NULL THEN
+    v_invoice_id := NEW.invoice_id;
+  ELSE
+    SELECT invoice_id INTO v_invoice_id FROM public.invoice_items
+    WHERE tenant_id = NEW.tenant_id AND id = NEW.invoice_item_id;
+  END IF;
+  IF v_invoice_id IS NOT NULL THEN
+    SELECT total_amount INTO v_invoice_total FROM public.invoices
+    WHERE tenant_id = NEW.tenant_id AND id = v_invoice_id FOR UPDATE;
+    SELECT COALESCE(sum(pa.amount), 0)::numeric(12,2) INTO v_invoice_allocated
+    FROM public.payment_allocations pa
+    LEFT JOIN public.invoice_items ii ON ii.id = pa.invoice_item_id AND ii.tenant_id = pa.tenant_id
+    WHERE pa.tenant_id = NEW.tenant_id AND pa.status = 'active' AND pa.id <> NEW.id
+      AND (pa.invoice_id = v_invoice_id OR ii.invoice_id = v_invoice_id);
+    v_writeoffs := public.invoice_approved_writeoff_total_internal(NEW.tenant_id, v_invoice_id);
+    v_writeoff_reserved := public.invoice_reserved_writeoff_total_internal(NEW.tenant_id, v_invoice_id);
+    IF v_invoice_allocated + NEW.amount + v_writeoffs + v_writeoff_reserved > v_invoice_total THEN
+      RAISE EXCEPTION 'Allocation amount exceeds invoice capacity after write-offs and reserved write-offs';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS payment_allocations_capacity_guard ON public.payment_allocations;
+CREATE TRIGGER payment_allocations_capacity_guard
+BEFORE INSERT OR UPDATE OF tenant_id, patient_id, payment_id, invoice_id, invoice_item_id, amount, currency, status, patient_fund_reservation_id, reservation_operation_key, reservation_operation_fingerprint
+ON public.payment_allocations
+FOR EACH ROW EXECUTE FUNCTION public.enforce_payment_allocation_capacity_internal();
+CREATE OR REPLACE FUNCTION public.enforce_refund_capacity_internal()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_allocated numeric(12,2);
+  v_completed numeric(12,2);
+  v_refund_reserved numeric(12,2);
+  v_deposit_reserved numeric(12,2);
+BEGIN
+  IF TG_OP = 'UPDATE' AND (
+       NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       OR NEW.patient_id IS DISTINCT FROM OLD.patient_id
+       OR NEW.payment_id IS DISTINCT FROM OLD.payment_id
+       OR NEW.amount IS DISTINCT FROM OLD.amount
+       OR NEW.currency IS DISTINCT FROM OLD.currency
+       OR NEW.refund_method IS DISTINCT FROM OLD.refund_method
+       OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     ) THEN
+    RAISE EXCEPTION 'Refund financial identity is immutable';
+  END IF;
+  IF TG_OP = 'INSERT' THEN
+    IF NOT public.consume_finance_mutation_authorization_internal('refund_insert', NEW.id) THEN
+      RAISE EXCEPTION 'Refund creation requires request_refund';
+    END IF;
+  ELSE
+    IF NOT public.consume_finance_mutation_authorization_internal('refund_update', NEW.id) THEN
+      RAISE EXCEPTION 'Refund transition requires an authoritative refund RPC';
+    END IF;
+  END IF;
+  IF NEW.status NOT IN ('pending', 'approved', 'completed') THEN RETURN NEW; END IF;
+  SELECT * INTO v_payment FROM public.payments
+  WHERE tenant_id = NEW.tenant_id AND id = NEW.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL
+     OR v_payment.patient_id <> NEW.patient_id
+     OR upper(btrim(v_payment.currency)) <> upper(btrim(NEW.currency)) THEN
+    RAISE EXCEPTION 'Refund tenant, patient, and currency must match payment';
+  END IF;
+  IF v_payment.status IN ('voided', 'archived') THEN RAISE EXCEPTION 'Payment is not refundable'; END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(NEW.tenant_id, NEW.payment_id);
+  v_allocated := public.payment_active_allocation_total_internal(NEW.tenant_id, NEW.payment_id);
+  v_completed := public.payment_completed_refund_total_internal(NEW.tenant_id, NEW.payment_id, NEW.id);
+  v_refund_reserved := public.payment_reserved_refund_total_internal(NEW.tenant_id, NEW.payment_id, NEW.id);
+  v_deposit_reserved := public.payment_active_deposit_reserved_total_internal(NEW.tenant_id, NEW.payment_id);
+  IF NEW.status = 'completed' THEN v_completed := v_completed + NEW.amount;
+  ELSE v_refund_reserved := v_refund_reserved + NEW.amount;
+  END IF;
+  IF v_allocated + v_completed + v_refund_reserved + v_deposit_reserved > v_payment.amount THEN
+    RAISE EXCEPTION 'Refund amount exceeds payment capacity after allocations and reservations';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS refunds_capacity_guard ON public.refunds;
+CREATE TRIGGER refunds_capacity_guard
+BEFORE INSERT OR UPDATE OF tenant_id, patient_id, payment_id, amount, currency, refund_method, idempotency_key, status
+ON public.refunds
+FOR EACH ROW EXECUTE FUNCTION public.enforce_refund_capacity_internal();
+CREATE OR REPLACE FUNCTION public.enforce_payment_refund_void_guard_internal()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NEW.status = 'voided' AND OLD.status <> 'voided' THEN
+    IF EXISTS (
+      SELECT 1 FROM public.refunds
+      WHERE tenant_id = NEW.tenant_id AND payment_id = NEW.id
+        AND status IN ('pending', 'approved', 'completed')
+    ) THEN
+      RAISE EXCEPTION 'Payment with active or completed refunds cannot be voided';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM public.patient_fund_reservations
+      WHERE tenant_id = NEW.tenant_id AND payment_id = NEW.id
+        AND status IN ('active', 'partially_used') AND remaining_amount > 0
+    ) THEN
+      RAISE EXCEPTION 'Нельзя аннулировать платёж с активным депозитом.';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS payments_refund_void_guard ON public.payments;
+CREATE TRIGGER payments_refund_void_guard
+BEFORE UPDATE OF status ON public.payments
+FOR EACH ROW EXECUTE FUNCTION public.enforce_payment_refund_void_guard_internal();
+CREATE OR REPLACE FUNCTION public.allocate_payment(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_amount numeric,
+  p_invoice_id uuid DEFAULT NULL,
+  p_invoice_item_id uuid DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.payment_allocations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_metadata jsonb := COALESCE(p_metadata, '{}'::jsonb);
+  v_payment public.payments;
+  v_invoice public.invoices;
+  v_item public.invoice_items;
+  v_allocation public.payment_allocations;
+  v_effective_invoice_id uuid;
+  v_capacity record;
+  v_target_remaining numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+
+  IF p_payment_id IS NULL THEN
+    RAISE EXCEPTION 'Payment ID is required';
+  END IF;
+  IF COALESCE(p_amount, 0) <= 0 THEN
+    RAISE EXCEPTION 'Allocation amount must be positive';
+  END IF;
+  IF p_invoice_id IS NULL AND p_invoice_item_id IS NULL THEN
+    RAISE EXCEPTION 'Allocation must reference invoice or invoice item';
+  END IF;
+  IF jsonb_typeof(v_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'Metadata must be a JSON object';
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE id = p_payment_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+  IF v_payment.id IS NULL THEN
+    RAISE EXCEPTION 'Payment not found in this tenant';
+  END IF;
+  IF v_payment.status NOT IN ('received', 'partially_allocated') THEN
+    RAISE EXCEPTION 'Cannot allocate payment with status %', v_payment.status;
+  END IF;
+
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id, p_payment_id);
+  SELECT * INTO v_capacity
+  FROM public.get_payment_fund_capacity_internal(p_tenant_id, p_payment_id);
+
+  IF p_amount > v_capacity.available_credit_amount THEN
+    IF v_capacity.reserved_deposit_amount > 0 THEN
+      RAISE EXCEPTION 'Часть средств зарезервирована как депозит. Сначала освободите резерв.';
+    END IF;
+    RAISE EXCEPTION 'Allocation amount exceeds available payment capacity';
+  END IF;
+
+  IF p_invoice_item_id IS NOT NULL THEN
+    SELECT * INTO v_item
+    FROM public.invoice_items
+    WHERE id = p_invoice_item_id AND tenant_id = p_tenant_id
+    FOR UPDATE;
+    IF v_item.id IS NULL THEN
+      RAISE EXCEPTION 'Invoice item not found in this tenant';
+    END IF;
+    IF v_item.status NOT IN ('active', 'adjusted') THEN
+      RAISE EXCEPTION 'Cannot allocate to invoice item with status %', v_item.status;
+    END IF;
+    v_effective_invoice_id := v_item.invoice_id;
+  ELSE
+    v_effective_invoice_id := p_invoice_id;
+  END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = v_effective_invoice_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+  IF v_invoice.id IS NULL THEN
+    RAISE EXCEPTION 'Invoice not found in this tenant';
+  END IF;
+  IF v_invoice.patient_id <> v_payment.patient_id THEN
+    RAISE EXCEPTION 'Payment and invoice patient mismatch';
+  END IF;
+  IF v_invoice.status NOT IN ('issued', 'partially_paid') THEN
+    RAISE EXCEPTION 'Cannot allocate to invoice with status %', v_invoice.status;
+  END IF;
+  IF p_invoice_item_id IS NOT NULL AND v_item.patient_id <> v_invoice.patient_id THEN
+    RAISE EXCEPTION 'Invoice item patient mismatch';
+  END IF;
+
+  PERFORM public.recalculate_invoice_financials_internal(v_invoice.id);
+  SELECT * INTO v_invoice FROM public.invoices WHERE id = v_effective_invoice_id AND tenant_id = p_tenant_id FOR UPDATE;
+
+  IF p_invoice_item_id IS NOT NULL THEN
+    SELECT (v_item.total_amount - COALESCE(sum(pa.amount), 0))::numeric(12,2)
+    INTO v_target_remaining
+    FROM public.payment_allocations pa
+    WHERE pa.tenant_id = p_tenant_id
+      AND pa.invoice_item_id = p_invoice_item_id
+      AND pa.status = 'active';
+  ELSE
+    v_target_remaining := v_invoice.balance_amount;
+  END IF;
+
+  IF p_amount > v_target_remaining THEN
+    RAISE EXCEPTION 'Allocation amount exceeds remaining invoice balance';
+  END IF;
+
+  INSERT INTO public.payment_allocations (
+    tenant_id, patient_id, payment_id, invoice_id, invoice_item_id, amount, currency, status, metadata, created_by
+  ) VALUES (
+    p_tenant_id, v_payment.patient_id, p_payment_id, CASE WHEN p_invoice_item_id IS NULL THEN v_invoice.id ELSE NULL END,
+    p_invoice_item_id, p_amount, v_payment.currency, 'active', v_metadata, auth.uid()
+  ) RETURNING * INTO v_allocation;
+
+  PERFORM public.recalculate_payment_status_internal(p_payment_id);
+  PERFORM public.recalculate_invoice_financials_internal(v_invoice.id);
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'payment_allocated', 'payment_allocation', v_allocation.id, v_payment.patient_id, p_payment_id,
+    p_metadata => jsonb_strip_nulls(jsonb_build_object(
+      'allocationId', v_allocation.id,
+      'paymentId', p_payment_id,
+      'invoiceId', v_invoice.id,
+      'invoiceItemId', p_invoice_item_id,
+      'amount', p_amount
+    ))
+  );
+
+  RETURN v_allocation;
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.request_refund(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_amount numeric,
+  p_refund_method text,
+  p_reason text,
+  p_idempotency_key text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.refunds
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_refund public.refunds;
+  v_metadata jsonb;
+  v_idempotency_key text := NULLIF(btrim(p_idempotency_key), '');
+  v_refundable numeric(12,2);
+  v_deposit_reserved numeric(12,2);
+  v_refund_id uuid := gen_random_uuid();
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+
+  IF p_payment_id IS NULL THEN RAISE EXCEPTION 'Payment ID is required'; END IF;
+  IF COALESCE(p_amount, 0) <= 0 THEN RAISE EXCEPTION 'Refund amount must be positive'; END IF;
+  IF p_refund_method IS NULL OR p_refund_method NOT IN ('cash', 'kaspi', 'halyk_terminal', 'card', 'bank_transfer', 'other') THEN
+    RAISE EXCEPTION 'Unsupported refund method: %', p_refund_method;
+  END IF;
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN RAISE EXCEPTION 'Refund reason is required'; END IF;
+  IF p_idempotency_key IS NOT NULL AND v_idempotency_key IS NULL THEN RAISE EXCEPTION 'Idempotency key must not be empty'; END IF;
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id AND id = p_payment_id
+  FOR UPDATE;
+
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  IF v_payment.status IN ('voided', 'archived') THEN
+    RAISE EXCEPTION 'Cannot refund payment with status %', v_payment.status;
+  END IF;
+
+  IF v_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_refund
+    FROM public.refunds
+    WHERE tenant_id = p_tenant_id AND idempotency_key = v_idempotency_key;
+
+    IF v_refund.id IS NOT NULL THEN
+      IF v_refund.payment_id <> p_payment_id
+         OR v_refund.amount <> p_amount::numeric(12,2)
+         OR v_refund.refund_method <> p_refund_method THEN
+        RAISE EXCEPTION 'Idempotency key is already used for a different refund request';
+      END IF;
+      RETURN v_refund;
+    END IF;
+  END IF;
+
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id, p_payment_id);
+  v_refundable := public.payment_refundable_amount_internal(p_tenant_id, p_payment_id);
+  v_deposit_reserved := public.payment_active_deposit_reserved_total_internal(p_tenant_id, p_payment_id);
+  IF p_amount > v_refundable THEN
+    IF v_deposit_reserved > 0 THEN
+      RAISE EXCEPTION 'Часть средств зарезервирована как депозит. Сначала освободите резерв.';
+    END IF;
+    RAISE EXCEPTION 'Refund amount exceeds currently unallocated refundable amount';
+  END IF;
+
+  PERFORM public.issue_finance_mutation_authorization_internal('refund_insert', v_refund_id);
+  INSERT INTO public.refunds (
+    id, tenant_id, patient_id, payment_id, status, refund_method, amount, currency,
+    reason, requested_by, requested_at, metadata, idempotency_key
+  ) VALUES (
+    v_refund_id, p_tenant_id, v_payment.patient_id, v_payment.id, 'pending', p_refund_method,
+    p_amount, v_payment.currency, btrim(p_reason), auth.uid(), now(), v_metadata, v_idempotency_key
+  ) RETURNING * INTO v_refund;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'refund_requested', 'refund', v_refund.id,
+    v_refund.patient_id, v_refund.payment_id, v_refund.reason,
+    jsonb_build_object(
+      'refundId', v_refund.id, 'paymentId', v_refund.payment_id,
+      'amount', v_refund.amount, 'currency', v_refund.currency,
+      'fromStatus', NULL, 'toStatus', 'pending'
+    )
+  );
+
+  RETURN v_refund;
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.approve_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid
+) RETURNS public.refunds
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, private_finance, pg_temp
+AS $$
+DECLARE
+  v_probe public.refunds;
+  v_refund public.refunds;
+  v_payment public.payments;
+  v_refundable numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(p_tenant_id, ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]);
+  SELECT * INTO v_probe FROM public.refunds WHERE tenant_id = p_tenant_id AND id = p_refund_id;
+  IF v_probe.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  SELECT * INTO v_payment FROM public.payments WHERE tenant_id = p_tenant_id AND id = v_probe.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id, v_payment.id);
+  SELECT * INTO v_refund FROM public.refunds WHERE tenant_id = p_tenant_id AND id = p_refund_id FOR UPDATE;
+  IF v_refund.payment_id <> v_payment.id THEN RAISE EXCEPTION 'Refund payment changed during transition'; END IF;
+  IF v_refund.status IN ('approved', 'completed') THEN RETURN v_refund; END IF;
+  IF v_refund.status <> 'pending' THEN RAISE EXCEPTION 'Only pending refunds can be approved'; END IF;
+  IF v_payment.status IN ('voided', 'archived') THEN RAISE EXCEPTION 'Cannot approve refund for payment with status %', v_payment.status; END IF;
+  v_refundable := public.payment_refundable_amount_internal(p_tenant_id, v_payment.id, v_refund.id);
+  IF v_refund.amount > v_refundable THEN RAISE EXCEPTION 'Refund amount exceeds currently refundable amount'; END IF;
+  PERFORM public.issue_finance_mutation_authorization_internal('refund_update', v_refund.id);
+  UPDATE public.refunds SET status='approved', approved_by=auth.uid(), approved_at=now()
+  WHERE id=v_refund.id RETURNING * INTO v_refund;
+  PERFORM public.log_finance_event_internal(p_tenant_id,'refund_approved','refund',v_refund.id,v_refund.patient_id,v_refund.payment_id,
+    p_metadata=>jsonb_build_object('refundId',v_refund.id,'paymentId',v_refund.payment_id,'amount',v_refund.amount,'currency',v_refund.currency,'fromStatus','pending','toStatus','approved'));
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_external_reference text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.refunds
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, private_finance, pg_temp
+AS $$
+DECLARE
+  v_probe public.refunds;
+  v_refund public.refunds;
+  v_payment public.payments;
+  v_metadata jsonb;
+  v_refundable numeric(12,2);
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(p_tenant_id, ARRAY['clinic_owner'::public.app_role,'clinic_admin'::public.app_role,'cashier'::public.app_role]);
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+  SELECT * INTO v_probe FROM public.refunds WHERE tenant_id=p_tenant_id AND id=p_refund_id;
+  IF v_probe.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  SELECT * INTO v_payment FROM public.payments WHERE tenant_id=p_tenant_id AND id=v_probe.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id,v_payment.id);
+  SELECT * INTO v_refund FROM public.refunds WHERE tenant_id=p_tenant_id AND id=p_refund_id FOR UPDATE;
+  IF v_refund.payment_id <> v_payment.id THEN RAISE EXCEPTION 'Refund payment changed during transition'; END IF;
+  IF v_refund.status='completed' THEN RETURN v_refund; END IF;
+  IF v_refund.status<>'approved' THEN RAISE EXCEPTION 'Only approved refunds can be completed'; END IF;
+  IF v_payment.status IN ('voided','archived') THEN RAISE EXCEPTION 'Cannot complete refund for payment with status %',v_payment.status; END IF;
+  v_refundable := public.payment_refundable_amount_internal(p_tenant_id,v_payment.id,v_refund.id);
+  IF v_refund.amount > v_refundable THEN RAISE EXCEPTION 'Refund amount exceeds currently refundable amount'; END IF;
+  PERFORM public.issue_finance_mutation_authorization_internal('refund_update',v_refund.id);
+  UPDATE public.refunds SET status='completed',completed_by=auth.uid(),completed_at=now(),
+    external_reference=COALESCE(NULLIF(btrim(p_external_reference),''),external_reference),
+    metadata=public.sanitize_finance_metadata_internal(metadata||v_metadata)
+  WHERE id=v_refund.id RETURNING * INTO v_refund;
+  PERFORM public.recalculate_payment_status_internal(v_payment.id);
+  PERFORM public.log_finance_event_internal(p_tenant_id,'refund_completed','refund',v_refund.id,v_refund.patient_id,v_refund.payment_id,
+    p_metadata=>jsonb_build_object('refundId',v_refund.id,'paymentId',v_refund.payment_id,'amount',v_refund.amount,'currency',v_refund.currency,'fromStatus','approved','toStatus','completed','externalReference',v_refund.external_reference));
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reject_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_reason text
+) RETURNS public.refunds
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, private_finance, pg_temp
+AS $$
+DECLARE
+  v_probe public.refunds;
+  v_refund public.refunds;
+  v_payment public.payments;
+  v_reason text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(p_tenant_id,ARRAY['clinic_owner'::public.app_role,'clinic_admin'::public.app_role]);
+  v_reason:=NULLIF(btrim(p_reason),''); IF v_reason IS NULL THEN RAISE EXCEPTION 'Rejection reason is required'; END IF;
+  SELECT * INTO v_probe FROM public.refunds WHERE tenant_id=p_tenant_id AND id=p_refund_id;
+  IF v_probe.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  SELECT * INTO v_payment FROM public.payments WHERE tenant_id=p_tenant_id AND id=v_probe.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id,v_payment.id);
+  SELECT * INTO v_refund FROM public.refunds WHERE tenant_id=p_tenant_id AND id=p_refund_id FOR UPDATE;
+  IF v_refund.payment_id <> v_payment.id THEN RAISE EXCEPTION 'Refund payment changed during transition'; END IF;
+  IF v_refund.status='rejected' THEN RETURN v_refund; END IF;
+  IF v_refund.status<>'pending' THEN RAISE EXCEPTION 'Only pending refunds can be rejected'; END IF;
+  PERFORM public.issue_finance_mutation_authorization_internal('refund_update',v_refund.id);
+  UPDATE public.refunds SET status='rejected',rejected_at=now(),metadata=public.sanitize_finance_metadata_internal(metadata||jsonb_build_object('rejectionReason',v_reason,'rejectedBy',auth.uid(),'rejectedAt',now()))
+  WHERE id=v_refund.id RETURNING * INTO v_refund;
+  PERFORM public.log_finance_event_internal(p_tenant_id,'refund_rejected','refund',v_refund.id,v_refund.patient_id,v_refund.payment_id,v_reason,
+    jsonb_build_object('refundId',v_refund.id,'paymentId',v_refund.payment_id,'amount',v_refund.amount,'currency',v_refund.currency,'fromStatus','pending','toStatus','rejected'));
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.void_refund(
+  p_tenant_id uuid,
+  p_refund_id uuid,
+  p_reason text
+) RETURNS public.refunds
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, private_finance, pg_temp
+AS $$
+DECLARE
+  v_probe public.refunds;
+  v_refund public.refunds;
+  v_payment public.payments;
+  v_reason text;
+  v_from_status text;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(p_tenant_id,ARRAY['clinic_owner'::public.app_role,'clinic_admin'::public.app_role]);
+  v_reason:=NULLIF(btrim(p_reason),''); IF v_reason IS NULL THEN RAISE EXCEPTION 'Void reason is required'; END IF;
+  SELECT * INTO v_probe FROM public.refunds WHERE tenant_id=p_tenant_id AND id=p_refund_id;
+  IF v_probe.id IS NULL THEN RAISE EXCEPTION 'Refund not found in this tenant'; END IF;
+  SELECT * INTO v_payment FROM public.payments WHERE tenant_id=p_tenant_id AND id=v_probe.payment_id FOR UPDATE;
+  IF v_payment.id IS NULL THEN RAISE EXCEPTION 'Payment not found in this tenant'; END IF;
+  PERFORM public.lock_payment_capacity_rows_internal(p_tenant_id,v_payment.id);
+  SELECT * INTO v_refund FROM public.refunds WHERE tenant_id=p_tenant_id AND id=p_refund_id FOR UPDATE;
+  IF v_refund.payment_id <> v_payment.id THEN RAISE EXCEPTION 'Refund payment changed during transition'; END IF;
+  IF v_refund.status='voided' THEN RETURN v_refund; END IF;
+  IF v_refund.status='completed' THEN RAISE EXCEPTION 'Completed refunds are immutable and cannot be voided'; END IF;
+  IF v_refund.status NOT IN ('pending','approved') THEN RAISE EXCEPTION 'Only pending or approved refunds can be voided'; END IF;
+  v_from_status:=v_refund.status;
+  PERFORM public.issue_finance_mutation_authorization_internal('refund_update',v_refund.id);
+  UPDATE public.refunds SET status='voided',voided_by=auth.uid(),voided_at=now(),void_reason=v_reason
+  WHERE id=v_refund.id RETURNING * INTO v_refund;
+  PERFORM public.log_finance_event_internal(p_tenant_id,'refund_voided','refund',v_refund.id,v_refund.patient_id,v_refund.payment_id,v_reason,
+    jsonb_build_object('refundId',v_refund.id,'paymentId',v_refund.payment_id,'amount',v_refund.amount,'currency',v_refund.currency,'fromStatus',v_from_status,'toStatus','voided'));
+  RETURN v_refund;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.void_payment_allocation(
+  p_tenant_id uuid,
+  p_allocation_id uuid,
+  p_reason text
+) RETURNS public.payment_allocations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_allocation public.payment_allocations;
+  v_invoice_id uuid;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN
+    RAISE EXCEPTION 'Void reason is required';
+  END IF;
+
+  SELECT * INTO v_allocation
+  FROM public.payment_allocations
+  WHERE id = p_allocation_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+  IF v_allocation.id IS NULL THEN
+    RAISE EXCEPTION 'Payment allocation not found in this tenant';
+  END IF;
+  IF v_allocation.status <> 'active' THEN
+    RAISE EXCEPTION 'Only active payment allocations can be voided';
+  END IF;
+  IF v_allocation.patient_fund_reservation_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Reservation-backed allocation cannot be voided by the generic allocation flow';
+  END IF;
+
+  IF v_allocation.invoice_id IS NOT NULL THEN
+    v_invoice_id := v_allocation.invoice_id;
+  ELSE
+    SELECT invoice_id INTO v_invoice_id FROM public.invoice_items WHERE id = v_allocation.invoice_item_id;
+  END IF;
+
+  UPDATE public.payment_allocations
+  SET status = 'voided',
+      voided_at = now(),
+      voided_by = auth.uid(),
+      void_reason = btrim(p_reason)
+  WHERE id = p_allocation_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_allocation;
+
+  PERFORM public.recalculate_payment_status_internal(v_allocation.payment_id);
+  IF v_invoice_id IS NOT NULL THEN
+    PERFORM public.recalculate_invoice_financials_internal(v_invoice_id);
+  END IF;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'payment_allocation_voided', 'payment_allocation', v_allocation.id,
+    v_allocation.patient_id, v_allocation.payment_id, btrim(p_reason),
+    jsonb_build_object('allocationId', v_allocation.id, 'status', v_allocation.status)
+  );
+
+  RETURN v_allocation;
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.void_payment(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_reason text
+) RETURNS public.payments
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_has_allocations boolean;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role]
+  );
+
+  IF p_reason IS NULL OR length(btrim(p_reason)) = 0 THEN
+    RAISE EXCEPTION 'Void reason is required';
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE id = p_payment_id AND tenant_id = p_tenant_id
+  FOR UPDATE;
+  IF v_payment.id IS NULL THEN
+    RAISE EXCEPTION 'Payment not found in this tenant';
+  END IF;
+  IF v_payment.status = 'voided' THEN
+    RAISE EXCEPTION 'Payment already voided';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.payment_allocations
+    WHERE tenant_id = p_tenant_id AND payment_id = p_payment_id AND status = 'active'
+  ) INTO v_has_allocations;
+  IF EXISTS (SELECT 1 FROM public.patient_fund_reservations WHERE tenant_id = p_tenant_id AND payment_id = p_payment_id AND status IN ('active', 'partially_used') AND remaining_amount > 0) THEN
+    RAISE EXCEPTION 'Нельзя аннулировать платёж с активным депозитом.';
+  END IF;
+
+  IF v_has_allocations THEN
+    RAISE EXCEPTION 'Cannot void payment with active allocations';
+  END IF;
+
+  UPDATE public.payments
+  SET status = 'voided',
+      voided_at = now(),
+      voided_by = auth.uid(),
+      void_reason = btrim(p_reason)
+  WHERE id = p_payment_id AND tenant_id = p_tenant_id
+  RETURNING * INTO v_payment;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id, 'payment_voided', 'payment', v_payment.id, v_payment.patient_id, v_payment.id,
+    btrim(p_reason), jsonb_build_object('paymentId', v_payment.id, 'status', v_payment.status)
+  );
+
+  RETURN v_payment;
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.get_patient_finance_summary(
+  p_tenant_id uuid,
+  p_patient_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_as_of timestamptz := statement_timestamp();
+  v_result jsonb;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+  IF p_tenant_id IS NULL OR p_patient_id IS NULL THEN
+    RAISE EXCEPTION 'Tenant and patient are required';
+  END IF;
+  IF NOT public.has_tenant_role(
+    p_tenant_id,
+    ARRAY[
+      'clinic_owner'::public.app_role,
+      'clinic_admin'::public.app_role,
+      'cashier'::public.app_role,
+      'registrar'::public.app_role,
+      'doctor'::public.app_role
+    ]
+  ) THEN
+    RAISE EXCEPTION 'Insufficient finance permissions';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.patients
+    WHERE tenant_id = p_tenant_id AND id = p_patient_id
+  ) THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  WITH valid_invoices AS (
+    SELECT i.*, upper(btrim(i.currency)) AS summary_currency
+    FROM public.invoices i
+    WHERE i.tenant_id = p_tenant_id
+      AND i.patient_id = p_patient_id
+      AND i.status IN ('issued', 'partially_paid', 'paid', 'written_off')
+  ),
+  valid_payments AS (
+    SELECT p.*, upper(btrim(p.currency)) AS summary_currency
+    FROM public.payments p
+    WHERE p.tenant_id = p_tenant_id
+      AND p.patient_id = p_patient_id
+      AND p.status NOT IN ('voided', 'archived')
+  ),
+  allocation_links AS (
+    SELECT pa.id, pa.payment_id,
+      COALESCE(pa.invoice_id, ii.invoice_id) AS invoice_id,
+      pa.amount,
+      vp.summary_currency
+    FROM public.payment_allocations pa
+    JOIN valid_payments vp
+      ON vp.id = pa.payment_id
+     AND vp.tenant_id = pa.tenant_id
+     AND vp.patient_id = pa.patient_id
+    LEFT JOIN public.invoice_items ii
+      ON ii.id = pa.invoice_item_id
+     AND ii.tenant_id = pa.tenant_id
+     AND ii.patient_id = pa.patient_id
+     AND ii.status IN ('active', 'adjusted')
+    JOIN valid_invoices vi
+      ON vi.id = COALESCE(pa.invoice_id, ii.invoice_id)
+     AND vi.tenant_id = pa.tenant_id
+     AND vi.patient_id = pa.patient_id
+    WHERE pa.tenant_id = p_tenant_id
+      AND pa.patient_id = p_patient_id
+      AND pa.status = 'active'
+  ),
+  payment_allocations AS (
+    SELECT payment_id, COALESCE(sum(amount), 0)::numeric(18,2) AS allocated_amount
+    FROM allocation_links GROUP BY payment_id
+  ),
+  invoice_allocations AS (
+    SELECT invoice_id, COALESCE(sum(amount), 0)::numeric(18,2) AS allocated_amount
+    FROM allocation_links GROUP BY invoice_id
+  ),
+  completed_refunds AS (
+    SELECT r.payment_id, COALESCE(sum(r.amount), 0)::numeric(18,2) AS completed_amount
+    FROM public.refunds r
+    JOIN valid_payments vp ON vp.id = r.payment_id
+    WHERE r.tenant_id = p_tenant_id
+      AND r.patient_id = p_patient_id
+      AND r.status = 'completed'
+    GROUP BY r.payment_id
+  ),
+  reserved_refunds AS (
+    SELECT r.payment_id, COALESCE(sum(r.amount), 0)::numeric(18,2) AS reserved_amount
+    FROM public.refunds r
+    JOIN valid_payments vp ON vp.id = r.payment_id
+    WHERE r.tenant_id = p_tenant_id
+      AND r.patient_id = p_patient_id
+      AND r.status IN ('pending', 'approved')
+    GROUP BY r.payment_id
+  ),
+  active_deposit_reservations AS (
+    SELECT r.payment_id, COALESCE(sum(r.remaining_amount), 0)::numeric(18,2) AS reserved_amount
+    FROM public.patient_fund_reservations r
+    JOIN valid_payments vp ON vp.id = r.payment_id
+    WHERE r.tenant_id = p_tenant_id
+      AND r.patient_id = p_patient_id
+      AND r.status IN ('active', 'partially_used')
+    GROUP BY r.payment_id
+  ),
+  approved_writeoffs AS (
+    SELECT fa.invoice_id, COALESCE(sum(fa.amount), 0)::numeric(18,2) AS writeoff_amount
+    FROM public.financial_adjustments fa
+    JOIN valid_invoices vi ON vi.id = fa.invoice_id
+    WHERE fa.tenant_id = p_tenant_id
+      AND fa.patient_id = p_patient_id
+      AND fa.adjustment_type = 'write_off'
+      AND fa.status = 'approved'
+    GROUP BY fa.invoice_id
+  ),
+  payment_facts AS (
+    SELECT vp.id, vp.status, vp.amount::numeric(18,2) AS amount,
+      vp.received_at, vp.summary_currency,
+      COALESCE(pa.allocated_amount, 0)::numeric(18,2) AS allocated_amount,
+      COALESCE(cr.completed_amount, 0)::numeric(18,2) AS completed_amount,
+      COALESCE(rr.reserved_amount, 0)::numeric(18,2) AS reserved_amount,
+      COALESCE(dr.reserved_amount, 0)::numeric(18,2) AS deposit_reserved_amount,
+      GREATEST(0, vp.amount - COALESCE(pa.allocated_amount, 0) - COALESCE(cr.completed_amount, 0))::numeric(18,2) AS gross_unallocated,
+      GREATEST(0, vp.amount - COALESCE(pa.allocated_amount, 0) - COALESCE(cr.completed_amount, 0) - COALESCE(rr.reserved_amount, 0) - COALESCE(dr.reserved_amount, 0))::numeric(18,2) AS available_credit,
+      CASE
+        WHEN COALESCE(cr.completed_amount, 0) >= vp.amount THEN 'refunded'
+        WHEN COALESCE(cr.completed_amount, 0) > 0 THEN 'partially_refunded'
+        WHEN COALESCE(pa.allocated_amount, 0) >= vp.amount THEN 'allocated'
+        WHEN COALESCE(pa.allocated_amount, 0) > 0 THEN 'partially_allocated'
+        ELSE 'received'
+      END AS expected_status
+    FROM valid_payments vp
+    LEFT JOIN payment_allocations pa ON pa.payment_id = vp.id
+    LEFT JOIN completed_refunds cr ON cr.payment_id = vp.id
+    LEFT JOIN reserved_refunds rr ON rr.payment_id = vp.id
+    LEFT JOIN active_deposit_reservations dr ON dr.payment_id = vp.id
+  ),
+  invoice_facts AS (
+    SELECT vi.id, vi.status, vi.summary_currency,
+      vi.total_amount::numeric(18,2) AS total_amount,
+      vi.paid_amount::numeric(18,2) AS stored_paid_amount,
+      vi.written_off_amount::numeric(18,2) AS stored_writeoff_amount,
+      vi.balance_amount::numeric(18,2) AS balance_amount,
+      COALESCE(ia.allocated_amount, 0)::numeric(18,2) AS allocated_amount,
+      COALESCE(aw.writeoff_amount, 0)::numeric(18,2) AS approved_writeoff_amount,
+      CASE
+        WHEN vi.balance_amount <= 0 AND COALESCE(aw.writeoff_amount, 0) > 0 THEN 'written_off'
+        WHEN vi.balance_amount <= 0 THEN 'paid'
+        WHEN COALESCE(ia.allocated_amount, 0) > 0 THEN 'partially_paid'
+        ELSE 'issued'
+      END AS expected_status
+    FROM valid_invoices vi
+    LEFT JOIN invoice_allocations ia ON ia.invoice_id = vi.id
+    LEFT JOIN approved_writeoffs aw ON aw.invoice_id = vi.id
+  ),
+  currency_keys AS (
+    SELECT summary_currency AS currency FROM invoice_facts
+    UNION
+    SELECT summary_currency AS currency FROM payment_facts
+  ),
+  bucket_rows AS (
+    SELECT ck.currency,
+      COALESCE((SELECT sum(total_amount) FROM invoice_facts i WHERE i.summary_currency = ck.currency), 0)::numeric(18,2) AS total_invoiced,
+      COALESCE((SELECT sum(allocated_amount) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS active_allocated,
+      COALESCE((SELECT sum(amount) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS cash_received,
+      COALESCE((SELECT sum(completed_amount) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS completed_refunds,
+      COALESCE((SELECT sum(approved_writeoff_amount) FROM invoice_facts i WHERE i.summary_currency = ck.currency), 0)::numeric(18,2) AS approved_writeoffs,
+      COALESCE((SELECT sum(GREATEST(0, balance_amount)) FROM invoice_facts i WHERE i.summary_currency = ck.currency), 0)::numeric(18,2) AS current_debt,
+      COALESCE((SELECT sum(gross_unallocated) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS gross_unallocated,
+      COALESCE((SELECT sum(reserved_amount) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS refund_reserved,
+      COALESCE((SELECT sum(deposit_reserved_amount) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS reserved_deposit,
+      COALESCE((SELECT sum(available_credit) FROM payment_facts p WHERE p.summary_currency = ck.currency), 0)::numeric(18,2) AS available_credit,
+      COALESCE((SELECT count(*) FROM invoice_facts i WHERE i.summary_currency = ck.currency AND i.balance_amount > 0), 0)::integer AS open_invoice_count,
+      COALESCE((SELECT count(*) FROM invoice_facts i WHERE i.summary_currency = ck.currency AND i.balance_amount > 0), 0)::integer AS unpaid_invoice_count,
+      COALESCE((SELECT count(*) FROM invoice_facts i WHERE i.summary_currency = ck.currency AND i.status = 'partially_paid'), 0)::integer AS partially_paid_count,
+      (SELECT max(received_at) FROM payment_facts p WHERE p.summary_currency = ck.currency) AS last_payment_at
+    FROM currency_keys ck
+  ),
+  warning_rows AS (
+    SELECT jsonb_build_object(
+      'code', 'PAYMENT_OVERCONSUMED', 'currency', summary_currency,
+      'entityType', 'payment', 'entityId', id,
+      'details', jsonb_build_object('paymentAmount', amount, 'allocatedAmount', allocated_amount, 'completedRefundAmount', completed_amount)
+    ) AS warning
+    FROM payment_facts WHERE allocated_amount + completed_amount > amount
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'REFUND_RESERVATION_EXCEEDS_CAPACITY', 'currency', summary_currency,
+      'entityType', 'payment', 'entityId', id,
+      'details', jsonb_build_object('reservedRefundAmount', reserved_amount, 'availableBeforeReservation', GREATEST(0, amount - allocated_amount - completed_amount))
+    )
+    FROM payment_facts WHERE reserved_amount > GREATEST(0, amount - allocated_amount - completed_amount)
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'DEPOSIT_RESERVATION_EXCEEDS_CAPACITY', 'currency', summary_currency,
+      'entityType', 'payment', 'entityId', id,
+      'details', jsonb_build_object(
+        'reservedDepositAmount', deposit_reserved_amount,
+        'availableBeforeDeposit', GREATEST(0, amount - allocated_amount - completed_amount - reserved_amount)
+      )
+    )
+    FROM payment_facts
+    WHERE deposit_reserved_amount > GREATEST(0, amount - allocated_amount - completed_amount - reserved_amount)
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'PAYMENT_STATUS_MISMATCH', 'currency', summary_currency,
+      'entityType', 'payment', 'entityId', id,
+      'details', jsonb_build_object('actualStatus', status, 'expectedStatus', expected_status)
+    )
+    FROM payment_facts WHERE status <> expected_status
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'INVOICE_NEGATIVE_BALANCE', 'currency', summary_currency,
+      'entityType', 'invoice', 'entityId', id,
+      'details', jsonb_build_object('balanceAmount', balance_amount)
+    )
+    FROM invoice_facts WHERE balance_amount < 0
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'INVOICE_PAID_MISMATCH', 'currency', summary_currency,
+      'entityType', 'invoice', 'entityId', id,
+      'details', jsonb_build_object('storedPaidAmount', stored_paid_amount, 'allocatedAmount', allocated_amount)
+    )
+    FROM invoice_facts WHERE abs(stored_paid_amount - allocated_amount) > 0.009
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'INVOICE_WRITEOFF_MISMATCH', 'currency', summary_currency,
+      'entityType', 'invoice', 'entityId', id,
+      'details', jsonb_build_object('storedWriteOffAmount', stored_writeoff_amount, 'approvedWriteOffAmount', approved_writeoff_amount)
+    )
+    FROM invoice_facts WHERE abs(stored_writeoff_amount - approved_writeoff_amount) > 0.009
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'INVOICE_STATUS_MISMATCH', 'currency', summary_currency,
+      'entityType', 'invoice', 'entityId', id,
+      'details', jsonb_build_object('actualStatus', status, 'expectedStatus', expected_status)
+    )
+    FROM invoice_facts WHERE status <> expected_status
+    UNION ALL
+    SELECT jsonb_build_object(
+      'code', 'MULTIPLE_CURRENCIES', 'currency', NULL,
+      'entityType', 'patient', 'entityId', p_patient_id,
+      'details', jsonb_build_object('currencyCount', (SELECT count(*) FROM currency_keys))
+    )
+    WHERE (SELECT count(*) FROM currency_keys) > 1
+  )
+  SELECT jsonb_build_object(
+    'tenantId', p_tenant_id,
+    'patientId', p_patient_id,
+    'asOf', v_as_of,
+    'modelVersion', 'finance-summary-v2',
+    'currencies', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'currency', currency,
+        'totalInvoiced', total_invoiced,
+        'activeAllocatedAmount', active_allocated,
+        'cashReceived', cash_received,
+        'completedRefundAmount', completed_refunds,
+        'approvedWriteOffAmount', approved_writeoffs,
+        'currentDebt', current_debt,
+        'grossUnallocatedAmount', gross_unallocated,
+        'refundReservedAmount', refund_reserved,
+        'reservedDepositAmount', reserved_deposit,
+        'availableCreditAmount', available_credit,
+        'netPositionAmount', available_credit - current_debt,
+        'openInvoiceCount', open_invoice_count,
+        'unpaidInvoiceCount', unpaid_invoice_count,
+        'partiallyPaidInvoiceCount', partially_paid_count,
+        'lastPaymentAt', last_payment_at
+      ) ORDER BY currency)
+      FROM bucket_rows
+    ), '[]'::jsonb),
+    'factComplete', true,
+    'warnings', COALESCE((SELECT jsonb_agg(warning) FROM warning_rows), '[]'::jsonb)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+COMMENT ON TABLE public.patient_fund_reservations IS
+  'Payment-linked purpose reservation. It blocks derived payment capacity but never records receipt of money.';
+COMMENT ON COLUMN public.patient_fund_reservations.remaining_amount IS
+  'Derived unconsumed and unreleased reservation remainder; active/partially_used remainder reduces available credit.';
+COMMENT ON COLUMN public.payment_allocations.patient_fund_reservation_id IS
+  'Optional immutable link used only by allocate_reserved_credit; generic allocations must leave reserved capacity untouched.';
+
+REVOKE ALL ON FUNCTION public.issue_finance_mutation_authorization_internal(text, uuid) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.consume_finance_mutation_authorization_internal(text, uuid) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON SCHEMA private_finance FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private_finance.mutation_authorizations FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.payment_active_deposit_reserved_total_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.lock_payment_capacity_rows_internal(uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_payment_fund_capacity_internal(uuid, uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_fund_reservation_result_internal(uuid, text, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_patient_fund_reservation_internal() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_refund_capacity_internal() FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.get_payment_fund_capacity(uuid, uuid, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_patient_fund_reservations(uuid, uuid, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.create_patient_fund_reservation(uuid, uuid, uuid, numeric, text, text, uuid, uuid, timestamptz, text, jsonb, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.release_patient_fund_reservation(uuid, uuid, numeric, text, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.allocate_reserved_credit(uuid, uuid, uuid, uuid, numeric, text) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.get_payment_fund_capacity(uuid, uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_patient_fund_reservations(uuid, uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_patient_fund_reservation(uuid, uuid, uuid, numeric, text, text, uuid, uuid, timestamptz, text, jsonb, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.release_patient_fund_reservation(uuid, uuid, numeric, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.allocate_reserved_credit(uuid, uuid, uuid, uuid, numeric, text) TO authenticated;

--- a/supabase/tests/0022_patient_credit_deposits_concurrency.ps1
+++ b/supabase/tests/0022_patient_credit_deposits_concurrency.ps1
@@ -1,0 +1,258 @@
+$ErrorActionPreference = 'Stop'
+
+# Local-only concurrency validation. No cloud credentials are read or used.
+$container = 'supabase_db_codex-test-supabase'
+$tenant = 'f2210000-0000-4000-8000-000000000001'
+$patient = 'f2220000-0000-4000-8000-000000000001'
+$admin = 'f2230000-0000-4000-8000-000000000001'
+$invoice = 'f2250000-0000-4000-8000-000000000001'
+$item = 'f2260000-0000-4000-8000-000000000001'
+$paymentReservationRace = 'f2240000-0000-4000-8000-000000000001'
+$paymentRefundRace = 'f2240000-0000-4000-8000-000000000002'
+$paymentAllocationRace = 'f2240000-0000-4000-8000-000000000003'
+$paymentReleaseRace = 'f2240000-0000-4000-8000-000000000004'
+$paymentConsumeRace = 'f2240000-0000-4000-8000-000000000005'
+$paymentIdempotentRace = 'f2240000-0000-4000-8000-000000000006'
+$paymentIdempotentConflict = 'f2240000-0000-4000-8000-000000000007'
+$paymentDifferentA = 'f2240000-0000-4000-8000-000000000008'
+$paymentDifferentB = 'f2240000-0000-4000-8000-000000000009'
+$paymentApproveRace = 'f2240000-0000-4000-8000-000000000010'
+$paymentCompleteRace = 'f2240000-0000-4000-8000-000000000011'
+$paymentRejectRace = 'f2240000-0000-4000-8000-000000000012'
+$paymentVoidRace = 'f2240000-0000-4000-8000-000000000013'
+
+function Invoke-Sql([string]$sql) {
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $previousPreference
+  if ($code -ne 0) { throw "SQL failed:`n$sql`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -At -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $previousPreference
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return ($output | Select-Object -Last 1).ToString().Trim()
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+
+  $completed = Wait-Job $jobA, $jobB -Timeout 60
+  if (@($completed).Count -ne 2) {
+    Stop-Job $jobA, $jobB -ErrorAction SilentlyContinue
+    Remove-Job $jobA, $jobB -Force -ErrorAction SilentlyContinue
+    throw 'Concurrency pair timed out; possible deadlock.'
+  }
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function Assert-Equal($actual, $expected, [string]$message) {
+  if ($actual -ne $expected) { throw "$message expected=$expected actual=$actual" }
+}
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id='$tenant'::uuid;
+DELETE FROM auth.users WHERE id='$admin'::uuid;
+"@
+
+$setup = @"
+BEGIN;
+INSERT INTO public.tenants(id,name) VALUES ('$tenant'::uuid,'Deposit concurrency tenant');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at)
+VALUES ('$admin'::uuid,'00000000-0000-0000-0000-000000000000','authenticated','authenticated','deposit-concurrency@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$admin'::uuid);
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES ('$tenant'::uuid,'$admin'::uuid,'clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,balance)
+VALUES ('$patient'::uuid,'$tenant'::uuid,'Deposit concurrency patient','+77009991111','phone',55);
+INSERT INTO public.invoices(id,tenant_id,patient_id,invoice_number,status,currency,issued_at,created_by,metadata)
+VALUES ('$invoice'::uuid,'$tenant'::uuid,'$patient'::uuid,'DEP-CONC-1','issued','KZT',now(),'$admin'::uuid,'{}');
+INSERT INTO public.invoice_items(id,tenant_id,invoice_id,patient_id,service_name,quantity,unit_price,total_amount,status,created_by,metadata)
+VALUES ('$item'::uuid,'$tenant'::uuid,'$invoice'::uuid,'$patient'::uuid,'Concurrency capacity',1,10000,10000,'active','$admin'::uuid,'{}');
+SELECT public.recalculate_invoice_financials_internal('$invoice'::uuid);
+INSERT INTO public.payments(id,tenant_id,patient_id,status,payment_method,amount,currency,received_by,metadata) VALUES
+ ('$paymentReservationRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentRefundRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentAllocationRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentReleaseRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentConsumeRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentIdempotentRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentIdempotentConflict'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentDifferentA'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentDifferentB'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentApproveRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentCompleteRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentRejectRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}'),
+ ('$paymentVoidRace'::uuid,'$tenant'::uuid,'$patient'::uuid,'received','cash',1000,'KZT','$admin'::uuid,'{}');
+COMMIT;
+"@
+
+$authContext = "BEGIN; SET LOCAL ROLE authenticated; SELECT set_config('request.jwt.claim.sub','$admin',true);"
+
+try {
+  Invoke-Sql $cleanup | Out-Null
+  Invoke-Sql $setup | Out-Null
+
+  # 1. Reservation vs reservation: only one 700 reservation can fit.
+  $reservationRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentReservationRace',700,'general',NULL,NULL,NULL,NULL,NULL,'{}','rr-a'); COMMIT;") `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentReservationRace',700,'general',NULL,NULL,NULL,NULL,NULL,'{}','rr-b'); COMMIT;"))
+  Assert-Equal @($reservationRace | Where-Object { $_.Code -eq 0 }).Count 1 'reservation-vs-reservation success count'
+  Assert-Equal @($reservationRace | Where-Object { $_.Code -ne 0 }).Count 1 'reservation-vs-reservation rejection count'
+  Assert-Equal ([decimal](Invoke-Scalar "select coalesce(sum(remaining_amount),0) from public.patient_fund_reservations where payment_id='$paymentReservationRace'::uuid and status in ('active','partially_used')")) 700 'reservation-vs-reservation reserved total'
+  Assert-Equal ([decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$paymentReservationRace')")) 300 'reservation-vs-reservation available credit'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='patient_fund_reservation_created' and payment_id='$paymentReservationRace'")) 1 'reservation-vs-reservation audit count'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.activity_events where type='patient_fund_reservation_created' and patient_id='$patient'::uuid and metadata->>'paymentId'='$paymentReservationRace'")) 1 'reservation-vs-reservation activity count'
+
+  # 2. Reservation vs refund: one claimant wins 700; total locked capacity stays 700.
+  $refundRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentRefundRace',700,'general',NULL,NULL,NULL,NULL,NULL,'{}','refund-race-reservation'); COMMIT;") `
+    ($authContext + " SELECT public.request_refund('$tenant','$paymentRefundRace',700,'cash','refund race','refund-race-refund','{}'); COMMIT;"))
+  Assert-Equal @($refundRace | Where-Object { $_.Code -eq 0 }).Count 1 'reservation-vs-refund success count'
+  Assert-Equal @($refundRace | Where-Object { $_.Code -ne 0 }).Count 1 'reservation-vs-refund rejection count'
+  $refundLocked = [decimal](Invoke-Scalar "select coalesce((select sum(remaining_amount) from public.patient_fund_reservations where payment_id='$paymentRefundRace'::uuid and status in ('active','partially_used')),0)+coalesce((select sum(amount) from public.refunds where payment_id='$paymentRefundRace'::uuid and status in ('pending','approved')),0)")
+  Assert-Equal $refundLocked 700 'reservation-vs-refund locked total'
+  Assert-Equal ([decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$paymentRefundRace')")) 300 'reservation-vs-refund available credit'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where payment_id='$paymentRefundRace' and action in ('patient_fund_reservation_created','refund_requested')")) 1 'reservation-vs-refund success audit count'
+
+  # 3. Reservation vs generic allocation: one claimant wins 700.
+  $allocationRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentAllocationRace',700,'general',NULL,NULL,NULL,NULL,NULL,'{}','allocation-race-reservation'); COMMIT;") `
+    ($authContext + " SELECT public.allocate_payment('$tenant','$paymentAllocationRace',700,'$invoice',NULL,'{}'); COMMIT;"))
+  Assert-Equal @($allocationRace | Where-Object { $_.Code -eq 0 }).Count 1 'reservation-vs-allocation success count'
+  Assert-Equal @($allocationRace | Where-Object { $_.Code -ne 0 }).Count 1 'reservation-vs-allocation rejection count'
+  $allocationLocked = [decimal](Invoke-Scalar "select coalesce((select sum(remaining_amount) from public.patient_fund_reservations where payment_id='$paymentAllocationRace'::uuid and status in ('active','partially_used')),0)+coalesce((select sum(amount) from public.payment_allocations where payment_id='$paymentAllocationRace'::uuid and status='active'),0)")
+  Assert-Equal $allocationLocked 700 'reservation-vs-allocation used total'
+  Assert-Equal ([decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$paymentAllocationRace')")) 300 'reservation-vs-allocation available credit'
+
+  # 4. Release vs generic allocation: release always succeeds; allocation may follow it or reject before it.
+  Invoke-Sql ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentReleaseRace',600,'general',NULL,NULL,NULL,NULL,NULL,'{}','release-race-create'); COMMIT;") | Out-Null
+  $releaseReservation = Invoke-Scalar "select id from public.patient_fund_reservations where tenant_id='$tenant'::uuid and idempotency_key='release-race-create'"
+  $releaseRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.release_patient_fund_reservation('$tenant','$releaseReservation',NULL,'release race','release-race-key'); COMMIT;") `
+    ($authContext + " SELECT public.allocate_payment('$tenant','$paymentReleaseRace',600,'$invoice',NULL,'{}'); COMMIT;"))
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.patient_fund_reservations where id='$releaseReservation'::uuid and status='released' and remaining_amount=0")) 1 'release-vs-allocation release state'
+  $releaseAllocation = [decimal](Invoke-Scalar "select coalesce(sum(amount),0) from public.payment_allocations where payment_id='$paymentReleaseRace'::uuid and status='active'")
+  if ($releaseAllocation -ne 0 -and $releaseAllocation -ne 600) { throw "release-vs-allocation unexpected allocation=$releaseAllocation" }
+  $releaseAvailable = [decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$paymentReleaseRace')")
+  if ($releaseAvailable -lt 0 -or ($releaseAvailable + $releaseAllocation) -ne 1000) { throw "release-vs-allocation capacity invalid available=$releaseAvailable allocation=$releaseAllocation" }
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='patient_fund_reservation_released' and target_id='$releaseReservation'")) 1 'release-vs-allocation release audit count'
+
+  # 5. Two consumes against the same reservation: one 400 consume wins, one loses against remainder 200.
+  Invoke-Sql ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentConsumeRace',600,'service','consume race',NULL,NULL,NULL,NULL,'{}','consume-race-create'); COMMIT;") | Out-Null
+  $consumeReservation = Invoke-Scalar "select id from public.patient_fund_reservations where tenant_id='$tenant'::uuid and idempotency_key='consume-race-create'"
+  $consumeRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.allocate_reserved_credit('$tenant','$patient','$consumeReservation','$invoice',400,'consume-race-a'); COMMIT;") `
+    ($authContext + " SELECT public.allocate_reserved_credit('$tenant','$patient','$consumeReservation','$invoice',400,'consume-race-b'); COMMIT;"))
+  Assert-Equal @($consumeRace | Where-Object { $_.Code -eq 0 }).Count 1 'consume-vs-consume success count'
+  Assert-Equal @($consumeRace | Where-Object { $_.Code -ne 0 }).Count 1 'consume-vs-consume rejection count'
+  Assert-Equal ([decimal](Invoke-Scalar "select consumed_amount from public.patient_fund_reservations where id='$consumeReservation'::uuid")) 400 'consume-vs-consume consumed amount'
+  Assert-Equal ([decimal](Invoke-Scalar "select remaining_amount from public.patient_fund_reservations where id='$consumeReservation'::uuid")) 200 'consume-vs-consume remainder'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.payment_allocations where patient_fund_reservation_id='$consumeReservation'::uuid")) 1 'consume-vs-consume allocation rows'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='reserved_credit_allocated' and metadata->>'reservationId'='$consumeReservation'")) 1 'consume-vs-consume allocation audit count'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.activity_events where type='reserved_credit_allocated' and metadata->>'reservationId'='$consumeReservation'")) 1 'consume-vs-consume allocation activity count'
+
+  # 6. Same idempotency key and same payload: both callers succeed, one row and one event.
+  $sameKeyRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentIdempotentRace',300,'general',NULL,NULL,NULL,NULL,NULL,'{}','same-key'); COMMIT;") `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentIdempotentRace',300,'general',NULL,NULL,NULL,NULL,NULL,'{}','same-key'); COMMIT;"))
+  Assert-Equal @($sameKeyRace | Where-Object { $_.Code -eq 0 }).Count 2 'same-key identical retries success count'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.patient_fund_reservations where tenant_id='$tenant'::uuid and idempotency_key='same-key'")) 1 'same-key reservation row count'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='patient_fund_reservation_created' and payment_id='$paymentIdempotentRace'")) 1 'same-key audit count'
+
+  # 7. Same key with different payload: one succeeds, one conflicts.
+  $differentPayloadRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentIdempotentConflict',200,'general',NULL,NULL,NULL,NULL,NULL,'{}','conflict-key'); COMMIT;") `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentIdempotentConflict',300,'general',NULL,NULL,NULL,NULL,NULL,'{}','conflict-key'); COMMIT;"))
+  Assert-Equal @($differentPayloadRace | Where-Object { $_.Code -eq 0 }).Count 1 'different-payload key success count'
+  Assert-Equal @($differentPayloadRace | Where-Object { $_.Code -ne 0 }).Count 1 'different-payload key rejection count'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.patient_fund_reservations where tenant_id='$tenant'::uuid and idempotency_key='conflict-key'")) 1 'different-payload key row count'
+
+  # 8. Refund transitions use payment -> refund lock order and do not deadlock with reservation creation.
+  Invoke-Sql ($authContext + " SELECT public.request_refund('$tenant','$paymentApproveRace',700,'cash','approve race','approve-race-refund','{}'); COMMIT;") | Out-Null
+  $approveRefund = Invoke-Scalar "select id from public.refunds where tenant_id='$tenant'::uuid and idempotency_key='approve-race-refund'"
+  $approveRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentApproveRace',400,'general',NULL,NULL,NULL,NULL,NULL,'{}','approve-race-reservation'); COMMIT;") `
+    ($authContext + " SELECT public.approve_refund('$tenant','$approveRefund'); COMMIT;"))
+  Assert-Equal @($approveRace | Where-Object { $_.Code -eq 0 }).Count 1 'reservation-vs-approve success count'
+  Assert-Equal @($approveRace | Where-Object { $_.Code -ne 0 }).Count 1 'reservation-vs-approve rejection count'
+  Assert-Equal (Invoke-Scalar "select status from public.refunds where id='$approveRefund'::uuid") 'approved' 'approve transition status'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='refund_approved' and target_id='$approveRefund'")) 1 'approve transition audit count'
+
+  Invoke-Sql ($authContext + " SELECT public.request_refund('$tenant','$paymentCompleteRace',700,'cash','complete race','complete-race-refund','{}'); COMMIT;") | Out-Null
+  $completeRefund = Invoke-Scalar "select id from public.refunds where tenant_id='$tenant'::uuid and idempotency_key='complete-race-refund'"
+  Invoke-Sql ($authContext + " SELECT public.approve_refund('$tenant','$completeRefund'); COMMIT;") | Out-Null
+  $completeRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentCompleteRace',400,'general',NULL,NULL,NULL,NULL,NULL,'{}','complete-race-reservation'); COMMIT;") `
+    ($authContext + " SELECT public.complete_refund('$tenant','$completeRefund','complete-race','{}'); COMMIT;"))
+  Assert-Equal @($completeRace | Where-Object { $_.Code -eq 0 }).Count 1 'reservation-vs-complete success count'
+  Assert-Equal @($completeRace | Where-Object { $_.Code -ne 0 }).Count 1 'reservation-vs-complete rejection count'
+  Assert-Equal (Invoke-Scalar "select status from public.refunds where id='$completeRefund'::uuid") 'completed' 'complete transition status'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='refund_completed' and target_id='$completeRefund'")) 1 'complete transition audit count'
+
+  Invoke-Sql ($authContext + " SELECT public.request_refund('$tenant','$paymentRejectRace',700,'cash','reject race','reject-race-refund','{}'); COMMIT;") | Out-Null
+  $rejectRefund = Invoke-Scalar "select id from public.refunds where tenant_id='$tenant'::uuid and idempotency_key='reject-race-refund'"
+  $rejectRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentRejectRace',700,'general',NULL,NULL,NULL,NULL,NULL,'{}','reject-race-reservation'); COMMIT;") `
+    ($authContext + " SELECT public.reject_refund('$tenant','$rejectRefund','reject race'); COMMIT;"))
+  if (@($rejectRace | Where-Object { $_.Code -eq 0 }).Count -lt 1) { throw 'reservation-vs-reject must complete the reject transition' }
+  Assert-Equal (Invoke-Scalar "select status from public.refunds where id='$rejectRefund'::uuid") 'rejected' 'reject transition status'
+  $rejectAvailable = [decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$paymentRejectRace')")
+  if ($rejectAvailable -ne 300 -and $rejectAvailable -ne 1000) { throw "reservation-vs-reject unexpected available credit=$rejectAvailable" }
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='refund_rejected' and target_id='$rejectRefund'")) 1 'reject transition audit count'
+
+  Invoke-Sql ($authContext + " SELECT public.request_refund('$tenant','$paymentVoidRace',700,'cash','void race','void-race-refund','{}'); COMMIT;") | Out-Null
+  $voidRefund = Invoke-Scalar "select id from public.refunds where tenant_id='$tenant'::uuid and idempotency_key='void-race-refund'"
+  $voidRace = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentVoidRace',700,'general',NULL,NULL,NULL,NULL,NULL,'{}','void-race-reservation'); COMMIT;") `
+    ($authContext + " SELECT public.void_refund('$tenant','$voidRefund','void race'); COMMIT;"))
+  if (@($voidRace | Where-Object { $_.Code -eq 0 }).Count -lt 1) { throw 'reservation-vs-void must complete the void transition' }
+  Assert-Equal (Invoke-Scalar "select status from public.refunds where id='$voidRefund'::uuid") 'voided' 'void transition status'
+  $voidAvailable = [decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$paymentVoidRace')")
+  if ($voidAvailable -ne 300 -and $voidAvailable -ne 1000) { throw "reservation-vs-void unexpected available credit=$voidAvailable" }
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.audit_events where action='refund_voided' and target_id='$voidRefund'")) 1 'void transition audit count'
+
+  # 9. Different payments do not serialize each other and both proceed.
+  $differentPayments = @(Invoke-ConcurrentPair `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentDifferentA',600,'general',NULL,NULL,NULL,NULL,NULL,'{}','different-a'); COMMIT;") `
+    ($authContext + " SELECT public.create_patient_fund_reservation('$tenant','$patient','$paymentDifferentB',600,'general',NULL,NULL,NULL,NULL,NULL,'{}','different-b'); COMMIT;"))
+  Assert-Equal @($differentPayments | Where-Object { $_.Code -eq 0 }).Count 2 'different payments success count'
+  Assert-Equal ([int](Invoke-Scalar "select count(*) from public.patient_fund_reservations where payment_id in ('$paymentDifferentA'::uuid,'$paymentDifferentB'::uuid)")) 2 'different payments row count'
+
+  $negativeCapacity = [int](Invoke-Scalar "select count(*) from (select p.id, p.amount-c.active_allocated_amount-c.completed_refund_amount-c.refund_reserved_amount-c.reserved_deposit_amount as free from public.payments p cross join lateral public.get_payment_fund_capacity_internal(p.tenant_id,p.id) c where p.tenant_id='$tenant'::uuid) q where free < 0")
+  Assert-Equal $negativeCapacity 0 'negative capacity rows'
+
+  Write-Output "RESERVATION_RACE success=1 rejected=1 reserved=700 available=300"
+  Write-Output "REFUND_RACE success=1 rejected=1 locked=$refundLocked available=300"
+  Write-Output "ALLOCATION_RACE success=1 rejected=1 used=$allocationLocked available=300"
+  Write-Output "RELEASE_RACE allocation=$releaseAllocation available=$releaseAvailable"
+  Write-Output "CONSUME_RACE success=1 rejected=1 consumed=400 remaining=200"
+  Write-Output "IDEMPOTENCY_RACE identical_success=2 rows=1 conflict_success=1 conflict_rejected=1"
+  Write-Output "REFUND_TRANSITION_RACES approve=approved complete=completed reject=rejected/$rejectAvailable void=voided/$voidAvailable deadlocks=0"
+  Write-Output 'PATIENT-CREDIT-DEPOSITS-FOUNDATION-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remainingTenant = [int](Invoke-Scalar "select count(*) from public.tenants where id='$tenant'::uuid")
+  $remainingUser = [int](Invoke-Scalar "select count(*) from auth.users where id='$admin'::uuid")
+  if ($remainingTenant -ne 0 -or $remainingUser -ne 0) {
+    throw "Concurrency cleanup failed: tenants=$remainingTenant users=$remainingUser"
+  }
+}

--- a/supabase/tests/0022_patient_credit_deposits_foundation_test.sql
+++ b/supabase/tests/0022_patient_credit_deposits_foundation_test.sql
@@ -1,0 +1,300 @@
+\set ON_ERROR_STOP on
+\echo 'PATIENT-CREDIT-DEPOSITS-FOUNDATION-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+\set tenant_a 'e2210000-0000-4000-8000-000000000001'
+\set tenant_b 'e2210000-0000-4000-8000-000000000002'
+\set patient_a 'e2220000-0000-4000-8000-000000000001'
+\set patient_a2 'e2220000-0000-4000-8000-000000000002'
+\set patient_b 'e2220000-0000-4000-8000-000000000003'
+\set owner_a 'e2230000-0000-4000-8000-000000000001'
+\set admin_a 'e2230000-0000-4000-8000-000000000002'
+\set cashier_a 'e2230000-0000-4000-8000-000000000003'
+\set doctor_a 'e2230000-0000-4000-8000-000000000004'
+\set registrar_a 'e2230000-0000-4000-8000-000000000005'
+\set notenant 'e2230000-0000-4000-8000-000000000006'
+\set admin_b 'e2230000-0000-4000-8000-000000000007'
+\set appointment_a 'e2270000-0000-4000-8000-000000000001'
+\set appointment_a2 'e2270000-0000-4000-8000-000000000002'
+\set plan_a 'e2280000-0000-4000-8000-000000000001'
+\set invoice_main 'e2250000-0000-4000-8000-000000000001'
+\set invoice_a2 'e2250000-0000-4000-8000-000000000002'
+\set invoice_b 'e2250000-0000-4000-8000-000000000003'
+\set invoice_voided 'e2250000-0000-4000-8000-000000000004'
+\set item_main 'e2260000-0000-4000-8000-000000000001'
+\set item_a2 'e2260000-0000-4000-8000-000000000002'
+\set item_b 'e2260000-0000-4000-8000-000000000003'
+\set payment_free 'e2240000-0000-4000-8000-000000000001'
+\set payment_allocated 'e2240000-0000-4000-8000-000000000002'
+\set payment_refunded 'e2240000-0000-4000-8000-000000000003'
+\set payment_refund_reserved 'e2240000-0000-4000-8000-000000000004'
+\set payment_release 'e2240000-0000-4000-8000-000000000005'
+\set payment_use 'e2240000-0000-4000-8000-000000000006'
+\set payment_voided 'e2240000-0000-4000-8000-000000000007'
+\set payment_archived 'e2240000-0000-4000-8000-000000000008'
+\set payment_a2 'e2240000-0000-4000-8000-000000000009'
+\set payment_b 'e2240000-0000-4000-8000-000000000010'
+\set payment_owner 'e2240000-0000-4000-8000-000000000011'
+\set payment_admin 'e2240000-0000-4000-8000-000000000012'
+\set payment_cashier 'e2240000-0000-4000-8000-000000000013'
+\set payment_usd 'e2240000-0000-4000-8000-000000000014'
+\set refund_completed 'e2290000-0000-4000-8000-000000000001'
+\set refund_pending 'e2290000-0000-4000-8000-000000000002'
+
+INSERT INTO public.tenants(id, name) VALUES
+  (:'tenant_a', 'Deposit Test A'),
+  (:'tenant_b', 'Deposit Test B');
+
+INSERT INTO auth.users(id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+VALUES
+  (:'owner_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-owner@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'admin_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-admin@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'cashier_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-cashier@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'doctor_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-doctor@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'registrar_a', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-registrar@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'notenant', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-notenant@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now()),
+  (:'admin_b', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'deposit-admin-b@example.local', 'x', now(), '{"provider":"email"}', '{}', now(), now());
+
+INSERT INTO public.profiles(id) VALUES
+  (:'owner_a'), (:'admin_a'), (:'cashier_a'), (:'doctor_a'), (:'registrar_a'), (:'notenant'), (:'admin_b');
+INSERT INTO public.tenant_users(tenant_id, user_id, role) VALUES
+  (:'tenant_a', :'owner_a', 'clinic_owner'),
+  (:'tenant_a', :'admin_a', 'clinic_admin'),
+  (:'tenant_a', :'cashier_a', 'cashier'),
+  (:'tenant_a', :'doctor_a', 'doctor'),
+  (:'tenant_a', :'registrar_a', 'registrar'),
+  (:'tenant_b', :'admin_b', 'clinic_admin');
+
+INSERT INTO public.patients(id, tenant_id, full_name, phone, source, balance) VALUES
+  (:'patient_a', :'tenant_a', 'Deposit Patient A', '+77002220001', 'phone', 777),
+  (:'patient_a2', :'tenant_a', 'Deposit Patient A2', '+77002220002', 'phone', 0),
+  (:'patient_b', :'tenant_b', 'Deposit Patient B', '+77002220003', 'phone', 0);
+
+INSERT INTO public.appointments(id, tenant_id, patient_id, service, status, start_time, end_time) VALUES
+  (:'appointment_a', :'tenant_a', :'patient_a', 'Deposit appointment', 'confirmed', now() + interval '1 day', now() + interval '1 day 1 hour'),
+  (:'appointment_a2', :'tenant_a', :'patient_a2', 'Other patient appointment', 'confirmed', now() + interval '2 days', now() + interval '2 days 1 hour');
+INSERT INTO public.treatment_plans(id, tenant_id, patient_id, title, status, total_price) VALUES
+  (:'plan_a', :'tenant_a', :'patient_a', 'Deposit treatment plan', 'approved', 5000);
+
+INSERT INTO public.invoices(id, tenant_id, patient_id, invoice_number, status, currency, issued_at, voided_at, voided_by, void_reason, created_by, metadata) VALUES
+  (:'invoice_main', :'tenant_a', :'patient_a', 'DEP-A-1', 'issued', 'KZT', now(), NULL, NULL, NULL, :'admin_a', '{}'),
+  (:'invoice_a2', :'tenant_a', :'patient_a2', 'DEP-A2-1', 'issued', 'KZT', now(), NULL, NULL, NULL, :'admin_a', '{}'),
+  (:'invoice_b', :'tenant_b', :'patient_b', 'DEP-B-1', 'issued', 'KZT', now(), NULL, NULL, NULL, :'admin_b', '{}'),
+  (:'invoice_voided', :'tenant_a', :'patient_a', 'DEP-A-VOID', 'voided', 'KZT', now(), now(), :'admin_a', 'fixture', :'admin_a', '{}');
+INSERT INTO public.invoice_items(id, tenant_id, invoice_id, patient_id, service_name, quantity, unit_price, total_amount, status, created_by, metadata) VALUES
+  (:'item_main', :'tenant_a', :'invoice_main', :'patient_a', 'Main invoice service', 1, 10000, 10000, 'active', :'admin_a', '{}'),
+  (:'item_a2', :'tenant_a', :'invoice_a2', :'patient_a2', 'Other patient service', 1, 1000, 1000, 'active', :'admin_a', '{}'),
+  (:'item_b', :'tenant_b', :'invoice_b', :'patient_b', 'Other tenant service', 1, 1000, 1000, 'active', :'admin_b', '{}');
+SELECT public.recalculate_invoice_financials_internal(:'invoice_main');
+SELECT public.recalculate_invoice_financials_internal(:'invoice_a2');
+SELECT public.recalculate_invoice_financials_internal(:'invoice_b');
+
+INSERT INTO public.payments(id, tenant_id, patient_id, status, payment_method, amount, currency, received_by, voided_by, void_reason, voided_at, archived_at, metadata) VALUES
+  (:'payment_free', :'tenant_a', :'patient_a', 'received', 'cash', 1000, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_allocated', :'tenant_a', :'patient_a', 'partially_allocated', 'cash', 1000, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_refunded', :'tenant_a', :'patient_a', 'partially_refunded', 'cash', 1000, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_refund_reserved', :'tenant_a', :'patient_a', 'received', 'cash', 1000, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_release', :'tenant_a', :'patient_a', 'received', 'cash', 500, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_use', :'tenant_a', :'patient_a', 'received', 'cash', 1000, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_voided', :'tenant_a', :'patient_a', 'voided', 'cash', 100, 'KZT', :'admin_a', :'admin_a', 'fixture', now(), NULL, '{}'),
+  (:'payment_archived', :'tenant_a', :'patient_a', 'archived', 'cash', 100, 'KZT', :'admin_a', NULL, NULL, NULL, now(), '{}'),
+  (:'payment_a2', :'tenant_a', :'patient_a2', 'received', 'cash', 100, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_b', :'tenant_b', :'patient_b', 'received', 'cash', 100, 'KZT', :'admin_b', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_owner', :'tenant_a', :'patient_a', 'received', 'cash', 100, 'KZT', :'owner_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_admin', :'tenant_a', :'patient_a', 'received', 'cash', 100, 'KZT', :'admin_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_cashier', :'tenant_a', :'patient_a', 'received', 'cash', 100, 'KZT', :'cashier_a', NULL, NULL, NULL, NULL, '{}'),
+  (:'payment_usd', :'tenant_a', :'patient_a', 'received', 'cash', 200, 'USD', :'admin_a', NULL, NULL, NULL, NULL, '{}');
+
+INSERT INTO public.payment_allocations(tenant_id, patient_id, payment_id, invoice_id, amount, currency, status, metadata, created_by)
+VALUES (:'tenant_a', :'patient_a', :'payment_allocated', :'invoice_main', 600, 'KZT', 'active', '{}', :'admin_a');
+SELECT public.issue_finance_mutation_authorization_internal('refund_insert', :'refund_completed');
+INSERT INTO public.refunds(id, tenant_id, patient_id, payment_id, status, refund_method, amount, currency, reason, requested_by, approved_by, completed_by, requested_at, approved_at, completed_at, metadata, idempotency_key)
+VALUES (:'refund_completed', :'tenant_a', :'patient_a', :'payment_refunded', 'completed', 'cash', 400, 'KZT', 'completed fixture', :'admin_a', :'admin_a', :'admin_a', now(), now(), now(), '{}', 'completed-fixture');
+SELECT public.issue_finance_mutation_authorization_internal('refund_insert', :'refund_pending');
+INSERT INTO public.refunds(id, tenant_id, patient_id, payment_id, status, refund_method, amount, currency, reason, requested_by, approved_by, completed_by, requested_at, approved_at, completed_at, metadata, idempotency_key)
+VALUES (:'refund_pending', :'tenant_a', :'patient_a', :'payment_refund_reserved', 'pending', 'cash', 300, 'KZT', 'pending fixture', :'admin_a', NULL, NULL, now(), NULL, NULL, '{}', 'pending-fixture');
+
+SELECT balance::text AS patient_balance_before FROM public.patients WHERE id = :'patient_a' \gset
+SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(a) ORDER BY id)::text, '[]'), 'sha256'), 'hex') AS appointments_before FROM public.appointments a WHERE patient_id = :'patient_a' \gset
+SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(tp) ORDER BY id)::text, '[]'), 'sha256'), 'hex') AS plans_before FROM public.treatment_plans tp WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS completed_services_before FROM public.completed_services WHERE patient_id = :'patient_a' \gset
+SELECT count(*)::text AS documents_before FROM public.documents WHERE patient_id = :'patient_a' \gset
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+
+-- 1-5: initial capacity and summary visibility.
+SELECT pg_temp.assert_true((SELECT payment_amount = 1000 AND gross_unallocated_amount = 1000 AND available_credit_amount = 1000 FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'payment_free')), 'fully unallocated payment exposes full credit');
+SELECT (public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_free', 300, 'general', NULL, NULL, NULL, NULL, 'first reserve', '{}', 'free-create-1')->'reservation'->>'id')::uuid AS free_reservation_1 \gset
+SELECT pg_temp.assert_true((SELECT reserved_deposit_amount = 300 AND gross_unallocated_amount = 1000 AND available_credit_amount = 700 FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'payment_free')), 'reservation reduces only available credit');
+SELECT pg_temp.assert_true(((public.get_patient_finance_summary(:'tenant_a', :'patient_a')->'currencies'->0->>'reservedDepositAmount')::numeric) >= 300, 'summary includes reserved deposits');
+SELECT pg_temp.assert_true((public.get_patient_finance_summary(:'tenant_a', :'patient_a')->>'modelVersion') = 'finance-summary-v2', 'summary model version updated');
+
+-- 6-11: capacity exclusions and idempotency.
+SELECT pg_temp.assert_true((public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_free', 300, 'general', NULL, NULL, NULL, NULL, 'first reserve', '{}', 'free-create-1')->>'status') = 'already_completed', 'same create key and payload returns existing result');
+SELECT pg_temp.assert_true((SELECT count(*) = 1 FROM public.patient_fund_reservations WHERE tenant_id = :'tenant_a' AND idempotency_key = 'free-create-1'), 'idempotent create has one row');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,301,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_free', '{}', 'free-create-1'), 'другими параметрами');
+SELECT (public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_free', 500, 'appointment', 'Visit deposit', :'appointment_a', NULL, NULL, NULL, '{}', 'free-create-2')->'reservation'->>'id')::uuid AS free_reservation_2 \gset
+SELECT pg_temp.assert_true((SELECT reserved_deposit_amount = 800 AND available_credit_amount = 200 FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'payment_free')), 'second reservation respects first reservation');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,201,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_free', '{}', 'free-over'), 'Недостаточно доступного кредита');
+
+-- 12-16: allocated, completed-refunded and refund-reserved money is unavailable.
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,401,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_allocated', '{}', 'allocated-over'), 'Недостаточно доступного кредита');
+SELECT public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_allocated', 400, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'allocated-exact');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,601,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_refunded', '{}', 'refunded-over'), 'Недостаточно доступного кредита');
+SELECT public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_refunded', 600, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'refunded-exact');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,701,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_refund_reserved', '{}', 'refund-reserved-over'), 'Недостаточно доступного кредита');
+SELECT public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_refund_reserved', 700, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'refund-reserved-exact');
+
+-- 17-22: generic allocation/refund/void cannot consume reserved capacity.
+SELECT pg_temp.expect_error(format('select public.allocate_payment(%L::uuid,%L::uuid,201,%L::uuid,NULL,%L::jsonb)', :'tenant_a', :'payment_free', :'invoice_main', '{}'), 'депозит');
+SELECT public.allocate_payment(:'tenant_a', :'payment_free', 200, :'invoice_main', NULL, '{}');
+SELECT pg_temp.assert_true((SELECT available_credit_amount = 0 AND reserved_deposit_amount = 800 FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'payment_free')), 'generic allocation consumes only unreserved capacity');
+SELECT pg_temp.expect_error(format('select public.request_refund(%L::uuid,%L::uuid,1,''cash'',''reserved funds'',%L,%L::jsonb)', :'tenant_a', :'payment_free', 'free-refund-blocked', '{}'), 'депозит');
+SELECT pg_temp.expect_error(format('select public.void_payment(%L::uuid,%L::uuid,''reserved funds'')', :'tenant_a', :'payment_free'), 'активным депозитом');
+SELECT pg_temp.assert_true((SELECT count(*) = 0 FROM public.refunds WHERE idempotency_key = 'free-refund-blocked'), 'rejected refund creates no row');
+
+-- 23-29: scope, payment status and purpose guards.
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_a2', '{}', 'wrong-patient'), 'Платёж недоступен');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_b', '{}', 'wrong-tenant'), 'Платёж недоступен');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_voided', '{}', 'voided-payment'), 'Платёж недоступен');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_archived', '{}', 'archived-payment'), 'Платёж недоступен');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''other'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_admin', '{}', 'other-no-label'), 'Purpose label');
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''appointment'',''wrong appointment'',%L::uuid,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_admin', :'appointment_a2', '{}', 'wrong-appointment'), 'does not belong');
+SELECT public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_admin', 10, 'treatment_plan', 'Plan reserve', NULL, :'plan_a', NULL, NULL, '{}', 'plan-purpose');
+
+-- 30-36: role matrix.
+SELECT set_config('request.jwt.claim.sub', :'owner_a', true);
+SELECT public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_owner', 10, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'owner-create');
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_cashier', 10, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'cashier-create')->'reservation'->>'id')::uuid AS cashier_reservation \gset
+SELECT pg_temp.expect_error(format('select public.release_patient_fund_reservation(%L::uuid,%L::uuid,NULL,''cashier release'',%L)', :'tenant_a', :'cashier_reservation', 'cashier-release'), 'insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'doctor_a', true);
+SELECT pg_temp.expect_error(format('select public.create_patient_fund_reservation(%L::uuid,%L::uuid,%L::uuid,10,''general'',NULL,NULL,NULL,NULL,NULL,%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_admin', '{}', 'doctor-create'), 'insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'registrar_a', true);
+SELECT pg_temp.expect_error(format('select public.get_patient_fund_reservations(%L::uuid,%L::uuid,NULL)', :'tenant_a', :'patient_a'), 'insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'notenant', true);
+SELECT pg_temp.expect_error(format('select public.get_payment_fund_capacity(%L::uuid,%L::uuid,%L::uuid)', :'tenant_a', :'patient_a', :'payment_free'), 'insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'admin_b', true);
+SELECT pg_temp.expect_error(format('select public.get_patient_fund_reservations(%L::uuid,%L::uuid,NULL)', :'tenant_a', :'patient_a'), 'insufficient finance permissions');
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+
+-- 37-43: release lifecycle and idempotency.
+SELECT (public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_release', 300, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'release-create')->'reservation'->>'id')::uuid AS release_reservation \gset
+SELECT pg_temp.expect_error(format('select public.release_patient_fund_reservation(%L::uuid,%L::uuid,100,''partial'',%L)', :'tenant_a', :'release_reservation', 'release-partial'), 'Only full');
+SELECT public.release_patient_fund_reservation(:'tenant_a', :'release_reservation', NULL, 'patient changed mind', 'release-key');
+SELECT pg_temp.assert_true((SELECT status = 'released' AND released_amount = 300 AND remaining_amount = 0 FROM public.patient_fund_reservations WHERE id = :'release_reservation'), 'full release updates lifecycle');
+SELECT pg_temp.assert_true((SELECT available_credit_amount = 500 FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'payment_release')), 'full release restores available credit');
+SELECT pg_temp.assert_true((public.release_patient_fund_reservation(:'tenant_a', :'release_reservation', NULL, 'patient changed mind', 'release-key')->>'status') = 'already_completed', 'release retry returns same result');
+SELECT pg_temp.expect_error(format('select public.release_patient_fund_reservation(%L::uuid,%L::uuid,NULL,''different reason'',%L)', :'tenant_a', :'release_reservation', 'release-key'), 'different details');
+SELECT pg_temp.expect_error(format('select public.allocate_reserved_credit(%L::uuid,%L::uuid,%L::uuid,%L::uuid,1,%L)', :'tenant_a', :'patient_a', :'release_reservation', :'invoice_main', 'released-consume'), 'exceeds reservation remainder');
+
+-- 44-55: controlled partial/full consumption and idempotency.
+SELECT (public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_use', 400, 'service', 'Implant', NULL, NULL, NULL, NULL, '{}', 'use-create')->'reservation'->>'id')::uuid AS use_reservation \gset
+SELECT pg_temp.expect_error(format('select public.allocate_reserved_credit(%L::uuid,%L::uuid,%L::uuid,%L::uuid,401,%L)', :'tenant_a', :'patient_a', :'use_reservation', :'invoice_main', 'consume-over'), 'exceeds reservation remainder');
+SELECT pg_temp.expect_error(format('select public.allocate_reserved_credit(%L::uuid,%L::uuid,%L::uuid,%L::uuid,10,%L)', :'tenant_a', :'patient_a', :'use_reservation', :'invoice_a2', 'consume-wrong-patient'), 'Invoice not found');
+SELECT pg_temp.expect_error(format('select public.allocate_reserved_credit(%L::uuid,%L::uuid,%L::uuid,%L::uuid,10,%L)', :'tenant_a', :'patient_a', :'use_reservation', :'invoice_b', 'consume-wrong-tenant'), 'Invoice not found');
+SELECT pg_temp.expect_error(format('select public.allocate_reserved_credit(%L::uuid,%L::uuid,%L::uuid,%L::uuid,10,%L)', :'tenant_a', :'patient_a', :'use_reservation', :'invoice_voided', 'consume-voided'), 'not available');
+SELECT (public.allocate_reserved_credit(:'tenant_a', :'patient_a', :'use_reservation', :'invoice_main', 250, 'consume-1')->'allocation'->>'id')::uuid AS consume_allocation_1 \gset
+SELECT pg_temp.assert_true((SELECT status = 'partially_used' AND consumed_amount = 250 AND remaining_amount = 150 FROM public.patient_fund_reservations WHERE id = :'use_reservation'), 'partial consume updates reservation');
+SELECT pg_temp.assert_true((public.allocate_reserved_credit(:'tenant_a', :'patient_a', :'use_reservation', :'invoice_main', 250, 'consume-1')->>'status') = 'already_completed', 'consume retry returns same result');
+SELECT pg_temp.assert_true((SELECT count(*) = 1 FROM public.payment_allocations WHERE reservation_operation_key = 'consume-1'), 'consume retry creates one allocation');
+SELECT pg_temp.expect_error(format('select public.allocate_reserved_credit(%L::uuid,%L::uuid,%L::uuid,%L::uuid,249,%L)', :'tenant_a', :'patient_a', :'use_reservation', :'invoice_main', 'consume-1'), 'different details');
+SELECT (public.allocate_reserved_credit(:'tenant_a', :'patient_a', :'use_reservation', :'invoice_main', 150, 'consume-2')->'allocation'->>'id')::uuid AS consume_allocation_2 \gset
+SELECT pg_temp.assert_true((SELECT status = 'fully_used' AND consumed_amount = 400 AND remaining_amount = 0 FROM public.patient_fund_reservations WHERE id = :'use_reservation'), 'full consume sets fully_used');
+SELECT pg_temp.assert_true((SELECT COALESCE(sum(amount),0) = 400 FROM public.payment_allocations WHERE patient_fund_reservation_id = :'use_reservation' AND status = 'active'), 'controlled consume creates matching allocations');
+SELECT pg_temp.expect_error(format('select public.void_payment_allocation(%L::uuid,%L::uuid,''generic void'')', :'tenant_a', :'consume_allocation_1'), 'cannot be voided');
+SELECT pg_temp.expect_error(format('select public.release_patient_fund_reservation(%L::uuid,%L::uuid,NULL,''fully used'',%L)', :'tenant_a', :'use_reservation', 'release-used'), 'cannot be released');
+
+-- 56-62: database backstops and grants.
+SELECT (public.request_refund(:'tenant_a', :'payment_release', 10, 'cash', 'forged complete fixture', 'forged-complete-refund', '{}')).id::text AS forged_approved_refund \gset
+SELECT public.approve_refund(:'tenant_a', :'forged_approved_refund');
+RESET ROLE;
+SELECT pg_temp.expect_error(format('insert into public.payment_allocations(tenant_id,patient_id,payment_id,invoice_id,amount,currency,status,metadata,created_by,patient_fund_reservation_id,reservation_operation_key,reservation_operation_fingerprint) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,1,''KZT'',''active'',%L::jsonb,%L::uuid,%L::uuid,%L,%L)', :'tenant_a', :'patient_a', :'payment_free', :'invoice_main', '{}', :'admin_a', :'free_reservation_1', 'direct-reserved', 'fingerprint'), 'requires allocate_reserved_credit');
+SELECT pg_temp.expect_error(format('update public.patient_fund_reservations set consumed_amount=1,status=''partially_used'' where id=%L::uuid', :'free_reservation_1'), 'requires allocate_reserved_credit');
+SELECT pg_temp.expect_error(format('update public.patient_fund_reservations set released_amount=1,status=''released'',released_at=now(),released_by=%L::uuid,release_reason=''direct'' where id=%L::uuid', :'admin_a', :'free_reservation_1'), 'requires release_patient_fund_reservation');
+SET LOCAL ROLE service_role;
+SELECT set_config('app.finance_mutation_token', gen_random_uuid()::text, true);
+SELECT pg_temp.expect_error(format('insert into public.payment_allocations(tenant_id,patient_id,payment_id,invoice_id,amount,currency,status,metadata,created_by,patient_fund_reservation_id,reservation_operation_key,reservation_operation_fingerprint) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,1,''KZT'',''active'',%L::jsonb,%L::uuid,%L::uuid,%L,%L)', :'tenant_a', :'patient_a', :'payment_free', :'invoice_main', '{}', :'admin_a', :'free_reservation_1', 'forged-reserved', 'fingerprint'), 'requires allocate_reserved_credit');
+SELECT pg_temp.expect_error(format('select public.issue_finance_mutation_authorization_internal(%L,%L::uuid)', 'reservation_consume', :'free_reservation_1'), 'permission denied');
+SELECT pg_temp.expect_error(format('insert into public.patient_fund_reservations(tenant_id,patient_id,payment_id,currency,purpose_type,original_amount,idempotency_key,operation_fingerprint,created_by) values(%L::uuid,%L::uuid,%L::uuid,''KZT'',''general'',1,%L,%L,%L::uuid)', :'tenant_a', :'patient_a', :'payment_release', 'service-role-create', 'fp', :'admin_a'), 'permission denied');
+SELECT pg_temp.expect_error(format('update public.patient_fund_reservations set consumed_amount=1,status=''partially_used'' where id=%L::uuid', :'free_reservation_1'), 'permission denied');
+SELECT pg_temp.expect_error(format('update public.patient_fund_reservations set released_amount=remaining_amount,status=''released'',released_at=now(),released_by=%L::uuid,release_reason=''forged'' where id=%L::uuid', :'admin_a', :'free_reservation_1'), 'permission denied');
+SELECT pg_temp.expect_error(format('update public.patient_fund_reservations set status=''archived'',archived_at=now(),archived_by=%L::uuid,archived_from_status=''fully_used'' where id=%L::uuid', :'admin_a', :'use_reservation'), 'permission denied');
+SELECT pg_temp.expect_error(format('update public.payment_allocations set tenant_id=%L::uuid where payment_id=%L::uuid and patient_fund_reservation_id is null', :'tenant_b', :'payment_free'), 'financial identity is immutable');
+SELECT pg_temp.expect_error(format('update public.refunds set patient_id=%L::uuid where id=%L::uuid', :'patient_a2', :'refund_pending'), 'financial identity is immutable');
+SELECT set_config('app.finance_mutation_token', gen_random_uuid()::text, true);
+SELECT pg_temp.expect_error(format('insert into public.refunds(id,tenant_id,patient_id,payment_id,status,refund_method,amount,currency,reason,requested_by,requested_at,metadata,idempotency_key) values(gen_random_uuid(),%L::uuid,%L::uuid,%L::uuid,''pending'',''cash'',1,''KZT'',''forged'',%L::uuid,now(),%L::jsonb,%L)', :'tenant_a', :'patient_a', :'payment_release', :'admin_a', '{}', 'forged-refund'), 'requires request_refund');
+SELECT set_config('app.finance_mutation_token', gen_random_uuid()::text, true);
+SELECT pg_temp.expect_error(format('update public.refunds set status=''approved'',approved_by=%L::uuid,approved_at=now() where id=%L::uuid', :'admin_a', :'refund_pending'), 'authoritative refund RPC');
+SELECT set_config('app.finance_mutation_token', gen_random_uuid()::text, true);
+SELECT pg_temp.expect_error(format('update public.refunds set status=''rejected'',rejected_at=now() where id=%L::uuid', :'refund_pending'), 'authoritative refund RPC');
+SELECT set_config('app.finance_mutation_token', gen_random_uuid()::text, true);
+SELECT pg_temp.expect_error(format('update public.refunds set status=''voided'',voided_by=%L::uuid,voided_at=now(),void_reason=''forged'' where id=%L::uuid', :'admin_a', :'refund_pending'), 'authoritative refund RPC');
+SELECT set_config('app.finance_mutation_token', gen_random_uuid()::text, true);
+SELECT pg_temp.expect_error(format('update public.refunds set status=''completed'',completed_by=%L::uuid,completed_at=now() where id=%L::uuid', :'admin_a', :'forged_approved_refund'), 'authoritative refund RPC');
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_error(format('insert into public.patient_fund_reservations(tenant_id,patient_id,payment_id,currency,purpose_type,original_amount,idempotency_key,operation_fingerprint,created_by) values(%L::uuid,%L::uuid,%L::uuid,''KZT'',''general'',1,%L,%L,%L::uuid)', :'tenant_a', :'patient_a', :'payment_release', 'direct-row', 'fp', :'admin_a'), 'permission denied');
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.assert_true(NOT has_function_privilege('anon', 'public.create_patient_fund_reservation(uuid,uuid,uuid,numeric,text,text,uuid,uuid,timestamptz,text,jsonb,text)', 'EXECUTE'), 'anon cannot create reservations');
+SELECT pg_temp.assert_true(NOT has_function_privilege('anon', 'public.allocate_reserved_credit(uuid,uuid,uuid,uuid,numeric,text)', 'EXECUTE'), 'anon cannot consume reservations');
+RESET ROLE;
+
+-- 63-69: archive semantics, stable reads, summary/multi-currency and event integrity.
+SELECT public.issue_finance_mutation_authorization_internal('reservation_archive', :'use_reservation');
+UPDATE public.patient_fund_reservations
+SET status = 'archived', archived_at = now(), archived_by = :'admin_a', archived_from_status = 'fully_used'
+WHERE id = :'use_reservation';
+SELECT pg_temp.assert_true((SELECT status = 'archived' AND remaining_amount = 0 FROM public.patient_fund_reservations WHERE id = :'use_reservation'), 'archive preserves terminal row and zero capacity');
+SELECT pg_temp.expect_error(format('update public.patient_fund_reservations set notes=''mutated'' where id=%L::uuid', :'use_reservation'), 'Archived reservation cannot be mutated');
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT jsonb_agg(to_jsonb(r) ORDER BY r.id)::text AS reservations_once FROM public.get_patient_fund_reservations(:'tenant_a', :'patient_a', NULL) r \gset
+SELECT pg_temp.assert_true(:'reservations_once' = (SELECT jsonb_agg(to_jsonb(r) ORDER BY r.id)::text FROM public.get_patient_fund_reservations(:'tenant_a', :'patient_a', NULL) r), 'repeated reservation reads are stable');
+SELECT public.create_patient_fund_reservation(:'tenant_a', :'patient_a', :'payment_usd', 50, 'general', NULL, NULL, NULL, NULL, NULL, '{}', 'usd-create');
+SELECT pg_temp.assert_true((SELECT count(*) = 2 FROM jsonb_array_elements(public.get_patient_finance_summary(:'tenant_a', :'patient_a')->'currencies')), 'summary preserves multiple currency buckets');
+SELECT pg_temp.assert_true(NOT EXISTS (SELECT 1 FROM public.audit_events WHERE action IN ('patient_fund_reservation_created','patient_fund_reservation_released','patient_fund_reservation_partially_used','patient_fund_reservation_fully_used','reserved_credit_allocated') AND actor_user_id IS NULL), 'all deposit success audit events have actors');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE action='reserved_credit_allocated' AND metadata->>'reservationId'=:'use_reservation') = 2, 'two successful consumes create exactly two allocation audit events');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type='reserved_credit_allocated' AND metadata->>'reservationId'=:'use_reservation') = 2, 'two successful consumes create exactly two activity events');
+
+-- 70-75: side-effect validation.
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id = :'patient_a') = :'patient_balance_before'::numeric, 'patients.balance remains unchanged');
+SELECT pg_temp.assert_true((SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(a) ORDER BY id)::text, '[]'), 'sha256'), 'hex') FROM public.appointments a WHERE patient_id = :'patient_a') = :'appointments_before', 'appointments remain unchanged');
+SELECT pg_temp.assert_true((SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(tp) ORDER BY id)::text, '[]'), 'sha256'), 'hex') FROM public.treatment_plans tp WHERE patient_id = :'patient_a') = :'plans_before', 'treatment plans remain unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.completed_services WHERE patient_id = :'patient_a') = :'completed_services_before'::integer, 'completed services remain unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.documents WHERE patient_id = :'patient_a') = :'documents_before'::integer, 'documents remain unchanged');
+SELECT pg_temp.assert_true(to_regclass('public.stock') IS NULL AND to_regclass('public.inventory') IS NULL, 'no stock ledger exists or changes');
+
+ROLLBACK;
+\echo 'PATIENT-CREDIT-DEPOSITS-FOUNDATION-001 SQL validation passed'


### PR DESCRIPTION
## Summary
- adds payment-linked patient fund reservations without introducing a second money ledger
- centralizes payment capacity across allocations, completed/pending refunds, and active reservation remainder
- adds scoped RPCs for capacity/read/create/release/controlled consume
- hardens direct-write paths with one-time internal mutation authorization and immutable finance identity
- aligns refund lock order to payment -> refund rows -> reservation rows
- exposes reserved and available patient credit in existing finance summaries

## Verification
- clean local Supabase reset applied migrations 0001-0022
- foundation SQL validation passed
- concurrency suite passed, including refund approve/complete/reject/void races with zero deadlocks and no negative capacity
- ESLint passed
- Vitest: 73 files, 767 tests passed
- TypeScript/Vite production build passed
- local browser A-F and role matrix smoke passed; expected HTTP 400 responses occurred only for intentionally blocked operations

## Boundaries
- no cloud Supabase changes
- no full deposit management UI
- no expiry automation, forfeiture, or correction flow for reservation-backed allocations
- does not mutate patients.balance or clinical/document/stock facts

## Report
_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-FOUNDATION-001_foundation.md

Do not merge automatically.