### PR TITLE
PATIENT-CREDIT-DEPOSITS-UI-001: add patient credit and deposit workflows

### DIFF
--- a/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-UI-001_ui.md
+++ b/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-UI-001_ui.md
@@ -12,15 +12,15 @@ Baseline: `84d32230b67627c0a8a778a533ca07c82ccabb09` from `origin/main`.
 
 ## 3. PR URL
 
-Pending publication.
+https://github.com/NckNA/codex-test/pull/341
 
 ## 4. PR head reviewed before final report update
 
-Pending publication. The local implementation was reviewed and verified before the initial commit.
+`325c1025ef4a0d38683bf085763a4cb32fc93600` was the implementation head reviewed before this final report update.
 
 ## 5. Report update commit
 
-N/A because the final report update commit cannot reference itself before creation.
+- Report update commit: N/A (the report commit cannot reference itself; use the finalization receipt).
 
 ## 6. Changed files
 
@@ -211,6 +211,8 @@ Vite was stopped. Temporary browser-only network shims, SPA switch control, SQL 
 
 ## 31. Lint/test/build
 
+Checks:
+
 - Eight required targeted test commands: passed.
 - Combined task-targeted suite: 153 passed.
 - Full suite: 79 files, 809 tests passed.
@@ -222,9 +224,11 @@ Vite was stopped. Temporary browser-only network shims, SPA switch control, SQL 
 
 ## 32. GitHub Actions CI
 
-Pending PR publication and a fresh run on the current PR head.
+PR #341 implementation CI run #680 (`29135644763`) completed successfully on `325c1025ef4a0d38683bf085763a4cb32fc93600`. ESLint, the full test suite, and the production build passed. A fresh CI run on the report-only update commit is verified in the final handoff because that commit does not exist until this report version is created.
 
 ## 33. Known limitations
+
+Issues/Limitations:
 
 - The current repository RPC returns a scoped reservation list without pagination; this task uses that existing behavior.
 - Actor display names are unavailable in the read DTO and are not shown.

--- a/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-UI-001_ui.md
+++ b/_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-UI-001_ui.md
@@ -1,0 +1,248 @@
+# PATIENT-CREDIT-DEPOSITS-UI-001
+
+## 1. Summary
+
+Operational patient-credit and deposit workflows were added to the patient finance area. Staff can view authoritative credit and reserve totals, list reservations, create a deposit from existing received funds, release the remaining reserve, and allocate reserved credit to an eligible invoice. No workflow creates a payment when existing credit is used, and releasing a reservation does not create a refund.
+
+## 2. Branch
+
+`feature/patient-credit-deposits-ui-001`
+
+Baseline: `84d32230b67627c0a8a778a533ca07c82ccabb09` from `origin/main`.
+
+## 3. PR URL
+
+Pending publication.
+
+## 4. PR head reviewed before final report update
+
+Pending publication. The local implementation was reviewed and verified before the initial commit.
+
+## 5. Report update commit
+
+N/A because the final report update commit cannot reference itself before creation.
+
+## 6. Changed files
+
+- `src/components/cashier/CashierPatientFinanceSummary.tsx`
+- `src/components/finance/FinanceSummaryCards.test.tsx`
+- `src/components/finance/PatientFinancePanel.test.tsx`
+- `src/components/finance/PatientFinancePanel.tsx`
+- `src/components/finance/CreateFundReservationDialog.tsx`
+- `src/components/finance/CreateFundReservationDialog.test.tsx`
+- `src/components/finance/PatientFundReservationCard.tsx`
+- `src/components/finance/PatientFundReservationsPanel.tsx`
+- `src/components/finance/PatientFundReservationsPanel.test.tsx`
+- `src/components/finance/ReleaseFundReservationDialog.tsx`
+- `src/components/finance/ReleaseFundReservationDialog.test.tsx`
+- `src/components/finance/UseReservedCreditDialog.tsx`
+- `src/components/finance/UseReservedCreditDialog.test.tsx`
+- `src/components/finance/fundReservationLabels.ts`
+- `src/components/finance/fundReservationPermissions.ts`
+- `src/data/hooks/usePatientFundReservations.ts`
+- `src/data/hooks/usePatientFundReservations.test.tsx`
+- `src/data/hooks/usePatientFundReservationFlow.ts`
+- `src/data/hooks/usePatientFundReservationFlow.test.tsx`
+- `src/data/repositories/FinanceRpcClient.ts`
+- `src/data/repositories/FinanceRpcClient.test.ts`
+- `_ai_work/REPORTS/PATIENT-CREDIT-DEPOSITS-UI-001_ui.md`
+
+No migration, seed, generated type, document, stock, timeline, or clinical file changed.
+
+## 7. Pre-read
+
+Reviewed the deposit reconstruction and foundation reports, finance-summary correctness report, cashier hardening report, refund/write-off UI report, finance security/role material, existing finance repository/client contracts, patient finance hooks, cashier payment flow, refund/write-off hooks, summary cards, invoice UI, role helpers, and related tests.
+
+## 8. Existing backend contract
+
+The UI reuses the existing methods without aliases:
+
+- `getPatientFundReservations` → `get_patient_fund_reservations`
+- `getPaymentFundCapacity` → `get_payment_fund_capacity`
+- `createPatientFundReservation` → `create_patient_fund_reservation`
+- `releasePatientFundReservation` → `release_patient_fund_reservation`
+- `allocateReservedCredit` → `allocate_reserved_credit`
+- `getPatientFinanceSummary` → `get_patient_finance_summary`
+
+Existing statuses, purpose types, idempotency behavior, server role enforcement, and safe error normalization remain authoritative. Cashier release remains disabled because the backend permits release only for owner/admin. Actor display names and rich invoice/payment display metadata are not returned by the current reservation read model, so the UI does not invent them.
+
+## 9. UI information architecture
+
+A dedicated `Кредит и депозиты` section was added inside the patient finance area. It does not collapse values into a generic balance. Each currency bucket separately shows available credit, deposit reserve, refund reserve, received cash, current debt, and gross unallocated funds before reserves.
+
+## 10. Reservation list
+
+Reservations are shown as cards under `Активные` and `Завершённые`. Optional filters are `Все`, `Активные`, `Использованные`, and `Освобождённые`. The empty state is `У пациента пока нет депозитов.`. Current repository behavior returns the scoped list without server pagination; no new pagination model was introduced.
+
+## 11. Status labels
+
+- `active` → `Активен`
+- `partially_used` → `Частично использован`
+- `fully_used` → `Использован полностью`
+- `released` → `Освобождён`
+- `refunded` → `Возвращён`
+- `archived` → `Архив`
+
+Active and partially used cards expose permitted actions. Terminal cards are read-only. Archived cards are visually subdued, and every state is communicated by text rather than color alone.
+
+## 12. Purpose labels
+
+- `general` → `Общий депозит`
+- `appointment` → `Под запись`
+- `treatment_plan` → `Под план лечения`
+- `service` → `Под услугу`, using the supplied service label when present
+- `other` → trimmed `purpose_label`
+
+`other` requires 2–120 characters. Appointment and treatment-plan selections only pass an existing identifier to the reservation RPC and do not mutate clinical or scheduling records. Raw metadata is never rendered.
+
+## 13. Create flow
+
+`Создать депозит` is available to owner, admin, and cashier only when tenant/patient context exists and at least one payment has authoritative available credit. The dialog shows payment date, method, amount, allocated amount, completed refunds, refund reserve, deposit reserve, and available credit. It validates amount, purpose, optional linkage, expiry, and note before invoking the existing create RPC. One idempotency key is generated per stable operation signature and retained through an ambiguous retry. Success text: `Депозит создан.`
+
+## 14. Release flow
+
+Only active or partially used reservations can be released. The UI exposes full release only, requires a reason, sends `amount: null`, and explicitly explains that funds return to available credit rather than being refunded to the patient. Owner/admin can release; cashier, doctor, and registrar cannot. Success text: `Резерв освобождён.`
+
+## 15. Use reserved credit flow
+
+`Использовать депозит` is shown only for actionable reservations with remaining funds and at least one eligible same-tenant, same-patient, same-currency invoice with positive debt. The dialog displays invoice debt, validates against both reservation remainder and invoice balance, then calls `allocate_reserved_credit`. It never calls the new-money payment flow. Partial success: `Часть депозита использована.` Full success: `Депозит использован полностью.`
+
+## 16. Payment capacity display
+
+Payment selection renders exact values from `getPaymentFundCapacity`:
+
+- payment amount;
+- active allocated amount;
+- completed refund amount;
+- refund-reserved amount;
+- deposit-reserved amount;
+- available credit.
+
+The UI does not recompute authoritative payment capacity.
+
+## 17. Finance summary integration
+
+The section renders `reservedDepositAmount`, `availableCreditAmount`, `refundReservedAmount`, and `grossUnallocatedAmount` from the existing finance summary. Copy explains that available credit is already-received money not allocated, refunded, or reserved. Gross unallocated is shown separately as the pre-reserve value.
+
+## 18. Cashier surface
+
+The cashier summary now includes a compact read-only `Резерв депозита` value alongside debt, available credit, and refund reserve. Full reservation management remains in the patient finance section. No cashier prepayment intake was added.
+
+## 19. Role matrix
+
+| Role | View summary | View reservation details | Create | Release | Use |
+|---|---:|---:|---:|---:|---:|
+| Owner | Yes | Yes | Yes | Yes | Yes |
+| Admin | Yes | Yes | Yes | Yes | Yes |
+| Cashier | Yes | Yes | Yes | No | Yes |
+| Doctor | Read-only indicator | No | No | No | No |
+| Registrar | Read-only indicator | No | No | No | No |
+| Unknown/no tenant | No fetch | No | No | No | No |
+
+Browser smoke confirmed tenant B cannot see tenant A patient reservations.
+
+## 20. Stale-context protection
+
+Reservation reads are keyed by tenant, patient, role, and payment state. Patient or tenant changes reset old reservation/capacity data. Request IDs suppress late list/capacity responses. Mutation context is captured and stale create/release/consume completions do not update a new patient. Open dialogs and action feedback reset on tenant, patient, or role changes.
+
+## 21. Uncertain-response reconciliation
+
+Create, release, and consume flows enter `Проверяем текущее состояние операции…` after ambiguous failures, refetch reservations/allocations/capacity, and inspect the intended transition. Confirmed commits become success; unconfirmed operations show a safe refreshed failure while retaining the same idempotency key. Browser smoke intentionally dropped one successful create response after commit; reconciliation found the single committed reservation and displayed success without a duplicate.
+
+## 22. Safe error mapping
+
+Mapped user-facing errors include insufficient credit, unavailable payment, terminal reservation, idempotency conflict, unavailable invoice, role denial, and deposit-reserved blocking. Generic failure is `Не удалось выполнить операцию. Данные обновлены, повторите попытку.` Raw SQLSTATE, trigger, constraint, stack, and PostgREST object data are not rendered.
+
+## 23. Accessibility
+
+Dialogs use `role="dialog"`, `aria-modal`, labelled controls, keyboard Escape dismissal when safe, explicit disabled states, progress messages, numeric constraints, safe decimal parsing, textual statuses, and empty/no-credit states. Duplicate submit is blocked while an operation or reconciliation is in flight.
+
+## 24. Repository/client tests
+
+Existing repository/client methods were reused. Tests verify reservation and capacity RPC calls, create/release/consume parameter mapping, numeric and null mapping, status/purpose validation, idempotency behavior, safe plain-object PostgREST normalization, and absence of direct table writes, localStorage, service-role use, or `patients.balance` truth. Targeted repository/client tests: 97 passed.
+
+## 25. Hook tests
+
+Hook tests cover no-context suppression, role-based no-fetch, list/capacity loading, patient/payment stale suppression, safe errors, create/release/consume mapping, idempotency retention, committed-response reconciliation, unconfirmed safe failure, duplicate submit blocking, role denial, stale mutation suppression, refresh callbacks, and raw-error hiding. Targeted hook tests: 16 passed.
+
+## 26. Component tests
+
+Component tests cover empty state, every lifecycle status, purpose labels, amounts, create/release/use role gating, terminal read-only behavior, authoritative capacity display, validations, invoice debt, duplicate-submit states, safe messages, cashier compact summary, doctor/registrar indicators, no-tenant behavior, keyboard dismissal, context-change closure, and absence of `Принять оплату` inside the reserved-credit dialog. New dialog/panel component tests: 25 passed.
+
+## 27. Browser smoke
+
+Real localhost UI and local Supabase Auth were used.
+
+- A: patient with no reservations showed the empty state and correct credit.
+- B: creating 300 from a 1000 payment produced an active card, reserve 300, available credit 700, gross unallocated 1000, and no payment row.
+- C: 800 with only 700 available was blocked and created no row/event.
+- D: release restored available credit and created no refund.
+- E: using 250 from a 400 reservation produced one allocation, `partially_used`, and remainder 150.
+- F: using the final 150 produced `fully_used` and zero remaining reserve.
+- G: generic allocation/refund paths were blocked while 700 remained reserved; no allocation/refund row was created.
+- H: a committed create response was intentionally lost; reconciliation showed progress and then success with one row.
+- I: admin/cashier/doctor/registrar/no-tenant/tenant-B behavior matched the role matrix.
+- J: a delayed patient-A reservation response never replaced patient-B state after an SPA switch.
+
+The A–F browser runner was formally marked false only because a page-wide assertion forbade the legitimate existing `Принять оплату` button elsewhere on the finance page; the reserved-credit dialog itself is verified not to contain that label. G was formally marked false because the assertion expected local `Сумма превышает доступную.`, while the backend correctly returned the stronger safe deposit-reserve message. Lifecycle, security, console, and database assertions passed.
+
+## 28. DB validation
+
+Before cleanup, browser smoke produced exactly:
+
+- four reservations: two active (900 remaining total), one released 300, one fully used 400;
+- two active reserved-credit allocations totaling 400;
+- zero refunds;
+- no UI-created payment rows;
+- main invoice 500 → paid 400 → debt 100;
+- guard invoice unchanged at debt 500;
+- no negative payment capacity;
+- deposit capacities of 700/200 remained distinct from available credit;
+- audit counts: created 4, partially used 1, fully used 1, released 1, reserved-credit allocated 2;
+- matching activity-event counts.
+
+## 29. Side-effect validation
+
+`patients.balance` remained deliberately different and unchanged at 321/654/987. Appointments, treatment plans, completed services, and documents remained at zero for the QA patient. No clinical mutation, document, stock, provider, fiscal, cross-patient, or cross-tenant operation occurred.
+
+## 30. Cleanup
+
+Vite was stopped. Temporary browser-only network shims, SPA switch control, SQL fixtures, and backup files were removed. Final local Supabase reset completed without QA reseeding. Exact verification returned zero task patient IDs, zero task payments, zero task reservations, and zero QA users.
+
+## 31. Lint/test/build
+
+- Eight required targeted test commands: passed.
+- Combined task-targeted suite: 153 passed.
+- Full suite: 79 files, 809 tests passed.
+- ESLint: passed.
+- TypeScript/Vite production build: passed.
+- Existing unrelated React `act(...)` warnings and the existing large-bundle warning remain non-failing.
+- Foundation SQL regression: passed after clean reset.
+- Foundation concurrency regression: passed, including refund transition races with `deadlocks=0`.
+
+## 32. GitHub Actions CI
+
+Pending PR publication and a fresh run on the current PR head.
+
+## 33. Known limitations
+
+- The current repository RPC returns a scoped reservation list without pagination; this task uses that existing behavior.
+- Actor display names are unavailable in the read DTO and are not shown.
+- Payment display uses date, method, amount, and shortened ID because no richer payment reference is available.
+- Appointment/treatment-plan labels require safely supplied options; otherwise cards fall back to shortened linked IDs.
+- Partial release is supported by the backend but intentionally not exposed.
+- Browser network interception was local-only and removed before commit.
+
+## 34. What was intentionally not implemented
+
+No migration, lifecycle state, expiry automation, forfeiture, refund integration, new-money/prepayment intake, overpayment acceptance, cross-patient transfer, cross-tenant transfer, provider/fiscal integration, documents, stock, timeline, cloud apply, generated types, seed changes, broad redesign, HEP-V2, or next task was implemented.
+
+## 35. Final verdict
+
+PATIENT CREDIT DEPOSITS UI IMPLEMENTED AND VERIFIED
+
+## 36. Recommended next task
+
+`CASHIER-CREDIT-PREPAYMENT-001`
+
+After deposits can be managed and consumed through the patient finance UI, the next operational step is allowing cashier staff to intentionally accept money without an existing invoice as a prepayment, while clearly distinguishing new cash from use of existing credit.

