### PR TITLE
Harden patient credit intake and recovery

### DIFF
--- a/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-HARDENING-001_hardening.md
+++ b/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-HARDENING-001_hardening.md
@@ -1,0 +1,456 @@
+# CASHIER-CREDIT-PREPAYMENT-HARDENING-001 Report
+
+## Task ID
+
+`CASHIER-CREDIT-PREPAYMENT-HARDENING-001`
+
+## Summary
+
+The existing unallocated payment intake path is now hardened for intentional patient-credit intake without creating a separate prepayment ledger.
+
+The authoritative money model remains unchanged:
+
+```text
+payment = money actually received
+payment allocation = where received money was applied
+unallocated payment capacity = available patient credit
+fund reservation = a purpose reservation over already received money
+```
+
+The implementation adds one tenant-scoped idempotency namespace to `payments`, an explicit transactional intake RPC, a recovery/read RPC, client DTO/error mapping, caller-side same-key reconciliation, SQL coverage, and real concurrent-request validation.
+
+No invoice, allocation, reservation, appointment, treatment plan, completed service, clinical fact, or `patients.balance` mutation is created by the hardened intake operation.
+
+## Branch
+
+`feature/cashier-credit-prepayment-hardening-001`
+
+## Base branch and verified baseline
+
+- base branch: `main`;
+- verified baseline: `7deb29cc3283afadd6543c5ed29f8a2152a4100a`;
+- PR #342 was confirmed merged into `origin/main` at that exact commit before implementation;
+- worktree was clean before changes.
+
+## PR URL
+
+Pending publication.
+
+## Implementation head reviewed
+
+Pending commit and PR publication.
+
+## Report update commit
+
+N/A before finalization. The finalization receipt and final response must verify the final PR head and fresh CI run.
+
+## Current payment-intake recon
+
+### 1. What called `record_payment` before this task?
+
+The real application path was:
+
+```text
+PatientFinancePanel
+→ PaymentActions
+→ useFinanceActions.recordPayment
+→ FinanceRpcClient.recordPayment
+→ public.record_payment
+```
+
+`record_and_allocate_payment` also calls `record_payment` internally as part of the already-hardened allocated cashier transaction.
+
+The legacy refund/write-off SQL regression test used `record_payment` only to create payment fixtures.
+
+### 2. Was it reachable from a real UI?
+
+Yes. The patient Finance tab exposed the existing `Принять оплату` form and called the generic `recordPayment` hook action. No new UI was needed or added by this task.
+
+### 3. Did it create unallocated payments?
+
+Yes. `record_payment` inserted a `payments` row with status `received`. It did not create an allocation, so the full available capacity became patient credit.
+
+### 4. Did it accept an invoice ID?
+
+No. The legacy generic RPC had no invoice or invoice-item parameter.
+
+### 5. Did it allocate automatically?
+
+No. Allocation was a separate operation. The existing `record_and_allocate_payment` cashier RPC explicitly creates allocations, but generic `record_payment` did not.
+
+### 6. Did it use an operation key?
+
+No. The payment table had `cashier_operation_key`, but only the allocated cashier flow used it. Generic unallocated intake had no idempotency key.
+
+### 7. Did it use a payload fingerprint?
+
+No. `cashier_operation_fingerprint` protected only `record_and_allocate_payment`.
+
+### 8. Could a retry create a duplicate payment?
+
+Yes. A lost successful response followed by the same `record_payment` retry created another payment fact and therefore duplicate money.
+
+### 9. Did it return enough data for recovery?
+
+No. It returned a payment row only. There was no operation identity, no recovery/read RPC, and no way to distinguish not committed from committed-but-response-lost without searching by unrelated fields.
+
+### 10. Which roles could execute it?
+
+The RPC allowed `clinic_owner`, `clinic_admin`, and `cashier` through `ensure_finance_write_role_internal`. Before this task, `authenticated` also retained direct EXECUTE privilege on the unsafe legacy signature.
+
+### 11. Did it create audit and activity events?
+
+Yes. A successful insert called `log_finance_event_internal` and created `payment_recorded` audit/activity events. Because the write itself was not idempotent, retries could also duplicate both money and events.
+
+### 12. Did it normalize KZT?
+
+It uppercased the currency value but did not limit generic intake to KZT. The hardened patient-credit path explicitly accepts operational currency `KZT` only.
+
+### 13. Did it mutate `patients.balance`?
+
+No. Patient credit was and remains derived from payment facts, active allocations, completed/pending refunds, and active fund reservations. `patients.balance` is not touched.
+
+### 14. Was it compatible with fund reservations?
+
+Yes at the data-model level. An unallocated payment became available capacity that `create_patient_fund_reservation` could reserve. The hardened operation preserves this model and returns current capacity directly.
+
+## Selected design
+
+### Option selected: B
+
+A new explicit application RPC was added:
+
+```text
+record_patient_credit_payment
+```
+
+A recovery RPC was added:
+
+```text
+get_patient_credit_payment_operation
+```
+
+The legacy `record_payment` function is retained only because `record_and_allocate_payment` already calls it internally inside the existing SECURITY DEFINER cashier transaction.
+
+Direct EXECUTE on the legacy function is revoked from `authenticated`. Therefore:
+
+- the application has exactly one authoritative path for new unallocated money;
+- the existing allocated cashier flow remains unchanged;
+- no unsafe application caller remains;
+- no duplicate client method with overlapping semantics was introduced.
+
+## Schema changes
+
+Migration:
+
+`supabase/migrations/0023_harden_patient_credit_intake.sql`
+
+Added nullable payment identity fields:
+
+- `credit_intake_operation_key`;
+- `credit_intake_operation_fingerprint`.
+
+Added constraints:
+
+- unique partial index on `(tenant_id, credit_intake_operation_key)`;
+- operation key and fingerprint must be present together;
+- one payment cannot belong to both cashier and patient-credit operation namespaces.
+
+No new payment, prepayment, deposit, ledger, invoice, allocation, shift, provider, or receipt table was created.
+
+## Idempotency and fingerprint model
+
+Required operation identity:
+
+```text
+tenant_id + credit_intake_operation_key
+```
+
+Canonical server fingerprint includes:
+
+- tenant ID;
+- patient ID;
+- rounded amount;
+- normalized payment method;
+- normalized KZT currency;
+- requested received timestamp;
+- trimmed external reference;
+- trimmed payer name;
+- trimmed notes;
+- sanitized metadata.
+
+The server stores an MD5 digest of the canonical JSON representation. The digest is an equality fingerprint, not a secret or authentication primitive.
+
+Behavior:
+
+- same tenant/key + same fingerprint returns the existing payment with `already_completed`;
+- same tenant/key + different patient is rejected with `PATIENT_CREDIT_PATIENT_MISMATCH`;
+- same tenant/key + different payload is rejected with `PATIENT_CREDIT_IDEMPOTENCY_CONFLICT`;
+- different keys may intentionally create separate payment facts.
+
+## Lock order and race safety
+
+The write RPC performs the following order:
+
+1. enforce tenant membership and finance role;
+2. normalize and validate input;
+3. verify patient belongs to tenant;
+4. compute canonical fingerprint;
+5. acquire `pg_advisory_xact_lock` for `patient-credit-intake:<tenant>:<operation-key>`;
+6. re-read the operation key under the lock;
+7. return the existing result or reject a conflict;
+8. insert exactly one payment;
+9. emit one success audit/activity pair;
+10. return payment plus current capacity.
+
+The unique partial index is the persistent backstop. The advisory lock gives deterministic same-key behavior and prevents a unique-violation race from becoming the application contract.
+
+## Transactional RPC result
+
+`record_patient_credit_payment` returns:
+
+- operation status;
+- operation ID/key;
+- tenant ID;
+- patient ID;
+- authoritative payment row;
+- current payment capacity:
+  - payment amount;
+  - allocated amount;
+  - completed refunds;
+  - pending refund reservation;
+  - deposit reservation;
+  - gross unallocated amount;
+  - available credit.
+
+A successful operation creates:
+
+- one `payments` row;
+- one `payment_recorded` audit event;
+- one `payment_recorded` activity event.
+
+It creates no allocation, invoice, reservation, clinical entity, schedule entity, or balance mutation.
+
+## Recovery/read RPC
+
+`get_patient_credit_payment_operation` accepts:
+
+- tenant ID;
+- patient ID;
+- the original operation key.
+
+It returns:
+
+- `completed` with the authoritative payment and current capacity; or
+- `not_found` without inventing a payment.
+
+If the key belongs to another patient in the same tenant, the request is rejected instead of leaking or reusing the operation.
+
+## Client and repository integration
+
+### `FinanceRpcClient`
+
+- `RecordPaymentInput` now requires `idempotencyKey`;
+- `recordPayment` calls only `record_patient_credit_payment`;
+- `getPatientCreditPaymentOperation` calls the recovery RPC;
+- composite payment/capacity results are mapped to typed DTOs;
+- safe categories distinguish permission, payload conflict, patient mismatch, validation, and uncertain transport outcomes;
+- raw SQL/database details are not surfaced.
+
+### `FinanceRepository`
+
+Payment mapping now includes:
+
+- `creditIntakeOperationKey`;
+- `creditIntakeOperationFingerprint`.
+
+No repository write method or direct table mutation was added.
+
+### Real application caller
+
+`useFinanceActions.recordPayment` now:
+
+1. creates one operation key for a normalized request;
+2. sends the hardened write;
+3. on an uncertain response, queries recovery using the same key;
+4. if recovery returns `not_found`, retries the write once with the same key;
+5. retains the key if the result is still uncertain;
+6. blocks a changed payload from silently replacing an unresolved operation;
+7. scopes unresolved keys by tenant and patient so one patient cannot inherit another patient's key;
+8. refreshes finance data only after a confirmed result.
+
+No localStorage persistence or fallback was added.
+
+## Authorization and security
+
+- allowed write/recovery roles: `clinic_owner`, `clinic_admin`, `cashier`;
+- doctor, registrar, unknown role, and no-tenant users are blocked by the backend guard;
+- cross-tenant patient IDs are rejected;
+- direct table INSERT remains unavailable to `authenticated`;
+- direct application EXECUTE on legacy `record_payment` is revoked;
+- the internal result helper is not executable by `authenticated`;
+- no `service_role` key or application use was added;
+- no cloud database action was performed;
+- no secret, `.env.local`, generated type, package, or seed change is committed.
+
+## Compatibility validation
+
+### Patient credit summary
+
+The new SQL test verifies that 100,000 KZT received with no allocation appears as:
+
+- `cashReceived = 100000`;
+- `availableCreditAmount = 100000`;
+- `reservedDepositAmount = 0`.
+
+### Fund reservations
+
+The test creates a 30,000 KZT reservation over the new payment, observes available credit fall to 70,000 KZT, verifies payment void is blocked while reserved, releases it, and observes credit return to 100,000 KZT.
+
+### Refund capacity
+
+The test requests a 10,000 KZT refund over the new payment, observes available credit fall to 90,000 KZT, rejects the refund, and observes credit return to 100,000 KZT.
+
+### Payment void behavior
+
+Existing controlled void rules remain authoritative. The new RPC does not add or bypass a void route.
+
+### Existing allocated cashier flow
+
+`record_and_allocate_payment` was not modified. SQL and concurrency regression checks confirm:
+
+- it still creates one cashier-keyed payment;
+- it still allocates the requested invoice amount;
+- its payment does not use the patient-credit operation namespace;
+- same-key concurrency still converges safely.
+
+### Existing refund/write-off fixture
+
+`0018_refund_writeoff_rpc_test.sql` now creates its payment fixtures through the new authoritative application RPC because direct authenticated use of legacy `record_payment` is intentionally revoked. Refund and write-off behavior itself was not changed.
+
+## Concurrency results
+
+New test:
+
+`supabase/tests/0023_patient_credit_intake_concurrency.ps1`
+
+Observed results:
+
+```text
+IDENTICAL_RETRY success=2 payments=1 uniquePaymentIds=1 audit=1 activity=1 credit=100000.00
+CONFLICTING_RETRY success=1 rejected=1 payments=1 audit=1
+DIFFERENT_KEYS success=2 payments=2 amount=33333.00
+PATIENT CREDIT INTAKE CONCURRENCY VALIDATION PASSED
+```
+
+This proves:
+
+- two simultaneous identical requests create exactly one payment;
+- both successful callers receive the same payment identity;
+- audit/activity success events are not duplicated;
+- conflicting same-key payloads result in one success and one controlled rejection;
+- distinct operation keys intentionally create distinct payment facts;
+- no invoice, allocation, reservation, or `patients.balance` mutation is produced by the intake operation.
+
+Existing concurrency regressions also passed:
+
+- `0019_cashier_payment_concurrency.ps1`;
+- `0022_patient_credit_deposits_concurrency.ps1`.
+
+## Changed files
+
+- `supabase/migrations/0023_harden_patient_credit_intake.sql`;
+- `supabase/tests/0023_patient_credit_intake_hardening_test.sql`;
+- `supabase/tests/0023_patient_credit_intake_concurrency.ps1`;
+- `supabase/tests/0018_refund_writeoff_rpc_test.sql`;
+- `src/data/repositories/FinanceRpcClient.ts`;
+- `src/data/repositories/FinanceRpcClient.test.ts`;
+- `src/data/repositories/FinanceRepository.ts`;
+- `src/data/repositories/FinanceRepository.test.ts`;
+- `src/data/hooks/useFinanceActions.ts`;
+- `src/data/hooks/useFinanceActions.test.tsx`;
+- `_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-HARDENING-001_hardening.md`.
+
+## Checks
+
+Completed locally:
+
+- clean reset applying migrations `0001` through `0023`: passed;
+- local QA user fixture creation: passed;
+- `0023_patient_credit_intake_hardening_test.sql`: passed;
+- `0023_patient_credit_intake_concurrency.ps1`: passed;
+- `0018_refund_writeoff_rpc_test.sql`: passed;
+- `0019_cashier_payment_hardening_test.sql`: passed;
+- `0018_refund_writeoff_concurrency.ps1`: passed;
+- `0019_cashier_payment_concurrency.ps1`: passed;
+- `0022_patient_credit_deposits_foundation_test.sql`: passed when executed as the UTF-8 file inside the database container;
+- `0022_patient_credit_deposits_concurrency.ps1`: passed;
+- `npx supabase db lint --level warning`: passed with no warning attributed to migration `0023`; remaining warnings are pre-existing in earlier migrations;
+- targeted TypeScript finance tests: passed;
+- final full `npm run lint`: passed;
+- final full `npm run test -- --run`: passed with 79 files / 817 tests;
+- final full `npm run build`: passed.
+
+## Issues / limitations
+
+1. `supabase/tests/0020_patient_finance_summary_test.sql` is a stale baseline fixture under the latest schema: it directly inserts into `refunds`, while migration 0022 correctly requires `request_refund`. It fails independently of migration 0023. Current patient-summary compatibility is covered by the new 0023 transactional SQL test using the supported RPC paths.
+2. Existing React test-suite `act(...)` warnings remain in unrelated baseline tests; all tests pass.
+3. Vite continues to report the pre-existing main-bundle size warning.
+4. The client retains unresolved operation keys only in the mounted hook instance. Durable recovery across a full browser restart requires the caller to preserve the operation key in a future UI workflow. This task intentionally adds no prepayment UI or browser persistence.
+5. The legacy `record_payment` function remains in the schema only for the nested existing cashier transaction. Authenticated application callers cannot execute it directly.
+6. No cloud migration was applied and no production data was touched.
+
+## Browser smoke
+
+`BROWSER SMOKE NOT REQUIRED: backend/client hardening only`
+
+The existing patient Finance UI caller is covered by hook/client tests. This task adds no new button, form, route, or visible prepayment workflow.
+
+## Safety notes
+
+- payment remains the only received-money fact;
+- no separate prepayment ledger exists;
+- no second cash ledger exists;
+- no invoice or allocation is created by patient-credit intake;
+- no deposit reservation is created automatically;
+- no treatment, appointment, plan, service, or tooth state is changed;
+- `patients.balance` remains untouched;
+- KZT is enforced for the hardened path;
+- retries cannot create duplicate money under one operation key;
+- patient and tenant identity are checked on both write and recovery;
+- existing cashier payment behavior is preserved.
+
+## What was not implemented
+
+- prepayment UI;
+- cashier UI changes;
+- new button or route;
+- automatic deposit creation;
+- invoice/allocation creation from this path;
+- cash shifts;
+- receipt/fiscal integration;
+- payment provider integration;
+- refund/write-off redesign;
+- invoice corrections;
+- payment splitting or mixed-tender redesign;
+- cloud migration apply;
+- broad finance refactor.
+
+## Fresh CI
+
+Pending PR publication and GitHub Actions on the final PR head.
+
+Required final verification:
+
+- CI tested commit equals final PR head;
+- ESLint passed;
+- all tests passed;
+- build passed;
+- changed-file scope matches this report;
+- PR remains open and unmerged.
+
+## Final verdict
+
+**PASS**
+
+The existing unallocated payment model is now safe for intentional patient-credit intake at the schema, transactional RPC, recovery, client, and concurrency levels. Future cashier prepayment UI can call this path without creating a second ledger or risking duplicate money after retries.

--- a/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-HARDENING-001_hardening.md
+++ b/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-HARDENING-001_hardening.md
@@ -34,15 +34,18 @@ No invoice, allocation, reservation, appointment, treatment plan, completed serv
 
 ## PR URL
 
-Pending publication.
+https://github.com/NckNA/codex-test/pull/343
 
 ## Implementation head reviewed
 
-Pending commit and PR publication.
+`f337b21b2f5836e55eea7f5395afab741d8bc7e4`
 
 ## Report update commit
 
-N/A before finalization. The finalization receipt and final response must verify the final PR head and fresh CI run.
+N/A because the final report update commit cannot reference itself before creation.
+
+- Report update commit: N/A (the report commit cannot reference itself; use the finalization receipt).
+- The final report-only commit and its fresh CI run are recorded in the finalization receipt, PR body, and final task response after push.
 
 ## Current payment-intake recon
 
@@ -438,16 +441,23 @@ The existing patient Finance UI caller is covered by hook/client tests. This tas
 
 ## Fresh CI
 
-Pending PR publication and GitHub Actions on the final PR head.
+Implementation CI completed successfully:
 
-Required final verification:
+- workflow: `CI`;
+- run: `#686` (`29154002773`);
+- tested commit: `f337b21b2f5836e55eea7f5395afab741d8bc7e4`;
+- conclusion: `success`;
+- ESLint: passed;
+- tests: passed;
+- build: passed.
 
-- CI tested commit equals final PR head;
-- ESLint passed;
-- all tests passed;
-- build passed;
-- changed-file scope matches this report;
-- PR remains open and unmerged.
+The final response verifies the report-only update commit against a fresh CI run and confirms that PR #343 remains open and unmerged.
+
+## Recommended next task
+
+`CASHIER-CREDIT-PREPAYMENT-UI-001`
+
+Add an explicit patient-credit/prepayment UI that preserves the operation key across a full browser restart and uses the hardened intake and recovery RPCs without introducing a second money ledger.
 
 ## Final verdict
 

--- a/src/data/hooks/useFinanceActions.test.tsx
+++ b/src/data/hooks/useFinanceActions.test.tsx
@@ -4,12 +4,23 @@ import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFinanceActions, type UseFinanceActionsResult } from './useFinanceActions';
-import type { FinanceRpcClient } from '../repositories/FinanceRpcClient';
+import { FinanceRpcClientError, type FinanceRpcClient, type PatientCreditPaymentOperationResult } from '../repositories/FinanceRpcClient';
 
 vi.mock('../../lib/supabaseClient', () => ({ supabase: {}, isSupabaseConfigured: true }));
 
 const tenantId = 'tenant-1';
 const patientId = 'patient-1';