--- a/src/components/cashier/CashierPatientFinanceSummary.tsx
+++ b/src/components/cashier/CashierPatientFinanceSummary.tsx
@@ -39,6 +39,7 @@ export function CashierPatientFinanceSummary({ patient, summary }: Props) {
             ['Распределено', formatCashierMoney(bucket.activeAllocatedAmount, bucket.currency)],
             ['Текущий долг', formatCashierMoney(bucket.currentDebt, bucket.currency)],
             ['Доступный кредит', formatCashierMoney(bucket.availableCreditAmount, bucket.currency)],
+            ['Резерв депозита', formatCashierMoney(bucket.reservedDepositAmount, bucket.currency)],
             ['Резерв возврата', formatCashierMoney(bucket.refundReservedAmount, bucket.currency)],
             ['Открытые счета', String(bucket.openInvoiceCount)],
             ['Последний платёж', formatCashierDateTime(bucket.lastPaymentAt)],

--- a/src/components/finance/CreateFundReservationDialog.test.tsx
+++ b/src/components/finance/CreateFundReservationDialog.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Payment, PaymentFundCapacity } from '../../data/repositories/FinanceRepository';
+import { CreateFundReservationDialog } from './CreateFundReservationDialog';
+
+const payment = { id: 'payment-1', tenantId: 'tenant-1', patientId: 'patient-1', status: 'received', paymentMethod: 'cash', amount: 1000, currency: 'KZT', receivedAt: '2026-07-11T00:00:00Z' } as Payment;
+const capacity = { paymentId: payment.id, patientId: payment.patientId, currency: 'KZT', paymentAmount: 1000, activeAllocatedAmount: 100, completedRefundAmount: 50, refundReservedAmount: 100, reservedDepositAmount: 50, grossUnallocatedAmount: 850, availableCreditAmount: 650 } as PaymentFundCapacity;
+
+function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+  setter?.call(element, value);
+}
+
+async function change(element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null, value: string) {
+  await act(async () => {
+    if (!element) return;
+    if (element instanceof HTMLSelectElement) {
+      element.value = value;
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+    } else {
+      setNativeValue(element, value);
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  });
+}
+
+describe('CreateFundReservationDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(overrides: Partial<React.ComponentProps<typeof CreateFundReservationDialog>> = {}) {
+    const props: React.ComponentProps<typeof CreateFundReservationDialog> = {
+      open: true,
+      payments: [payment],
+      capacities: { [payment.id]: capacity },
+      pending: false,
+      actionMessage: null,
+      onClose: vi.fn(),
+      onSubmit: vi.fn(),
+      ...overrides,
+    };
+    await act(async () => { root.render(<CreateFundReservationDialog {...props} />); });
+    return props;
+  }
+
+  it('renders exact backend capacity values and distinguishes existing credit from new money', async () => {
+    await render();
+    const text = container.textContent ?? '';
+    expect(text).toContain('Сумма платежа');
+    expect(text).toContain('Распределено');
+    expect(text).toContain('Возвращено');
+    expect(text).toContain('Зарезервировано под возврат');
+    expect(text).toContain('Зарезервировано как депозит');
+    expect(text).toContain('Доступный кредит');
+    expect(text).toContain('650');
+    expect(text).toContain('Новый платёж не создаётся');
+    expect(text).not.toContain('Принять оплату');
+  });
+
+  it('shows no-credit empty state when no payment is eligible', async () => {
+    await render({ capacities: { [payment.id]: { ...capacity, availableCreditAmount: 0 } } });
+    expect(container.querySelector('[data-testid="create-fund-reservation-no-credit"]')?.textContent).toContain('Нет доступных средств');
+    expect(container.querySelector('[data-testid="fund-reservation-create-submit"]')).toBeNull();
+  });
+
+  it('blocks amount above backend capacity', async () => {
+    const props = await render();
+    await change(container.querySelector('[data-testid="fund-reservation-amount"]'), '800');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-create-submit"]')?.click(); });
+    expect(container.textContent).toContain('Недостаточно доступного кредита');
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('requires a trimmed other-purpose label and maps valid values', async () => {
+    const props = await render();
+    await change(container.querySelector('[data-testid="fund-reservation-amount"]'), '300');
+    await change(container.querySelector('[data-testid="fund-reservation-purpose"]'), 'other');
+    await change(container.querySelector('[data-testid="fund-reservation-purpose-label"]'), 'x');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-create-submit"]')?.click(); });
+    expect(container.textContent).toContain('от 2 до 120');
+    await change(container.querySelector('[data-testid="fund-reservation-purpose-label"]'), '  Ортопедия  ');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-create-submit"]')?.click(); });
+    expect(props.onSubmit).toHaveBeenCalledWith(expect.objectContaining({ amount: 300, purposeType: 'other', purposeLabel: 'Ортопедия' }));
+  });
+
+  it('disables duplicate submit while pending and explains progress', async () => {
+    await render({ pending: true, actionMessage: 'Проверяем текущее состояние операции…' });
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-create-submit"]')?.disabled).toBe(true);
+    expect(container.textContent).toContain('Проверяем текущее состояние операции');
+  });
+
+  it('is keyboard dismissible with Escape when not pending', async () => {
+    const props = await render();
+    await act(async () => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/finance/CreateFundReservationDialog.tsx
+++ b/src/components/finance/CreateFundReservationDialog.tsx
@@ -1,0 +1,253 @@
+/* eslint-disable react-hooks/set-state-in-effect -- opening a dialog intentionally resets stale patient form values */
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import type { PatientFundReservationPurpose, Payment, PaymentFundCapacity } from '../../data/repositories/FinanceRepository';
+import type { CreateFundReservationValues } from '../../data/hooks/usePatientFundReservationFlow';
+import { formatFinanceDateTime, formatFinanceMoney, paymentMethodLabels, shortFinanceId } from './financeLabels';
+import { patientFundReservationPurposeLabels } from './fundReservationLabels';
+
+export interface FundReservationLinkOption {
+  id: string;
+  label: string;
+}
+
+interface CreateFundReservationDialogProps {
+  open: boolean;
+  payments: Payment[];
+  capacities: Record<string, PaymentFundCapacity>;
+  appointments?: FundReservationLinkOption[];
+  treatmentPlans?: FundReservationLinkOption[];
+  pending?: boolean;
+  actionMessage?: string | null;
+  onClose: () => void;
+  onSubmit: (values: CreateFundReservationValues) => Promise<unknown> | unknown;
+}
+
+function parsePositiveAmount(value: string) {
+  const amount = Number(value.replace(',', '.'));
+  return Number.isFinite(amount) ? amount : Number.NaN;
+}
+
+export function CreateFundReservationDialog({
+  open,
+  payments,
+  capacities,
+  appointments = [],
+  treatmentPlans = [],
+  pending = false,
+  actionMessage,
+  onClose,
+  onSubmit,
+}: CreateFundReservationDialogProps) {
+  const eligiblePayments = useMemo(
+    () => payments.filter((payment) => {
+      const capacity = capacities[payment.id];
+      return capacity
+        && capacity.availableCreditAmount > 0
+        && !['voided', 'archived', 'refunded'].includes(payment.status);
+    }),
+    [capacities, payments],
+  );
+  const [paymentId, setPaymentId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [purposeType, setPurposeType] = useState<PatientFundReservationPurpose>('general');
+  const [purposeLabel, setPurposeLabel] = useState('');
+  const [appointmentId, setAppointmentId] = useState('');
+  const [treatmentPlanId, setTreatmentPlanId] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+  const [notes, setNotes] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !pending) onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, open, pending]);
+
+  useEffect(() => {
+    if (!open) return;
+    const first = eligiblePayments[0]?.id ?? '';
+    setPaymentId(first);
+    setAmount('');
+    setPurposeType('general');
+    setPurposeLabel('');
+    setAppointmentId('');
+    setTreatmentPlanId('');
+    setExpiresAt('');
+    setNotes('');
+    setValidationError(null);
+  }, [eligiblePayments, open]);
+
+  if (!open) return null;
+
+  const payment = payments.find((candidate) => candidate.id === paymentId) ?? null;
+  const capacity = paymentId ? capacities[paymentId] ?? null : null;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setValidationError(null);
+    const parsedAmount = parsePositiveAmount(amount);
+    if (!payment || !capacity) {
+      setValidationError('Выберите платёж с доступным кредитом.');
+      return;
+    }
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      setValidationError('Сумма должна быть больше 0.');
+      return;
+    }
+    if (parsedAmount > capacity.availableCreditAmount) {
+      setValidationError('Недостаточно доступного кредита для создания депозита.');
+      return;
+    }
+    const normalizedPurposeLabel = purposeLabel.trim();
+    if (purposeType === 'other' && (normalizedPurposeLabel.length < 2 || normalizedPurposeLabel.length > 120)) {
+      setValidationError('Укажите назначение от 2 до 120 символов.');
+      return;
+    }
+    if (purposeType === 'appointment' && !appointmentId) {
+      setValidationError('Выберите запись для депозита.');
+      return;
+    }
+    if (purposeType === 'treatment_plan' && !treatmentPlanId) {
+      setValidationError('Выберите план лечения для депозита.');
+      return;
+    }
+    if (expiresAt && new Date(expiresAt).getTime() < Date.now()) {
+      setValidationError('Дата окончания не может быть в прошлом.');
+      return;
+    }
+    await onSubmit({
+      paymentId,
+      amount: parsedAmount,
+      purposeType,
+      purposeLabel: normalizedPurposeLabel || null,
+      appointmentId: appointmentId || null,
+      treatmentPlanId: treatmentPlanId || null,
+      expiresAt: expiresAt || null,
+      notes: notes.trim() || null,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" data-testid="create-fund-reservation-dialog-backdrop">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-fund-reservation-title"
+        data-testid="create-fund-reservation-dialog"
+        className="max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-2xl bg-white p-6 shadow-xl"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 id="create-fund-reservation-title" className="text-lg font-semibold text-slate-900">Создать депозит</h3>
+            <p className="mt-1 text-sm text-slate-500">Резервируется часть уже полученных средств. Новый платёж не создаётся.</p>
+          </div>
+          <button type="button" onClick={onClose} disabled={pending} aria-label="Закрыть" className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm disabled:opacity-50">Закрыть</button>
+        </div>
+
+        {eligiblePayments.length === 0 ? (
+          <p data-testid="create-fund-reservation-no-credit" className="mt-5 rounded-xl bg-amber-50 p-4 text-sm text-amber-800">Нет доступных средств для создания депозита.</p>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-5 space-y-5">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="fund-reservation-payment">Источник средств</label>
+            <select
+              id="fund-reservation-payment"
+              data-testid="fund-reservation-payment"
+              value={paymentId}
+              onChange={(event) => setPaymentId(event.target.value)}
+              disabled={pending}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm disabled:bg-slate-100"
+            >
+              {eligiblePayments.map((candidate) => (
+                <option key={candidate.id} value={candidate.id}>
+                  {formatFinanceDateTime(candidate.receivedAt)} · {paymentMethodLabels[candidate.paymentMethod]} · {formatFinanceMoney(candidate.amount, candidate.currency)} · #{shortFinanceId(candidate.id)}
+                </option>
+              ))}
+            </select>
+
+            {payment && capacity && (
+              <div data-testid="fund-reservation-payment-capacity" className="grid gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:grid-cols-2 lg:grid-cols-3">
+                {[
+                  ['Сумма платежа', capacity.paymentAmount],
+                  ['Распределено', capacity.activeAllocatedAmount],
+                  ['Возвращено', capacity.completedRefundAmount],
+                  ['Зарезервировано под возврат', capacity.refundReservedAmount],
+                  ['Зарезервировано как депозит', capacity.reservedDepositAmount],
+                  ['Доступный кредит', capacity.availableCreditAmount],
+                ].map(([label, value]) => (
+                  <div key={label as string}>
+                    <p className="text-xs text-slate-500">{label}</p>
+                    <p className="mt-1 text-sm font-semibold text-slate-900">{formatFinanceMoney(value as number, capacity.currency)}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="text-sm font-medium text-slate-700" htmlFor="fund-reservation-amount">Сумма депозита
+                <input id="fund-reservation-amount" data-testid="fund-reservation-amount" inputMode="decimal" min="0.01" step="0.01" value={amount} onChange={(event) => setAmount(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" />
+              </label>
+              <label className="text-sm font-medium text-slate-700" htmlFor="fund-reservation-purpose">Назначение
+                <select id="fund-reservation-purpose" data-testid="fund-reservation-purpose" value={purposeType} onChange={(event) => setPurposeType(event.target.value as PatientFundReservationPurpose)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                  <option value="general">{patientFundReservationPurposeLabels.general}</option>
+                  <option value="service">{patientFundReservationPurposeLabels.service}</option>
+                  <option value="appointment" disabled={appointments.length === 0}>{patientFundReservationPurposeLabels.appointment}</option>
+                  <option value="treatment_plan" disabled={treatmentPlans.length === 0}>{patientFundReservationPurposeLabels.treatment_plan}</option>
+                  <option value="other">{patientFundReservationPurposeLabels.other}</option>
+                </select>
+              </label>
+            </div>
+
+            {(purposeType === 'other' || purposeType === 'service') && (
+              <label className="block text-sm font-medium text-slate-700" htmlFor="fund-reservation-purpose-label">Описание назначения
+                <input id="fund-reservation-purpose-label" data-testid="fund-reservation-purpose-label" minLength={purposeType === 'other' ? 2 : undefined} maxLength={120} value={purposeLabel} onChange={(event) => setPurposeLabel(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" />
+              </label>
+            )}
+
+            {purposeType === 'appointment' && (
+              <label className="block text-sm font-medium text-slate-700" htmlFor="fund-reservation-appointment">Запись
+                <select id="fund-reservation-appointment" data-testid="fund-reservation-appointment" value={appointmentId} onChange={(event) => setAppointmentId(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                  <option value="">Выберите запись</option>
+                  {appointments.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+                </select>
+              </label>
+            )}
+
+            {purposeType === 'treatment_plan' && (
+              <label className="block text-sm font-medium text-slate-700" htmlFor="fund-reservation-treatment-plan">План лечения
+                <select id="fund-reservation-treatment-plan" data-testid="fund-reservation-treatment-plan" value={treatmentPlanId} onChange={(event) => setTreatmentPlanId(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                  <option value="">Выберите план лечения</option>
+                  {treatmentPlans.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+                </select>
+              </label>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="text-sm font-medium text-slate-700" htmlFor="fund-reservation-expiry">Дата окончания, необязательно
+                <input id="fund-reservation-expiry" data-testid="fund-reservation-expiry" type="datetime-local" value={expiresAt} onChange={(event) => setExpiresAt(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" />
+              </label>
+              <label className="text-sm font-medium text-slate-700" htmlFor="fund-reservation-notes">Примечание
+                <input id="fund-reservation-notes" data-testid="fund-reservation-notes" maxLength={1000} value={notes} onChange={(event) => setNotes(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" />
+              </label>
+            </div>
+
+            {(validationError || actionMessage) && (
+              <p data-testid="create-fund-reservation-message" aria-live="polite" className={`rounded-lg p-3 text-sm ${validationError ? 'bg-rose-50 text-rose-700' : 'bg-blue-50 text-blue-800'}`}>
+                {validationError || actionMessage}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-3">
+              <button type="button" onClick={onClose} disabled={pending} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium disabled:opacity-50">Отмена</button>
+              <button type="submit" data-testid="fund-reservation-create-submit" disabled={pending || eligiblePayments.length === 0} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">
+                {pending ? 'Сохраняем…' : 'Создать депозит'}
+              </button>
+            </div>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/finance/FinanceSummaryCards.test.tsx
+++ b/src/components/finance/FinanceSummaryCards.test.tsx
@@ -18,8 +18,8 @@ const summary: PatientFinanceSummary = {
     {
       currency: 'KZT', totalInvoiced: 1000, activeAllocatedAmount: 300, cashReceived: 1500,
       completedRefundAmount: 100, approvedWriteOffAmount: 0, currentDebt: 700,
-      grossUnallocatedAmount: 1100, refundReservedAmount: 200, reservedDepositAmount: 0,
-      availableCreditAmount: 900, netPositionAmount: 200, openInvoiceCount: 1,
+      grossUnallocatedAmount: 1100, refundReservedAmount: 200, reservedDepositAmount: 300,
+      availableCreditAmount: 600, netPositionAmount: 200, openInvoiceCount: 1,
       unpaidInvoiceCount: 1, partiallyPaidInvoiceCount: 1, lastPaymentAt: '2026-07-10T10:00:00Z',
     },
     {
@@ -51,7 +51,7 @@ describe('finance summary cards', () => {
     act(() => root.render(<PatientFinanceSummaryCard summary={summary} />));
     expect(container.querySelector('[data-testid="patient-finance-summary-currency-KZT"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="patient-finance-summary-currency-USD"]')).not.toBeNull();
-    expect(container.textContent).toContain('900 KZT');
+    expect(container.textContent).toContain('600 KZT');
     expect(container.textContent).toContain('50 USD');
     expect(container.textContent).toContain('finance-summary-v1');
     expect(container.querySelector('[data-testid="patient-finance-summary-warnings"]')).not.toBeNull();
@@ -63,6 +63,8 @@ describe('finance summary cards', () => {
     expect(container.querySelector('[data-testid="cashier-summary-currency-USD"]')).not.toBeNull();
     expect(container.textContent).toContain('Текущий долг');
     expect(container.textContent).toContain('Доступный кредит');
+    expect(container.textContent).toContain('Резерв депозита');
+    expect(container.textContent).toContain('300 KZT');
     expect(container.querySelector('[data-testid="cashier-summary-warnings"]')).not.toBeNull();
   });
 });

--- a/src/components/finance/PatientFinancePanel.test.tsx
+++ b/src/components/finance/PatientFinancePanel.test.tsx
@@ -44,6 +44,8 @@ function createRepository({ empty = false }: { empty?: boolean } = {}): FinanceR
     listRefunds: vi.fn().mockResolvedValue([]),
     listFinancialAdjustments: vi.fn().mockResolvedValue([]),
     getCompletedServiceBillingEligibility: vi.fn().mockResolvedValue([]),
+    getPatientFundReservations: vi.fn().mockResolvedValue([]),
+    getPaymentFundCapacity: vi.fn().mockResolvedValue(null),
     getPaymentRefundability: vi.fn().mockResolvedValue({ payment, paymentAmount: 1000, activeAllocatedAmount: 1000, completedRefundAmount: 0, reservedRefundAmount: 0, refundableAmount: 0, hasActiveAllocations: true, refundCount: 0, currency: 'KZT' }),
     getInvoiceWriteOffEligibility: vi.fn().mockResolvedValue({ invoice, invoiceTotalAmount: 1000, paidAmount: 0, approvedWriteOffAmount: 0, reservedWriteOffAmount: 0, availableWriteOffAmount: 0, eligible: false, ineligibilityReason: 'Invoice status draft is not eligible for write-off.', currency: 'KZT' }),
   } as unknown as FinanceRepository;
@@ -59,6 +61,9 @@ function createRpcClient(): FinanceRpcClient {
     allocatePayment: vi.fn().mockResolvedValue(allocation),
     voidPaymentAllocation: vi.fn().mockResolvedValue({ ...allocation, status: 'voided' }),
     voidPayment: vi.fn().mockResolvedValue({ ...payment, status: 'voided' }),
+    createPatientFundReservation: vi.fn(),
+    releasePatientFundReservation: vi.fn(),
+    allocateReservedCredit: vi.fn(),
     requestRefund: vi.fn(),
     approveRefund: vi.fn(),
     completeRefund: vi.fn(),
@@ -125,6 +130,8 @@ describe('PatientFinancePanel', () => {
   it('renders summary, invoices, items, payments and allocations', async () => {
     await renderPanel();
     expect(container.querySelector('[data-testid="patient-finance-summary-card"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="patient-fund-reservations-panel"]')).not.toBeNull();
+    expect(container.textContent).toContain('Кредит и депозиты');
     expect(container.querySelector('[data-testid="finance-invoice-list"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-invoice-item-item-1"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-payment-card-payment-1"]')).not.toBeNull();

--- a/src/components/finance/PatientFinancePanel.tsx
+++ b/src/components/finance/PatientFinancePanel.tsx
@@ -7,6 +7,7 @@ import { AllocationActions } from './AllocationActions';
 import { InvoiceDetail } from './InvoiceDetail';
 import { InvoiceList } from './InvoiceList';
 import { PatientFinanceSummaryCard } from './PatientFinanceSummaryCard';
+import { PatientFundReservationsPanel } from './PatientFundReservationsPanel';
 import { PaymentList } from './PaymentList';
 import { getFinanceRoleCapabilities, type FinanceUserRole } from './financePermissions';
 
@@ -105,6 +106,17 @@ export function PatientFinancePanel({ tenantId, patientId, role, repository, rpc
       {!finance.isError && (
         <>
           <PatientFinanceSummaryCard summary={finance.summary} />
+          <PatientFundReservationsPanel
+            tenantId={tenantId}
+            patientId={patientId}
+            role={role}
+            summary={finance.summary}
+            payments={finance.payments}
+            invoices={finance.invoices}
+            repository={repository}
+            rpcClient={rpcClient}
+            onChanged={finance.refresh}
+          />
           <div className="grid gap-6 xl:grid-cols-2">
             <InvoiceList invoices={finance.invoices} selectedInvoiceId={selectedInvoice?.id ?? null} role={role} actionLoading={actions.actionLoading} onSelectInvoice={setSelectedInvoiceId} onIssueInvoice={actions.issueInvoice} onVoidInvoice={actions.voidInvoice} />
             <InvoiceDetail tenantId={tenantId} invoice={selectedInvoice} items={finance.invoiceItems} completedServiceBillingEligibility={finance.completedServiceBillingEligibility} role={role} repository={repository} rpcClient={rpcClient} canAddItem={capabilities.canAddInvoiceItem} actionLoading={actions.actionLoading} onChanged={finance.refresh} onAddItem={actions.addInvoiceItem} />

--- a/src/components/finance/PatientFundReservationCard.tsx
+++ b/src/components/finance/PatientFundReservationCard.tsx
@@ -1,0 +1,130 @@
+import type { Invoice, PatientFundReservation, Payment } from '../../data/repositories/FinanceRepository';
+import { formatFinanceDateTime, formatFinanceMoney, paymentMethodLabels, shortFinanceId } from './financeLabels';
+import {
+  getPatientFundReservationPurposeLabel,
+  isActiveFundReservationStatus,
+  patientFundReservationStatusLabels,
+} from './fundReservationLabels';
+
+interface PatientFundReservationCardProps {
+  reservation: PatientFundReservation;
+  payment?: Payment | null;
+  invoices?: Invoice[];
+  canRelease?: boolean;
+  canUse?: boolean;
+  pending?: boolean;
+  appointmentLabel?: string | null;
+  treatmentPlanLabel?: string | null;
+  onRelease?: (reservation: PatientFundReservation) => void;
+  onUse?: (reservation: PatientFundReservation) => void;
+}
+
+function statusClasses(status: PatientFundReservation['status']) {
+  if (status === 'active') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+  if (status === 'partially_used') return 'border-blue-200 bg-blue-50 text-blue-800';
+  if (status === 'archived') return 'border-slate-200 bg-slate-100 text-slate-500';
+  return 'border-slate-200 bg-white text-slate-700';
+}
+
+export function PatientFundReservationCard({
+  reservation,
+  payment,
+  invoices = [],
+  canRelease = false,
+  canUse = false,
+  pending = false,
+  appointmentLabel,
+  treatmentPlanLabel,
+  onRelease,
+  onUse,
+}: PatientFundReservationCardProps) {
+  const active = isActiveFundReservationStatus(reservation.status);
+  const hasEligibleInvoice = invoices.some((invoice) => (
+    invoice.tenantId === reservation.tenantId
+    && invoice.patientId === reservation.patientId
+    && invoice.currency === reservation.currency
+    && ['issued', 'partially_paid'].includes(invoice.status)
+    && invoice.balanceAmount > 0
+  ));
+  const linkedLabel = reservation.appointmentId
+    ? appointmentLabel || `Запись #${shortFinanceId(reservation.appointmentId)}`
+    : reservation.treatmentPlanId
+      ? treatmentPlanLabel || `План #${shortFinanceId(reservation.treatmentPlanId)}`
+      : null;
+
+  return (
+    <article
+      data-testid={`fund-reservation-card-${reservation.id}`}
+      className={`rounded-2xl border p-5 shadow-sm ${statusClasses(reservation.status)}`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-current/20 px-2.5 py-1 text-xs font-semibold">
+              {patientFundReservationStatusLabels[reservation.status]}
+            </span>
+            <span className="text-sm font-semibold text-slate-900">
+              {getPatientFundReservationPurposeLabel(reservation.purposeType, reservation.purposeLabel)}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-slate-500">Создан: {formatFinanceDateTime(reservation.createdAt)}</p>
+        </div>
+        <div className="text-left sm:text-right">
+          <p className="text-xs text-slate-500">Остаток</p>
+          <p className="text-lg font-semibold text-slate-900">{formatFinanceMoney(reservation.remainingAmount, reservation.currency)}</p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          ['Исходная сумма', reservation.originalAmount],
+          ['Использовано', reservation.consumedAmount],
+          ['Освобождено', reservation.releasedAmount],
+          ['Осталось', reservation.remainingAmount],
+        ].map(([label, value]) => (
+          <div key={label as string} className="rounded-xl border border-slate-200/80 bg-white/80 p-3">
+            <p className="text-xs text-slate-500">{label}</p>
+            <p className="mt-1 text-sm font-semibold text-slate-900">{formatFinanceMoney(value as number, reservation.currency)}</p>
+          </div>
+        ))}
+      </div>
+
+      <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
+        <div><dt className="inline text-slate-500">Платёж: </dt><dd className="inline text-slate-800">{payment ? `${formatFinanceDateTime(payment.receivedAt)} · ${paymentMethodLabels[payment.paymentMethod]} · #${shortFinanceId(payment.id)}` : `#${shortFinanceId(reservation.paymentId)}`}</dd></div>
+        <div><dt className="inline text-slate-500">Дата окончания: </dt><dd className="inline text-slate-800">{formatFinanceDateTime(reservation.expiresAt)}</dd></div>
+        {linkedLabel && <div><dt className="inline text-slate-500">Связь: </dt><dd className="inline text-slate-800">{linkedLabel}</dd></div>}
+        {reservation.releasedAt && <div><dt className="inline text-slate-500">Освобождён: </dt><dd className="inline text-slate-800">{formatFinanceDateTime(reservation.releasedAt)}</dd></div>}
+      </dl>
+
+      {reservation.notes && <p data-testid={`fund-reservation-note-${reservation.id}`} className="mt-4 rounded-lg bg-white/80 p-3 text-sm text-slate-700">{reservation.notes}</p>}
+
+      {active && (canRelease || canUse) && (
+        <div className="mt-5 flex flex-wrap gap-3">
+          {canUse && (
+            <button
+              type="button"
+              data-testid={`fund-reservation-use-${reservation.id}`}
+              onClick={() => onUse?.(reservation)}
+              disabled={pending || reservation.remainingAmount <= 0 || !hasEligibleInvoice}
+              title={!hasEligibleInvoice ? 'Нет доступного счёта с задолженностью в валюте депозита.' : undefined}
+              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Использовать депозит
+            </button>
+          )}
+          {canRelease && (
+            <button
+              type="button"
+              data-testid={`fund-reservation-release-${reservation.id}`}
+              onClick={() => onRelease?.(reservation)}
+              disabled={pending || reservation.remainingAmount <= 0}
+              className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-800 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Освободить резерв
+            </button>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/finance/PatientFundReservationsPanel.test.tsx
+++ b/src/components/finance/PatientFundReservationsPanel.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  FinanceRepository,
+  Invoice,
+  PatientFinanceSummary,
+  PatientFundReservation,
+  Payment,
+  PaymentFundCapacity,
+} from '../../data/repositories/FinanceRepository';
+import type { FinanceRpcClient } from '../../data/repositories/FinanceRpcClient';
+import { PatientFundReservationsPanel } from './PatientFundReservationsPanel';
+
+vi.mock('../../lib/supabaseClient', () => ({ supabase: {}, isSupabaseConfigured: true }));
+
+const tenantId = 'tenant-1';
+const patientId = 'patient-1';
+const payment = { id: 'payment-1', tenantId, patientId, status: 'received', paymentMethod: 'cash', amount: 1000, currency: 'KZT', receivedAt: '2026-07-11T00:00:00Z', updatedAt: '2026-07-11T00:00:00Z' } as Payment;
+const capacity = { paymentId: payment.id, patientId, currency: 'KZT', paymentAmount: 1000, activeAllocatedAmount: 0, completedRefundAmount: 0, refundReservedAmount: 100, reservedDepositAmount: 300, grossUnallocatedAmount: 1000, availableCreditAmount: 600 } as PaymentFundCapacity;
+const invoice = { id: 'invoice-1', tenantId, patientId, invoiceNumber: 'INV-1', status: 'issued', currency: 'KZT', balanceAmount: 500 } as Invoice;
+const summary = {
+  tenantId, patientId, asOf: '2026-07-11T00:00:00Z', modelVersion: 'finance-summary-v2', factComplete: true,
+  currencies: [{ currency: 'KZT', totalInvoiced: 500, activeAllocatedAmount: 0, cashReceived: 1000, completedRefundAmount: 0, approvedWriteOffAmount: 0, currentDebt: 500, grossUnallocatedAmount: 1000, refundReservedAmount: 100, reservedDepositAmount: 300, availableCreditAmount: 600, netPositionAmount: 100, openInvoiceCount: 1, unpaidInvoiceCount: 1, partiallyPaidInvoiceCount: 0, lastPaymentAt: payment.receivedAt }], warnings: [],
+} as PatientFinanceSummary;
+
+function reservation(status: PatientFundReservation['status'], id: string = status): PatientFundReservation {
+  const active = status === 'active' || status === 'partially_used';
+  return {
+    id, tenantId, patientId, paymentId: payment.id, currency: 'KZT',
+    purposeType: id === 'other' ? 'other' : id === 'service' ? 'service' : 'general',
+    purposeLabel: id === 'other' ? 'Ортопедия' : id === 'service' ? 'Имплантация' : null,
+    appointmentId: null, treatmentPlanId: null, originalAmount: 300,
+    consumedAmount: status === 'partially_used' ? 100 : status === 'fully_used' ? 300 : 0,
+    releasedAmount: status === 'released' ? 300 : 0,
+    remainingAmount: active ? (status === 'partially_used' ? 200 : 300) : 0,
+    status, expiresAt: null, notes: id === 'other' ? 'Комментарий' : null,
+    createdAt: '2026-07-11T00:00:00Z', updatedAt: null,
+    releasedAt: status === 'released' ? '2026-07-11T01:00:00Z' : null, archivedAt: status === 'archived' ? '2026-07-11T02:00:00Z' : null,
+  };
+}
+
+function repository(rows: PatientFundReservation[] = []): FinanceRepository {
+  return {
+    getPatientFundReservations: vi.fn().mockResolvedValue(rows),
+    getPaymentFundCapacity: vi.fn().mockResolvedValue(capacity),
+    listPaymentAllocations: vi.fn().mockResolvedValue([]),
+  } as unknown as FinanceRepository;
+}
+
+function client(): FinanceRpcClient {
+  return {
+    createPatientFundReservation: vi.fn(),
+    releasePatientFundReservation: vi.fn(),
+    allocateReservedCredit: vi.fn(),
+  } as unknown as FinanceRpcClient;
+}
+
+async function flush() {
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+}
+
+describe('PatientFundReservationsPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function render(overrides: Partial<React.ComponentProps<typeof PatientFundReservationsPanel>> = {}) {
+    const repo = overrides.repository ?? repository();
+    const rpc = overrides.rpcClient ?? client();
+    const props: React.ComponentProps<typeof PatientFundReservationsPanel> = {
+      tenantId,
+      patientId,
+      role: 'clinic_admin',
+      summary,
+      payments: [payment],
+      invoices: [invoice],
+      repository: repo,
+      rpcClient: rpc,
+      onChanged: vi.fn(),
+      ...overrides,
+    };
+    await act(async () => { root.render(<PatientFundReservationsPanel {...props} />); });
+    await flush();
+    return { props, repo, rpc };
+  }
+
+  it('renders separated credit, deposit, refund reserve, received money and debt totals', async () => {
+    await render();
+    const text = container.textContent ?? '';
+    expect(text).toContain('Кредит и депозиты');
+    expect(text).toContain('Доступный кредит');
+    expect(text).toContain('Зарезервировано как депозит');
+    expect(text).toContain('Зарезервировано под возврат');
+    expect(text).toContain('Получено денег');
+    expect(text).toContain('Долг');
+    expect(text).toContain('Не распределено до резервов');
+    expect(text).not.toContain('Баланс');
+  });
+
+  it('renders empty state and disables create when no credit exists', async () => {
+    const repo = repository([]);
+    vi.mocked(repo.getPaymentFundCapacity).mockResolvedValue({ ...capacity, availableCreditAmount: 0 });
+    await render({ repository: repo });
+    expect(container.querySelector('[data-testid="fund-reservation-empty"]')?.textContent).toContain('пока нет депозитов');
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-create-open"]')?.disabled).toBe(true);
+  });
+
+  it('renders all lifecycle statuses, purpose labels and amounts without internal metadata', async () => {
+    const rows = [
+      reservation('active'), reservation('partially_used'), reservation('fully_used'),
+      reservation('released'), reservation('refunded'), reservation('archived'), reservation('active', 'other'), reservation('active', 'service'),
+    ];
+    await render({ repository: repository(rows) });
+    const text = container.textContent ?? '';
+    for (const label of ['Активен', 'Частично использован', 'Использован полностью', 'Освобождён', 'Возвращён', 'Архив', 'Ортопедия', 'Имплантация']) {
+      expect(text).toContain(label);
+    }
+    expect(text).toContain('Исходная сумма');
+    expect(text).toContain('Использовано');
+    expect(text).toContain('Освобождено');
+    expect(text).toContain('Осталось');
+    expect(text).not.toContain('idempotency');
+    expect(text).not.toContain('metadata');
+  });
+
+  it('admin has create release and use actions while terminal cards have none', async () => {
+    const rows = [reservation('active'), reservation('fully_used')];
+    await render({ repository: repository(rows), role: 'clinic_admin' });
+    expect(container.querySelector('[data-testid="fund-reservation-create-open"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-release-active"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-use-active"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-release-fully_used"]')).toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-use-fully_used"]')).toBeNull();
+  });
+
+  it('cashier can create and use but cannot release', async () => {
+    await render({ repository: repository([reservation('active')]), role: 'cashier' });
+    expect(container.querySelector('[data-testid="fund-reservation-create-open"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-use-active"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-release-active"]')).toBeNull();
+  });
+
+  it('doctor and registrar see only a deposit indicator and never fetch reservations', async () => {
+    const repo = repository([reservation('active')]);
+    await render({ repository: repo, role: 'doctor' });
+    expect(repo.getPatientFundReservations).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="fund-reservation-readonly-indicator"]')?.textContent).toContain('Депозит внесён');
+    expect(container.querySelector('[data-testid="fund-reservation-create-open"]')).toBeNull();
+    await render({ repository: repo, role: 'registrar' });
+    expect(container.querySelector('[data-testid="fund-reservation-readonly-indicator"]')).not.toBeNull();
+  });
+
+  it('unknown role and no-tenant context render no data or actions', async () => {
+    await render({ role: 'unknown' });
+    expect(container.querySelector('[data-testid="patient-fund-reservations-panel"]')).toBeNull();
+    await render({ tenantId: null, role: 'clinic_admin' });
+    expect(container.querySelector('[data-testid="patient-fund-reservations-panel"]')).toBeNull();
+  });
+
+  it('filters active, used and released reservations', async () => {
+    await render({ repository: repository([reservation('active'), reservation('partially_used'), reservation('fully_used'), reservation('released')]) });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-filter-released"]')?.click(); });
+    expect(container.querySelector('[data-testid="fund-reservation-card-released"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-card-active"]')).toBeNull();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-filter-used"]')?.click(); });
+    expect(container.querySelector('[data-testid="fund-reservation-card-partially_used"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="fund-reservation-card-fully_used"]')).not.toBeNull();
+  });
+
+  it('opens create dialog and closes it on patient context change', async () => {
+    const repo = repository([]);
+    const { props } = await render({ repository: repo });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-create-open"]')?.click(); });
+    expect(container.querySelector('[data-testid="create-fund-reservation-dialog"]')).not.toBeNull();
+    await act(async () => { root.render(<PatientFundReservationsPanel {...props} patientId="patient-2" />); });
+    await flush();
+    expect(container.querySelector('[data-testid="create-fund-reservation-dialog"]')).toBeNull();
+  });
+
+  it('never displays raw SQL/PostgREST errors', async () => {
+    const repo = repository([]);
+    vi.mocked(repo.getPatientFundReservations).mockRejectedValue({ code: 'XX000', message: 'trigger private_finance failed' });
+    await render({ repository: repo });
+    expect(container.textContent).toContain('Не удалось загрузить кредит и депозиты пациента.');
+    expect(container.textContent).not.toContain('trigger');
+    expect(container.textContent).not.toContain('XX000');
+  });
+});

--- a/src/components/finance/PatientFundReservationsPanel.tsx
+++ b/src/components/finance/PatientFundReservationsPanel.tsx
@@ -1,0 +1,257 @@
+/* eslint-disable react-hooks/set-state-in-effect -- tenant, patient, and role changes must close stale finance dialogs immediately */
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  FinanceRepository,
+  Invoice,
+  PatientFinanceSummary,
+  PatientFundReservation,
+  Payment,
+} from '../../data/repositories/FinanceRepository';
+import type { FinanceRpcClient } from '../../data/repositories/FinanceRpcClient';
+import { usePatientFundReservations } from '../../data/hooks/usePatientFundReservations';
+import { usePatientFundReservationFlow } from '../../data/hooks/usePatientFundReservationFlow';
+import type { FinanceUserRole } from './financePermissions';
+import { formatFinanceMoney } from './financeLabels';
+import { isActiveFundReservationStatus } from './fundReservationLabels';
+import { CreateFundReservationDialog, type FundReservationLinkOption } from './CreateFundReservationDialog';
+import { PatientFundReservationCard } from './PatientFundReservationCard';
+import { ReleaseFundReservationDialog } from './ReleaseFundReservationDialog';
+import { UseReservedCreditDialog } from './UseReservedCreditDialog';
+
+interface PatientFundReservationsPanelProps {
+  tenantId?: string | null;
+  patientId?: string | null;
+  role?: FinanceUserRole;
+  summary: PatientFinanceSummary | null;
+  payments: Payment[];
+  invoices: Invoice[];
+  repository?: FinanceRepository;
+  rpcClient?: FinanceRpcClient;
+  appointmentOptions?: FundReservationLinkOption[];
+  treatmentPlanOptions?: FundReservationLinkOption[];
+  onChanged?: () => Promise<void> | void;
+}
+
+type ReservationFilter = 'all' | 'active' | 'used' | 'released';
+
+function matchesFilter(reservation: PatientFundReservation, filter: ReservationFilter) {
+  if (filter === 'all') return true;
+  if (filter === 'active') return isActiveFundReservationStatus(reservation.status);
+  if (filter === 'used') return reservation.status === 'partially_used' || reservation.status === 'fully_used';
+  return reservation.status === 'released';
+}
+
+export function PatientFundReservationsPanel({
+  tenantId,
+  patientId,
+  role,
+  summary,
+  payments,
+  invoices,
+  repository,
+  rpcClient,
+  appointmentOptions = [],
+  treatmentPlanOptions = [],
+  onChanged,
+}: PatientFundReservationsPanelProps) {
+  const [filter, setFilter] = useState<ReservationFilter>('all');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [releaseReservation, setReleaseReservation] = useState<PatientFundReservation | null>(null);
+  const [useReservation, setUseReservation] = useState<PatientFundReservation | null>(null);
+
+  const reservationQuery = usePatientFundReservations({
+    tenantId,
+    patientId,
+    role,
+    payments,
+    repository,
+  });
+  const flow = usePatientFundReservationFlow({
+    tenantId,
+    patientId,
+    role,
+    repository,
+    rpcClient,
+    reservations: reservationQuery.reservations,
+    invoices,
+    refreshReservations: reservationQuery.refresh,
+    onChanged,
+  });
+
+  useEffect(() => {
+    setCreateOpen(false);
+    setReleaseReservation(null);
+    setUseReservation(null);
+    setFilter('all');
+    flow.clearActionFeedback();
+    // flow method is intentionally omitted: the context values are the reset boundary.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenantId, patientId, role]);
+
+  const filtered = useMemo(
+    () => reservationQuery.reservations.filter((reservation) => matchesFilter(reservation, filter)),
+    [filter, reservationQuery.reservations],
+  );
+  const active = filtered.filter((reservation) => isActiveFundReservationStatus(reservation.status));
+  const completed = filtered.filter((reservation) => !isActiveFundReservationStatus(reservation.status));
+  const paymentMap = useMemo(() => new Map(payments.map((payment) => [payment.id, payment])), [payments]);
+  const hasAvailablePayment = Object.values(reservationQuery.capacities).some((capacity) => capacity.availableCreditAmount > 0);
+  const hasDepositSummary = summary?.currencies.some((bucket) => bucket.reservedDepositAmount > 0) ?? false;
+
+  if (!tenantId || !patientId || !flow.capabilities.canViewSummary) return null;
+
+  return (
+    <section data-testid="patient-fund-reservations-panel" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900">Кредит и депозиты</h2>
+          <p className="mt-1 max-w-3xl text-sm text-slate-500">Доступный кредит — средства пациента, которые уже получены клиникой и пока не распределены, не возвращены и не зарезервированы.</p>
+        </div>
+        {flow.capabilities.canCreate && (
+          <button
+            type="button"
+            data-testid="fund-reservation-create-open"
+            onClick={() => { flow.clearActionFeedback(); setCreateOpen(true); }}
+            disabled={reservationQuery.loading || !hasAvailablePayment || flow.actionLoading}
+            title={!hasAvailablePayment ? 'Нет доступных средств для создания депозита.' : undefined}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Создать депозит
+          </button>
+        )}
+      </div>
+
+      <div data-testid="fund-reservation-summary" className="mt-5 space-y-4">
+        {(summary?.currencies ?? []).map((bucket) => (
+          <div key={bucket.currency} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{bucket.currency}</p>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+              {[
+                ['Доступный кредит', bucket.availableCreditAmount, 'Средства, доступные после вычета резервов.'],
+                ['Зарезервировано как депозит', bucket.reservedDepositAmount, 'Средства, удерживаемые под будущую услугу или цель.'],
+                ['Зарезервировано под возврат', bucket.refundReservedAmount, 'Средства по ожидающим или одобренным возвратам.'],
+                ['Получено денег', bucket.cashReceived, 'Фактически полученные клиникой деньги.'],
+                ['Долг', bucket.currentDebt, 'Текущая задолженность по счетам.'],
+              ].map(([label, amount, help]) => (
+                <div key={label as string} title={help as string} className="rounded-lg bg-white p-3">
+                  <p className="text-xs text-slate-500">{label}</p>
+                  <p className="mt-1 text-sm font-semibold text-slate-900">{formatFinanceMoney(amount as number, bucket.currency)}</p>
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-xs text-slate-500" title="Сумма до вычета резервов под возврат и депозит.">Не распределено до резервов: {formatFinanceMoney(bucket.grossUnallocatedAmount, bucket.currency)}</p>
+          </div>
+        ))}
+      </div>
+
+      {!flow.capabilities.canViewReservations && (
+        <div data-testid="fund-reservation-readonly-indicator" className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          {hasDepositSummary ? 'Депозит внесён. Управление доступно финансовым сотрудникам.' : 'Активный депозит не указан.'}
+        </div>
+      )}
+
+      {flow.capabilities.canViewReservations && (
+        <>
+          <div className="mt-6 flex flex-wrap gap-2" aria-label="Фильтры депозитов">
+            {([
+              ['all', 'Все'],
+              ['active', 'Активные'],
+              ['used', 'Использованные'],
+              ['released', 'Освобождённые'],
+            ] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                data-testid={`fund-reservation-filter-${value}`}
+                aria-pressed={filter === value}
+                onClick={() => setFilter(value)}
+                className={`rounded-full px-3 py-1.5 text-sm font-medium ${filter === value ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700'}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {reservationQuery.loading && <p data-testid="fund-reservation-loading" className="mt-5 text-sm text-slate-500">Загружаем кредит и депозиты…</p>}
+          {reservationQuery.error && <p data-testid="fund-reservation-load-error" className="mt-5 rounded-lg bg-rose-50 p-3 text-sm text-rose-700">{reservationQuery.error.message}</p>}
+          {flow.actionMessage && !createOpen && !releaseReservation && !useReservation && (
+            <p data-testid="fund-reservation-action-message" aria-live="polite" className={`mt-5 rounded-lg p-3 text-sm ${flow.actionState === 'failed' ? 'bg-rose-50 text-rose-700' : flow.actionState === 'succeeded' ? 'bg-emerald-50 text-emerald-800' : 'bg-blue-50 text-blue-800'}`}>{flow.actionMessage}</p>
+          )}
+
+          {!reservationQuery.loading && !reservationQuery.error && reservationQuery.reservations.length === 0 && (
+            <p data-testid="fund-reservation-empty" className="mt-5 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500">У пациента пока нет депозитов.</p>
+          )}
+          {!reservationQuery.loading && !reservationQuery.error && reservationQuery.reservations.length > 0 && filtered.length === 0 && (
+            <p data-testid="fund-reservation-filter-empty" className="mt-5 rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500">По выбранному фильтру депозитов нет.</p>
+          )}
+
+          {active.length > 0 && (
+            <div className="mt-6 space-y-4" data-testid="fund-reservation-active-section">
+              <h3 className="text-base font-semibold text-slate-900">Активные</h3>
+              {active.map((reservation) => (
+                <PatientFundReservationCard
+                  key={reservation.id}
+                  reservation={reservation}
+                  payment={paymentMap.get(reservation.paymentId)}
+                  invoices={invoices}
+                  canRelease={flow.capabilities.canRelease}
+                  canUse={flow.capabilities.canUse}
+                  pending={flow.actionLoading}
+                  onRelease={(selected) => { flow.clearActionFeedback(); setReleaseReservation(selected); }}
+                  onUse={(selected) => { flow.clearActionFeedback(); setUseReservation(selected); }}
+                />
+              ))}
+            </div>
+          )}
+
+          {completed.length > 0 && (
+            <div className="mt-6 space-y-4" data-testid="fund-reservation-completed-section">
+              <h3 className="text-base font-semibold text-slate-900">Завершённые</h3>
+              {completed.map((reservation) => (
+                <PatientFundReservationCard key={reservation.id} reservation={reservation} payment={paymentMap.get(reservation.paymentId)} invoices={invoices} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <CreateFundReservationDialog
+        open={createOpen}
+        payments={payments}
+        capacities={reservationQuery.capacities}
+        appointments={appointmentOptions}
+        treatmentPlans={treatmentPlanOptions}
+        pending={flow.actionLoading && flow.actionState !== 'failed'}
+        actionMessage={flow.actionMessage}
+        onClose={() => { setCreateOpen(false); flow.clearActionFeedback(); }}
+        onSubmit={async (values) => {
+          const result = await flow.createReservation(values);
+          if (result) setCreateOpen(false);
+        }}
+      />
+      <ReleaseFundReservationDialog
+        open={Boolean(releaseReservation)}
+        reservation={releaseReservation}
+        pending={flow.actionLoading && flow.actionState !== 'failed'}
+        actionMessage={flow.actionMessage}
+        onClose={() => { setReleaseReservation(null); flow.clearActionFeedback(); }}
+        onSubmit={async (values) => {
+          const result = await flow.releaseReservation(values);
+          if (result) setReleaseReservation(null);
+        }}
+      />
+      <UseReservedCreditDialog
+        open={Boolean(useReservation)}
+        reservation={useReservation}
+        invoices={invoices}
+        pending={flow.actionLoading && flow.actionState !== 'failed'}
+        actionMessage={flow.actionMessage}
+        onClose={() => { setUseReservation(null); flow.clearActionFeedback(); }}
+        onSubmit={async (values) => {
+          const result = await flow.useReservedCredit(values);
+          if (result) setUseReservation(null);
+        }}
+      />
+    </section>
+  );
+}

--- a/src/components/finance/ReleaseFundReservationDialog.test.tsx
+++ b/src/components/finance/ReleaseFundReservationDialog.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PatientFundReservation } from '../../data/repositories/FinanceRepository';
+import { ReleaseFundReservationDialog } from './ReleaseFundReservationDialog';
+
+const reservation = { id: 'reservation-1', tenantId: 'tenant-1', patientId: 'patient-1', paymentId: 'payment-1', currency: 'KZT', purposeType: 'general', purposeLabel: null, appointmentId: null, treatmentPlanId: null, originalAmount: 300, consumedAmount: 50, releasedAmount: 0, remainingAmount: 250, status: 'partially_used', expiresAt: null, notes: null, createdAt: '2026-07-11T00:00:00Z', updatedAt: null, releasedAt: null, archivedAt: null } as PatientFundReservation;
+
+describe('ReleaseFundReservationDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(overrides: Partial<React.ComponentProps<typeof ReleaseFundReservationDialog>> = {}) {
+    const props: React.ComponentProps<typeof ReleaseFundReservationDialog> = {
+      open: true,
+      reservation,
+      pending: false,
+      actionMessage: null,
+      onClose: vi.fn(),
+      onSubmit: vi.fn(),
+      ...overrides,
+    };
+    await act(async () => { root.render(<ReleaseFundReservationDialog {...props} />); });
+    return props;
+  }
+
+  it('shows full-release warning without refund language', async () => {
+    await render();
+    expect(container.textContent).toContain('250');
+    expect(container.textContent).toContain('вернуть сумму в доступный кредит');
+    expect(container.textContent).toContain('Это не возврат денег пациенту');
+  });
+
+  it('requires a release reason', async () => {
+    const props = await render();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-release-submit"]')?.click(); });
+    expect(container.textContent).toContain('Укажите причину освобождения резерва');
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits reservation id and trimmed reason with no partial amount', async () => {
+    const props = await render();
+    const field = container.querySelector<HTMLTextAreaElement>('[data-testid="fund-reservation-release-reason"]');
+    await act(async () => {
+      if (field) {
+        const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+        setter?.call(field, '  Отмена записи  ');
+        field.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-release-submit"]')?.click(); });
+    expect(props.onSubmit).toHaveBeenCalledWith({ reservationId: reservation.id, reason: 'Отмена записи' });
+  });
+
+  it('blocks duplicate submit while pending and closes with Escape otherwise', async () => {
+    const pendingProps = await render({ pending: true });
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="fund-reservation-release-submit"]')?.disabled).toBe(true);
+    await act(async () => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(pendingProps.onClose).not.toHaveBeenCalled();
+    const props = await render({ pending: false });
+    await act(async () => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/finance/ReleaseFundReservationDialog.tsx
+++ b/src/components/finance/ReleaseFundReservationDialog.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react-hooks/set-state-in-effect -- opening a dialog intentionally resets stale patient form values */
+import { useEffect, useState, type FormEvent } from 'react';
+import type { PatientFundReservation } from '../../data/repositories/FinanceRepository';
+import type { ReleaseFundReservationValues } from '../../data/hooks/usePatientFundReservationFlow';
+import { formatFinanceMoney } from './financeLabels';
+
+interface ReleaseFundReservationDialogProps {
+  open: boolean;
+  reservation: PatientFundReservation | null;
+  pending?: boolean;
+  actionMessage?: string | null;
+  onClose: () => void;
+  onSubmit: (values: ReleaseFundReservationValues) => Promise<unknown> | unknown;
+}
+
+export function ReleaseFundReservationDialog({
+  open,
+  reservation,
+  pending = false,
+  actionMessage,
+  onClose,
+  onSubmit,
+}: ReleaseFundReservationDialogProps) {
+  const [reason, setReason] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !pending) onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, open, pending]);
+
+  useEffect(() => {
+    if (!open) return;
+    setReason('');
+    setValidationError(null);
+  }, [open, reservation?.id]);
+
+  if (!open || !reservation) return null;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalized = reason.trim();
+    if (!normalized) {
+      setValidationError('Укажите причину освобождения резерва.');
+      return;
+    }
+    setValidationError(null);
+    await onSubmit({ reservationId: reservation.id, reason: normalized });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" data-testid="release-fund-reservation-dialog-backdrop">
+      <section role="dialog" aria-modal="true" aria-labelledby="release-fund-reservation-title" data-testid="release-fund-reservation-dialog" className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <h3 id="release-fund-reservation-title" className="text-lg font-semibold text-slate-900">Освободить резерв</h3>
+        <p className="mt-2 text-sm text-slate-600">Оставшийся резерв: <strong>{formatFinanceMoney(reservation.remainingAmount, reservation.currency)}</strong>.</p>
+        <p className="mt-3 rounded-lg bg-amber-50 p-3 text-sm text-amber-800">Освободить оставшийся резерв и вернуть сумму в доступный кредит? Это не возврат денег пациенту.</p>
+        <form onSubmit={handleSubmit} className="mt-5 space-y-4">
+          <label className="block text-sm font-medium text-slate-700" htmlFor="fund-reservation-release-reason">Причина
+            <textarea id="fund-reservation-release-reason" data-testid="fund-reservation-release-reason" value={reason} onChange={(event) => setReason(event.target.value)} disabled={pending} maxLength={1000} rows={3} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" />
+          </label>
+          {(validationError || actionMessage) && (
+            <p data-testid="release-fund-reservation-message" aria-live="polite" className={`rounded-lg p-3 text-sm ${validationError ? 'bg-rose-50 text-rose-700' : 'bg-blue-50 text-blue-800'}`}>{validationError || actionMessage}</p>
+          )}
+          <div className="flex justify-end gap-3">
+            <button type="button" onClick={onClose} disabled={pending} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium disabled:opacity-50">Отмена</button>
+            <button type="submit" data-testid="fund-reservation-release-submit" disabled={pending} className="rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{pending ? 'Проверяем…' : 'Освободить резерв'}</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/components/finance/UseReservedCreditDialog.test.tsx
+++ b/src/components/finance/UseReservedCreditDialog.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Invoice, PatientFundReservation } from '../../data/repositories/FinanceRepository';
+import { UseReservedCreditDialog } from './UseReservedCreditDialog';
+
+const reservation = { id: 'reservation-1', tenantId: 'tenant-1', patientId: 'patient-1', paymentId: 'payment-1', currency: 'KZT', purposeType: 'service', purposeLabel: 'Имплантация', appointmentId: null, treatmentPlanId: null, originalAmount: 400, consumedAmount: 100, releasedAmount: 0, remainingAmount: 300, status: 'partially_used', expiresAt: null, notes: null, createdAt: '2026-07-11T00:00:00Z', updatedAt: null, releasedAt: null, archivedAt: null } as PatientFundReservation;
+const invoice = { id: 'invoice-1', tenantId: reservation.tenantId, patientId: reservation.patientId, invoiceNumber: 'INV-1', status: 'issued', currency: 'KZT', balanceAmount: 250 } as Invoice;
+const unavailable = { ...invoice, id: 'invoice-2', status: 'voided', balanceAmount: 1000 } as Invoice;
+
+function setNativeInputValue(element: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(element, value);
+}
+
+async function change(element: HTMLInputElement | HTMLSelectElement | null, value: string) {
+  await act(async () => {
+    if (!element) return;
+    if (element instanceof HTMLSelectElement) {
+      element.value = value;
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+    } else {
+      setNativeInputValue(element, value);
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  });
+}
+
+describe('UseReservedCreditDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(overrides: Partial<React.ComponentProps<typeof UseReservedCreditDialog>> = {}) {
+    const props: React.ComponentProps<typeof UseReservedCreditDialog> = {
+      open: true,
+      reservation,
+      invoices: [invoice, unavailable],
+      pending: false,
+      actionMessage: null,
+      onClose: vi.fn(),
+      onSubmit: vi.fn(),
+      ...overrides,
+    };
+    await act(async () => { root.render(<UseReservedCreditDialog {...props} />); });
+    return props;
+  }
+
+  it('shows eligible invoice debt and excludes voided invoices', async () => {
+    await render();
+    const select = container.querySelector<HTMLSelectElement>('[data-testid="use-reserved-credit-invoice"]');
+    expect(select?.options).toHaveLength(1);
+    expect(select?.textContent).toContain('INV-1');
+    expect(container.textContent).toContain('Долг по счёту');
+    expect(container.textContent).toContain('250');
+  });
+
+  it('limits amount by reservation remainder and invoice debt', async () => {
+    const props = await render();
+    await change(container.querySelector('[data-testid="use-reserved-credit-amount"]'), '260');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="use-reserved-credit-submit"]')?.click(); });
+    expect(container.textContent).toContain('превышает доступный остаток депозита или долг по счёту');
+    expect(props.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('shows remaining reservation and submits controlled allocation values', async () => {
+    const props = await render();
+    await change(container.querySelector('[data-testid="use-reserved-credit-amount"]'), '200');
+    expect(container.querySelector('[data-testid="use-reserved-credit-remaining"]')?.textContent).toContain('100');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="use-reserved-credit-submit"]')?.click(); });
+    expect(props.onSubmit).toHaveBeenCalledWith({ reservationId: reservation.id, invoiceId: invoice.id, amount: 200 });
+    expect(container.textContent).not.toContain('Принять оплату');
+  });
+
+  it('renders safe no-invoice state', async () => {
+    await render({ invoices: [unavailable] });
+    expect(container.querySelector('[data-testid="use-reserved-credit-no-invoices"]')?.textContent).toContain('Нет доступных счетов');
+    expect(container.querySelector('[data-testid="use-reserved-credit-submit"]')).toBeNull();
+  });
+
+  it('disables duplicate submit during reconciliation and supports Escape', async () => {
+    const pendingProps = await render({ pending: true, actionMessage: 'Проверяем текущее состояние операции…' });
+    expect(container.querySelector<HTMLButtonElement>('[data-testid="use-reserved-credit-submit"]')?.disabled).toBe(true);
+    expect(container.textContent).toContain('Проверяем текущее состояние операции');
+    await act(async () => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(pendingProps.onClose).not.toHaveBeenCalled();
+    const props = await render({ pending: false });
+    await act(async () => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/finance/UseReservedCreditDialog.tsx
+++ b/src/components/finance/UseReservedCreditDialog.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable react-hooks/set-state-in-effect -- opening a dialog intentionally resets stale patient form values */
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import type { Invoice, PatientFundReservation } from '../../data/repositories/FinanceRepository';
+import type { UseReservedCreditValues } from '../../data/hooks/usePatientFundReservationFlow';
+import { formatFinanceMoney } from './financeLabels';
+import { getPatientFundReservationPurposeLabel } from './fundReservationLabels';
+
+interface UseReservedCreditDialogProps {
+  open: boolean;
+  reservation: PatientFundReservation | null;
+  invoices: Invoice[];
+  pending?: boolean;
+  actionMessage?: string | null;
+  onClose: () => void;
+  onSubmit: (values: UseReservedCreditValues) => Promise<unknown> | unknown;
+}
+
+function parseAmount(value: string) {
+  const amount = Number(value.replace(',', '.'));
+  return Number.isFinite(amount) ? amount : Number.NaN;
+}
+
+export function UseReservedCreditDialog({
+  open,
+  reservation,
+  invoices,
+  pending = false,
+  actionMessage,
+  onClose,
+  onSubmit,
+}: UseReservedCreditDialogProps) {
+  const eligibleInvoices = useMemo(() => {
+    if (!reservation) return [];
+    return invoices.filter((invoice) => (
+      invoice.tenantId === reservation.tenantId
+      && invoice.patientId === reservation.patientId
+      && invoice.currency === reservation.currency
+      && ['issued', 'partially_paid'].includes(invoice.status)
+      && invoice.balanceAmount > 0
+    ));
+  }, [invoices, reservation]);
+  const [invoiceId, setInvoiceId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !pending) onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, open, pending]);
+
+  useEffect(() => {
+    if (!open) return;
+    setInvoiceId(eligibleInvoices[0]?.id ?? '');
+    setAmount('');
+    setValidationError(null);
+  }, [eligibleInvoices, open, reservation?.id]);
+
+  if (!open || !reservation) return null;
+  const invoice = eligibleInvoices.find((candidate) => candidate.id === invoiceId) ?? null;
+  const parsedAmount = parseAmount(amount);
+  const remainingAfter = Number.isFinite(parsedAmount)
+    ? Math.max(0, reservation.remainingAmount - parsedAmount)
+    : reservation.remainingAmount;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setValidationError(null);
+    if (!invoice) {
+      setValidationError('Выбранный счёт недоступен для использования депозита.');
+      return;
+    }
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      setValidationError('Сумма должна быть больше 0.');
+      return;
+    }
+    if (parsedAmount > reservation.remainingAmount || parsedAmount > invoice.balanceAmount) {
+      setValidationError('Сумма превышает доступный остаток депозита или долг по счёту.');
+      return;
+    }
+    await onSubmit({ reservationId: reservation.id, invoiceId: invoice.id, amount: parsedAmount });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" data-testid="use-reserved-credit-dialog-backdrop">
+      <section role="dialog" aria-modal="true" aria-labelledby="use-reserved-credit-title" data-testid="use-reserved-credit-dialog" className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
+        <h3 id="use-reserved-credit-title" className="text-lg font-semibold text-slate-900">Использовать депозит</h3>
+        <p className="mt-1 text-sm text-slate-500">Распределяется ранее полученный кредит. Новая оплата не принимается.</p>
+        <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm">
+          <p><span className="text-slate-500">Назначение:</span> <strong>{getPatientFundReservationPurposeLabel(reservation.purposeType, reservation.purposeLabel)}</strong></p>
+          <p className="mt-1"><span className="text-slate-500">Остаток:</span> <strong>{formatFinanceMoney(reservation.remainingAmount, reservation.currency)}</strong></p>
+        </div>
+
+        {eligibleInvoices.length === 0 ? (
+          <p data-testid="use-reserved-credit-no-invoices" className="mt-5 rounded-lg bg-amber-50 p-3 text-sm text-amber-800">Нет доступных счетов с задолженностью в валюте депозита.</p>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-5 space-y-4">
+            <label className="block text-sm font-medium text-slate-700" htmlFor="use-reserved-credit-invoice">Счёт
+              <select id="use-reserved-credit-invoice" data-testid="use-reserved-credit-invoice" value={invoiceId} onChange={(event) => setInvoiceId(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                {eligibleInvoices.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>{candidate.invoiceNumber || candidate.id.slice(0, 8)} · долг {formatFinanceMoney(candidate.balanceAmount, candidate.currency)}</option>
+                ))}
+              </select>
+            </label>
+            {invoice && (
+              <p data-testid="use-reserved-credit-invoice-balance" className="rounded-lg bg-slate-50 p-3 text-sm text-slate-700">Долг по счёту: <strong>{formatFinanceMoney(invoice.balanceAmount, invoice.currency)}</strong></p>
+            )}
+            <label className="block text-sm font-medium text-slate-700" htmlFor="use-reserved-credit-amount">Сумма
+              <input id="use-reserved-credit-amount" data-testid="use-reserved-credit-amount" inputMode="decimal" min="0.01" step="0.01" value={amount} onChange={(event) => setAmount(event.target.value)} disabled={pending} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" />
+            </label>
+            <p data-testid="use-reserved-credit-remaining" className="text-sm text-slate-600">Останется в резерве: <strong>{formatFinanceMoney(remainingAfter, reservation.currency)}</strong></p>
+            {(validationError || actionMessage) && (
+              <p data-testid="use-reserved-credit-message" aria-live="polite" className={`rounded-lg p-3 text-sm ${validationError ? 'bg-rose-50 text-rose-700' : 'bg-blue-50 text-blue-800'}`}>{validationError || actionMessage}</p>
+            )}
+            <div className="flex justify-end gap-3">
+              <button type="button" onClick={onClose} disabled={pending} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium disabled:opacity-50">Отмена</button>
+              <button type="submit" data-testid="use-reserved-credit-submit" disabled={pending || eligibleInvoices.length === 0} className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{pending ? 'Проверяем…' : 'Использовать депозит'}</button>
+            </div>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/finance/fundReservationLabels.ts
+++ b/src/components/finance/fundReservationLabels.ts
@@ -1,0 +1,42 @@
+import type {
+  PatientFundReservationPurpose,
+  PatientFundReservationStatus,
+} from '../../data/repositories/FinanceRepository';
+
+export const patientFundReservationStatusLabels: Record<PatientFundReservationStatus, string> = {
+  active: 'Активен',
+  partially_used: 'Частично использован',
+  fully_used: 'Использован полностью',
+  released: 'Освобождён',
+  refunded: 'Возвращён',
+  archived: 'Архив',
+};
+
+export const patientFundReservationPurposeLabels: Record<PatientFundReservationPurpose, string> = {
+  general: 'Общий депозит',
+  appointment: 'Под запись',
+  treatment_plan: 'Под план лечения',
+  service: 'Под услугу',
+  other: 'Другое',
+};
+
+export function getPatientFundReservationPurposeLabel(
+  purposeType: PatientFundReservationPurpose,
+  purposeLabel?: string | null,
+) {
+  if (purposeType === 'other') return purposeLabel?.trim() || 'Другое';
+  if (purposeType === 'service' && purposeLabel?.trim()) return purposeLabel.trim();
+  return patientFundReservationPurposeLabels[purposeType];
+}
+
+export function isActiveFundReservationStatus(status: PatientFundReservationStatus) {
+  return status === 'active' || status === 'partially_used';
+}
+
+export function isUsedFundReservationStatus(status: PatientFundReservationStatus) {
+  return status === 'partially_used' || status === 'fully_used';
+}
+
+export function isTerminalFundReservationStatus(status: PatientFundReservationStatus) {
+  return !isActiveFundReservationStatus(status);
+}

--- a/src/components/finance/fundReservationPermissions.ts
+++ b/src/components/finance/fundReservationPermissions.ts
@@ -1,0 +1,48 @@
+import type { FinanceUserRole } from './financePermissions';
+
+export interface FundReservationCapabilities {
+  canViewSummary: boolean;
+  canViewReservations: boolean;
+  canCreate: boolean;
+  canRelease: boolean;
+  canUse: boolean;
+}
+
+export function getFundReservationCapabilities(role: FinanceUserRole): FundReservationCapabilities {
+  switch (role) {
+    case 'clinic_owner':
+    case 'clinic_admin':
+      return {
+        canViewSummary: true,
+        canViewReservations: true,
+        canCreate: true,
+        canRelease: true,
+        canUse: true,
+      };
+    case 'cashier':
+      return {
+        canViewSummary: true,
+        canViewReservations: true,
+        canCreate: true,
+        canRelease: false,
+        canUse: true,
+      };
+    case 'doctor':
+    case 'registrar':
+      return {
+        canViewSummary: true,
+        canViewReservations: false,
+        canCreate: false,
+        canRelease: false,
+        canUse: false,
+      };
+    default:
+      return {
+        canViewSummary: false,
+        canViewReservations: false,
+        canCreate: false,
+        canRelease: false,
+        canUse: false,
+      };
+  }
+}

--- a/src/data/hooks/usePatientFundReservationFlow.test.tsx
+++ b/src/data/hooks/usePatientFundReservationFlow.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  FinanceRepository,
+  Invoice,
+  PatientFundReservation,
+  PaymentAllocation,
+  PaymentFundCapacity,
+} from '../repositories/FinanceRepository';
+import type { FinanceRpcClient, PatientFundReservationOperationResult } from '../repositories/FinanceRpcClient';
+import { usePatientFundReservationFlow } from './usePatientFundReservationFlow';
+
+vi.mock('../../lib/supabaseClient', () => ({ supabase: {}, isSupabaseConfigured: true }));
+
+const tenantId = 'tenant-1';
+const patientId = 'patient-1';
+const paymentId = 'payment-1';
+const invoice = {
+  id: 'invoice-1', tenantId, patientId, invoiceNumber: 'INV-1', status: 'issued', currency: 'KZT', balanceAmount: 500,
+} as Invoice;
+const capacity = {
+  paymentId, patientId, currency: 'KZT', paymentAmount: 1000, activeAllocatedAmount: 0,
+  completedRefundAmount: 0, refundReservedAmount: 0, reservedDepositAmount: 300,
+  grossUnallocatedAmount: 1000, availableCreditAmount: 700,
+} as PaymentFundCapacity;
+const activeReservation = {
+  id: 'reservation-1', tenantId, patientId, paymentId, currency: 'KZT', purposeType: 'general', purposeLabel: null,
+  appointmentId: null, treatmentPlanId: null, originalAmount: 300, consumedAmount: 0, releasedAmount: 0,
+  remainingAmount: 300, status: 'active', expiresAt: null, notes: null, createdAt: '2026-07-11T00:00:00Z',
+  updatedAt: null, releasedAt: null, archivedAt: null,
+} as PatientFundReservation;
+const allocation = {
+  id: 'allocation-1', tenantId, patientId, paymentId, invoiceId: invoice.id, invoiceItemId: null,
+  amount: 100, currency: 'KZT', status: 'active', allocatedAt: '2026-07-11T00:00:00Z', metadata: {},
+  createdBy: null, voidedBy: null, voidReason: null, voidedAt: null, createdAt: '2026-07-11T00:00:00Z',
+  updatedAt: '2026-07-11T00:00:00Z', patientFundReservationId: activeReservation.id,
+  reservationOperationKey: null, reservationOperationFingerprint: null,
+} as PaymentAllocation;
+
+function result(reservation = activeReservation, allocationValue: PaymentAllocation | null = null): PatientFundReservationOperationResult {
+  return { status: 'completed', reservation, allocation: allocationValue, capacity };
+}
+
+function repository(): FinanceRepository {
+  return {
+    getPaymentFundCapacity: vi.fn().mockResolvedValue(capacity),
+    getPatientFundReservations: vi.fn().mockResolvedValue([activeReservation]),
+    listPaymentAllocations: vi.fn().mockResolvedValue([]),
+  } as unknown as FinanceRepository;
+}
+
+function rpcClient(): FinanceRpcClient {
+  return {
+    createPatientFundReservation: vi.fn().mockResolvedValue(result()),
+    releasePatientFundReservation: vi.fn().mockResolvedValue(result({ ...activeReservation, status: 'released', releasedAmount: 300, remainingAmount: 0 })),
+    allocateReservedCredit: vi.fn().mockResolvedValue(result({ ...activeReservation, status: 'partially_used', consumedAmount: 100, remainingAmount: 200 }, allocation)),
+  } as unknown as FinanceRpcClient;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe('usePatientFundReservationFlow', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: ReturnType<typeof usePatientFundReservationFlow> | null;
+
+  function Harness(props: {
+    tenant?: string | null;
+    patient?: string | null;
+    role?: string;
+    repo: FinanceRepository;
+    client: FinanceRpcClient;
+    reservations?: PatientFundReservation[];
+    invoices?: Invoice[];
+    onChanged?: () => Promise<void> | void;
+    refreshReservations?: () => Promise<void> | void;
+  }) {
+    latest = usePatientFundReservationFlow({
+      tenantId: props.tenant,
+      patientId: props.patient,
+      role: props.role,
+      repository: props.repo,
+      rpcClient: props.client,
+      reservations: props.reservations,
+      invoices: props.invoices,
+      onChanged: props.onChanged,
+      refreshReservations: props.refreshReservations,
+    });
+    return null;
+  }
+
+  beforeEach(() => {
+    latest = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function renderFlow(overrides: Partial<Parameters<typeof Harness>[0]> = {}) {
+    const repo = overrides.repo ?? repository();
+    const client = overrides.client ?? rpcClient();
+    await act(async () => {
+      root.render(<Harness tenant={tenantId} patient={patientId} role="clinic_admin" repo={repo} client={client} reservations={[activeReservation]} invoices={[invoice]} {...overrides} />);
+    });
+    return { repo, client };
+  }
+
+  it('maps create parameters and refreshes list and summary', async () => {
+    const onChanged = vi.fn();
+    const refreshReservations = vi.fn();
+    const { client } = await renderFlow({ onChanged, refreshReservations, reservations: [] });
+    await act(async () => {
+      await latest?.createReservation({ paymentId, amount: 300, purposeType: 'other', purposeLabel: '  Имплантация  ', notes: '  note  ' });
+    });
+    expect(client.createPatientFundReservation).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId, patientId, paymentId, amount: 300, purposeType: 'other', purposeLabel: 'Имплантация', notes: 'note',
+      idempotencyKey: expect.stringContaining('fund-create:'),
+    }));
+    expect(refreshReservations).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(latest?.actionMessage).toBe('Депозит создан.');
+  });
+
+  it('retains the same create idempotency key after ambiguous unconfirmed response', async () => {
+    const repo = repository();
+    vi.mocked(repo.getPatientFundReservations).mockResolvedValue([]);
+    const client = rpcClient();
+    vi.mocked(client.createPatientFundReservation).mockRejectedValue({ code: 'PGRST', message: 'network response lost' });
+    await renderFlow({ repo, client, reservations: [] });
+    const values = { paymentId, amount: 300, purposeType: 'general' as const };
+    await act(async () => { await latest?.createReservation(values); });
+    await act(async () => { await latest?.createReservation(values); });
+    const first = vi.mocked(client.createPatientFundReservation).mock.calls[0][0].idempotencyKey;
+    const second = vi.mocked(client.createPatientFundReservation).mock.calls[1][0].idempotencyKey;
+    expect(second).toBe(first);
+    expect(latest?.actionMessage).toBe('Не удалось выполнить операцию. Данные обновлены, повторите попытку.');
+  });
+
+  it('treats committed create with lost response as success after reconciliation', async () => {
+    const repo = repository();
+    const committed = { ...activeReservation, id: 'reservation-created', originalAmount: 250, remainingAmount: 250, notes: 'lost' };
+    vi.mocked(repo.getPatientFundReservations).mockResolvedValue([committed]);
+    const client = rpcClient();
+    vi.mocked(client.createPatientFundReservation).mockRejectedValue(new Error('network timeout'));
+    await renderFlow({ repo, client, reservations: [] });
+    let operationResult: unknown;
+    await act(async () => {
+      operationResult = await latest?.createReservation({ paymentId, amount: 250, purposeType: 'general', notes: 'lost' });
+    });
+    expect(operationResult).toEqual(expect.objectContaining({ status: 'already_completed', reservation: committed }));
+    expect(latest?.actionState).toBe('succeeded');
+    expect(latest?.actionMessage).toBe('Депозит создан.');
+  });
+
+  it('reconciles a release after an uncertain response and keeps release full-only', async () => {
+    const repo = repository();
+    const released = { ...activeReservation, status: 'released' as const, releasedAmount: 300, remainingAmount: 0, releasedAt: '2026-07-11T01:00:00Z' };
+    vi.mocked(repo.getPatientFundReservations).mockResolvedValue([released]);
+    const client = rpcClient();
+    vi.mocked(client.releasePatientFundReservation).mockRejectedValue(new Error('response lost'));
+    await renderFlow({ repo, client });
+    await act(async () => { await latest?.releaseReservation({ reservationId: activeReservation.id, reason: '  По просьбе пациента  ' }); });
+    expect(client.releasePatientFundReservation).toHaveBeenCalledWith(expect.objectContaining({
+      reservationId: activeReservation.id, amount: null, reason: 'По просьбе пациента', idempotencyKey: expect.stringContaining('fund-release:'),
+    }));
+    expect(latest?.actionMessage).toBe('Резерв освобождён.');
+  });
+
+  it('reconciles a reserved-credit allocation and never calls recordPayment', async () => {
+    const repo = repository();
+    const consumed = { ...activeReservation, status: 'partially_used' as const, consumedAmount: 100, remainingAmount: 200 };
+    vi.mocked(repo.getPatientFundReservations).mockResolvedValue([consumed]);
+    vi.mocked(repo.listPaymentAllocations)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([allocation]);
+    const client = rpcClient();
+    vi.mocked(client.allocateReservedCredit).mockRejectedValue(new Error('response lost'));
+    await renderFlow({ repo, client });
+    await act(async () => { await latest?.useReservedCredit({ reservationId: activeReservation.id, invoiceId: invoice.id, amount: 100 }); });
+    expect(client.allocateReservedCredit).toHaveBeenCalledWith(expect.objectContaining({ amount: 100, invoiceId: invoice.id, idempotencyKey: expect.stringContaining('fund-consume:') }));
+    expect((client as unknown as { recordPayment?: unknown }).recordPayment).toBeUndefined();
+    expect(latest?.actionMessage).toBe('Часть депозита использована.');
+  });
+
+  it('blocks release for cashier and mutations for doctor', async () => {
+    const { client } = await renderFlow({ role: 'cashier' });
+    await act(async () => { await latest?.releaseReservation({ reservationId: activeReservation.id, reason: 'reason' }); });
+    expect(client.releasePatientFundReservation).not.toHaveBeenCalled();
+    expect(latest?.actionMessage).toBe('Недостаточно прав для этой операции.');
+
+    await act(async () => {
+      root.render(<Harness tenant={tenantId} patient={patientId} role="doctor" repo={repository()} client={client} reservations={[activeReservation]} invoices={[invoice]} />);
+    });
+    await act(async () => { await latest?.createReservation({ paymentId, amount: 100, purposeType: 'general' }); });
+    expect(client.createPatientFundReservation).not.toHaveBeenCalled();
+  });
+
+  it('blocks invalid amount, other purpose and unavailable invoice before RPC', async () => {
+    const { client } = await renderFlow();
+    await act(async () => { await latest?.createReservation({ paymentId, amount: 0, purposeType: 'general' }); });
+    expect(latest?.actionMessage).toBe('Сумма должна быть больше 0.');
+    await act(async () => { await latest?.createReservation({ paymentId, amount: 10, purposeType: 'other', purposeLabel: 'x' }); });
+    expect(latest?.actionMessage).toBe('Укажите назначение от 2 до 120 символов.');
+    await act(async () => { await latest?.useReservedCredit({ reservationId: activeReservation.id, invoiceId: 'missing', amount: 10 }); });
+    expect(latest?.actionMessage).toBe('Выбранный счёт недоступен для использования депозита.');
+    expect(client.allocateReservedCredit).not.toHaveBeenCalled();
+  });
+
+  it('blocks duplicate submit while the same action is in flight', async () => {
+    const client = rpcClient();
+    const pending = deferred<PatientFundReservationOperationResult>();
+    vi.mocked(client.createPatientFundReservation).mockReturnValue(pending.promise);
+    await renderFlow({ client, reservations: [] });
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
+    await act(async () => {
+      first = latest!.createReservation({ paymentId, amount: 100, purposeType: 'general' });
+      second = latest!.createReservation({ paymentId, amount: 100, purposeType: 'general' });
+      await Promise.resolve();
+    });
+    expect(client.createPatientFundReservation).toHaveBeenCalledTimes(1);
+    pending.resolve(result({ ...activeReservation, originalAmount: 100, remainingAmount: 100 }));
+    await act(async () => { await Promise.all([first, second]); });
+  });
+
+  it('ignores stale mutation completion after patient switch and clears dialog state', async () => {
+    const client = rpcClient();
+    const pending = deferred<PatientFundReservationOperationResult>();
+    vi.mocked(client.createPatientFundReservation).mockReturnValue(pending.promise);
+    const repo = repository();
+    await renderFlow({ client, repo, reservations: [] });
+    let call!: Promise<unknown>;
+    await act(async () => { call = latest!.createReservation({ paymentId, amount: 100, purposeType: 'general' }); await Promise.resolve(); });
+    await act(async () => {
+      root.render(<Harness tenant={tenantId} patient="patient-2" role="clinic_admin" repo={repo} client={client} reservations={[]} invoices={[]} />);
+    });
+    expect(latest?.actionState).toBe('idle');
+    pending.resolve(result({ ...activeReservation, originalAmount: 100, remainingAmount: 100 }));
+    await act(async () => { await call; });
+    expect(latest?.actionState).toBe('idle');
+    expect(latest?.actionMessage).toBeNull();
+  });
+
+  it('hides raw PostgREST details behind a safe failure', async () => {
+    const repo = repository();
+    vi.mocked(repo.getPatientFundReservations).mockResolvedValue([]);
+    const client = rpcClient();
+    vi.mocked(client.createPatientFundReservation).mockRejectedValue({ code: '23514', message: 'trigger private_finance.secret constraint failed' });
+    await renderFlow({ repo, client, reservations: [] });
+    await act(async () => { await latest?.createReservation({ paymentId, amount: 100, purposeType: 'general' }); });
+    expect(latest?.actionMessage).toBe('Не удалось выполнить операцию. Данные обновлены, повторите попытку.');
+    expect(latest?.actionMessage).not.toContain('trigger');
+    expect(latest?.actionMessage).not.toContain('23514');
+  });
+});

--- a/src/data/hooks/usePatientFundReservationFlow.ts
+++ b/src/data/hooks/usePatientFundReservationFlow.ts
@@ -1,0 +1,487 @@
+/* eslint-disable react-hooks/set-state-in-effect -- finance context changes intentionally clear stale mutation state */
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { getFundReservationCapabilities } from '../../components/finance/fundReservationPermissions';
+import type { FinanceUserRole } from '../../components/finance/financePermissions';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import {
+  createFinanceRepository,
+  type FinanceRepository,
+  type Invoice,
+  type PatientFundReservation,
+  type PaymentAllocation,
+  type PaymentFundCapacity,
+} from '../repositories/FinanceRepository';
+import {
+  createFinanceRpcClient,
+  type FinanceRpcClient,
+  type PatientFundReservationOperationResult,
+} from '../repositories/FinanceRpcClient';
+
+export type FundReservationActionName = 'create' | 'release' | 'consume';
+export type FundReservationActionState = 'idle' | 'submitting' | 'reconciling' | 'succeeded' | 'failed';
+
+export interface CreateFundReservationValues {
+  paymentId: string;
+  amount: number;
+  purposeType: PatientFundReservation['purposeType'];
+  purposeLabel?: string | null;
+  appointmentId?: string | null;
+  treatmentPlanId?: string | null;
+  expiresAt?: string | null;
+  notes?: string | null;
+}
+
+export interface ReleaseFundReservationValues {
+  reservationId: string;
+  reason: string;
+}
+
+export interface UseReservedCreditValues {
+  reservationId: string;
+  invoiceId: string;
+  amount: number;
+}
+
+export interface UsePatientFundReservationFlowOptions {
+  tenantId?: string | null;
+  patientId?: string | null;
+  role?: FinanceUserRole;
+  repository?: FinanceRepository;
+  rpcClient?: FinanceRpcClient;
+  reservations?: PatientFundReservation[];
+  invoices?: Invoice[];
+  onChanged?: () => Promise<void> | void;
+  refreshReservations?: () => Promise<void> | void;
+}
+
+interface OperationKeyRecord {
+  signature: string;
+  key: string;
+}
+
+interface ReconciledFacts {
+  reservations: PatientFundReservation[];
+  allocations: PaymentAllocation[];
+  capacity: PaymentFundCapacity | null;
+}
+
+const GENERIC_SAFE_FAILURE = 'Не удалось выполнить операцию. Данные обновлены, повторите попытку.';
+const RECONCILING_MESSAGE = 'Проверяем текущее состояние операции…';
+
+function operationKey(prefix: string, tenantId: string, patientId: string, entityId: string) {
+  const suffix = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}:${tenantId}:${patientId}:${entityId}:${suffix}`;
+}
+
+function normalizeOptional(value?: string | null) {
+  const normalized = value?.trim() ?? '';
+  return normalized || null;
+}
+
+function validatePurpose(values: CreateFundReservationValues) {
+  if (!['general', 'appointment', 'treatment_plan', 'service', 'other'].includes(values.purposeType)) {
+    throw new Error('Выберите назначение депозита.');
+  }
+  if (values.purposeType === 'other') {
+    const label = normalizeOptional(values.purposeLabel);
+    if (!label || label.length < 2 || label.length > 120) {
+      throw new Error('Укажите назначение от 2 до 120 символов.');
+    }
+  }
+  if (values.purposeType === 'appointment' && !normalizeOptional(values.appointmentId)) {
+    throw new Error('Выберите запись для депозита.');
+  }
+  if (values.purposeType === 'treatment_plan' && !normalizeOptional(values.treatmentPlanId)) {
+    throw new Error('Выберите план лечения для депозита.');
+  }
+  if (values.expiresAt) {
+    const expiry = new Date(values.expiresAt);
+    if (Number.isNaN(expiry.getTime()) || expiry.getTime() < Date.now()) {
+      throw new Error('Дата окончания не может быть в прошлом.');
+    }
+  }
+}
+
+export function safeFundReservationError(error: unknown) {
+  const lower = error instanceof Error ? error.message.toLowerCase() : '';
+  if (lower.includes('недостаточно доступного кредита') || lower.includes('exceeds payment capacity')) {
+    return 'Недостаточно доступного кредита для создания депозита.';
+  }
+  if (lower.includes('платёж недоступен') || lower.includes('payment is not available')) {
+    return 'Платёж недоступен для резервирования.';
+  }
+  if (lower.includes('terminal') || lower.includes('fully used') || lower.includes('cannot be released') || lower.includes('больше нельзя')) {
+    return 'Этот депозит больше нельзя изменить.';
+  }
+  if (lower.includes('already') || lower.includes('idempotency') || lower.includes('ключ операции')) {
+    return 'Операция уже была выполнена или параметры изменились.';
+  }
+  if (lower.includes('invoice') || lower.includes('счёт') || lower.includes('not available')) {
+    return 'Выбранный счёт недоступен для использования депозита.';
+  }
+  if (lower.includes('permission') || lower.includes('denied') || lower.includes('insufficient') || lower.includes('прав')) {
+    return 'Недостаточно прав для этой операции.';
+  }
+  if (lower.includes('зарезервирована как депозит')) {
+    return 'Часть средств зарезервирована как депозит.';
+  }
+  return GENERIC_SAFE_FAILURE;
+}
+
+function findReservation(reservations: PatientFundReservation[], id: string) {
+  return reservations.find((reservation) => reservation.id === id) ?? null;
+}
+
+function createSignature(values: CreateFundReservationValues) {
+  return JSON.stringify([
+    values.paymentId,
+    values.amount,
+    values.purposeType,
+    normalizeOptional(values.purposeLabel),
+    normalizeOptional(values.appointmentId),
+    normalizeOptional(values.treatmentPlanId),
+    values.expiresAt ? new Date(values.expiresAt).toISOString() : null,
+    normalizeOptional(values.notes),
+  ]);
+}
+
+export function usePatientFundReservationFlow({
+  tenantId,
+  patientId,
+  role,
+  repository,
+  rpcClient,
+  reservations = [],
+  invoices = [],
+  onChanged,
+  refreshReservations,
+}: UsePatientFundReservationFlowOptions) {
+  const capabilities = useMemo(() => getFundReservationCapabilities(role), [role]);
+  const financeRepository = useMemo(() => {
+    if (repository) return repository;
+    if (!isSupabaseConfigured) return null;
+    return createFinanceRepository({ backend: 'supabase' });
+  }, [repository]);
+  const client = useMemo(() => {
+    if (rpcClient) return rpcClient;
+    if (!isSupabaseConfigured) return null;
+    return createFinanceRpcClient({ backend: 'supabase' });
+  }, [rpcClient]);
+
+  const contextKey = tenantId && patientId ? `${tenantId}:${patientId}:${role ?? ''}` : null;
+  const contextRef = useRef(contextKey);
+  const reservationsRef = useRef(reservations);
+  const invoicesRef = useRef(invoices);
+  const keyRefs = useRef<Record<FundReservationActionName, OperationKeyRecord | null>>({
+    create: null,
+    release: null,
+    consume: null,
+  });
+  const inFlightRef = useRef<Record<FundReservationActionName, Promise<unknown> | null>>({
+    create: null,
+    release: null,
+    consume: null,
+  });
+  const [actionState, setActionState] = useState<FundReservationActionState>('idle');
+  const [actionName, setActionName] = useState<FundReservationActionName | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    contextRef.current = contextKey;
+    reservationsRef.current = reservations;
+    invoicesRef.current = invoices;
+  }, [contextKey, invoices, reservations]);
+
+  useEffect(() => {
+    setActionState('idle');
+    setActionName(null);
+    setActionMessage(null);
+    keyRefs.current = { create: null, release: null, consume: null };
+    inFlightRef.current = { create: null, release: null, consume: null };
+  }, [contextKey]);
+
+  const refreshAll = useCallback(async () => {
+    await refreshReservations?.();
+    await onChanged?.();
+  }, [onChanged, refreshReservations]);
+
+  const fetchFacts = useCallback(async (paymentId?: string): Promise<ReconciledFacts> => {
+    if (!tenantId || !patientId || !financeRepository) {
+      return { reservations: [], allocations: [], capacity: null };
+    }
+    const [latestReservations, allocations, capacity] = await Promise.all([
+      financeRepository.getPatientFundReservations({ tenantId, patientId }),
+      financeRepository.listPaymentAllocations({ tenantId, patientId, includeVoided: true, limit: 200 }),
+      paymentId
+        ? financeRepository.getPaymentFundCapacity({ tenantId, patientId, paymentId })
+        : Promise.resolve(null),
+    ]);
+    return { reservations: latestReservations, allocations, capacity };
+  }, [financeRepository, patientId, tenantId]);
+
+  const ensureKey = useCallback((action: FundReservationActionName, signature: string, entityId: string) => {
+    if (!tenantId || !patientId) return '';
+    const current = keyRefs.current[action];
+    if (!current || current.signature !== signature) {
+      keyRefs.current[action] = {
+        signature,
+        key: operationKey(`fund-${action}`, tenantId, patientId, entityId),
+      };
+    }
+    return keyRefs.current[action]?.key ?? '';
+  }, [patientId, tenantId]);
+
+  const run = useCallback(async <T extends PatientFundReservationOperationResult>(
+    action: FundReservationActionName,
+    mutation: () => Promise<T>,
+    reconcile: () => Promise<T | null>,
+    successMessage: (result: T) => string,
+  ): Promise<T | undefined> => {
+    if (!contextKey || !client) {
+      setActionState('failed');
+      setActionMessage(GENERIC_SAFE_FAILURE);
+      return undefined;
+    }
+    const existing = inFlightRef.current[action];
+    if (existing) return existing as Promise<T>;
+    const capturedContext = contextKey;
+    setActionName(action);
+    setActionState('submitting');
+    setActionMessage(null);
+    const promise = mutation();
+    inFlightRef.current[action] = promise;
+    try {
+      const result = await promise;
+      if (contextRef.current !== capturedContext) return result;
+      await refreshAll();
+      if (contextRef.current === capturedContext) {
+        keyRefs.current[action] = null;
+        setActionState('succeeded');
+        setActionMessage(successMessage(result));
+      }
+      return result;
+    } catch (error) {
+      if (contextRef.current !== capturedContext) return undefined;
+      setActionState('reconciling');
+      setActionMessage(RECONCILING_MESSAGE);
+      let reconciled: T | null;
+      try {
+        reconciled = await reconcile();
+        await refreshAll();
+      } catch {
+        reconciled = null;
+      }
+      if (contextRef.current !== capturedContext) return reconciled ?? undefined;
+      if (reconciled) {
+        keyRefs.current[action] = null;
+        setActionState('succeeded');
+        setActionMessage(successMessage(reconciled));
+        return reconciled;
+      }
+      setActionState('failed');
+      setActionMessage(safeFundReservationError(error));
+      return undefined;
+    } finally {
+      if (inFlightRef.current[action] === promise) inFlightRef.current[action] = null;
+      if (contextRef.current === capturedContext) setActionName(null);
+    }
+  }, [client, contextKey, refreshAll]);
+
+  const createReservation = useCallback(async (values: CreateFundReservationValues) => {
+    if (!tenantId || !patientId || !client || !financeRepository || !capabilities.canCreate) {
+      setActionState('failed');
+      setActionMessage('Недостаточно прав для этой операции.');
+      return undefined;
+    }
+    if (!Number.isFinite(values.amount) || values.amount <= 0) {
+      setActionState('failed');
+      setActionMessage('Сумма должна быть больше 0.');
+      return undefined;
+    }
+    try {
+      validatePurpose(values);
+    } catch (error) {
+      setActionState('failed');
+      setActionMessage(error instanceof Error ? error.message : GENERIC_SAFE_FAILURE);
+      return undefined;
+    }
+    let capacity: PaymentFundCapacity | null;
+    try {
+      capacity = await financeRepository.getPaymentFundCapacity({
+        tenantId,
+        patientId,
+        paymentId: values.paymentId,
+      });
+    } catch {
+      setActionState('failed');
+      setActionMessage(GENERIC_SAFE_FAILURE);
+      return undefined;
+    }
+    if (!capacity || capacity.patientId !== patientId || values.amount > capacity.availableCreditAmount) {
+      setActionState('failed');
+      setActionMessage('Недостаточно доступного кредита для создания депозита.');
+      return undefined;
+    }
+    const signature = createSignature(values);
+    const idempotencyKey = ensureKey('create', signature, values.paymentId);
+    const beforeIds = new Set(reservationsRef.current.map((reservation) => reservation.id));
+    const normalizedLabel = normalizeOptional(values.purposeLabel);
+    const normalizedNotes = normalizeOptional(values.notes);
+    return run(
+      'create',
+      () => client.createPatientFundReservation({
+        tenantId,
+        patientId,
+        paymentId: values.paymentId,
+        amount: values.amount,
+        purposeType: values.purposeType,
+        purposeLabel: normalizedLabel,
+        appointmentId: normalizeOptional(values.appointmentId),
+        treatmentPlanId: normalizeOptional(values.treatmentPlanId),
+        expiresAt: values.expiresAt ? new Date(values.expiresAt).toISOString() : null,
+        notes: normalizedNotes,
+        metadata: { source: 'patient_finance_ui' },
+        idempotencyKey,
+      }),
+      async () => {
+        const facts = await fetchFacts(values.paymentId);
+        const reservation = facts.reservations.find((candidate) => (
+          !beforeIds.has(candidate.id)
+          && candidate.paymentId === values.paymentId
+          && candidate.originalAmount === values.amount
+          && candidate.purposeType === values.purposeType
+          && (candidate.purposeLabel ?? null) === normalizedLabel
+          && (candidate.notes ?? null) === normalizedNotes
+        ));
+        if (!reservation || !facts.capacity) return null;
+        return { status: 'already_completed', reservation, allocation: null, capacity: facts.capacity };
+      },
+      () => 'Депозит создан.',
+    );
+  }, [capabilities.canCreate, client, ensureKey, fetchFacts, financeRepository, patientId, run, tenantId]);
+
+  const releaseReservation = useCallback(async ({ reservationId, reason }: ReleaseFundReservationValues) => {
+    if (!tenantId || !patientId || !client || !capabilities.canRelease) {
+      setActionState('failed');
+      setActionMessage('Недостаточно прав для этой операции.');
+      return undefined;
+    }
+    const current = findReservation(reservationsRef.current, reservationId);
+    if (!current || !['active', 'partially_used'].includes(current.status) || current.remainingAmount <= 0) {
+      setActionState('failed');
+      setActionMessage('Этот депозит больше нельзя изменить.');
+      return undefined;
+    }
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      setActionState('failed');
+      setActionMessage('Укажите причину освобождения резерва.');
+      return undefined;
+    }
+    const signature = JSON.stringify([reservationId, current.remainingAmount, normalizedReason]);
+    const idempotencyKey = ensureKey('release', signature, reservationId);
+    return run(
+      'release',
+      () => client.releasePatientFundReservation({
+        tenantId,
+        reservationId,
+        amount: null,
+        reason: normalizedReason,
+        idempotencyKey,
+      }),
+      async () => {
+        const facts = await fetchFacts(current.paymentId);
+        const reservation = findReservation(facts.reservations, reservationId);
+        if (!reservation || reservation.status !== 'released' || reservation.remainingAmount !== 0 || !facts.capacity) return null;
+        return { status: 'already_completed', reservation, allocation: null, capacity: facts.capacity };
+      },
+      () => 'Резерв освобождён.',
+    );
+  }, [capabilities.canRelease, client, ensureKey, fetchFacts, patientId, run, tenantId]);
+
+  const useReservedCredit = useCallback(async ({ reservationId, invoiceId, amount }: UseReservedCreditValues) => {
+    if (!tenantId || !patientId || !client || !capabilities.canUse) {
+      setActionState('failed');
+      setActionMessage('Недостаточно прав для этой операции.');
+      return undefined;
+    }
+    const current = findReservation(reservationsRef.current, reservationId);
+    const invoice = invoicesRef.current.find((candidate) => candidate.id === invoiceId) ?? null;
+    if (!current || !['active', 'partially_used'].includes(current.status) || current.remainingAmount <= 0) {
+      setActionState('failed');
+      setActionMessage('Этот депозит больше нельзя изменить.');
+      return undefined;
+    }
+    if (!invoice || invoice.patientId !== patientId || invoice.tenantId !== tenantId || !['issued', 'partially_paid'].includes(invoice.status) || invoice.balanceAmount <= 0 || invoice.currency !== current.currency) {
+      setActionState('failed');
+      setActionMessage('Выбранный счёт недоступен для использования депозита.');
+      return undefined;
+    }
+    if (!Number.isFinite(amount) || amount <= 0 || amount > current.remainingAmount || amount > invoice.balanceAmount) {
+      setActionState('failed');
+      setActionMessage('Сумма превышает доступный остаток депозита или долг по счёту.');
+      return undefined;
+    }
+    const signature = JSON.stringify([reservationId, invoiceId, amount]);
+    const idempotencyKey = ensureKey('consume', signature, reservationId);
+    const beforeConsumed = current.consumedAmount;
+    const beforeAllocationIds = new Set<string>();
+    if (financeRepository) {
+      try {
+        const beforeAllocations = await financeRepository.listPaymentAllocations({ tenantId, patientId, includeVoided: true, limit: 200 });
+        beforeAllocations.forEach((allocation) => beforeAllocationIds.add(allocation.id));
+      } catch {
+        setActionState('failed');
+        setActionMessage(GENERIC_SAFE_FAILURE);
+        return undefined;
+      }
+    }
+    return run(
+      'consume',
+      () => client.allocateReservedCredit({
+        tenantId,
+        patientId,
+        reservationId,
+        invoiceId,
+        amount,
+        idempotencyKey,
+      }),
+      async () => {
+        const facts = await fetchFacts(current.paymentId);
+        const reservation = findReservation(facts.reservations, reservationId);
+        const allocation = facts.allocations.find((candidate) => (
+          !beforeAllocationIds.has(candidate.id)
+          && candidate.patientFundReservationId === reservationId
+          && candidate.invoiceId === invoiceId
+          && candidate.amount === amount
+          && candidate.status === 'active'
+        )) ?? null;
+        if (!reservation || reservation.consumedAmount < beforeConsumed + amount || !allocation || !facts.capacity) return null;
+        return { status: 'already_completed', reservation, allocation, capacity: facts.capacity };
+      },
+      (result) => result.reservation.status === 'fully_used'
+        ? 'Депозит использован полностью.'
+        : 'Часть депозита использована.',
+    );
+  }, [capabilities.canUse, client, ensureKey, fetchFacts, financeRepository, patientId, run, tenantId]);
+
+  const clearActionFeedback = useCallback(() => {
+    setActionState('idle');
+    setActionMessage(null);
+    setActionName(null);
+  }, []);
+
+  return {
+    createReservation,
+    releaseReservation,
+    useReservedCredit,
+    actionState,
+    actionName,
+    actionMessage,
+    actionLoading: actionState === 'submitting' || actionState === 'reconciling',
+    capabilities,
+    clearActionFeedback,
+  };
+}

--- a/src/data/hooks/usePatientFundReservations.test.tsx
+++ b/src/data/hooks/usePatientFundReservations.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FinanceRepository, PatientFundReservation, Payment, PaymentFundCapacity } from '../repositories/FinanceRepository';
+import { usePatientFundReservations } from './usePatientFundReservations';
+
+vi.mock('../../lib/supabaseClient', () => ({ supabase: {}, isSupabaseConfigured: true }));
+
+const tenantA = 'tenant-a';
+const patientA = 'patient-a';
+const patientB = 'patient-b';
+const paymentA = { id: 'payment-a', tenantId: tenantA, patientId: patientA, status: 'received', paymentMethod: 'cash', amount: 1000, currency: 'KZT', receivedAt: '2026-07-11T00:00:00Z', updatedAt: '2026-07-11T00:00:00Z' } as Payment;
+const reservationA = { id: 'reservation-a', tenantId: tenantA, patientId: patientA, paymentId: paymentA.id, currency: 'KZT', purposeType: 'general', purposeLabel: null, appointmentId: null, treatmentPlanId: null, originalAmount: 300, consumedAmount: 0, releasedAmount: 0, remainingAmount: 300, status: 'active', expiresAt: null, notes: null, createdAt: '2026-07-11T00:00:00Z', updatedAt: null, releasedAt: null, archivedAt: null } as PatientFundReservation;
+const capacityA = { paymentId: paymentA.id, patientId: patientA, currency: 'KZT', paymentAmount: 1000, activeAllocatedAmount: 0, completedRefundAmount: 0, refundReservedAmount: 0, reservedDepositAmount: 300, grossUnallocatedAmount: 1000, availableCreditAmount: 700 } as PaymentFundCapacity;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+function repository(): FinanceRepository {
+  return {
+    getPatientFundReservations: vi.fn().mockResolvedValue([reservationA]),
+    getPaymentFundCapacity: vi.fn().mockResolvedValue(capacityA),
+  } as unknown as FinanceRepository;
+}
+
+async function flush() {
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+}
+
+describe('usePatientFundReservations', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: ReturnType<typeof usePatientFundReservations> | null;
+
+  function Harness(props: { tenantId?: string | null; patientId?: string | null; role?: string; payments?: Payment[]; repo: FinanceRepository }) {
+    latest = usePatientFundReservations({ tenantId: props.tenantId, patientId: props.patientId, role: props.role, payments: props.payments, repository: props.repo });
+    return null;
+  }
+
+  beforeEach(() => {
+    latest = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('does not fetch without tenant or patient', async () => {
+    const repo = repository();
+    await act(async () => { root.render(<Harness tenantId={null} patientId={patientA} role="clinic_admin" payments={[paymentA]} repo={repo} />); });
+    await flush();
+    expect(repo.getPatientFundReservations).not.toHaveBeenCalled();
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={null} role="clinic_admin" payments={[paymentA]} repo={repo} />); });
+    await flush();
+    expect(repo.getPatientFundReservations).not.toHaveBeenCalled();
+  });
+
+  it('loads reservations and authoritative payment capacity', async () => {
+    const repo = repository();
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientA} role="clinic_admin" payments={[paymentA]} repo={repo} />); });
+    await flush();
+    expect(repo.getPatientFundReservations).toHaveBeenCalledWith({ tenantId: tenantA, patientId: patientA });
+    expect(repo.getPaymentFundCapacity).toHaveBeenCalledWith({ tenantId: tenantA, patientId: patientA, paymentId: paymentA.id });
+    expect(latest?.reservations).toEqual([reservationA]);
+    expect(latest?.capacities[paymentA.id]).toEqual(capacityA);
+  });
+
+  it('doctor and registrar do not fetch reservation details', async () => {
+    const repo = repository();
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientA} role="doctor" payments={[paymentA]} repo={repo} />); });
+    await flush();
+    expect(repo.getPatientFundReservations).not.toHaveBeenCalled();
+    expect(latest?.capabilities.canViewSummary).toBe(true);
+    expect(latest?.capabilities.canViewReservations).toBe(false);
+  });
+
+  it('clears old patient data immediately and ignores stale list response', async () => {
+    const repo = repository();
+    const old = deferred<PatientFundReservation[]>();
+    const current = deferred<PatientFundReservation[]>();
+    vi.mocked(repo.getPatientFundReservations)
+      .mockReturnValueOnce(old.promise)
+      .mockReturnValueOnce(current.promise);
+    vi.mocked(repo.getPaymentFundCapacity).mockResolvedValue(null);
+
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientA} role="clinic_admin" payments={[]} repo={repo} />); });
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientB} role="clinic_admin" payments={[]} repo={repo} />); });
+    expect(latest?.reservations).toEqual([]);
+    current.resolve([{ ...reservationA, id: 'reservation-b', patientId: patientB }]);
+    await flush();
+    expect(latest?.reservations[0]?.patientId).toBe(patientB);
+    old.resolve([reservationA]);
+    await flush();
+    expect(latest?.reservations[0]?.patientId).toBe(patientB);
+  });
+
+  it('ignores stale capacity response after payment context changes', async () => {
+    const repo = repository();
+    const oldCapacity = deferred<PaymentFundCapacity | null>();
+    const paymentB = { ...paymentA, id: 'payment-b' };
+    vi.mocked(repo.getPatientFundReservations).mockResolvedValue([]);
+    vi.mocked(repo.getPaymentFundCapacity)
+      .mockReturnValueOnce(oldCapacity.promise)
+      .mockResolvedValueOnce({ ...capacityA, paymentId: paymentB.id, availableCreditAmount: 900 });
+
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientA} role="clinic_admin" payments={[paymentA]} repo={repo} />); });
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientA} role="clinic_admin" payments={[paymentB]} repo={repo} />); });
+    await flush();
+    expect(latest?.capacities[paymentB.id]?.availableCreditAmount).toBe(900);
+    oldCapacity.resolve(capacityA);
+    await flush();
+    expect(latest?.capacities[paymentA.id]).toBeUndefined();
+  });
+
+  it('returns only safe load errors', async () => {
+    const repo = repository();
+    vi.mocked(repo.getPatientFundReservations).mockRejectedValue({ code: 'XX000', message: 'trigger secret_table failed' });
+    await act(async () => { root.render(<Harness tenantId={tenantA} patientId={patientA} role="clinic_admin" payments={[]} repo={repo} />); });
+    await flush();
+    expect(latest?.error?.message).toBe('Не удалось загрузить кредит и депозиты пациента.');
+    expect(latest?.error?.message).not.toContain('trigger');
+  });
+});

--- a/src/data/hooks/usePatientFundReservations.ts
+++ b/src/data/hooks/usePatientFundReservations.ts
@@ -1,0 +1,112 @@
+import { useCallback, useMemo } from 'react';
+import { getFundReservationCapabilities } from '../../components/finance/fundReservationPermissions';
+import type { FinanceUserRole } from '../../components/finance/financePermissions';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import {
+  createFinanceRepository,
+  type FinanceRepository,
+  type PatientFundReservation,
+  type Payment,
+  type PaymentFundCapacity,
+} from '../repositories/FinanceRepository';
+import { useAsyncQuery } from './useAsyncQuery';
+
+export interface UsePatientFundReservationsOptions {
+  tenantId?: string | null;
+  patientId?: string | null;
+  role?: FinanceUserRole;
+  payments?: Payment[];
+  repository?: FinanceRepository;
+  enabled?: boolean;
+}
+
+export interface PatientFundReservationsData {
+  reservations: PatientFundReservation[];
+  capacities: Record<string, PaymentFundCapacity>;
+}
+
+const EMPTY_DATA: PatientFundReservationsData = { reservations: [], capacities: {} };
+
+function safeListError() {
+  return new Error('Не удалось загрузить кредит и депозиты пациента.');
+}
+
+export function usePatientFundReservations({
+  tenantId,
+  patientId,
+  role,
+  payments = [],
+  repository,
+  enabled = true,
+}: UsePatientFundReservationsOptions) {
+  const capabilities = useMemo(() => getFundReservationCapabilities(role), [role]);
+  const financeRepository = useMemo(() => {
+    if (repository) return repository;
+    if (!isSupabaseConfigured) return null;
+    return createFinanceRepository({ backend: 'supabase' });
+  }, [repository]);
+
+  const paymentKey = useMemo(
+    () => payments.map((payment) => `${payment.id}:${payment.status}:${payment.updatedAt ?? ''}`).sort().join('|'),
+    [payments],
+  );
+  const contextKey = tenantId && patientId
+    ? `${tenantId}:${patientId}:${role ?? ''}:${paymentKey}`
+    : null;
+  const canFetch = Boolean(
+    enabled
+    && contextKey
+    && capabilities.canViewReservations
+    && financeRepository,
+  );
+
+  const queryFn = useCallback(async (): Promise<PatientFundReservationsData> => {
+    if (!tenantId || !patientId || !financeRepository || !capabilities.canViewReservations) return EMPTY_DATA;
+    try {
+      const reservationsPromise = financeRepository.getPatientFundReservations({ tenantId, patientId });
+      const capacityEntriesPromise = Promise.all(
+        payments
+          .filter((payment) => payment.tenantId === tenantId && payment.patientId === patientId)
+          .map(async (payment) => {
+            const capacity = await financeRepository.getPaymentFundCapacity({
+              tenantId,
+              patientId,
+              paymentId: payment.id,
+            });
+            return [payment.id, capacity] as const;
+          }),
+      );
+      const [reservations, capacityEntries] = await Promise.all([reservationsPromise, capacityEntriesPromise]);
+      const capacities: Record<string, PaymentFundCapacity> = {};
+      for (const [paymentId, capacity] of capacityEntries) {
+        if (capacity) capacities[paymentId] = capacity;
+      }
+      return { reservations, capacities };
+    } catch {
+      throw safeListError();
+    }
+  }, [capabilities.canViewReservations, financeRepository, patientId, payments, tenantId]);
+
+  const query = useAsyncQuery<PatientFundReservationsData>({
+    queryFn,
+    initialData: EMPTY_DATA,
+    enabled: canFetch,
+    queryKey: contextKey,
+    resetOnDisable: true,
+  });
+
+  const refresh = useCallback(async () => {
+    await query.refetch();
+  }, [query]);
+
+  return {
+    reservations: query.data.reservations,
+    capacities: query.data.capacities,
+    loading: query.isLoading,
+    isLoading: query.isLoading,
+    error: query.error ? safeListError() : null,
+    isError: query.isError,
+    refresh,
+    capabilities,
+  };
+}

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -1029,13 +1029,27 @@ describe('FinanceRpcClient patient fund reservation operations', () => {
 
     const conflict = createClientMock({ data: null, error: { code: 'P0001', message: 'Release idempotency key is already used with different details', details: 'sensitive SQL', hint: null } as unknown as PostgrestError });
     await expect(conflict.rpcClient.releasePatientFundReservation({ tenantId, reservationId, reason: 'x', idempotencyKey: 'same' }))
-      .rejects.toMatchObject({ category: 'duplicate_conflict', message: 'Ключ операции уже использован с другими параметрами.' });
+      .rejects.toMatchObject({ category: 'duplicate_conflict', message: 'Операция уже была выполнена или параметры изменились.' });
 
     const raw = createClientMock({ data: null, error: { code: 'XX000', message: 'duplicate key on private_index with table details', details: 'secret', hint: null } as unknown as PostgrestError });
     await raw.rpcClient.allocateReservedCredit({ tenantId, patientId, reservationId, invoiceId, amount: 1, idempotencyKey: 'x' }).catch((error: Error) => {
       expect(error.message).toBe('Не удалось выполнить финансовую операцию.');
       expect(error.message).not.toContain('private_index');
     });
+  });
+
+  it('maps terminal, invoice-unavailable and permission reservation failures to exact safe messages', async () => {
+    const terminal = createClientMock({ data: null, error: { code: 'P0001', message: 'Fully used reservation cannot be released', details: null, hint: null } as unknown as PostgrestError }).rpcClient;
+    await expect(terminal.releasePatientFundReservation({ tenantId, reservationId, reason: 'x', idempotencyKey: 'release-terminal' }))
+      .rejects.toMatchObject({ category: 'validation', message: 'Этот депозит больше нельзя изменить.' });
+
+    const unavailableInvoice = createClientMock({ data: null, error: { code: 'P0001', message: 'Invoice is not available for reserved allocation', details: 'private details', hint: null } as unknown as PostgrestError }).rpcClient;
+    await expect(unavailableInvoice.allocateReservedCredit({ tenantId, patientId, reservationId, invoiceId, amount: 1, idempotencyKey: 'consume-unavailable' }))
+      .rejects.toMatchObject({ category: 'validation', message: 'Выбранный счёт недоступен для использования депозита.' });
+
+    const denied = createClientMock({ data: null, error: { code: '42501', message: 'access denied', details: null, hint: null } as unknown as PostgrestError }).rpcClient;
+    await expect(denied.createPatientFundReservation({ tenantId, patientId, paymentId, amount: 1, purposeType: 'general', idempotencyKey: 'create-denied' }))
+      .rejects.toMatchObject({ category: 'permission', message: 'Недостаточно прав для этой операции.' });
   });
 
   it('maps reserved-deposit allocation, refund, and payment-void failures to exact safe messages', async () => {

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -390,11 +390,17 @@ function normalizeRpcError(error: unknown, operation: string): FinanceRpcClientE
       if (normalizedDetail.includes('платёж недоступен') || normalizedDetail.includes('payment is not available')) {
         return new FinanceRpcClientError({ operation, code, category: 'validation', message: 'Платёж недоступен для резервирования.' });
       }
-      if (normalizedDetail.includes('already') || normalizedDetail.includes('idempotency') || normalizedDetail.includes('уже создан')) {
-        return new FinanceRpcClientError({ operation, code, category: 'duplicate_conflict', message: 'Ключ операции уже использован с другими параметрами.' });
+      if (normalizedDetail.includes('terminal') || normalizedDetail.includes('fully used') || normalizedDetail.includes('cannot be released') || normalizedDetail.includes('больше нельзя')) {
+        return new FinanceRpcClientError({ operation, code, category: 'validation', message: 'Этот депозит больше нельзя изменить.' });
+      }
+      if (normalizedDetail.includes('invoice not found') || normalizedDetail.includes('invoice is not available') || normalizedDetail.includes('счёт недоступен')) {
+        return new FinanceRpcClientError({ operation, code, category: 'validation', message: 'Выбранный счёт недоступен для использования депозита.' });
+      }
+      if (normalizedDetail.includes('already') || normalizedDetail.includes('idempotency') || normalizedDetail.includes('уже создан') || normalizedDetail.includes('different details')) {
+        return new FinanceRpcClientError({ operation, code, category: 'duplicate_conflict', message: 'Операция уже была выполнена или параметры изменились.' });
       }
       if (normalizedDetail.includes('insufficient finance permissions') || normalizedDetail.includes('access denied') || code === '42501') {
-        return new FinanceRpcClientError({ operation, code, category: 'permission', message: 'Недостаточно прав для операции с депозитом.' });
+        return new FinanceRpcClientError({ operation, code, category: 'permission', message: 'Недостаточно прав для этой операции.' });
       }
       return new FinanceRpcClientError({ operation, code, category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE });
     }


### PR DESCRIPTION
## Summary
- add patient finance UI for available credit and deposit reservations
- add create, full release, and reserved-credit allocation workflows through existing RPCs
- add role gating, stale-context suppression, ambiguous-response reconciliation, safe errors, and cashier read-only reserve summary

## Verification
- required targeted tests passed
- full suite: 79 files / 809 tests passed
- ESLint and production build passed
- localhost browser smoke A-J completed with DB validation
- foundation SQL and concurrency regressions passed
- cleanup verified

No migrations, cloud apply, new-money intake, expiry automation, forfeiture, generated types, or seed changes. Do not merge automatically.