+
+function completedPatientCreditOperation(operationId = 'patient-credit-operation-1'): PatientCreditPaymentOperationResult {
+  return {
+    status: 'completed',
+    operationId,
+    tenantId,
+    patientId,
+    payment: { id: 'payment-1' } as PatientCreditPaymentOperationResult['payment'],
+    capacity: { availableCreditAmount: 1000 } as PatientCreditPaymentOperationResult['capacity'],
+  };
+}
 
 function createRpcClient(): FinanceRpcClient {
   return {
@@ -17,7 +28,8 @@ function createRpcClient(): FinanceRpcClient {
     addInvoiceItem: vi.fn().mockResolvedValue({ id: 'item-1' }),
     issueInvoice: vi.fn().mockResolvedValue({ id: 'invoice-1' }),
     voidInvoice: vi.fn().mockResolvedValue({ id: 'invoice-1' }),
-    recordPayment: vi.fn().mockResolvedValue({ id: 'payment-1' }),
+    recordPayment: vi.fn().mockImplementation(async (input: { idempotencyKey: string }) => completedPatientCreditOperation(input.idempotencyKey)),
+    getPatientCreditPaymentOperation: vi.fn().mockResolvedValue(completedPatientCreditOperation()),
     allocatePayment: vi.fn().mockResolvedValue({ id: 'allocation-1' }),
     voidPaymentAllocation: vi.fn().mockResolvedValue({ id: 'allocation-1' }),
     voidPayment: vi.fn().mockResolvedValue({ id: 'payment-1' }),
@@ -85,10 +97,95 @@ describe('useFinanceActions', () => {
     expect(rpcClient.issueInvoice).toHaveBeenCalledWith({ tenantId, invoiceId: 'invoice-1' });
   });
 
-  it('calls recordPayment', async () => {
+  it('calls hardened recordPayment with a stable patient-credit operation key', async () => {
     const rpcClient = await renderHook();
     await act(async () => { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
-    expect(rpcClient.recordPayment).toHaveBeenCalledWith(expect.objectContaining({ tenantId, patientId, amount: 1000, paymentMethod: 'cash' }));
+    expect(rpcClient.recordPayment).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId,
+      patientId,
+      amount: 1000,
+      paymentMethod: 'cash',
+      idempotencyKey: expect.stringMatching(/^patient-credit:tenant-1:patient-1:/),
+    }));
+    expect(rpcClient.getPatientCreditPaymentOperation).not.toHaveBeenCalled();
+  });
+
+  it('recovers an uncertain response with the same operation key without creating a new request', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment).mockRejectedValueOnce(new FinanceRpcClientError({
+      operation: 'recordPayment',
+      category: 'operation_uncertain',
+      message: 'network',
+    }));
+    vi.mocked(rpcClient.getPatientCreditPaymentOperation).mockImplementationOnce(async (input) => completedPatientCreditOperation(input.idempotencyKey));
+    await renderHook(rpcClient);
+
+    await act(async () => { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
+
+    const writeKey = vi.mocked(rpcClient.recordPayment).mock.calls[0][0].idempotencyKey;
+    expect(rpcClient.getPatientCreditPaymentOperation).toHaveBeenCalledWith({ tenantId, patientId, idempotencyKey: writeKey });
+    expect(rpcClient.recordPayment).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it('retries a confirmed not_found operation exactly once with the same operation key', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment)
+      .mockRejectedValueOnce(new FinanceRpcClientError({ operation: 'recordPayment', category: 'operation_uncertain', message: 'network' }))
+      .mockImplementationOnce(async (input) => completedPatientCreditOperation(input.idempotencyKey));
+    vi.mocked(rpcClient.getPatientCreditPaymentOperation).mockImplementationOnce(async (input) => ({
+      status: 'not_found', operationId: input.idempotencyKey, tenantId, patientId, payment: null, capacity: null,
+    }));
+    await renderHook(rpcClient);
+
+    await act(async () => { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
+
+    expect(rpcClient.recordPayment).toHaveBeenCalledTimes(2);
+    const firstKey = vi.mocked(rpcClient.recordPayment).mock.calls[0][0].idempotencyKey;
+    const retryKey = vi.mocked(rpcClient.recordPayment).mock.calls[1][0].idempotencyKey;
+    expect(retryKey).toBe(firstKey);
+  });
+
+  it('retains an unresolved key and blocks a changed payload until reconciliation succeeds', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment).mockRejectedValue(new FinanceRpcClientError({ operation: 'recordPayment', category: 'operation_uncertain', message: 'network' }));
+    vi.mocked(rpcClient.getPatientCreditPaymentOperation).mockRejectedValue(new FinanceRpcClientError({ operation: 'getPatientCreditPaymentOperation', category: 'operation_uncertain', message: 'network' }));
+    await renderHook(rpcClient);
+
+    let firstError: unknown;
+    await act(async () => {
+      try { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); } catch (error) { firstError = error; }
+    });
+    expect(firstError).toBeInstanceOf(Error);
+
+    let changedError: unknown;
+    await act(async () => {
+      try { await latest?.recordPayment({ amount: 2000, paymentMethod: 'cash' }); } catch (error) { changedError = error; }
+    });
+    expect((changedError as Error).message).toContain('предыдущую оплату');
+    expect(rpcClient.recordPayment).toHaveBeenCalledOnce();
+  });
+
+  it('keeps unresolved operation keys scoped to the correct patient', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment).mockRejectedValue(new FinanceRpcClientError({ operation: 'recordPayment', category: 'operation_uncertain', message: 'network' }));
+    vi.mocked(rpcClient.getPatientCreditPaymentOperation).mockRejectedValue(new FinanceRpcClientError({ operation: 'getPatientCreditPaymentOperation', category: 'operation_uncertain', message: 'network' }));
+    await renderHook(rpcClient);
+
+    await act(async () => {
+      try { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); } catch { /* unresolved for patient 1 */ }
+    });
+    await act(async () => { root.render(<Probe rpcClient={rpcClient} patient="patient-2" />); });
+    await act(async () => {
+      try { await latest?.recordPayment({ amount: 2000, paymentMethod: 'cash' }); } catch { /* unresolved for patient 2 */ }
+    });
+
+    expect(rpcClient.recordPayment).toHaveBeenCalledTimes(2);
+    const first = vi.mocked(rpcClient.recordPayment).mock.calls[0][0];
+    const second = vi.mocked(rpcClient.recordPayment).mock.calls[1][0];
+    expect(first.patientId).toBe(patientId);
+    expect(second.patientId).toBe('patient-2');
+    expect(first.idempotencyKey).not.toBe(second.idempotencyKey);
   });
 
   it('calls allocatePayment', async () => {

--- a/src/data/hooks/useFinanceActions.ts
+++ b/src/data/hooks/useFinanceActions.ts
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
-import { createFinanceRpcClient, type FinanceRpcClient } from '../repositories/FinanceRpcClient';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { createFinanceRpcClient, FinanceRpcClientError, type FinanceRpcClient, type RecordPaymentInput } from '../repositories/FinanceRpcClient';
 import type { PaymentMethod } from '../repositories/FinanceRepository';
 import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
@@ -92,9 +92,32 @@ function isCompletedServiceDuplicate(error: unknown) {
   return error instanceof Error && error.message.toLowerCase().includes(COMPLETED_SERVICE_ALREADY_BILLED_ERROR.toLowerCase());
 }
 
+interface PendingPatientCreditOperation {
+  idempotencyKey: string;
+  fingerprint: string;
+}
+
+function patientCreditFingerprint(input: Omit<RecordPaymentInput, 'tenantId' | 'patientId' | 'idempotencyKey'>): string {
+  return JSON.stringify({
+    amount: input.amount,
+    paymentMethod: input.paymentMethod,
+    currency: input.currency,
+    receivedAt: input.receivedAt,
+    externalReference: input.externalReference,
+    payerName: input.payerName,
+    notes: input.notes,
+    metadata: input.metadata,
+  });
+}
+
+function createPatientCreditOperationKey(tenantId: string, patientId: string): string {
+  return `patient-credit:${tenantId}:${patientId}:${crypto.randomUUID()}`;
+}
+
 export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: UseFinanceActionsOptions): UseFinanceActionsResult {
   const [actionLoading, setActionLoading] = useState<FinanceActionName | null>(null);
   const [actionError, setActionError] = useState<Error | null>(null);
+  const pendingPatientCreditOperations = useRef(new Map<string, PendingPatientCreditOperation>());
 
   const client = useMemo(() => {
     if (rpcClient) return rpcClient;
@@ -178,9 +201,8 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
     await runAction('recordPayment', async () => {
       const actionClient = requireClient();
       if (!patientId) throw new Error('Пациент не выбран.');
-      await actionClient.recordPayment({
-        tenantId: tenantId!,
-        patientId,
+
+      const normalizedInput = {
         amount: input.amount,
         paymentMethod: input.paymentMethod,
         currency: input.currency?.trim() || 'KZT',
@@ -189,7 +211,75 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
         payerName: normalizeOptionalText(input.payerName),
         notes: normalizeOptionalText(input.notes),
         metadata: ACTION_METADATA,
-      });
+      } satisfies Omit<RecordPaymentInput, 'tenantId' | 'patientId' | 'idempotencyKey'>;
+      const fingerprint = patientCreditFingerprint(normalizedInput);
+      const operationScope = `${tenantId}:${patientId}`;
+      const pending = pendingPatientCreditOperations.current.get(operationScope);
+
+      if (pending && pending.fingerprint !== fingerprint) {
+        throw new FinanceRpcClientError({
+          operation: 'recordPayment',
+          category: 'operation_uncertain',
+          message: 'Сначала повторите предыдущую оплату с теми же параметрами, чтобы проверить её результат.',
+        });
+      }
+
+      const idempotencyKey = pending?.idempotencyKey ?? createPatientCreditOperationKey(tenantId!, patientId);
+      pendingPatientCreditOperations.current.set(operationScope, { idempotencyKey, fingerprint });
+      const request: RecordPaymentInput = {
+        tenantId: tenantId!,
+        patientId,
+        idempotencyKey,
+        ...normalizedInput,
+      };
+
+      try {
+        const result = await actionClient.recordPayment(request);
+        if (!result.payment || result.tenantId !== tenantId || result.patientId !== patientId) {
+          throw new FinanceRpcClientError({
+            operation: 'recordPayment',
+            category: 'stale_patient',
+            message: 'Ответ операции относится к другому пациенту или клинике.',
+          });
+        }
+        pendingPatientCreditOperations.current.delete(operationScope);
+        return;
+      } catch (error) {
+        if (!(error instanceof FinanceRpcClientError) || error.category !== 'operation_uncertain') {
+          pendingPatientCreditOperations.current.delete(operationScope);
+          throw error;
+        }
+      }
+
+      try {
+        const recovered = await actionClient.getPatientCreditPaymentOperation({ tenantId: tenantId!, patientId, idempotencyKey });
+        if (recovered.status !== 'not_found') {
+          if (!recovered.payment || recovered.tenantId !== tenantId || recovered.patientId !== patientId) {
+            throw new FinanceRpcClientError({
+              operation: 'getPatientCreditPaymentOperation',
+              category: 'stale_patient',
+              message: 'Восстановленная операция относится к другому пациенту или клинике.',
+            });
+          }
+          pendingPatientCreditOperations.current.delete(operationScope);
+          return;
+        }
+
+        const retried = await actionClient.recordPayment(request);
+        if (!retried.payment || retried.tenantId !== tenantId || retried.patientId !== patientId) {
+          throw new FinanceRpcClientError({
+            operation: 'recordPayment',
+            category: 'stale_patient',
+            message: 'Повторная операция относится к другому пациенту или клинике.',
+          });
+        }
+        pendingPatientCreditOperations.current.delete(operationScope);
+      } catch (error) {
+        if (!(error instanceof FinanceRpcClientError) || error.category !== 'operation_uncertain') {
+          pendingPatientCreditOperations.current.delete(operationScope);
+        }
+        throw error;
+      }
     });
   }, [patientId, requireClient, runAction, tenantId]);
 

--- a/src/data/repositories/FinanceRepository.test.ts
+++ b/src/data/repositories/FinanceRepository.test.ts
@@ -200,6 +200,10 @@ const paymentRow = {
   external_reference: 'KSP-1',
   payer_name: 'Patient',
   notes: null,
+  cashier_operation_key: null,
+  cashier_operation_fingerprint: null,
+  credit_intake_operation_key: 'patient-credit-operation-1',
+  credit_intake_operation_fingerprint: 'credit-fingerprint-1',
   metadata: { terminal: 'kaspi' },
   received_by: 'cashier-1',
   voided_by: null,
@@ -347,7 +351,12 @@ describe('FinanceRepository', () => {
       metadata: { source: 'test' },
     });
     expect(mapInvoiceItemRow(invoiceItemRow)).toMatchObject({ completedServiceId, serviceName: 'Consultation', unitPrice: 12000 });
-    expect(mapPaymentRow(paymentRow)).toMatchObject({ paymentMethod: 'kaspi', receivedAt: '2026-06-21T02:00:00Z' });
+    expect(mapPaymentRow(paymentRow)).toMatchObject({
+      paymentMethod: 'kaspi',
+      receivedAt: '2026-06-21T02:00:00Z',
+      creditIntakeOperationKey: 'patient-credit-operation-1',
+      creditIntakeOperationFingerprint: 'credit-fingerprint-1',
+    });
     expect(mapPaymentAllocationRow(allocationRow)).toMatchObject({ invoiceId, invoiceItemId, amount: 4000 });
     expect(mapRefundRow(refundRow)).toMatchObject({ reason: 'Overpayment return', refundMethod: 'kaspi', status: 'completed' });
     expect(mapFinancialAdjustmentRow(adjustmentRow)).toMatchObject({ adjustmentType: 'write_off', reason: 'Manager approval' });

--- a/src/data/repositories/FinanceRepository.ts
+++ b/src/data/repositories/FinanceRepository.ts
@@ -138,6 +138,8 @@ export interface Payment {
   notes: string | null;
   cashierOperationKey: string | null;
   cashierOperationFingerprint: string | null;
+  creditIntakeOperationKey: string | null;
+  creditIntakeOperationFingerprint: string | null;
   metadata: Record<string, unknown>;
   receivedBy: string | null;
   voidedBy: string | null;
@@ -594,6 +596,8 @@ export function mapPaymentRow(row: Record<string, unknown>): Payment {
     notes: nullableString(row.notes),
     cashierOperationKey: nullableString(row.cashier_operation_key),
     cashierOperationFingerprint: nullableString(row.cashier_operation_fingerprint),
+    creditIntakeOperationKey: nullableString(row.credit_intake_operation_key),
+    creditIntakeOperationFingerprint: nullableString(row.credit_intake_operation_fingerprint),
     metadata: metadataObject(row.metadata),
     receivedBy: nullableString(row.received_by),
     voidedBy: nullableString(row.voided_by),

--- a/src/data/repositories/FinanceRpcClient.test.ts
+++ b/src/data/repositories/FinanceRpcClient.test.ts
@@ -150,6 +150,30 @@ const paymentRow = {
   updated_at: '2026-06-21T02:00:02Z',
 };
 
+const patientCreditOperationRow = {
+  status: 'completed',
+  operation_id: 'patient-credit-operation-1',
+  tenant_id: tenantId,
+  patient_id: patientId,
+  payment: {
+    ...paymentRow,
+    credit_intake_operation_key: 'patient-credit-operation-1',
+    credit_intake_operation_fingerprint: 'credit-fingerprint-1',
+  },
+  capacity: {
+    paymentId,
+    patientId,
+    currency: 'KZT',
+    paymentAmount: '11000.00',
+    activeAllocatedAmount: '0.00',
+    completedRefundAmount: '0.00',
+    refundReservedAmount: '0.00',
+    reservedDepositAmount: '0.00',
+    grossUnallocatedAmount: '11000.00',
+    availableCreditAmount: '11000.00',
+  },
+};
+
 const paymentAllocationRow = {
   id: allocationId,
   tenant_id: tenantId,
@@ -378,8 +402,8 @@ describe('FinanceRpcClient RPC mapping', () => {
     expect(rpcCalls).toEqual([{ rpcName: 'void_invoice', params: { p_tenant_id: tenantId, p_invoice_id: invoiceId, p_reason: 'Wrong patient' } }]);
   });
 
-  it('recordPayment calls record_payment with exact p_* params', async () => {
-    const { rpcClient, rpcCalls } = createClientMock({ data: [paymentRow], error: null });
+  it('recordPayment calls record_patient_credit_payment with exact idempotent p_* params', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [patientCreditOperationRow], error: null });
     await rpcClient.recordPayment({
       tenantId,
       patientId,
@@ -390,10 +414,11 @@ describe('FinanceRpcClient RPC mapping', () => {
       externalReference: 'KSP-1',
       payerName: 'Patient',
       notes: 'Paid',
+      idempotencyKey: ' patient-credit-operation-1 ',
       metadata: { terminal: true },
     });
 
-    expect(rpcCalls).toEqual([{ rpcName: 'record_payment', params: {
+    expect(rpcCalls).toEqual([{ rpcName: 'record_patient_credit_payment', params: {
       p_tenant_id: tenantId,
       p_patient_id: patientId,
       p_amount: 11000,
@@ -403,7 +428,18 @@ describe('FinanceRpcClient RPC mapping', () => {
       p_external_reference: 'KSP-1',
       p_payer_name: 'Patient',
       p_notes: 'Paid',
+      p_operation_key: 'patient-credit-operation-1',
       p_metadata: { terminal: true },
+    } }]);
+  });
+
+  it('getPatientCreditPaymentOperation calls the tenant- and patient-scoped recovery RPC', async () => {
+    const { rpcClient, rpcCalls } = createClientMock({ data: [patientCreditOperationRow], error: null });
+    await rpcClient.getPatientCreditPaymentOperation({ tenantId, patientId, idempotencyKey: ' patient-credit-operation-1 ' });
+    expect(rpcCalls).toEqual([{ rpcName: 'get_patient_credit_payment_operation', params: {
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_operation_key: 'patient-credit-operation-1',
     } }]);
   });
 
@@ -480,13 +516,13 @@ describe('FinanceRpcClient validation', () => {
 
   it('recordPayment rejects amount <= 0', async () => {
     const { rpcClient } = createClientMock({ data: paymentRow, error: null });
-    await expectFinanceClientError(rpcClient.recordPayment({ tenantId, patientId, amount: 0, paymentMethod: 'cash' }), 'Сумма должна быть больше 0.');
+    await expectFinanceClientError(rpcClient.recordPayment({ tenantId, patientId, amount: 0, paymentMethod: 'cash', idempotencyKey: 'payment-zero' }), 'Сумма должна быть больше 0.');
   });
 
   it('recordPayment rejects invalid paymentMethod', async () => {
     const { rpcClient } = createClientMock({ data: paymentRow, error: null });
     await expectFinanceClientError(
-      rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'crypto' as PaymentMethod }),
+      rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'crypto' as PaymentMethod, idempotencyKey: 'payment-invalid-method' }),
       'Некорректный способ оплаты.',
     );
   });
@@ -554,12 +590,25 @@ describe('FinanceRpcClient result mapping', () => {
     expect(item.totalAmount).toBe(11000);
   });
 
-  it('recordPayment maps returned payment row to camelCase', async () => {
-    const { rpcClient } = createClientMock({ data: [paymentRow], error: null });
-    const payment = await rpcClient.recordPayment({ tenantId, patientId, amount: 11000, paymentMethod: 'cash' });
-    expect(payment.paymentMethod).toBe('cash');
-    expect(payment.externalReference).toBeNull();
-    expect(payment.amount).toBe(11000);
+  it('recordPayment maps payment, operation identity, and current credit capacity', async () => {
+    const { rpcClient } = createClientMock({ data: [patientCreditOperationRow], error: null });
+    const result = await rpcClient.recordPayment({ tenantId, patientId, amount: 11000, paymentMethod: 'cash', idempotencyKey: 'patient-credit-operation-1' });
+    expect(result.status).toBe('completed');
+    expect(result.operationId).toBe('patient-credit-operation-1');
+    expect(result.payment?.paymentMethod).toBe('cash');
+    expect(result.payment?.creditIntakeOperationKey).toBe('patient-credit-operation-1');
+    expect(result.payment?.creditIntakeOperationFingerprint).toBe('credit-fingerprint-1');
+    expect(result.capacity?.availableCreditAmount).toBe(11000);
+  });
+
+  it('maps a patient-credit recovery not_found result without inventing money', async () => {
+    const { rpcClient } = createClientMock({ data: [{
+      status: 'not_found', operation_id: 'missing-credit-operation', tenant_id: tenantId,
+      patient_id: patientId, payment: null, capacity: null,
+    }], error: null });
+    await expect(rpcClient.getPatientCreditPaymentOperation({ tenantId, patientId, idempotencyKey: 'missing-credit-operation' })).resolves.toEqual({
+      status: 'not_found', operationId: 'missing-credit-operation', tenantId, patientId, payment: null, capacity: null,
+    });
   });
 
   it('allocatePayment maps returned allocation row to camelCase', async () => {
@@ -620,6 +669,36 @@ describe('FinanceRpcClient error behavior', () => {
   });
 });
 
+describe('FinanceRpcClient patient-credit error normalization', () => {
+  it('maps permission, idempotency conflict, and patient mismatch safely', async () => {
+    const permission = createClientMock({ data: null, error: Object.assign(new Error('Access denied: insufficient finance permissions for this tenant'), { code: '42501' }) }).rpcClient;
+    await expect(permission.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash', idempotencyKey: 'permission-key' })).rejects.toMatchObject({
+      category: 'permission', message: 'Недостаточно прав для приёма денег.',
+    });
+
+    const conflict = createClientMock({ data: null, error: new Error('PATIENT_CREDIT_IDEMPOTENCY_CONFLICT: operation key was reused with different payment details') }).rpcClient;
+    await expect(conflict.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash', idempotencyKey: 'conflict-key' })).rejects.toMatchObject({
+      category: 'duplicate_conflict', message: 'Ключ операции уже использован с другими параметрами.',
+    });
+
+    const mismatch = createClientMock({ data: null, error: new Error('PATIENT_CREDIT_PATIENT_MISMATCH: operation key belongs to another patient') }).rpcClient;
+    await expect(mismatch.getPatientCreditPaymentOperation({ tenantId, patientId, idempotencyKey: 'mismatch-key' })).rejects.toMatchObject({
+      category: 'stale_patient', message: 'Операция относится к другому пациенту.',
+    });
+  });
+
+  it('treats unknown transport failure as operation_uncertain and requires the same key', async () => {
+    const { rpcClient } = createClientMock({ data: null, error: new Error('socket closed with raw details') });
+    await expect(rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash', idempotencyKey: 'uncertain-key' })).rejects.toMatchObject({
+      category: 'operation_uncertain', message: 'Не удалось получить ответ сервера. Проверьте операцию по тому же ключу.',
+    });
+    await expectFinanceClientError(
+      rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash', idempotencyKey: ' ' }),
+      'Ключ идемпотентности не должен быть пустым.',
+    );
+  });
+});
+
 describe('FinanceRpcClient safety boundaries', () => {
   it('factory creates a Supabase-backed client and rejects local backend', () => {
     const client = { rpc: vi.fn() } as unknown as SupabaseClient;
@@ -628,8 +707,8 @@ describe('FinanceRpcClient safety boundaries', () => {
   });
 
   it('client never calls from/insert/update/delete/upsert during a write operation', async () => {
-    const { rpcClient, client } = createClientMock({ data: [paymentRow], error: null });
-    await rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash' });
+    const { rpcClient, client } = createClientMock({ data: [patientCreditOperationRow], error: null });
+    await rpcClient.recordPayment({ tenantId, patientId, amount: 100, paymentMethod: 'cash', idempotencyKey: 'direct-write-boundary' });
     expect(client.rpc).toHaveBeenCalledOnce();
     expectNoDirectWriteCalls(client);
   });

--- a/src/data/repositories/FinanceRpcClient.ts
+++ b/src/data/repositories/FinanceRpcClient.ts
@@ -106,7 +106,25 @@ export interface RecordPaymentInput {
   externalReference?: string | null;
   payerName?: string | null;
   notes?: string | null;
+  idempotencyKey: string;
   metadata?: Record<string, unknown>;
+}
+
+export type PatientCreditPaymentOperationStatus = 'completed' | 'already_completed' | 'not_found';
+
+export interface PatientCreditPaymentOperationResult {
+  status: PatientCreditPaymentOperationStatus;
+  operationId: string;
+  tenantId: string;
+  patientId: string;
+  payment: Payment | null;
+  capacity: PaymentFundCapacity | null;
+}
+
+export interface GetPatientCreditPaymentOperationInput {
+  tenantId: string;
+  patientId: string;
+  idempotencyKey: string;
 }
 
 export interface RecordAndAllocatePaymentInput {
@@ -242,7 +260,8 @@ export interface FinanceRpcClient {
   getCompletedServiceBillingEligibility(input: GetCompletedServiceBillingEligibilityInput): Promise<CompletedServiceBillingEligibility[]>;
   issueInvoice(input: IssueInvoiceInput): Promise<Invoice>;
   voidInvoice(input: VoidInvoiceInput): Promise<Invoice>;
-  recordPayment(input: RecordPaymentInput): Promise<Payment>;
+  recordPayment(input: RecordPaymentInput): Promise<PatientCreditPaymentOperationResult>;
+  getPatientCreditPaymentOperation(input: GetPatientCreditPaymentOperationInput): Promise<PatientCreditPaymentOperationResult>;
   recordAndAllocatePayment(input: RecordAndAllocatePaymentInput): Promise<CashierPaymentOperationResult>;
   getCashierPaymentOperation(input: GetCashierPaymentOperationInput): Promise<CashierPaymentOperationResult>;
   allocatePayment(input: AllocatePaymentInput): Promise<PaymentAllocation>;
@@ -492,6 +511,14 @@ function requireCashierIdempotencyKey(value?: string | null): string {
   return normalized;
 }
 
+function requirePatientCreditIdempotencyKey(value?: string | null): string {
+  const normalized = normalizeIdempotencyKey(value);
+  if (!normalized) {
+    throw new FinanceRpcClientError({ operation: 'validation', category: 'validation', message: 'Ключ операции приёма денег обязателен.' });
+  }
+  return normalized;
+}
+
 function validateInvoiceIds(invoiceIds: string[] | null | undefined): string[] {
   if (!Array.isArray(invoiceIds) || invoiceIds.length === 0) {
     throw new FinanceRpcClientError({ operation: 'validation', category: 'validation', message: 'Нужно выбрать хотя бы один счёт.' });
@@ -555,6 +582,80 @@ function mapPatientFundReservationOperationRow(row: Record<string, unknown>): Pa
     allocation,
     capacity: mapOperationCapacity(row.capacity),
   };
+}
+
+function mapPatientCreditPaymentOperationRow(row: Record<string, unknown>): PatientCreditPaymentOperationResult {
+  const status = requiredResultString(row.status, 'status') as PatientCreditPaymentOperationStatus;
+  if (!['completed', 'already_completed', 'not_found'].includes(status)) {
+    throw new FinanceRpcClientError({ operation: 'mapPatientCreditPaymentOperation', category: 'operation_failed', message: 'Некорректный статус операции приёма денег.' });
+  }
+
+  const paymentRow = isPlainObject(row.payment) ? row.payment : null;
+  const capacity = row.capacity == null
+    ? null
+    : isPlainObject(row.capacity)
+      ? mapOperationCapacity(row.capacity)
+      : (() => { throw new FinanceRpcClientError({ operation: 'mapPatientCreditPaymentOperation', category: 'operation_failed', message: FINANCE_RPC_OPERATION_FAILED_MESSAGE }); })();
+
+  return {
+    status,
+    operationId: requiredResultString(row.operation_id, 'operation_id'),
+    tenantId: requiredResultString(row.tenant_id, 'tenant_id'),
+    patientId: requiredResultString(row.patient_id, 'patient_id'),
+    payment: paymentRow ? mapPaymentRow(paymentRow) : null,
+    capacity,
+  };
+}
+
+function normalizePatientCreditRpcError(error: unknown, operation: string): FinanceRpcClientError {
+  if (error instanceof FinanceRpcClientError && error.category) return error;
+  const raw = error instanceof Error ? error.message : String(error ?? '');
+  const normalized = raw.toLowerCase();
+  const code = error instanceof Error && typeof (error as Error & { code?: unknown }).code === 'string'
+    ? (error as Error & { code?: string }).code
+    : undefined;
+
+  if (normalized.includes('access denied') || normalized.includes('insufficient finance permissions') || code === '42501') {
+    return new FinanceRpcClientError({ operation, code, category: 'permission', message: 'Недостаточно прав для приёма денег.' });
+  }
+  if (normalized.includes('patient_credit_idempotency_conflict') || normalized.includes('operation key was reused')) {
+    return new FinanceRpcClientError({ operation, code, category: 'duplicate_conflict', message: 'Ключ операции уже использован с другими параметрами.' });
+  }
+  if (normalized.includes('patient_credit_patient_mismatch') || normalized.includes('belongs to another patient')) {
+    return new FinanceRpcClientError({ operation, code, category: 'stale_patient', message: 'Операция относится к другому пациенту.' });
+  }
+  if (
+    normalized.includes('must be positive') ||
+    normalized.includes('unsupported payment method') ||
+    normalized.includes('patient') ||
+    normalized.includes('metadata') ||
+    normalized.includes('currency') ||
+    normalized.includes('operation key') ||
+    normalized.includes('kzt only')
+  ) {
+    return new FinanceRpcClientError({ operation, code, category: 'validation', message: 'Проверьте пациента, сумму, валюту и способ оплаты.' });
+  }
+  return new FinanceRpcClientError({
+    operation,
+    code,
+    category: 'operation_uncertain',
+    message: 'Не удалось получить ответ сервера. Проверьте операцию по тому же ключу.',
+  });
+}
+
+async function callPatientCreditRpc(
+  client: SupabaseClient,
+  operation: string,
+  rpcName: string,
+  params: Record<string, unknown>,
+): Promise<PatientCreditPaymentOperationResult> {
+  try {
+    const { data, error } = await client.rpc(rpcName, params);
+    if (error) throw error;
+    return mapPatientCreditPaymentOperationRow(extractSingleRow(data, operation));
+  } catch (error) {
+    throw normalizePatientCreditRpcError(error, operation);
+  }
 }
 
 function mapCashierPaymentOperationRow(row: Record<string, unknown>): CashierPaymentOperationResult {
@@ -718,13 +819,15 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
     return mapInvoiceRow(row);
   }
 
-  async recordPayment(input: RecordPaymentInput): Promise<Payment> {
+  async recordPayment(input: RecordPaymentInput): Promise<PatientCreditPaymentOperationResult> {
     const operation = 'recordPayment';
     const tenantId = requireTenantId(input.tenantId);
     const patientId = requireNonEmptyString(input.patientId, 'Пациент не выбран.');
     const amount = requirePositiveNumber(input.amount, 'Сумма должна быть больше 0.');
     const paymentMethod = validatePaymentMethod(input.paymentMethod);
-    const row = await callRpc(this.client, operation, 'record_payment', {
+    const idempotencyKey = requirePatientCreditIdempotencyKey(input.idempotencyKey);
+
+    return callPatientCreditRpc(this.client, operation, 'record_patient_credit_payment', {
       p_tenant_id: tenantId,
       p_patient_id: patientId,
       p_amount: amount,
@@ -734,9 +837,17 @@ export class SupabaseFinanceRpcClient implements FinanceRpcClient {
       p_external_reference: input.externalReference || null,
       p_payer_name: input.payerName || null,
       p_notes: input.notes || null,
+      p_operation_key: idempotencyKey,
       p_metadata: normalizeMetadata(input.metadata),
     });
-    return mapPaymentRow(row);
+  }
+
+  async getPatientCreditPaymentOperation(input: GetPatientCreditPaymentOperationInput): Promise<PatientCreditPaymentOperationResult> {
+    return callPatientCreditRpc(this.client, 'getPatientCreditPaymentOperation', 'get_patient_credit_payment_operation', {
+      p_tenant_id: requireTenantId(input.tenantId),
+      p_patient_id: requireNonEmptyString(input.patientId, 'Пациент не выбран.'),
+      p_operation_key: requirePatientCreditIdempotencyKey(input.idempotencyKey),
+    });
   }
 
   async recordAndAllocatePayment(input: RecordAndAllocatePaymentInput): Promise<CashierPaymentOperationResult> {

--- a/supabase/migrations/0023_harden_patient_credit_intake.sql
+++ b/supabase/migrations/0023_harden_patient_credit_intake.sql
@@ -1,0 +1,352 @@
+-- 0023_harden_patient_credit_intake.sql
+-- Idempotent, recoverable intake of new patient money that remains unallocated.
+--
+-- Domain boundary:
+-- - payments remains the only fact that money was received;
+-- - no invoice, allocation, reservation, clinical, schedule or patients.balance writes;
+-- - existing record_and_allocate_payment remains unchanged and continues using the
+--   legacy record_payment function internally;
+-- - application callers must use record_patient_credit_payment.
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS credit_intake_operation_key text,
+  ADD COLUMN IF NOT EXISTS credit_intake_operation_fingerprint text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payments_tenant_credit_intake_operation_key
+  ON public.payments (tenant_id, credit_intake_operation_key)
+  WHERE credit_intake_operation_key IS NOT NULL;
+
+ALTER TABLE public.payments
+  DROP CONSTRAINT IF EXISTS payments_credit_intake_operation_key_check;
+ALTER TABLE public.payments
+  ADD CONSTRAINT payments_credit_intake_operation_key_check
+  CHECK (
+    (credit_intake_operation_key IS NULL AND credit_intake_operation_fingerprint IS NULL)
+    OR (
+      length(btrim(credit_intake_operation_key)) BETWEEN 1 AND 240
+      AND length(btrim(credit_intake_operation_fingerprint)) > 0
+    )
+  );
+
+ALTER TABLE public.payments
+  DROP CONSTRAINT IF EXISTS payments_single_intake_operation_namespace_check;
+ALTER TABLE public.payments
+  ADD CONSTRAINT payments_single_intake_operation_namespace_check
+  CHECK (NOT (
+    cashier_operation_key IS NOT NULL
+    AND credit_intake_operation_key IS NOT NULL
+  ));
+
+COMMENT ON COLUMN public.payments.credit_intake_operation_key
+  IS 'Tenant-scoped idempotency key for intentional unallocated patient-credit intake.';
+COMMENT ON COLUMN public.payments.credit_intake_operation_fingerprint
+  IS 'Canonical request fingerprint used to reject materially different reuse of a patient-credit intake operation key.';
+
+CREATE OR REPLACE FUNCTION public.patient_credit_payment_operation_result_internal(
+  p_tenant_id uuid,
+  p_payment_id uuid,
+  p_status text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_payment public.payments;
+  v_capacity record;
+BEGIN
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id
+    AND id = p_payment_id;
+
+  IF v_payment.id IS NULL THEN
+    RAISE EXCEPTION 'Patient credit payment operation not found';
+  END IF;
+
+  SELECT * INTO v_capacity
+  FROM public.get_payment_fund_capacity_internal(p_tenant_id, p_payment_id);
+
+  RETURN jsonb_build_object(
+    'status', p_status,
+    'operation_id', v_payment.credit_intake_operation_key,
+    'tenant_id', v_payment.tenant_id,
+    'patient_id', v_payment.patient_id,
+    'payment', to_jsonb(v_payment),
+    'capacity', jsonb_build_object(
+      'paymentId', v_payment.id,
+      'patientId', v_payment.patient_id,
+      'currency', v_payment.currency,
+      'paymentAmount', v_capacity.payment_amount,
+      'activeAllocatedAmount', v_capacity.active_allocated_amount,
+      'completedRefundAmount', v_capacity.completed_refund_amount,
+      'refundReservedAmount', v_capacity.refund_reserved_amount,
+      'reservedDepositAmount', v_capacity.reserved_deposit_amount,
+      'grossUnallocatedAmount', v_capacity.gross_unallocated_amount,
+      'availableCreditAmount', v_capacity.available_credit_amount
+    )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_patient_credit_payment(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_amount numeric,
+  p_payment_method text,
+  p_currency text DEFAULT 'KZT',
+  p_received_at timestamptz DEFAULT NULL,
+  p_external_reference text DEFAULT NULL,
+  p_payer_name text DEFAULT NULL,
+  p_notes text DEFAULT NULL,
+  p_operation_key text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_amount numeric(12,2);
+  v_payment_method text;
+  v_currency text;
+  v_external_reference text;
+  v_payer_name text;
+  v_notes text;
+  v_operation_key text;
+  v_metadata jsonb;
+  v_fingerprint text;
+  v_existing public.payments;
+  v_payment public.payments;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+
+  IF p_patient_id IS NULL THEN
+    RAISE EXCEPTION 'Patient ID is required';
+  END IF;
+
+  v_amount := round(COALESCE(p_amount, 0)::numeric, 2)::numeric(12,2);
+  IF v_amount <= 0 THEN
+    RAISE EXCEPTION 'Payment amount must be positive';
+  END IF;
+
+  v_payment_method := lower(btrim(COALESCE(p_payment_method, '')));
+  IF v_payment_method NOT IN (
+    'cash', 'kaspi', 'halyk_terminal', 'card', 'bank_transfer', 'insurance', 'osms', 'mixed', 'other'
+  ) THEN
+    RAISE EXCEPTION 'Unsupported payment method';
+  END IF;
+
+  v_currency := upper(btrim(COALESCE(p_currency, '')));
+  IF v_currency <> 'KZT' THEN
+    RAISE EXCEPTION 'Patient credit intake supports KZT only';
+  END IF;
+
+  v_operation_key := btrim(COALESCE(p_operation_key, ''));
+  IF length(v_operation_key) = 0 THEN
+    RAISE EXCEPTION 'Patient credit operation key is required';
+  END IF;
+  IF length(v_operation_key) > 240 THEN
+    RAISE EXCEPTION 'Patient credit operation key is too long';
+  END IF;
+
+  v_external_reference := nullif(btrim(COALESCE(p_external_reference, '')), '');
+  v_payer_name := nullif(btrim(COALESCE(p_payer_name, '')), '');
+  v_notes := nullif(btrim(COALESCE(p_notes, '')), '');
+  v_metadata := public.sanitize_finance_metadata_internal(p_metadata);
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.patients
+    WHERE tenant_id = p_tenant_id
+      AND id = p_patient_id
+  ) THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  v_fingerprint := md5(jsonb_build_object(
+    'tenantId', p_tenant_id,
+    'patientId', p_patient_id,
+    'amount', v_amount,
+    'paymentMethod', v_payment_method,
+    'currency', v_currency,
+    'receivedAt', p_received_at,
+    'externalReference', v_external_reference,
+    'payerName', v_payer_name,
+    'notes', v_notes,
+    'metadata', v_metadata
+  )::text);
+
+  -- Serialize same tenant/key before lookup or insert. Concurrent identical retries
+  -- converge on one payment; a different payload under the same key is rejected.
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('patient-credit-intake:' || p_tenant_id::text || ':' || v_operation_key, 0)
+  );
+
+  SELECT * INTO v_existing
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id
+    AND credit_intake_operation_key = v_operation_key;
+
+  IF v_existing.id IS NOT NULL THEN
+    IF v_existing.patient_id <> p_patient_id THEN
+      RAISE EXCEPTION 'PATIENT_CREDIT_PATIENT_MISMATCH: operation key belongs to another patient';
+    END IF;
+    IF v_existing.credit_intake_operation_fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'PATIENT_CREDIT_IDEMPOTENCY_CONFLICT: operation key was reused with different payment details';
+    END IF;
+    RETURN public.patient_credit_payment_operation_result_internal(
+      p_tenant_id,
+      v_existing.id,
+      'already_completed'
+    );
+  END IF;
+
+  v_metadata := jsonb_strip_nulls(v_metadata || jsonb_build_object(
+    'source', 'patient_credit_intake',
+    'patientCreditOperationKey', v_operation_key
+  ));
+
+  INSERT INTO public.payments (
+    tenant_id,
+    patient_id,
+    status,
+    payment_method,
+    amount,
+    currency,
+    received_at,
+    external_reference,
+    payer_name,
+    notes,
+    metadata,
+    received_by,
+    credit_intake_operation_key,
+    credit_intake_operation_fingerprint
+  ) VALUES (
+    p_tenant_id,
+    p_patient_id,
+    'received',
+    v_payment_method,
+    v_amount,
+    v_currency,
+    COALESCE(p_received_at, now()),
+    v_external_reference,
+    v_payer_name,
+    v_notes,
+    v_metadata,
+    auth.uid(),
+    v_operation_key,
+    v_fingerprint
+  ) RETURNING * INTO v_payment;
+
+  PERFORM public.log_finance_event_internal(
+    p_tenant_id,
+    'payment_recorded',
+    'payment',
+    v_payment.id,
+    v_payment.patient_id,
+    v_payment.id,
+    p_metadata => jsonb_build_object(
+      'source', 'patient_credit_intake',
+      'operationKey', v_operation_key,
+      'paymentId', v_payment.id,
+      'amount', v_payment.amount,
+      'currency', v_payment.currency,
+      'paymentMethod', v_payment.payment_method,
+      'status', v_payment.status
+    )
+  );
+
+  RETURN public.patient_credit_payment_operation_result_internal(
+    p_tenant_id,
+    v_payment.id,
+    'completed'
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_patient_credit_payment_operation(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_operation_key text := btrim(COALESCE(p_operation_key, ''));
+  v_payment public.payments;
+BEGIN
+  PERFORM public.ensure_finance_write_role_internal(
+    p_tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'cashier'::public.app_role]
+  );
+
+  IF p_patient_id IS NULL THEN
+    RAISE EXCEPTION 'Patient ID is required';
+  END IF;
+  IF length(v_operation_key) = 0 THEN
+    RAISE EXCEPTION 'Patient credit operation key is required';
+  END IF;
+  IF length(v_operation_key) > 240 THEN
+    RAISE EXCEPTION 'Patient credit operation key is too long';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.patients
+    WHERE tenant_id = p_tenant_id
+      AND id = p_patient_id
+  ) THEN
+    RAISE EXCEPTION 'Patient not found in this tenant';
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.payments
+  WHERE tenant_id = p_tenant_id
+    AND credit_intake_operation_key = v_operation_key;
+
+  IF v_payment.id IS NULL THEN
+    RETURN jsonb_build_object(
+      'status', 'not_found',
+      'operation_id', v_operation_key,
+      'tenant_id', p_tenant_id,
+      'patient_id', p_patient_id,
+      'payment', NULL,
+      'capacity', NULL
+    );
+  END IF;
+
+  IF v_payment.patient_id <> p_patient_id THEN
+    RAISE EXCEPTION 'PATIENT_CREDIT_PATIENT_MISMATCH: operation key belongs to another patient';
+  END IF;
+
+  RETURN public.patient_credit_payment_operation_result_internal(
+    p_tenant_id,
+    v_payment.id,
+    'completed'
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_patient_credit_payment(uuid, uuid, numeric, text, text, timestamptz, text, text, text, text, jsonb)
+  IS 'Authoritative idempotent intake of received patient money that remains unallocated and becomes available patient credit.';
+COMMENT ON FUNCTION public.get_patient_credit_payment_operation(uuid, uuid, text)
+  IS 'Tenant- and patient-scoped recovery lookup for an unallocated patient-credit intake operation key.';
+COMMENT ON FUNCTION public.record_payment(uuid, uuid, numeric, text, text, timestamptz, text, text, text, jsonb)
+  IS 'Legacy internal payment insert used by record_and_allocate_payment. Application callers must use record_patient_credit_payment.';
+
+REVOKE ALL ON FUNCTION public.patient_credit_payment_operation_result_internal(uuid, uuid, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.record_patient_credit_payment(uuid, uuid, numeric, text, text, timestamptz, text, text, text, text, jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_patient_credit_payment_operation(uuid, uuid, text) FROM PUBLIC, anon;
+
+-- Remove the unsafe direct application entry point while retaining the owner-only
+-- function for the existing atomic cashier flow's internal call.
+REVOKE ALL ON FUNCTION public.record_payment(uuid, uuid, numeric, text, text, timestamptz, text, text, text, jsonb) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION public.record_patient_credit_payment(uuid, uuid, numeric, text, text, timestamptz, text, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_patient_credit_payment_operation(uuid, uuid, text) TO authenticated;

--- a/supabase/tests/0018_refund_writeoff_rpc_test.sql
+++ b/supabase/tests/0018_refund_writeoff_rpc_test.sql
@@ -80,7 +80,7 @@ SELECT pg_temp.expect_error(
 );
 
 SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
-SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 1000, 'cash')).id::text AS refund_payment \gset
+SELECT (public.record_patient_credit_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 1000, 'cash', 'KZT', NULL, NULL, NULL, NULL, 'refund-test-payment-key', '{}'::jsonb)#>>'{payment,id}') AS refund_payment \gset
 
 SELECT pg_temp.expect_error(
   format('select public.request_refund(%L::uuid,%L::uuid,0,''cash'',''bad amount'',null,''{}''::jsonb)', :'tenant_a', :'refund_payment'),
@@ -152,7 +152,7 @@ SELECT pg_temp.expect_error(
 );
 
 -- Pending cannot complete, pending/approved can void, rejection releases reserve.
-SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 500, 'cash')).id::text AS reserve_payment \gset
+SELECT (public.record_patient_credit_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 500, 'cash', 'KZT', NULL, NULL, NULL, NULL, 'refund-test-reserve-key', '{}'::jsonb)#>>'{payment,id}') AS reserve_payment \gset
 SELECT (public.request_refund(:'tenant_a'::uuid, :'reserve_payment'::uuid, 400, 'cash', 'Pending flow', 'refund-pending-flow', '{}'::jsonb)).id::text AS pending_refund \gset
 SELECT pg_temp.expect_error(
   format('select public.complete_refund(%L::uuid,%L::uuid,null,''{}''::jsonb)', :'tenant_a', :'pending_refund'),
@@ -173,7 +173,7 @@ SELECT (public.create_invoice(:'tenant_a'::uuid, :'patient_a'::uuid)).id::text A
 SELECT public.add_invoice_item(:'tenant_a'::uuid, :'allocated_invoice'::uuid, 'Allocated refund test', 1, 1000);
 SELECT public.issue_invoice(:'tenant_a'::uuid, :'allocated_invoice'::uuid);
 SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
-SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 1000, 'cash')).id::text AS allocated_payment \gset
+SELECT (public.record_patient_credit_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 1000, 'cash', 'KZT', NULL, NULL, NULL, NULL, 'refund-test-allocated-key', '{}'::jsonb)#>>'{payment,id}') AS allocated_payment \gset
 SELECT (public.allocate_payment(:'tenant_a'::uuid, :'allocated_payment'::uuid, 1000, :'allocated_invoice'::uuid)).id::text AS allocation_id \gset
 SELECT pg_temp.expect_error(
   format('select public.request_refund(%L::uuid,%L::uuid,100,''cash'',''allocated money'',null,''{}''::jsonb)', :'tenant_a', :'allocated_payment'),
@@ -233,7 +233,7 @@ SELECT (public.create_invoice(:'tenant_a'::uuid, :'patient_a'::uuid)).id::text A
 SELECT public.add_invoice_item(:'tenant_a'::uuid, :'paid_invoice'::uuid, 'Paid writeoff negative', 1, 100);
 SELECT public.issue_invoice(:'tenant_a'::uuid, :'paid_invoice'::uuid);
 SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
-SELECT (public.record_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 100, 'cash')).id::text AS paid_invoice_payment \gset
+SELECT (public.record_patient_credit_payment(:'tenant_a'::uuid, :'patient_a'::uuid, 100, 'cash', 'KZT', NULL, NULL, NULL, NULL, 'refund-test-paid-invoice-key', '{}'::jsonb)#>>'{payment,id}') AS paid_invoice_payment \gset
 SELECT public.allocate_payment(:'tenant_a'::uuid, :'paid_invoice_payment'::uuid, 100, :'paid_invoice'::uuid);
 SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
 SELECT pg_temp.expect_error(

--- a/supabase/tests/0023_patient_credit_intake_concurrency.ps1
+++ b/supabase/tests/0023_patient_credit_intake_concurrency.ps1
@@ -1,0 +1,105 @@
+$ErrorActionPreference = 'Stop'
+
+$container = 'supabase_db_codex-test-supabase'
+$tenant = '11111111-1111-1111-1111-111111111111'
+$patient = 'd2330000-0000-4000-8000-000000000001'
+
+function Invoke-Scalar([string]$sql) {
+  return (& docker exec $container psql -U postgres -d postgres -Atc $sql).Trim()
+}
+
+function Invoke-Sql([string]$sql) {
+  $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw 'Local SQL command failed.' }
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -At -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n").Trim() }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -At -v ON_ERROR_STOP=1 2>&1
+    [pscustomobject]@{ Code = [int]$LASTEXITCODE; Text = ($output -join "`n").Trim() }
+  } -ArgumentList $container, $sqlB
+
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+$admin = Invoke-Scalar "select id from auth.users where email='qa.admin.a@example.local'"
+$cashier = Invoke-Scalar "select id from auth.users where email='qa.cashier.a@example.local'"
+if (-not $admin -or -not $cashier) { throw 'Local QA users are missing.' }
+
+$cleanup = "DELETE FROM public.patients WHERE id='$patient'::uuid;"
+
+try {
+  Invoke-Sql $cleanup
+  Invoke-Sql @"
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,balance)
+VALUES ('$patient','$tenant','Patient Credit Concurrency Smoke','+77002339999','phone',4321);
+"@
+
+  $context = "BEGIN; SET LOCAL ROLE authenticated; SELECT set_config('request.jwt.claim.sub','$cashier',true);"
+  $sameCall = "SELECT (public.record_patient_credit_payment('$tenant','$patient',100000,'cash','KZT',NULL,'PCI-SAME','Concurrent payer','Same retry','patient-credit-concurrent-same','{`"source`":`"concurrency`"}'::jsonb)#>>'{payment,id}'); COMMIT;"
+  $sameSql = "$context $sameCall"
+  $identical = @(Invoke-ConcurrentPair $sameSql $sameSql)
+  $sameFailures = @($identical | Where-Object { $_.Code -ne 0 }).Count
+  if ($sameFailures -ne 0) {
+    throw "Concurrent identical retries failed: $sameFailures`n$($identical.Text -join "`n---`n")"
+  }
+
+  $sameIds = @($identical | ForEach-Object { $_.Text.Split("`n") | Where-Object { $_ -match '^[0-9a-f-]{36}$' } | Select-Object -Last 1 })
+  $sameUniqueIds = @($sameIds | Sort-Object -Unique)
+  $samePayments = [int](Invoke-Scalar "select count(*) from public.payments where tenant_id='$tenant' and credit_intake_operation_key='patient-credit-concurrent-same'")
+  $samePaymentId = Invoke-Scalar "select id from public.payments where tenant_id='$tenant' and credit_intake_operation_key='patient-credit-concurrent-same'"
+  $sameAudit = [int](Invoke-Scalar "select count(*) from public.audit_events where payment_id='$samePaymentId' and action='payment_recorded'")
+  $sameActivity = [int](Invoke-Scalar "select count(*) from public.activity_events where metadata->>'paymentId'='$samePaymentId' and type='payment_recorded'")
+  $sameCapacity = [decimal](Invoke-Scalar "select available_credit_amount from public.get_payment_fund_capacity_internal('$tenant','$samePaymentId')")
+  if ($samePayments -ne 1 -or $sameUniqueIds.Count -ne 1 -or $sameAudit -ne 1 -or $sameActivity -ne 1 -or $sameCapacity -ne 100000) {
+    throw "Identical retry invariant failed: payments=$samePayments uniqueIds=$($sameUniqueIds.Count) audit=$sameAudit activity=$sameActivity capacity=$sameCapacity"
+  }
+
+  $conflictA = "$context SELECT public.record_patient_credit_payment('$tenant','$patient',70000,'kaspi','KZT',NULL,'PCI-CONFLICT-A',NULL,NULL,'patient-credit-concurrent-conflict','{}'::jsonb); COMMIT;"
+  $conflictB = "$context SELECT public.record_patient_credit_payment('$tenant','$patient',80000,'kaspi','KZT',NULL,'PCI-CONFLICT-B',NULL,NULL,'patient-credit-concurrent-conflict','{}'::jsonb); COMMIT;"
+  $conflict = @(Invoke-ConcurrentPair $conflictA $conflictB)
+  $conflictSuccess = @($conflict | Where-Object { $_.Code -eq 0 }).Count
+  $conflictRejected = @($conflict | Where-Object { $_.Code -ne 0 -and $_.Text -match 'PATIENT_CREDIT_IDEMPOTENCY_CONFLICT' }).Count
+  $conflictPayments = [int](Invoke-Scalar "select count(*) from public.payments where tenant_id='$tenant' and credit_intake_operation_key='patient-credit-concurrent-conflict'")
+  $conflictAudit = [int](Invoke-Scalar "select count(*) from public.audit_events where payment_id=(select id::text from public.payments where tenant_id='$tenant' and credit_intake_operation_key='patient-credit-concurrent-conflict') and action='payment_recorded'")
+  if ($conflictSuccess -ne 1 -or $conflictRejected -ne 1 -or $conflictPayments -ne 1 -or $conflictAudit -ne 1) {
+    throw "Conflicting retry invariant failed: success=$conflictSuccess rejected=$conflictRejected payments=$conflictPayments audit=$conflictAudit`n$($conflict.Text -join "`n---`n")"
+  }
+
+  $differentA = "$context SELECT public.record_patient_credit_payment('$tenant','$patient',11111,'card','KZT',NULL,'PCI-DIFF-A',NULL,NULL,'patient-credit-concurrent-different-a','{}'::jsonb); COMMIT;"
+  $differentB = "$context SELECT public.record_patient_credit_payment('$tenant','$patient',22222,'card','KZT',NULL,'PCI-DIFF-B',NULL,NULL,'patient-credit-concurrent-different-b','{}'::jsonb); COMMIT;"
+  $different = @(Invoke-ConcurrentPair $differentA $differentB)
+  $differentSuccess = @($different | Where-Object { $_.Code -eq 0 }).Count
+  $differentPayments = [int](Invoke-Scalar "select count(*) from public.payments where tenant_id='$tenant' and credit_intake_operation_key in ('patient-credit-concurrent-different-a','patient-credit-concurrent-different-b')")
+  $differentTotal = [decimal](Invoke-Scalar "select coalesce(sum(amount),0) from public.payments where tenant_id='$tenant' and credit_intake_operation_key in ('patient-credit-concurrent-different-a','patient-credit-concurrent-different-b')")
+  if ($differentSuccess -ne 2 -or $differentPayments -ne 2 -or $differentTotal -ne 33333) {
+    throw "Different-key invariant failed: success=$differentSuccess payments=$differentPayments total=$differentTotal"
+  }
+
+  $patientBalance = [decimal](Invoke-Scalar "select balance from public.patients where id='$patient'")
+  $allocations = [int](Invoke-Scalar "select count(*) from public.payment_allocations where patient_id='$patient'")
+  $reservations = [int](Invoke-Scalar "select count(*) from public.patient_fund_reservations where patient_id='$patient'")
+  $invoices = [int](Invoke-Scalar "select count(*) from public.invoices where patient_id='$patient'")
+  if ($patientBalance -ne 4321 -or $allocations -ne 0 -or $reservations -ne 0 -or $invoices -ne 0) {
+    throw "Forbidden side effect invariant failed: balance=$patientBalance allocations=$allocations reservations=$reservations invoices=$invoices"
+  }
+
+  Write-Output "IDENTICAL_RETRY success=2 payments=$samePayments uniquePaymentIds=$($sameUniqueIds.Count) audit=$sameAudit activity=$sameActivity credit=$sameCapacity"
+  Write-Output "CONFLICTING_RETRY success=$conflictSuccess rejected=$conflictRejected payments=$conflictPayments audit=$conflictAudit"
+  Write-Output "DIFFERENT_KEYS success=$differentSuccess payments=$differentPayments amount=$differentTotal"
+  Write-Output 'PATIENT CREDIT INTAKE CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup
+  $remaining = [int](Invoke-Scalar "select count(*) from public.patients where id='$patient'")
+  if ($remaining -ne 0) { throw "Concurrency cleanup failed: remaining=$remaining" }
+}

--- a/supabase/tests/0023_patient_credit_intake_hardening_test.sql
+++ b/supabase/tests/0023_patient_credit_intake_hardening_test.sql
@@ -1,0 +1,322 @@
+\set ON_ERROR_STOP on
+\echo 'CASHIER-CREDIT-PREPAYMENT-HARDENING-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_any_error(p_sql text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected operation to fail';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+
+SELECT id::text AS admin_a FROM auth.users WHERE email = 'qa.admin.a@example.local' \gset
+SELECT id::text AS cashier_a FROM auth.users WHERE email = 'qa.cashier.a@example.local' \gset
+SELECT id::text AS doctor_a FROM auth.users WHERE email = 'qa.doctor.a@example.local' \gset
+SELECT id::text AS notenant FROM auth.users WHERE email = 'qa.notenant@example.local' \gset
+SELECT id::text AS admin_b FROM auth.users WHERE email = 'qa.admin.b@example.local' \gset
+
+\set tenant_a '11111111-1111-1111-1111-111111111111'
+\set tenant_b '22222222-2222-2222-2222-222222222222'
+\set patient_a 'd2300000-0000-4000-8000-000000000001'
+\set patient_a2 'd2300000-0000-4000-8000-000000000002'
+\set patient_b 'd2300000-0000-4000-8000-000000000003'
+\set invoice_a 'd2310000-0000-4000-8000-000000000001'
+\set item_a 'd2320000-0000-4000-8000-000000000001'
+
+INSERT INTO public.patients (id, tenant_id, full_name, phone, source, balance)
+VALUES
+  (:'patient_a', :'tenant_a', 'Patient Credit Intake A', '+77002300001', 'phone', 321),
+  (:'patient_a2', :'tenant_a', 'Patient Credit Intake A2', '+77002300002', 'phone', 654),
+  (:'patient_b', :'tenant_b', 'Patient Credit Intake B', '+77002300003', 'phone', 987);
+
+INSERT INTO public.invoices (
+  id, tenant_id, patient_id, invoice_number, status, currency,
+  issue_date, issued_at, subtotal_amount, total_amount, balance_amount,
+  created_by, issued_by, metadata
+) VALUES (
+  :'invoice_a', :'tenant_a', :'patient_a', 'PCI-001', 'issued', 'KZT',
+  now(), now(), 1000, 1000, 1000, :'admin_a', :'admin_a', '{"marker":"patient-credit-intake"}'
+);
+
+INSERT INTO public.invoice_items (
+  id, tenant_id, invoice_id, patient_id, service_name, quantity,
+  unit_price, total_amount, status, created_by, metadata
+) VALUES (
+  :'item_a', :'tenant_a', :'invoice_a', :'patient_a', 'Compatibility service', 1,
+  1000, 1000, 'active', :'admin_a', '{"marker":"patient-credit-intake"}'
+);
+
+SELECT pg_temp.assert_true(
+  NOT has_function_privilege(
+    'authenticated',
+    'public.record_payment(uuid,uuid,numeric,text,text,timestamptz,text,text,text,jsonb)',
+    'EXECUTE'
+  ),
+  'legacy record_payment must not remain callable by application users'
+);
+SELECT pg_temp.assert_true(
+  has_function_privilege(
+    'authenticated',
+    'public.record_patient_credit_payment(uuid,uuid,numeric,text,text,timestamptz,text,text,text,text,jsonb)',
+    'EXECUTE'
+  ),
+  'hardened patient-credit intake must be callable by authenticated users'
+);
+SELECT pg_temp.assert_true(
+  has_function_privilege(
+    'authenticated',
+    'public.get_patient_credit_payment_operation(uuid,uuid,text)',
+    'EXECUTE'
+  ),
+  'recovery lookup must be callable by authenticated users'
+);
+SELECT pg_temp.assert_true(
+  NOT has_table_privilege('authenticated', 'public.payments', 'INSERT'),
+  'authenticated users must not insert payments directly'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+
+WITH result AS (
+  SELECT public.record_patient_credit_payment(
+    :'tenant_a', :'patient_a', 100000, 'cash', 'kzt', NULL,
+    ' CREDIT-100K ', ' Patient A ', ' Advance payment ',
+    'patient-credit-success-key', '{"source":"sql-test"}'::jsonb
+  ) AS payload
+)
+SELECT
+  payload->>'status' AS first_status,
+  payload->>'operation_id' AS first_operation_id,
+  payload#>>'{payment,id}' AS first_payment_id,
+  payload#>>'{payment,currency}' AS first_currency,
+  payload#>>'{payment,status}' AS first_payment_status,
+  payload#>>'{capacity,availableCreditAmount}' AS first_available_credit
+FROM result \gset
+
+SELECT pg_temp.assert_true(:'first_status' = 'completed', 'first intake must complete');
+SELECT pg_temp.assert_true(:'first_operation_id' = 'patient-credit-success-key', 'operation key must be normalized and returned');
+SELECT pg_temp.assert_true(:'first_currency' = 'KZT', 'currency must normalize to KZT');
+SELECT pg_temp.assert_true(:'first_payment_status' = 'received', 'unallocated payment must remain received');
+SELECT pg_temp.assert_true(:'first_available_credit'::numeric = 100000, 'full payment must become available credit');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payment_allocations WHERE payment_id=:'first_payment_id') = 0, 'intake must not allocate money');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.patient_fund_reservations WHERE payment_id=:'first_payment_id') = 0, 'intake must not create a deposit reservation');
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id=:'patient_a') = 321, 'patients.balance must remain unchanged');
+
+WITH summary AS (
+  SELECT public.get_patient_finance_summary(:'tenant_a', :'patient_a') AS payload
+)
+SELECT
+  payload#>>'{currencies,0,cashReceived}' AS summary_cash_received,
+  payload#>>'{currencies,0,availableCreditAmount}' AS summary_available_credit,
+  payload#>>'{currencies,0,reservedDepositAmount}' AS summary_reserved_deposit
+FROM summary \gset
+SELECT pg_temp.assert_true(:'summary_cash_received'::numeric = 100000, 'patient finance summary must include the new received money');
+SELECT pg_temp.assert_true(:'summary_available_credit'::numeric = 100000, 'patient finance summary must expose the new available credit');
+SELECT pg_temp.assert_true(:'summary_reserved_deposit'::numeric = 0, 'new money intake must not create a deposit reservation');
+
+WITH retry AS (
+  SELECT public.record_patient_credit_payment(
+    :'tenant_a', :'patient_a', 100000, 'cash', 'KZT', NULL,
+    'CREDIT-100K', 'Patient A', 'Advance payment',
+    'patient-credit-success-key', '{"source":"sql-test"}'::jsonb
+  ) AS payload
+)
+SELECT
+  payload->>'status' AS retry_status,
+  payload#>>'{payment,id}' AS retry_payment_id
+FROM retry \gset
+
+SELECT pg_temp.assert_true(:'retry_status' = 'already_completed', 'identical retry must return already_completed');
+SELECT pg_temp.assert_true(:'retry_payment_id' = :'first_payment_id', 'identical retry must return the same payment');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments WHERE tenant_id=:'tenant_a' AND credit_intake_operation_key='patient-credit-success-key') = 1, 'identical retry must not duplicate money');
+
+-- Audit rows are intentionally admin-visible, so inspect them outside the cashier RLS role.
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE payment_id=:'first_payment_id' AND action='payment_recorded') = 1, 'success audit event must not duplicate on retry');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE metadata->>'paymentId'=:'first_payment_id' AND type='payment_recorded') = 1, 'success activity event must not duplicate on retry');
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+
+SELECT pg_temp.expect_error(
+  format(
+    $$SELECT public.record_patient_credit_payment(%L::uuid,%L::uuid,99999,'cash','KZT',NULL,'CREDIT-100K','Patient A','Advance payment','patient-credit-success-key','{"source":"sql-test"}'::jsonb)$$,
+    :'tenant_a', :'patient_a'
+  ),
+  'PATIENT_CREDIT_IDEMPOTENCY_CONFLICT'
+);
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments WHERE tenant_id=:'tenant_a' AND credit_intake_operation_key='patient-credit-success-key') = 1, 'conflicting retry must not insert another payment');
+
+WITH recovered AS (
+  SELECT public.get_patient_credit_payment_operation(:'tenant_a', :'patient_a', 'patient-credit-success-key') AS payload
+)
+SELECT
+  payload->>'status' AS recovery_status,
+  payload#>>'{payment,id}' AS recovery_payment_id,
+  payload#>>'{capacity,availableCreditAmount}' AS recovery_available_credit
+FROM recovered \gset
+SELECT pg_temp.assert_true(:'recovery_status' = 'completed', 'recovery must find the committed operation');
+SELECT pg_temp.assert_true(:'recovery_payment_id' = :'first_payment_id', 'recovery must return the same payment');
+SELECT pg_temp.assert_true(:'recovery_available_credit'::numeric = 100000, 'recovery must return current credit capacity');
+
+WITH missing AS (
+  SELECT public.get_patient_credit_payment_operation(:'tenant_a', :'patient_a', 'patient-credit-missing-key') AS payload
+)
+SELECT payload->>'status' AS missing_status, payload->'payment' = 'null'::jsonb AS missing_payment_is_null FROM missing \gset
+SELECT pg_temp.assert_true(:'missing_status' = 'not_found', 'unknown operation key must return not_found');
+SELECT pg_temp.assert_true(:'missing_payment_is_null'::boolean, 'not_found recovery must not invent a payment');
+
+SELECT pg_temp.expect_error(
+  format(
+    $$SELECT public.get_patient_credit_payment_operation(%L::uuid,%L::uuid,'patient-credit-success-key')$$,
+    :'tenant_a', :'patient_a2'
+  ),
+  'PATIENT_CREDIT_PATIENT_MISMATCH'
+);
+
+WITH second_payment AS (
+  SELECT public.record_patient_credit_payment(
+    :'tenant_a', :'patient_a', 100000, 'cash', 'KZT', NULL,
+    NULL, NULL, NULL, 'patient-credit-second-key', '{}'::jsonb
+  ) AS payload
+)
+SELECT payload#>>'{payment,id}' AS second_payment_id FROM second_payment \gset
+SELECT pg_temp.assert_true(:'second_payment_id' <> :'first_payment_id', 'different operation keys may intentionally create two payments');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments WHERE tenant_id=:'tenant_a' AND credit_intake_operation_key IN ('patient-credit-success-key','patient-credit-second-key')) = 2, 'different keys must create two payment facts');
+
+WITH reservation AS (
+  SELECT public.create_patient_fund_reservation(
+    :'tenant_a', :'patient_a', :'first_payment_id', 30000,
+    'general', 'Future treatment', NULL, NULL, NULL, NULL,
+    '{"source":"sql-test"}'::jsonb, 'patient-credit-reservation-key'
+  ) AS payload
+)
+SELECT
+  payload#>>'{reservation,id}' AS reservation_id,
+  payload#>>'{capacity,availableCreditAmount}' AS reserved_available_credit
+FROM reservation \gset
+SELECT pg_temp.assert_true(:'reserved_available_credit'::numeric = 70000, 'deposit reservation must reduce available credit from the new payment');
+
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT pg_temp.expect_any_error(
+  format($$SELECT public.void_payment(%L::uuid,%L::uuid,'must remain reserved')$$, :'tenant_a', :'first_payment_id')
+);
+
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.release_patient_fund_reservation(
+  :'tenant_a', :'reservation_id', NULL, 'Reservation released for test', 'patient-credit-release-key'
+);
+SELECT pg_temp.assert_true(
+  (SELECT available_credit_amount FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'first_payment_id')) = 100000,
+  'released reservation must restore available credit'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT (public.request_refund(
+  :'tenant_a', :'first_payment_id', 10000, 'cash', 'Compatibility refund',
+  'patient-credit-refund-key', '{"source":"sql-test"}'::jsonb
+)).id::text AS refund_id \gset
+SELECT pg_temp.assert_true(
+  (SELECT available_credit_amount FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'first_payment_id')) = 90000,
+  'pending refund must reserve capacity from the new payment'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'admin_a', true);
+SELECT public.reject_refund(:'tenant_a', :'refund_id', 'Compatibility check complete');
+SELECT pg_temp.assert_true(
+  (SELECT available_credit_amount FROM public.get_payment_fund_capacity(:'tenant_a', :'patient_a', :'first_payment_id')) = 100000,
+  'rejected refund must restore available credit'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'doctor_a', true);
+SELECT pg_temp.expect_error(
+  format(
+    $$SELECT public.record_patient_credit_payment(%L::uuid,%L::uuid,100,'cash','KZT',NULL,NULL,NULL,NULL,'patient-credit-doctor-key','{}'::jsonb)$$,
+    :'tenant_a', :'patient_a'
+  ),
+  'Access denied'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'notenant', true);
+SELECT pg_temp.expect_error(
+  format(
+    $$SELECT public.record_patient_credit_payment(%L::uuid,%L::uuid,100,'cash','KZT',NULL,NULL,NULL,NULL,'patient-credit-no-tenant-key','{}'::jsonb)$$,
+    :'tenant_a', :'patient_a'
+  ),
+  'Access denied'
+);
+
+SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
+SELECT pg_temp.expect_error(
+  format(
+    $$SELECT public.record_patient_credit_payment(%L::uuid,%L::uuid,100,'cash','KZT',NULL,NULL,NULL,NULL,'patient-credit-cross-tenant-key','{}'::jsonb)$$,
+    :'tenant_a', :'patient_b'
+  ),
+  'Patient not found in this tenant'
+);
+SELECT pg_temp.expect_error(
+  format(
+    $$SELECT public.record_patient_credit_payment(%L::uuid,%L::uuid,100,'cash','USD',NULL,NULL,NULL,NULL,'patient-credit-usd-key','{}'::jsonb)$$,
+    :'tenant_a', :'patient_a'
+  ),
+  'KZT only'
+);
+
+-- Existing allocated cashier flow must still work even though direct legacy
+-- record_payment execution is revoked from authenticated users.
+WITH cashier_result AS (
+  SELECT public.record_and_allocate_payment(
+    :'tenant_a', :'patient_a', 1000, 'cash', 'KZT', NULL,
+    'PCI-CASHIER', NULL, NULL, ARRAY[:'invoice_a'::uuid],
+    'patient-credit-cashier-compat-key', '{"source":"sql-test"}'::jsonb
+  ) AS payload
+)
+SELECT
+  payload#>>'{payment,id}' AS cashier_payment_id,
+  payload#>>'{payment,cashier_operation_key}' AS cashier_operation_key,
+  payload#>'{payment,credit_intake_operation_key}' = 'null'::jsonb AS cashier_credit_operation_is_null,
+  payload->>'allocated_amount' AS cashier_allocated_amount
+FROM cashier_result \gset
+SELECT pg_temp.assert_true(:'cashier_operation_key' = 'patient-credit-cashier-compat-key', 'allocated cashier flow must retain its operation key');
+SELECT pg_temp.assert_true(:'cashier_credit_operation_is_null'::boolean, 'allocated cashier flow must not use patient-credit intake namespace');
+SELECT pg_temp.assert_true(:'cashier_allocated_amount'::numeric = 1000, 'allocated cashier flow must remain fully allocated');
+
+RESET ROLE;
+
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoices WHERE patient_id=:'patient_a' AND id<>:'invoice_a') = 0, 'patient-credit intake must not create invoices');
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id=:'patient_a') = 321, 'all finance operations must leave patients.balance unchanged');
+
+ROLLBACK;
+\echo 'PATIENT CREDIT INTAKE HARDENING SQL VALIDATION PASSED'


### PR DESCRIPTION
## Summary

Adds an explicit idempotent patient-credit intake RPC and recovery lookup, keeps received money represented only by `payments`, revokes direct authenticated use of legacy `record_payment`, preserves the existing atomic allocated cashier flow, and wires the current patient Finance action through same-key recovery. Includes SQL, concurrency, client, hook, regression tests, and the hardening report. No cloud migration was applied. Final PR head is `37dfeef6b755930a75ca0bff96b92766ba09d567`; fresh CI run #687 (`29154116178`) completed successfully on that exact commit.

## Checks

- Clean local Supabase reset through migration 0023
- Patient-credit SQL hardening test passed
- Concurrent identical retry: 1 payment, 1 audit, 1 activity
- Conflicting same-key retry: 1 success, 1 controlled rejection
- Distinct keys: distinct payment facts
- Refund, cashier, and deposit SQL/concurrency regressions passed
- ESLint passed
- 79 test files / 817 tests passed
- Production build passed
- Schema lint has no warning attributable to migration 0023
- Final CI #687 succeeded on PR head 37dfeef6b755930a75ca0bff96b92766ba09d567

## Limitations

- No prepayment UI or browser persistence was added
- Operation-key recovery is retained only while the finance hook remains mounted
- No cloud Supabase migration or production data change
- Existing unrelated schema-lint and React act warnings remain baseline
- The built-in report finalizer failed with `replaceReportPlaceholders is not defined`; final head and CI were recorded in the PR body and local finalization receipt instead
