### PR TITLE
CASHIER-CREDIT-PREPAYMENT-UI-001: add safe cashier prepayment intake

### DIFF
--- a/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-UI-001_ui.md
+++ b/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-UI-001_ui.md
@@ -34,7 +34,7 @@ One Chrome-discovered integration defect was fixed during QA: a cashier finance 
 
 ## 4. PR URL
 
-Pending publication.
+https://github.com/NckNA/codex-test/pull/344
 
 ## 5. Baseline
 
@@ -46,7 +46,12 @@ Pending publication.
 
 ## 6. PR head reviewed before final report update
 
-Pending implementation commit and PR publication.
+- implementation head: `e9409eb227e0d059e713261a27d680d1a008a546`;
+- GitHub Actions workflow: `CI`;
+- implementation CI run: `#689`;
+- run ID: `29156651306`;
+- conclusion: `success`;
+- tested commit matched the implementation head.
 
 ## 7. Report update commit
 
@@ -368,7 +373,7 @@ Targeted final result:
 
 All 21 hook tests passed.
 
-## 23. Real browser smoke
+## 23. Browser smoke: real browser smoke
 
 A real local browser was run against Vite on port 5187 and local Supabase.
 
@@ -485,7 +490,7 @@ Completed cleanup:
 - tenants: 0;
 - QA auth users: 0.
 
-## 28. Lint/test/build
+## 28. Checks: lint/test/build
 
 Final checks after cleanup and after removing all temporary code:
 
@@ -505,17 +510,21 @@ No package dependency was changed in this task.
 
 ## 29. GitHub Actions CI
 
-Pending PR publication and fresh GitHub Actions CI on the final PR head.
+Implementation CI:
 
-Required final confirmation:
+- workflow: `CI`;
+- run: `#689`;
+- run ID: `29156651306`;
+- conclusion: `success`;
+- tested commit: `e9409eb227e0d059e713261a27d680d1a008a546`;
+- ESLint: passed;
+- tests: passed;
+- build: passed;
+- tested commit matched the implementation head.
 
-- CI tested commit equals final PR head;
-- ESLint passed;
-- tests passed;
-- build passed;
-- PR remains open and unmerged.
+A fresh CI run on the final report-only PR head is required after the report metadata commit. The PR must remain open and unmerged.
 
-## 30. Known limitations
+## 30. Limitations / known limitations
 
 1. An unresolved operation key is retained in the mounted hook instance. Durable recovery across a full browser restart is not added by this UI task and remains a future workflow concern.
 2. The no-tenant browser context correctly showed no prepayment action, but the application-level pre-cashier screen did not expose the component's internal `cashier-no-tenant` text in that isolated route assertion.

--- a/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-UI-001_ui.md
+++ b/_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-UI-001_ui.md
@@ -1,0 +1,555 @@
+# CASHIER-CREDIT-PREPAYMENT-UI-001
+
+## 1. Final verdict
+
+Task verdict: **CASHIER CREDIT PREPAYMENT UI IMPLEMENTED AND VERIFIED**
+
+Machine-readable final verdict: **PASS**
+
+The operational cashier UI for receiving new patient money without paying an invoice is implemented, tested in a real browser, reconciled against the hardened migration 0023 contract, validated in PostgreSQL, cleaned locally, and ready for review. The PR must remain open and unmerged.
+
+## 2. Summary
+
+A single reusable `AcceptPatientPrepaymentDialog` now provides intentional patient-credit intake from two authorized surfaces:
+
+1. the cashier patient workspace;
+2. the patient Finance tab.
+
+The workflow calls the existing hardened `record_patient_credit_payment` contract through `useFinanceActions` and `FinanceRpcClient`. It does not introduce a prepayment table or a second money ledger.
+
+The domain distinction is explicit:
+
+```text
+new money now -> Принять предоплату
+invoice payment -> Принять оплату по счетам
+existing reserved credit -> Использовать депозит
+new reservation -> Создать депозит
+```
+
+One Chrome-discovered integration defect was fixed during QA: a cashier finance refresh temporarily unmounted the prepayment dialog and erased the visible success result. The prepayment block is now preserved while its own operation is active, and a regression test protects that behavior.
+
+## 3. Branch
+
+`feature/cashier-credit-prepayment-ui-001`
+
+## 4. PR URL
+
+Pending publication.
+
+## 5. Baseline
+
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- verified baseline: `4794a2e6552ccd224165bfd0dda5314aba5edb84`;
+- PR #343 was confirmed merged into `origin/main` at that exact commit;
+- the task worktree was clean before implementation.
+
+## 6. PR head reviewed before final report update
+
+Pending implementation commit and PR publication.
+
+## 7. Report update commit
+
+Report update commit: N/A because final report commit cannot reference itself; use the finalization receipt and final task response for the final report-only commit and fresh CI.
+
+## 8. Changed files
+
+Implementation and tests:
+
+- `src/components/cashier/AcceptPatientPrepaymentDialog.tsx`;
+- `src/components/cashier/AcceptPatientPrepaymentDialog.test.tsx`;
+- `src/components/cashier/CashierPaymentForm.tsx`;
+- `src/components/cashier/CashierPaymentPanel.tsx`;
+- `src/components/cashier/CashierPaymentPanel.test.tsx`;
+- `src/components/finance/PatientFinancePanel.tsx`;
+- `src/components/finance/PatientFinancePanel.test.tsx`;
+- `src/components/finance/PaymentActions.tsx`;
+- `src/components/finance/PaymentList.tsx`;
+- `src/data/hooks/useFinanceActions.ts`;
+- `src/data/hooks/useFinanceActions.test.tsx`;
+- `src/pages/PatientCardPage.tsx`;
+- `_ai_work/REPORTS/CASHIER-CREDIT-PREPAYMENT-UI-001_ui.md`.
+
+No migration, seed, package, lockfile, generated type, screenshot, QA helper, environment file, or Supabase client shim is included in the final diff.
+
+## 9. Pre-read
+
+Reviewed before implementation:
+
+- `POST-FINANCE-ROADMAP-RECON-001`;
+- `CASHIER-CREDIT-PREPAYMENT-HARDENING-001`;
+- `CASHIER-PAYMENT-FLOW-001`;
+- `CASHIER-PAYMENT-FLOW-HARDENING-001`;
+- `PATIENT-CREDIT-DEPOSITS-FOUNDATION-001`;
+- `PATIENT-CREDIT-DEPOSITS-UI-001`;
+- `FINANCE-SUMMARY-CORRECTNESS-001`;
+- cashier page, summary, search, invoice list, payment form, result panel and permissions;
+- patient Finance panel, payment history/actions and deposit UI;
+- `useFinanceActions`, `useCashierPaymentFlow`, `FinanceRpcClient`, `FinanceRepository` and their tests;
+- migrations 0016 through 0023 and relevant SQL/concurrency tests.
+
+## 10. Existing UI inventory
+
+Before this task:
+
+1. The patient Finance tab contained an inline generic action labelled `Принять оплату`.
+2. That action already reached the hardened 0023 RPC through `useFinanceActions` and `FinanceRpcClient`.
+3. It allowed a payment without an invoice and therefore produced unallocated patient credit.
+4. Its wording did not clearly distinguish invoice payment from unallocated new money.
+5. Patient credit was shown in the patient Finance summary and cashier summary.
+6. Owner, admin and cashier could reach the backend action through finance permissions.
+7. The hook performed same-key recovery, but the UI exposed only a generic loading flag and no reconciliation state.
+8. The form had a local pending guard, while the hook did not yet deduplicate concurrent calls at the same scope.
+9. The action was patient-scoped.
+10. Cashier and patient-card surfaces had adjacent but different payment concepts, creating a risk of a second duplicate form.
+
+## 11. Non-duplication decision
+
+The old inline generic patient payment form was not copied.
+
+A single reusable dialog was created and embedded in both allowed entry points. The old `PaymentActions` component now handles only payment void controls. Payment history remains in `PaymentList`.
+
+The authoritative money model remains:
+
+```text
+payments = money received
+payment_allocations = application of received money to invoices
+patient_fund_reservations = explicit reservation of existing credit
+patient credit = server-derived remaining payment capacity
+```
+
+No `prepayments` table, local financial ledger, localStorage fallback, new SQL migration, or direct table write was added.
+
+## 12. Entry points
+
+Two and only two operational entry points were added:
+
+1. cashier patient workspace, test id `cashier-prepayment-open`;
+2. patient Finance tab, test id `patient-finance-prepayment-open`.
+
+The same dialog and the same hook contract are reused in both places.
+
+The cashier entry is kept separate from the existing allocated cashier form. The patient Finance entry is kept separate from payment history, refund, void, allocation and deposit actions.
+
+## 13. Dialog design
+
+The dialog contains:
+
+- patient name;
+- current available credit;
+- current debt;
+- reserved deposit amount;
+- refund reserve amount;
+- fixed currency KZT;
+- amount;
+- payment method;
+- optional received date/time;
+- optional external reference;
+- optional payer name;
+- optional note.
+
+There is no currency selector.
+
+The fixed explanation is:
+
+> Деньги будут приняты клиникой и сохранены как доступный кредит пациента. Счёт и депозит автоматически не создаются.
+
+Before submit, the dialog shows:
+
+- patient;
+- amount;
+- payment method;
+- `Счёт не выбран`;
+- `Деньги станут доступным кредитом пациента`;
+- the warning that this records new money and does not use existing credit.
+
+## 14. Wording separation
+
+Implemented labels:
+
+- unallocated new money: `Принять предоплату`;
+- allocated cashier payment: `Принять оплату по счетам`;
+- explicit reservation: `Создать депозит`;
+- reserved-credit consumption: `Использовать депозит`.
+
+The prepayment success state never says:
+
+- `Счёт оплачен`;
+- `Депозит создан`;
+- `Кредит использован`.
+
+The wording `Пополнить баланс` is not used, and `patients.balance` is not treated as financial truth.
+
+## 15. Validation
+
+Client validation enforces:
+
+- amount greater than zero;
+- finite numeric amount;
+- maximum two decimal places;
+- selected patient;
+- selected tenant;
+- selected backend-supported payment method;
+- trimming of external reference, payer name and note;
+- whitespace-only optional values become `null`;
+- KZT is fixed.
+
+Safe validation messages include:
+
+- `Введите сумму больше нуля.`;
+- `Выберите способ оплаты.`;
+- `Пациент не выбран.`;
+- `Клиника не выбрана.`.
+
+The backend remains authoritative.
+
+## 16. Idempotency handling
+
+Idempotency remains owned by `useFinanceActions`, not duplicated in the component.
+
+The hook now exposes explicit patient-credit operation status and result while preserving the hardened behavior:
+
+- one key is generated for the first submission;
+- the same key survives ambiguous transport results;
+- recovery uses the same key;
+- confirmed `not_found` retries once with the same key;
+- changed payload while unresolved is rejected;
+- definitive validation or permission failures clear pending identity;
+- confirmed success clears pending identity;
+- unresolved failure retains it;
+- an in-flight map returns the same promise for rapid duplicate submissions at the same tenant/patient scope.
+
+The dialog also has a synchronous submit guard and disables the form while submitting or reconciling.
+
+## 17. Uncertain-response recovery
+
+Visible operation states:
+
+- submitting: `Сохраняем платёж…`;
+- reconciliation: `Проверяем, был ли платёж сохранён…`;
+- unresolved: `Не удалось подтвердить результат операции. Повторите попытку с теми же данными.`;
+- confirmed success: `Предоплата принята.`.
+
+Real browser recovery used a temporary DEV-only network shim:
+
+1. `record_patient_credit_payment` committed 1200 KZT;
+2. the successful response was replaced with a transport failure;
+3. the recovery RPC was delayed so the reconciliation state was visible;
+4. `get_patient_credit_payment_operation` found the committed payment;
+5. the dialog showed one success;
+6. the database contained one payment.
+
+For the unresolved conflict scenario:
+
+1. 1300 KZT was committed;
+2. both write and recovery responses were made ambiguous;
+3. the dialog retained its operation identity;
+4. changing the amount to 1400 KZT was blocked locally;
+5. no second payment was created.
+
+The temporary shim was fully restored before final tests and is absent from the diff.
+
+## 18. Stale-context protection
+
+Operation state is scoped by:
+
+- tenant id;
+- patient id;
+- current operation fingerprint/key;
+- current React context.
+
+Implemented behavior:
+
+- patient or tenant changes reset visible dialog state;
+- a late success does not update another patient;
+- a late response does not trigger refresh for the new context;
+- old success, credit and patient name do not flash under the new patient;
+- unresolved operation identity remains tied to the original tenant/patient map entry.
+
+Real browser smoke delayed a 1600 KZT response for Patient I, switched by keyboard to Patient B, waited for the old response, and confirmed:
+
+- Patient B remained selected;
+- no `Предоплата принята.` appeared;
+- no `1 600 KZT` appeared;
+- Patient I's name disappeared.
+
+## 19. Role matrix
+
+| Role | View cashier finance | Receive prepayment |
+| --- | --- | --- |
+| clinic_owner | yes | yes |
+| clinic_admin | yes | yes |
+| cashier | yes | yes |
+| doctor | no action | no |
+| registrar | no action | no |
+| unknown | no action | no |
+| no tenant | no mutation entry point | no |
+| no patient | no action | no |
+
+The backend still performs final authorization.
+
+Real browser contexts confirmed owner, admin and cashier visibility, doctor and registrar denial, and no action for the no-tenant user.
+
+## 20. Accessibility
+
+Implemented:
+
+- `role="dialog"` and `aria-modal="true"`;
+- accessible title via `aria-labelledby`;
+- linked labels and inputs;
+- focus moves to amount on open;
+- Escape closes only when not submitting/reconciling;
+- amount uses decimal input mode;
+- field errors use `aria-invalid` and `aria-describedby`;
+- progress uses `role="status"`;
+- operation errors use `role="alert"`;
+- disabled state is represented with native disabled controls and `aria-disabled` on submit;
+- confirmation summary is textual and does not rely on color;
+- the dialog is width-bounded, scrollable and mobile-safe;
+- keyboard submission is guarded to one in-flight call.
+
+## 21. Component tests
+
+`AcceptPatientPrepaymentDialog.test.tsx` contains all 38 required component scenarios:
+
+1. owner visibility;
+2. admin visibility;
+3. cashier visibility;
+4. doctor hidden;
+5. registrar hidden;
+6. no tenant hidden;
+7. no patient hidden;
+8. open;
+9. patient name;
+10. credit;
+11. debt;
+12. deposit reserve;
+13. refund reserve;
+14. fixed KZT;
+15. no currency selector;
+16–20. amount/method validation;
+21. optional-field trimming;
+22–23. confirmation wording;
+24. one hardened action call;
+25. duplicate submit blocked;
+26–27. submitting/reconciliation UI;
+28–30. correct success wording;
+31–33. safe permission/conflict/generic errors;
+34–36. patient/tenant/stale protection;
+37. allocated cashier wording unchanged;
+38. reserved-credit wording unchanged.
+
+`CashierPaymentPanel.test.tsx` now has 14 tests and includes the real-browser regression: prepayment success remains visible while the cashier finance refresh is pending and after it completes.
+
+`PatientFinancePanel.test.tsx` was updated for the reusable entry point and hardened result contract.
+
+Targeted final result:
+
+- 3 files;
+- 73 tests passed.
+
+## 22. Hook tests
+
+`useFinanceActions.test.tsx` now contains 21 tests, including:
+
+- same key retained after uncertainty;
+- recovery success becomes confirmed success;
+- confirmed `not_found` retries once with the same key;
+- a second uncertain result retains operation identity;
+- changed payload is blocked while unresolved;
+- success clears pending identity;
+- permission and validation failures clear pending identity;
+- stale patient response is ignored;
+- stale tenant response is ignored;
+- refresh occurs once after confirmed success;
+- no refresh occurs after unresolved failure;
+- rapid concurrent mutation calls are deduplicated;
+- explicit submitting, reconciling and succeeded statuses are observable.
+
+All 21 hook tests passed.
+
+## 23. Real browser smoke
+
+A real local browser was run against Vite on port 5187 and local Supabase.
+
+Completed scenarios:
+
+- role visibility for owner, admin, cashier, doctor, registrar and no-tenant;
+- normal prepayment of 1000 KZT;
+- duplicate-click protection with 1100 KZT and one database row;
+- confirmed success view after cashier refetch;
+- lost committed response and recovery for 1200 KZT;
+- unresolved conflict protection for 1300 KZT versus changed 1400 KZT;
+- stale Patient I response after switch to Patient B;
+- explicit deposit reservation of 300 KZT over the 1000 KZT prepayment;
+- available credit reduced to 700 KZT;
+- existing allocated cashier payment of 500 KZT;
+- patient Finance entry point and adjacent deposit/use labels.
+
+Console observations:
+
+- no fatal console errors;
+- no unhandled promise rejection;
+- no raw SQL output;
+- no secrets visible.
+
+A temporary no-tenant screenshot was created outside the repository and deleted during cleanup. No screenshot is committed.
+
+## 24. Network validation
+
+Local Supabase gateway logs showed:
+
+- `record_patient_credit_payment` requests: 16, including intentional retry/recovery smoke traffic;
+- `get_patient_credit_payment_operation` requests: 4;
+- application calls to legacy `record_payment`: 0;
+- direct `POST /rest/v1/payments` inserts: 0.
+
+The allocated cashier flow continued to use its separate hardened atomic RPC.
+
+The browser test tools reported no failed requests in successful scenarios and no secrets in captured output.
+
+## 25. Database validation
+
+Browser QA used isolated deterministic patients so each scenario could be counted independently.
+
+Final pre-cleanup financial counts:
+
+- hardened patient-credit payments: 8;
+- hardened amount: 9400 KZT;
+- allocated cashier payments: 1;
+- all task-patient payments: 9;
+- payment allocations: 1 for 500 KZT;
+- invoices: 1, total 500 KZT, paid 500 KZT, balance 0;
+- fund reservations: 1 for 300 KZT, remaining 300 KZT;
+- refunds: 0;
+- financial adjustments/write-offs: 0;
+- negative capacity: none observed.
+
+Critical isolated results:
+
+- normal prepayment patient: one hardened 1000 KZT row;
+- duplicate-submit patient: one 1100 KZT row and one operation key;
+- uncertain recovery patient: one 1200 KZT row and one operation key;
+- unresolved conflict patient: one 1300 KZT row despite the attempted changed payload;
+- stale patients: one committed row each, with no cross-patient visual update;
+- deposit creation created no new payment;
+- allocated cashier flow created one separate payment and one allocation.
+
+Audit events:
+
+- `payment_recorded`: 9;
+- `payment_allocated`: 1;
+- `patient_fund_reservation_created`: 1.
+
+Activity events matched the same 9 / 1 / 1 counts.
+
+All control values in `patients.balance` remained unchanged: 321, 654, 987, 444, 555, 666, 777, 888, 999 and 1010.
+
+## 26. Side-effect validation
+
+For task patients, all counts remained zero in:
+
+- appointments;
+- treatment plans;
+- completed services;
+- clinical encounters;
+- patient visits;
+- documents;
+- financial adjustments;
+- integration tokens / amoCRM.
+
+No stock or mailing table exists in the current schema, and no stock/mailing source file was changed.
+
+No treatment, appointment, plan, completed-service, encounter, document, stock, mailing or integration mutation was issued by the prepayment workflow.
+
+## 27. Cleanup
+
+Completed cleanup:
+
+- Vite process stopped;
+- temporary network shim restored from backup;
+- temporary backup removed;
+- PID and Vite log removed;
+- temporary screenshot removed;
+- temporary owner seed modification restored;
+- no `.env.local` was created;
+- local database reset with `npx supabase db reset --no-seed`;
+- task QA patients: 0;
+- payments: 0;
+- allocations: 0;
+- reservations: 0;
+- invoices: 0;
+- refunds: 0;
+- audit events: 0;
+- activity events: 0;
+- tenants: 0;
+- QA auth users: 0.
+
+## 28. Lint/test/build
+
+Final checks after cleanup and after removing all temporary code:
+
+- targeted prepayment/cashier/hook tests: 73 passed;
+- ESLint: passed;
+- full Vitest suite: 80 files, 864 tests passed;
+- TypeScript build: passed;
+- Vite production build: passed;
+- transformed modules: 1946.
+
+Non-blocking baseline warnings:
+
+- existing React `act(...)` warnings in older tests;
+- existing Vite warning for the large main bundle.
+
+No package dependency was changed in this task.
+
+## 29. GitHub Actions CI
+
+Pending PR publication and fresh GitHub Actions CI on the final PR head.
+
+Required final confirmation:
+
+- CI tested commit equals final PR head;
+- ESLint passed;
+- tests passed;
+- build passed;
+- PR remains open and unmerged.
+
+## 30. Known limitations
+
+1. An unresolved operation key is retained in the mounted hook instance. Durable recovery across a full browser restart is not added by this UI task and remains a future workflow concern.
+2. The no-tenant browser context correctly showed no prepayment action, but the application-level pre-cashier screen did not expose the component's internal `cashier-no-tenant` text in that isolated route assertion.
+3. The task does not add a legal receipt or fiscal document.
+4. Existing bundle-size and unrelated React test warnings remain.
+5. No cloud migration was applied; migration 0023 was already part of the verified baseline.
+
+## 31. What was intentionally not implemented
+
+- no prepayment table;
+- no new SQL migration;
+- no backend redesign;
+- no direct table write;
+- no service-role frontend path;
+- no localStorage financial fallback;
+- no automatic invoice;
+- no automatic allocation;
+- no automatic deposit;
+- no treatment completion;
+- no appointment/treatment-plan/completed-service change;
+- no `patients.balance` mutation or display as financial truth;
+- no cash shift;
+- no fiscal receipt;
+- no payment-provider integration;
+- no mixed-tender redesign;
+- no invoice correction;
+- no refund or write-off change;
+- no cloud write;
+- no seed, generated type, package or HEP-V2 change.
+
+## 32. Recommended next task
+
+`SCHEDULE-OPERATIONS-RECON-001`
+
+Reason: the prepayment intake chain is now operationally complete. The next P0 integrity gap identified by the repository-wide roadmap is server-side protection against double booking and a verified schedule-operations lifecycle.
+
+This next task was not started.

--- a/src/components/cashier/AcceptPatientPrepaymentDialog.test.tsx
+++ b/src/components/cashier/AcceptPatientPrepaymentDialog.test.tsx
@@ -1,0 +1,267 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PatientFinanceSummary, Payment } from '../../data/repositories/FinanceRepository';
+import type { PatientCreditPaymentOperationResult } from '../../data/repositories/FinanceRpcClient';
+import { CashierPaymentForm } from './CashierPaymentForm';
+import { AcceptPatientPrepaymentDialog, type PrepaymentPatient } from './AcceptPatientPrepaymentDialog';
+import { UseReservedCreditDialog } from '../finance/UseReservedCreditDialog';
+
+const tenantId = 'tenant-a';
+const patient: PrepaymentPatient = { id: 'patient-a', fullName: 'Алина Тестова' };
+const summary: PatientFinanceSummary = {
+  tenantId,
+  patientId: patient.id,
+  asOf: '2026-07-11T12:00:00Z',
+  modelVersion: 'finance-summary-v1',
+  factComplete: true,
+  warnings: [],
+  currencies: [{
+    currency: 'KZT',
+    totalInvoiced: 500,
+    activeAllocatedAmount: 0,
+    cashReceived: 1000,
+    completedRefundAmount: 0,
+    approvedWriteOffAmount: 0,
+    currentDebt: 200,
+    grossUnallocatedAmount: 850,
+    refundReservedAmount: 50,
+    reservedDepositAmount: 100,
+    availableCreditAmount: 700,
+    netPositionAmount: 500,
+    openInvoiceCount: 1,
+    unpaidInvoiceCount: 1,
+    partiallyPaidInvoiceCount: 0,
+    lastPaymentAt: '2026-07-11T10:00:00Z',
+  }],
+};
+const payment = {
+  id: 'payment-prepayment-1', tenantId, patientId: patient.id, status: 'received', paymentMethod: 'cash', amount: 1000,
+  currency: 'KZT', receivedAt: '2026-07-11T12:00:00Z', externalReference: null, payerName: null, notes: null,
+} as Payment;
+const operationResult: PatientCreditPaymentOperationResult = {
+  status: 'completed', operationId: 'operation-1', tenantId, patientId: patient.id, payment,
+  capacity: {
+    paymentId: payment.id, patientId: patient.id, currency: 'KZT', paymentAmount: 1000,
+    activeAllocatedAmount: 0, completedRefundAmount: 0, refundReservedAmount: 0,
+    reservedDepositAmount: 0, grossUnallocatedAmount: 1000, availableCreditAmount: 1000,
+  },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolver) => { resolve = resolver; });
+  return { promise, resolve };
+}
+
+function setNativeValue(element: HTMLInputElement | HTMLSelectElement, value: string) {
+  const prototype = element instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+  setter?.call(element, value);
+  element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? 'change' : 'input', { bubbles: true }));
+}
+
+describe('AcceptPatientPrepaymentDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onSubmit = vi.fn().mockResolvedValue(operationResult);
+  const onResetOperation = vi.fn();
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    onSubmit.mockReset().mockResolvedValue(operationResult);
+    onResetOperation.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  async function renderDialog(overrides: Partial<React.ComponentProps<typeof AcceptPatientPrepaymentDialog>> = {}) {
+    const props: React.ComponentProps<typeof AcceptPatientPrepaymentDialog> = {
+      tenantId,
+      patient,
+      role: 'clinic_admin',
+      summary,
+      operationStatus: 'idle',
+      operationResult: null,
+      operationError: null,
+      onSubmit,
+      onResetOperation,
+      testIdPrefix: 'test-prepayment',
+      ...overrides,
+    };
+    await act(async () => { root.render(<AcceptPatientPrepaymentDialog {...props} />); });
+    return props;
+  }
+
+  async function openDialog() {
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-open"]')?.click(); });
+  }
+
+  async function fillValidForm(amount = '1000', method = 'cash') {
+    await act(async () => {
+      setNativeValue(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-amount"]')!, amount);
+      setNativeValue(container.querySelector<HTMLSelectElement>('[data-testid="test-prepayment-method"]')!, method);
+    });
+  }
+
+  it('1. action is visible for owner', async () => { await renderDialog({ role: 'clinic_owner' }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).not.toBeNull(); });
+  it('2. action is visible for admin', async () => { await renderDialog({ role: 'clinic_admin' }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).not.toBeNull(); });
+  it('3. action is visible for cashier', async () => { await renderDialog({ role: 'cashier' }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).not.toBeNull(); });
+  it('4. action is hidden for doctor', async () => { await renderDialog({ role: 'doctor' }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).toBeNull(); });
+  it('5. action is hidden for registrar', async () => { await renderDialog({ role: 'registrar' }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).toBeNull(); });
+  it('6. action is hidden without tenant', async () => { await renderDialog({ tenantId: null }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).toBeNull(); });
+  it('7. action is hidden without patient', async () => { await renderDialog({ patient: null }); expect(container.querySelector('[data-testid="test-prepayment-open"]')).toBeNull(); });
+  it('8. dialog opens', async () => { await renderDialog(); await openDialog(); expect(container.querySelector('[role="dialog"]')).not.toBeNull(); });
+  it('9. patient is displayed', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('Алина Тестова'); });
+  it('10. current credit is displayed', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('700 KZT'); });
+  it('11. current debt is displayed', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('200 KZT'); });
+  it('12. deposit reserve is displayed', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('100 KZT'); });
+  it('13. refund reserve is displayed', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('50 KZT'); });
+  it('14. KZT is fixed', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('ВалютаKZT'); });
+  it('15. currency selector is absent', async () => { await renderDialog(); await openDialog(); expect(container.querySelector('[data-testid="test-prepayment-currency"]')).toBeNull(); });
+
+  it('16. amount is required', async () => {
+    await renderDialog(); await openDialog();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(container.textContent).toContain('Введите сумму больше нуля.');
+  });
+  it('17. zero is rejected', async () => {
+    await renderDialog(); await openDialog(); await fillValidForm('0');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+  it('18. negative value is rejected', async () => {
+    await renderDialog(); await openDialog(); await fillValidForm('-1');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+  it('19. more than two decimal places are rejected', async () => {
+    await renderDialog(); await openDialog(); await fillValidForm('1.234');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+  it('20. method is required', async () => {
+    await renderDialog(); await openDialog();
+    await act(async () => { setNativeValue(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-amount"]')!, '1000'); });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(container.textContent).toContain('Выберите способ оплаты.');
+  });
+  it('21. optional text is trimmed', async () => {
+    await renderDialog(); await openDialog(); await fillValidForm();
+    await act(async () => {
+      setNativeValue(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-external-reference"]')!, '  REF-1  ');
+      setNativeValue(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-payer-name"]')!, '  Плательщик  ');
+      setNativeValue(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-notes"]')!, '  заметка  ');
+      container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click();
+    });
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ externalReference: 'REF-1', payerName: 'Плательщик', notes: 'заметка' }));
+  });
+  it('22. confirmation explicitly says no invoice is selected', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('Счёт не выбран'); });
+  it('23. confirmation explicitly says this is new money', async () => { await renderDialog(); await openDialog(); expect(container.textContent).toContain('фиксирует получение новых денег'); });
+  it('24. submit calls the hardened action once', async () => {
+    await renderDialog(); await openDialog(); await fillValidForm();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ amount: 1000, paymentMethod: 'cash', currency: 'KZT' }));
+  });
+  it('25. duplicate submit is blocked', async () => {
+    const pending = deferred<PatientCreditPaymentOperationResult>();
+    onSubmit.mockReturnValueOnce(pending.promise);
+    await renderDialog(); await openDialog(); await fillValidForm();
+    const submit = container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')!;
+    await act(async () => { submit.click(); submit.click(); });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    pending.resolve(operationResult);
+    await act(async () => { await pending.promise; });
+  });
+  it('26. submitting progress is shown and fields are disabled', async () => {
+    await renderDialog(); await openDialog(); await renderDialog({ operationStatus: 'submitting' });
+    expect(container.textContent).toContain('Сохраняем платёж…');
+    expect(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-amount"]')?.disabled).toBe(true);
+  });
+  it('27. reconciliation progress is shown', async () => {
+    await renderDialog(); await openDialog(); await renderDialog({ operationStatus: 'reconciling' });
+    expect(container.textContent).toContain('Проверяем, был ли платёж сохранён…');
+  });
+  it('28. success message and details are correct', async () => {
+    await renderDialog(); await openDialog(); await renderDialog({ operationStatus: 'succeeded', operationResult });
+    expect(container.textContent).toContain('Предоплата принята.');
+    expect(container.textContent).toContain('1 000 KZT');
+    expect(container.textContent).toContain('Наличные');
+  });
+  it('29. success never says invoice paid', async () => {
+    await renderDialog(); await openDialog(); await renderDialog({ operationStatus: 'succeeded', operationResult });
+    expect(container.textContent).not.toContain('Счёт оплачен');
+  });
+  it('30. success never says deposit was created', async () => {
+    await renderDialog(); await openDialog(); await renderDialog({ operationStatus: 'succeeded', operationResult });
+    expect(container.textContent).not.toContain('Депозит создан');
+  });
+  it('31. permission error is safe', async () => {
+    onSubmit.mockRejectedValueOnce(new Error('Недостаточно прав для приёма предоплаты.'));
+    await renderDialog(); await openDialog(); await fillValidForm();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(container.textContent).toContain('Недостаточно прав для приёма предоплаты.');
+  });
+  it('32. idempotency conflict is safe', async () => {
+    onSubmit.mockRejectedValueOnce(new Error('Эта операция уже была выполнена с другими параметрами.'));
+    await renderDialog(); await openDialog(); await fillValidForm();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(container.textContent).toContain('Эта операция уже была выполнена с другими параметрами.');
+  });
+  it('33. generic error hides raw details', async () => {
+    onSubmit.mockRejectedValueOnce(new Error('SQLSTATE 23505 uq_payments secret stack'));
+    await renderDialog(); await openDialog(); await fillValidForm();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    expect(container.textContent).toContain('Не удалось принять предоплату. Проверьте текущее состояние операции.');
+    expect(container.textContent).not.toContain('23505');
+    expect(container.textContent).not.toContain('uq_payments');
+  });
+  it('34. patient switch closes the dialog', async () => {
+    await renderDialog(); await openDialog();
+    await renderDialog({ patient: { id: 'patient-b', fullName: 'Борис Тестов' } });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+  it('35. tenant switch clears the form', async () => {
+    await renderDialog(); await openDialog(); await fillValidForm('555');
+    await renderDialog({ tenantId: 'tenant-b' });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-open"]')?.click(); });
+    expect(container.querySelector<HTMLInputElement>('[data-testid="test-prepayment-amount"]')?.value).toBe('');
+  });
+  it('36. late success for the old patient is ignored visually', async () => {
+    const pending = deferred<PatientCreditPaymentOperationResult>();
+    onSubmit.mockReturnValueOnce(pending.promise);
+    await renderDialog(); await openDialog(); await fillValidForm();
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="test-prepayment-submit"]')?.click(); });
+    await renderDialog({ patient: { id: 'patient-b', fullName: 'Борис Тестов' } });
+    pending.resolve(operationResult);
+    await act(async () => { await pending.promise; });
+    expect(container.textContent).not.toContain('Предоплата принята.');
+    expect(container.textContent).not.toContain('Алина Тестова');
+  });
+  it('37. allocated cashier flow keeps the distinct label', async () => {
+    await act(async () => { root.render(<CashierPaymentForm onSubmit={vi.fn().mockResolvedValue(null)} />); });
+    expect(container.textContent).toContain('Принять оплату по счетам');
+    expect(container.textContent).not.toContain('Принять предоплату');
+  });
+  it('38. existing deposit use keeps its distinct label', async () => {
+    const reservation = {
+      id: 'reservation-1', tenantId, patientId: patient.id, paymentId: payment.id, currency: 'KZT', status: 'active',
+      purposeType: 'general', purposeLabel: null, appointmentId: null, treatmentPlanId: null,
+      originalAmount: 300, consumedAmount: 0, releasedAmount: 0, remainingAmount: 300,
+      releaseReason: null, expiresAt: null, notes: null, createdAt: '2026-07-11T00:00:00Z', updatedAt: null, releasedAt: null, archivedAt: null,
+    } as const;
+    const invoice = { id: 'invoice-1', tenantId, patientId: patient.id, currency: 'KZT', status: 'issued', balanceAmount: 300, invoiceNumber: 'INV-1' } as never;
+    await act(async () => { root.render(<UseReservedCreditDialog open reservation={reservation as never} invoices={[invoice]} onClose={vi.fn()} onSubmit={vi.fn()} />); });
+    expect(container.textContent).toContain('Использовать депозит');
+    expect(container.textContent).not.toContain('Принять предоплату');
+  });
+});

--- a/src/components/cashier/AcceptPatientPrepaymentDialog.tsx
+++ b/src/components/cashier/AcceptPatientPrepaymentDialog.tsx
@@ -1,0 +1,351 @@
+/* eslint-disable react-hooks/set-state-in-effect -- changing tenant/patient must synchronously clear stale dialog state */
+import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent, type ReactNode } from 'react';
+import type { PatientFinanceSummary, PaymentMethod } from '../../data/repositories/FinanceRepository';
+import { getPatientFinanceCurrencySummaries } from '../../data/repositories/FinanceRepository';
+import type { PatientCreditPaymentOperationResult } from '../../data/repositories/FinanceRpcClient';
+import type {
+  PatientCreditOperationStatus,
+  RecordPaymentActionInput,
+} from '../../data/hooks/useFinanceActions';
+import { getFinanceRoleCapabilities, type FinanceUserRole } from '../finance/financePermissions';
+import { CASHIER_PAYMENT_METHODS, cashierPaymentMethodLabels, formatCashierMoney, shortCashierId } from './cashierLabels';
+
+export interface PrepaymentPatient {
+  id: string;
+  fullName: string;
+}
+
+interface AcceptPatientPrepaymentDialogProps {
+  tenantId?: string | null;
+  patient?: PrepaymentPatient | null;
+  role?: FinanceUserRole;
+  summary: PatientFinanceSummary | null;
+  operationStatus: PatientCreditOperationStatus;
+  operationResult: PatientCreditPaymentOperationResult | null;
+  operationError?: Error | null;
+  onSubmit: (input: RecordPaymentActionInput) => Promise<PatientCreditPaymentOperationResult>;
+  onResetOperation?: () => void;
+  triggerClassName?: string;
+  triggerSlot?: ReactNode;
+  testIdPrefix?: string;
+}
+
+type PaymentMethodValue = PaymentMethod | '';
+
+function normalizeAmount(value: string) {
+  const trimmed = value.trim().replace(',', '.');
+  if (!/^\d+(?:\.\d{1,2})?$/.test(trimmed)) return null;
+  const amount = Number(trimmed);
+  return Number.isFinite(amount) && amount > 0 ? amount : null;
+}
+
+function trimOptional(value: string) {
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function safeDialogError(error: unknown) {
+  const message = error instanceof Error ? error.message : '';
+  const allowed = [
+    'Недостаточно прав для приёма предоплаты.',
+    'Эта операция уже была выполнена с другими параметрами.',
+    'Операция относится к другому пациенту. Данные обновлены.',
+    'Предоплата принимается только в KZT.',
+    'Не удалось подтвердить результат операции. Повторите попытку с теми же данными.',
+    'Не удалось принять предоплату. Проверьте текущее состояние операции.',
+  ];
+  return allowed.includes(message) ? message : 'Не удалось принять предоплату. Проверьте текущее состояние операции.';
+}
+
+export function AcceptPatientPrepaymentDialog({
+  tenantId,
+  patient,
+  role,
+  summary,
+  operationStatus,
+  operationResult,
+  operationError,
+  onSubmit,
+  onResetOperation,
+  triggerClassName,
+  triggerSlot,
+  testIdPrefix = 'prepayment',
+}: AcceptPatientPrepaymentDialogProps) {
+  const capabilities = getFinanceRoleCapabilities(role);
+  const contextKey = tenantId && patient ? `${tenantId}:${patient.id}` : null;
+  const contextRef = useRef(contextKey);
+  const amountInputRef = useRef<HTMLInputElement>(null);
+  const submitGuardRef = useRef(false);
+  const [open, setOpen] = useState(false);
+  const [amount, setAmount] = useState('');
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethodValue>('');
+  const [receivedAt, setReceivedAt] = useState('');
+  const [externalReference, setExternalReference] = useState('');
+  const [payerName, setPayerName] = useState('');
+  const [notes, setNotes] = useState('');
+  const [amountError, setAmountError] = useState<string | null>(null);
+  const [methodError, setMethodError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successInput, setSuccessInput] = useState<{ amount: number; paymentMethod: PaymentMethod } | null>(null);
+
+  const currencySummary = useMemo(
+    () => getPatientFinanceCurrencySummaries(summary).find((item) => item.currency === 'KZT') ?? null,
+    [summary],
+  );
+  const isSubmitting = operationStatus === 'submitting';
+  const isReconciling = operationStatus === 'reconciling';
+  const isBusy = isSubmitting || isReconciling;
+  const isUncertain = operationStatus === 'uncertain';
+  const isSucceeded = operationStatus === 'succeeded' && Boolean(operationResult?.payment);
+
+  useEffect(() => {
+    contextRef.current = contextKey;
+    setOpen(false);
+    setAmount('');
+    setPaymentMethod('');
+    setReceivedAt('');
+    setExternalReference('');
+    setPayerName('');
+    setNotes('');
+    setAmountError(null);
+    setMethodError(null);
+    setFormError(null);
+    setSuccessInput(null);
+    onResetOperation?.();
+  }, [contextKey, onResetOperation]);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => amountInputRef.current?.focus(), 0);
+    return () => window.clearTimeout(timer);
+  }, [open]);
+
+  const displayedError = formError ?? (operationError ? safeDialogError(operationError) : null);
+
+  if (!tenantId || !patient || !capabilities.canRecordPayment) return null;
+
+  const resetCompletedForm = () => {
+    setAmount('');
+    setPaymentMethod('');
+    setReceivedAt('');
+    setExternalReference('');
+    setPayerName('');
+    setNotes('');
+    setAmountError(null);
+    setMethodError(null);
+    setFormError(null);
+    setSuccessInput(null);
+    onResetOperation?.();
+  };
+
+  const close = () => {
+    if (isBusy) return;
+    setOpen(false);
+    if (isSucceeded) resetCompletedForm();
+  };
+
+  const handleDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && !isBusy) {
+      event.preventDefault();
+      close();
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitGuardRef.current || isBusy) return;
+    setAmountError(null);
+    setMethodError(null);
+    setFormError(null);
+
+    const parsedAmount = normalizeAmount(amount);
+    if (parsedAmount === null) {
+      setAmountError('Введите сумму больше нуля.');
+      return;
+    }
+    if (!paymentMethod) {
+      setMethodError('Выберите способ оплаты.');
+      return;
+    }
+    if (!tenantId) {
+      setFormError('Клиника не выбрана.');
+      return;
+    }
+    if (!patient) {
+      setFormError('Пациент не выбран.');
+      return;
+    }
+
+    const submittedContext = `${tenantId}:${patient.id}`;
+    const submittedInput = { amount: parsedAmount, paymentMethod };
+    submitGuardRef.current = true;
+    try {
+      await onSubmit({
+        amount: parsedAmount,
+        paymentMethod,
+        currency: 'KZT',
+        receivedAt: trimOptional(receivedAt),
+        externalReference: trimOptional(externalReference),
+        payerName: trimOptional(payerName),
+        notes: trimOptional(notes),
+      });
+      if (contextRef.current !== submittedContext) return;
+      setSuccessInput(submittedInput);
+      setFormError(null);
+    } catch (error) {
+      if (contextRef.current !== submittedContext) return;
+      setFormError(safeDialogError(error));
+    } finally {
+      submitGuardRef.current = false;
+    }
+  };
+
+  const availableCredit = currencySummary?.availableCreditAmount ?? 0;
+  const currentDebt = currencySummary?.currentDebt ?? 0;
+  const depositReserve = currencySummary?.reservedDepositAmount ?? 0;
+  const refundReserve = currencySummary?.refundReservedAmount ?? 0;
+  const displaySuccessInput = successInput ?? (operationResult?.payment
+    ? { amount: operationResult.payment.amount, paymentMethod: operationResult.payment.paymentMethod }
+    : null);
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid={`${testIdPrefix}-open`}
+        onClick={() => {
+          setOpen(true);
+          setFormError(null);
+        }}
+        className={triggerClassName ?? 'rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700'}
+      >
+        {triggerSlot ?? 'Принять предоплату'}
+      </button>
+
+      {open && (
+        <div
+          data-testid={`${testIdPrefix}-overlay`}
+          className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-slate-950/45 p-3 sm:p-6"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) close();
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`${testIdPrefix}-title`}
+            data-testid={`${testIdPrefix}-dialog`}
+            onKeyDown={handleDialogKeyDown}
+            className="w-full max-w-2xl max-h-[calc(100vh-1.5rem)] overflow-y-auto rounded-2xl bg-white p-5 shadow-2xl sm:p-6"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 id={`${testIdPrefix}-title`} className="text-xl font-semibold text-slate-900">Принять предоплату</h2>
+                <p className="mt-2 text-sm text-slate-600">
+                  Деньги будут приняты клиникой и сохранены как доступный кредит пациента. Счёт и депозит автоматически не создаются.
+                </p>
+              </div>
+              <button type="button" aria-label="Закрыть" disabled={isBusy} onClick={close} className="rounded-lg px-2 py-1 text-slate-500 hover:bg-slate-100 disabled:opacity-50">×</button>
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid={`${testIdPrefix}-finance-facts`}>
+              <Fact label="Пациент" value={patient.fullName} />
+              <Fact label="Валюта" value="KZT" />
+              <Fact label="Доступный кредит" value={formatCashierMoney(availableCredit)} />
+              <Fact label="Текущий долг" value={formatCashierMoney(currentDebt)} />
+              <Fact label="Резерв депозита" value={formatCashierMoney(depositReserve)} />
+              <Fact label="Резерв возврата" value={formatCashierMoney(refundReserve)} />
+            </div>
+
+            {isSucceeded && operationResult?.payment && displaySuccessInput ? (
+              <div data-testid={`${testIdPrefix}-success`} className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-950">
+                <p className="font-semibold">Предоплата принята.</p>
+                <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <Fact label="Сумма" value={formatCashierMoney(displaySuccessInput.amount)} />
+                  <Fact label="Способ оплаты" value={cashierPaymentMethodLabels[displaySuccessInput.paymentMethod]} />
+                  <Fact label="Новый доступный кредит" value={formatCashierMoney(operationResult.capacity?.availableCreditAmount ?? availableCredit)} />
+                  <Fact label="Платёж" value={`#${shortCashierId(operationResult.payment.id)}`} />
+                </dl>
+                <button type="button" onClick={close} className="mt-4 rounded-lg bg-emerald-700 px-4 py-2 font-semibold text-white">Закрыть</button>
+              </div>
+            ) : (
+              <form data-testid={`${testIdPrefix}-form`} onSubmit={handleSubmit} className="mt-5 space-y-4" noValidate>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label htmlFor={`${testIdPrefix}-amount`} className="text-sm font-medium text-slate-700">
+                    Сумма
+                    <input
+                      ref={amountInputRef}
+                      id={`${testIdPrefix}-amount`}
+                      data-testid={`${testIdPrefix}-amount`}
+                      inputMode="decimal"
+                      value={amount}
+                      disabled={isBusy}
+                      aria-invalid={Boolean(amountError)}
+                      aria-describedby={amountError ? `${testIdPrefix}-amount-error` : undefined}
+                      onChange={(event) => setAmount(event.target.value)}
+                      className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 disabled:bg-slate-100"
+                    />
+                    {amountError && <span id={`${testIdPrefix}-amount-error`} data-testid={`${testIdPrefix}-amount-error`} className="mt-1 block text-sm text-rose-600">{amountError}</span>}
+                  </label>
+
+                  <label htmlFor={`${testIdPrefix}-method`} className="text-sm font-medium text-slate-700">
+                    Способ оплаты
+                    <select
+                      id={`${testIdPrefix}-method`}
+                      data-testid={`${testIdPrefix}-method`}
+                      value={paymentMethod}
+                      disabled={isBusy}
+                      aria-invalid={Boolean(methodError)}
+                      aria-describedby={methodError ? `${testIdPrefix}-method-error` : undefined}
+                      onChange={(event) => setPaymentMethod(event.target.value as PaymentMethodValue)}
+                      className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 disabled:bg-slate-100"
+                    >
+                      <option value="">Выберите способ оплаты</option>
+                      {CASHIER_PAYMENT_METHODS.map((method) => <option key={method} value={method}>{cashierPaymentMethodLabels[method]}</option>)}
+                    </select>
+                    {methodError && <span id={`${testIdPrefix}-method-error`} data-testid={`${testIdPrefix}-method-error`} className="mt-1 block text-sm text-rose-600">{methodError}</span>}
+                  </label>
+
+                  <label htmlFor={`${testIdPrefix}-received-at`} className="text-sm font-medium text-slate-700">Дата и время получения<input id={`${testIdPrefix}-received-at`} data-testid={`${testIdPrefix}-received-at`} type="datetime-local" value={receivedAt} disabled={isBusy} onChange={(event) => setReceivedAt(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 disabled:bg-slate-100" /></label>
+                  <label htmlFor={`${testIdPrefix}-external-reference`} className="text-sm font-medium text-slate-700">Внешняя ссылка<input id={`${testIdPrefix}-external-reference`} data-testid={`${testIdPrefix}-external-reference`} value={externalReference} disabled={isBusy} onChange={(event) => setExternalReference(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 disabled:bg-slate-100" /></label>
+                  <label htmlFor={`${testIdPrefix}-payer-name`} className="text-sm font-medium text-slate-700">Плательщик<input id={`${testIdPrefix}-payer-name`} data-testid={`${testIdPrefix}-payer-name`} value={payerName} disabled={isBusy} onChange={(event) => setPayerName(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 disabled:bg-slate-100" /></label>
+                  <label htmlFor={`${testIdPrefix}-notes`} className="text-sm font-medium text-slate-700">Примечание<input id={`${testIdPrefix}-notes`} data-testid={`${testIdPrefix}-notes`} value={notes} disabled={isBusy} onChange={(event) => setNotes(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 disabled:bg-slate-100" /></label>
+                </div>
+
+                <div data-testid={`${testIdPrefix}-confirmation`} className="rounded-2xl border border-blue-200 bg-blue-50 p-4 text-sm text-blue-950">
+                  <p><strong>Пациент:</strong> {patient.fullName}</p>
+                  <p><strong>Сумма:</strong> {normalizeAmount(amount) === null ? 'не указана' : formatCashierMoney(normalizeAmount(amount))}</p>
+                  <p><strong>Способ оплаты:</strong> {paymentMethod ? cashierPaymentMethodLabels[paymentMethod] : 'не выбран'}</p>
+                  <p><strong>Счёт:</strong> Счёт не выбран</p>
+                  <p><strong>Результат:</strong> Деньги станут доступным кредитом пациента</p>
+                  <p className="mt-2 font-medium">Эта операция фиксирует получение новых денег. Она не использует уже существующий кредит пациента.</p>
+                </div>
+
+                {isSubmitting && <p role="status" data-testid={`${testIdPrefix}-submitting`} className="text-sm font-medium text-blue-700">Сохраняем платёж…</p>}
+                {isReconciling && <p role="status" data-testid={`${testIdPrefix}-reconciling`} className="text-sm font-medium text-blue-700">Проверяем, был ли платёж сохранён…</p>}
+                {isUncertain && <p role="alert" data-testid={`${testIdPrefix}-uncertain`} className="text-sm font-medium text-amber-800">Не удалось подтвердить результат операции. Повторите попытку с теми же данными.</p>}
+                {displayedError && <p role="alert" data-testid={`${testIdPrefix}-error`} className="text-sm font-medium text-rose-700">{displayedError}</p>}
+
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <button type="button" disabled={isBusy} onClick={close} className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 disabled:opacity-50">Отмена</button>
+                  <button type="submit" data-testid={`${testIdPrefix}-submit`} disabled={isBusy} aria-disabled={isBusy} className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50">
+                    {isSubmitting ? 'Сохраняем платёж…' : isReconciling ? 'Проверяем платёж…' : 'Принять предоплату'}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl bg-slate-50 p-3">
+      <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className="mt-1 font-semibold text-slate-900">{value}</dd>
+    </div>
+  );
+}

--- a/src/components/cashier/CashierPaymentForm.tsx
+++ b/src/components/cashier/CashierPaymentForm.tsx
@@ -57,13 +57,13 @@ export function CashierPaymentForm({
         amount: numericAmount,
         paymentMethod,
         receivedAt: receivedAt || null,
-        externalReference: externalReference || null,
-        payerName: payerName || null,
-        notes: notes || null,
+        externalReference: externalReference.trim() || null,
+        payerName: payerName.trim() || null,
+        notes: notes.trim() || null,
       });
       clearAfterSuccess();
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Оплата не была создана.');
+      setError(submitError instanceof Error ? submitError.message : 'Оплата не была сохранена.');
     } finally {
       submitGuardRef.current = false;
     }
@@ -77,7 +77,7 @@ export function CashierPaymentForm({
       await action();
       clearAfterSuccess();
     } catch (recoveryError) {
-      setError(recoveryError instanceof Error ? recoveryError.message : 'Не удалось проверить результат операции.');
+      setError(recoveryError instanceof Error ? recoveryError.message : 'Не удалось подтвердить результат операции.');
     } finally {
       submitGuardRef.current = false;
     }
@@ -89,7 +89,8 @@ export function CashierPaymentForm({
 
   return (
     <section data-testid="cashier-payment-form-section" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h2 className="text-lg font-semibold text-slate-900">Оплата</h2>
+      <h2 className="text-lg font-semibold text-slate-900">Принять оплату по счетам</h2>
+      <p className="mt-1 text-sm text-slate-500">Деньги будут распределены только по выбранным ниже счетам.</p>
       <form data-testid="cashier-payment-form" onSubmit={handleSubmit} className="mt-4 grid gap-3 md:grid-cols-2">
         <label className="text-sm font-medium text-slate-700">
           Сумма
@@ -115,7 +116,7 @@ export function CashierPaymentForm({
           </div>
         ) : (
           <button type="submit" data-testid="cashier-payment-submit" disabled={disabled || loading} className="md:col-span-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-60">
-            {isReconciling ? 'Проверяем результат...' : isSubmitting ? 'Сохраняем оплату...' : 'Принять оплату'}
+            {isReconciling ? 'Проверяем результат...' : isSubmitting ? 'Сохраняем оплату...' : 'Принять оплату по счетам'}
           </button>
         )}
       </form>

--- a/src/components/cashier/CashierPaymentPanel.test.tsx
+++ b/src/components/cashier/CashierPaymentPanel.test.tsx
@@ -7,7 +7,7 @@ import { CashierPaymentPanel } from './CashierPaymentPanel';
 import { CashierPaymentForm } from './CashierPaymentForm';
 import { useCashierPaymentFlow } from '../../data/hooks/useCashierPaymentFlow';
 import type { FinanceRepository, Invoice, InvoiceItem, PatientFinanceSummary, Payment, PaymentAllocation } from '../../data/repositories/FinanceRepository';
-import { FinanceRpcClientError, type CashierPaymentOperationResult, type FinanceRpcClient } from '../../data/repositories/FinanceRpcClient';
+import { FinanceRpcClientError, type CashierPaymentOperationResult, type FinanceRpcClient, type PatientCreditPaymentOperationResult } from '../../data/repositories/FinanceRpcClient';
 import type { PatientRepository } from '../../data/repositories/PatientRepository';
 import type { Patient } from '../../types';
 
@@ -114,6 +114,50 @@ describe('CashierPaymentPanel', () => {
     expect(repos.rpcClient.recordPayment).not.toHaveBeenCalled();
     expect(repos.rpcClient.allocatePayment).not.toHaveBeenCalled();
     expect(container.querySelector('[data-testid="cashier-payment-result"]')).not.toBeNull();
+  });
+
+  it('keeps prepayment success visible while cashier finance refresh is pending', async () => {
+    const refreshSummary = deferred<PatientFinanceSummary>();
+    const financeRepository = createFinanceRepo();
+    vi.mocked(financeRepository.getPatientFinanceSummary)
+      .mockResolvedValueOnce(summary)
+      .mockReturnValueOnce(refreshSummary.promise);
+    const rpcClient = createRpcClient();
+    const prepaymentResult: PatientCreditPaymentOperationResult = {
+      status: 'completed',
+      operationId: 'prepayment-operation-1',
+      tenantId,
+      patientId,
+      payment,
+      capacity: {
+        paymentId: payment.id,
+        patientId,
+        currency: 'KZT',
+        paymentAmount: 1000,
+        activeAllocatedAmount: 0,
+        completedRefundAmount: 0,
+        refundReservedAmount: 0,
+        reservedDepositAmount: 0,
+        grossUnallocatedAmount: 1000,
+        availableCreditAmount: 1000,
+      },
+    };
+    vi.mocked(rpcClient.recordPayment).mockResolvedValue(prepaymentResult);
+    await searchAndSelect({ patientRepository: createPatientRepo(), financeRepository, rpcClient });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="cashier-prepayment-open"]')!.click(); });
+    const amount = container.querySelector<HTMLInputElement>('[data-testid="cashier-prepayment-amount"]')!;
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(amount, '1000');
+    amount.dispatchEvent(new Event('input', { bubbles: true }));
+    const method = container.querySelector<HTMLSelectElement>('[data-testid="cashier-prepayment-method"]')!;
+    Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set?.call(method, 'cash');
+    method.dispatchEvent(new Event('change', { bubbles: true }));
+    act(() => { container.querySelector<HTMLButtonElement>('[data-testid="cashier-prepayment-submit"]')!.click(); });
+    await flush();
+    expect(container.querySelector('[data-testid="cashier-prepayment-success"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="cashier-loading"]')).not.toBeNull();
+    refreshSummary.resolve({ ...summary, currencies: [{ ...summary.currencies[0], cashReceived: 1000, grossUnallocatedAmount: 1000, availableCreditAmount: 1000, netPositionAmount: 0 }] });
+    await flush();
+    expect(container.querySelector('[data-testid="cashier-prepayment-success"]')).not.toBeNull();
   });
 
   it('cashier does not see void controls or legal receipt/fiscal wording', async () => {

--- a/src/components/cashier/CashierPaymentPanel.tsx
+++ b/src/components/cashier/CashierPaymentPanel.tsx
@@ -5,6 +5,8 @@ import type { PatientRepository } from '../../data/repositories/PatientRepositor
 import type { Patient } from '../../types';
 import { useCashierPatientSearch } from '../../data/hooks/useCashierPatientSearch';
 import { useCashierPaymentFlow } from '../../data/hooks/useCashierPaymentFlow';
+import { useFinanceActions } from '../../data/hooks/useFinanceActions';
+import { AcceptPatientPrepaymentDialog } from './AcceptPatientPrepaymentDialog';
 import { CashierAllocationPreview } from './CashierAllocationPreview';
 import { CashierOpenInvoiceList } from './CashierOpenInvoiceList';
 import { CashierPatientFinanceSummary } from './CashierPatientFinanceSummary';
@@ -33,6 +35,12 @@ export function CashierPaymentPanel({ tenantId, role, patientRepository, finance
     rpcClient,
     enabled: Boolean(capabilities.canAccessCashier && selectedPatient),
   });
+  const prepaymentActions = useFinanceActions({
+    tenantId,
+    patientId: selectedPatient?.id,
+    refresh: flow.refresh,
+    rpcClient,
+  });
 
   if (!tenantId) {
     return <section data-testid="cashier-no-tenant" className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-800">Не выбрана клиника.</section>;
@@ -45,6 +53,7 @@ export function CashierPaymentPanel({ tenantId, role, patientRepository, finance
   const writeInFlight = flow.operationStatus === 'submitting' || flow.operationStatus === 'reconciling';
   const patientFinanceLoading = flow.operationStatus === 'loading_patient_finance';
   const financeReady = Boolean(selectedPatient && !patientFinanceLoading);
+  const prepaymentVisible = Boolean(selectedPatient && (financeReady || prepaymentActions.patientCreditOperationStatus !== 'idle'));
 
   const selectPatient = (patient: Patient) => {
     if (writeInFlight) return;
@@ -100,6 +109,27 @@ export function CashierPaymentPanel({ tenantId, role, patientRepository, finance
           {flow.refreshWarning && (
             <div data-testid="cashier-refresh-warning" className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
               {flow.refreshWarning}
+            </div>
+          )}
+
+          {prepaymentVisible && (
+            <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="font-semibold text-slate-900">Предоплата без счёта</h2>
+                <p className="mt-1 text-sm text-slate-500">Новые деньги поступят в доступный кредит пациента и не будут распределены автоматически.</p>
+              </div>
+              <AcceptPatientPrepaymentDialog
+                tenantId={tenantId}
+                patient={selectedPatient}
+                role={role}
+                summary={flow.summary}
+                operationStatus={prepaymentActions.patientCreditOperationStatus}
+                operationResult={prepaymentActions.patientCreditOperationResult}
+                operationError={prepaymentActions.actionError}
+                onSubmit={prepaymentActions.recordPayment}
+                onResetOperation={prepaymentActions.resetPatientCreditOperation}
+                testIdPrefix="cashier-prepayment"
+              />
             </div>
           )}
 

--- a/src/components/finance/PatientFinancePanel.test.tsx
+++ b/src/components/finance/PatientFinancePanel.test.tsx
@@ -57,7 +57,8 @@ function createRpcClient(): FinanceRpcClient {
     addInvoiceItem: vi.fn().mockResolvedValue(invoiceItem),
     issueInvoice: vi.fn().mockResolvedValue({ ...invoice, status: 'issued' }),
     voidInvoice: vi.fn().mockResolvedValue({ ...invoice, status: 'voided' }),
-    recordPayment: vi.fn().mockResolvedValue(payment),
+    recordPayment: vi.fn().mockResolvedValue({ status: 'completed', operationId: 'prepayment-op', tenantId, patientId, payment, capacity: { paymentId: payment.id, patientId, currency: 'KZT', paymentAmount: 1000, activeAllocatedAmount: 0, completedRefundAmount: 0, refundReservedAmount: 0, reservedDepositAmount: 0, grossUnallocatedAmount: 1000, availableCreditAmount: 1000 } }),
+    getPatientCreditPaymentOperation: vi.fn(),
     allocatePayment: vi.fn().mockResolvedValue(allocation),
     voidPaymentAllocation: vi.fn().mockResolvedValue({ ...allocation, status: 'voided' }),
     voidPayment: vi.fn().mockResolvedValue({ ...payment, status: 'voided' }),
@@ -106,7 +107,7 @@ describe('PatientFinancePanel', () => {
 
   async function renderPanel({ role = 'clinic_admin', repository = createRepository(), rpcClient = createRpcClient(), tenant = tenantId }: { role?: string | null; repository?: FinanceRepository; rpcClient?: FinanceRpcClient; tenant?: string | null } = {}) {
     await act(async () => {
-      root.render(<PatientFinancePanel tenantId={tenant} patientId={patientId} role={role} repository={repository} rpcClient={rpcClient} />);
+      root.render(<PatientFinancePanel tenantId={tenant} patientId={patientId} patientName="Test Patient" role={role} repository={repository} rpcClient={rpcClient} />);
     });
     await flush();
     return { repository, rpcClient };
@@ -147,7 +148,7 @@ describe('PatientFinancePanel', () => {
     await renderPanel({ role: 'clinic_admin' });
     expect(container.querySelector('[data-testid="finance-create-invoice-form"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-issue-invoice-invoice-1"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="finance-record-payment-form"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="patient-finance-prepayment-open"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-allocation-form"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-void-invoice-invoice-1"]')).not.toBeNull();
   });
@@ -155,7 +156,7 @@ describe('PatientFinancePanel', () => {
   it('cashier can mutate finance but cannot see void actions', async () => {
     await renderPanel({ role: 'cashier' });
     expect(container.querySelector('[data-testid="finance-create-invoice-form"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="finance-record-payment-form"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="patient-finance-prepayment-open"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-allocation-form"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="finance-void-invoice-invoice-1"]')).toBeNull();
     expect(container.querySelector('[data-testid="finance-void-payment-box"]')).toBeNull();
@@ -164,7 +165,7 @@ describe('PatientFinancePanel', () => {
   it('doctor and registrar see no mutation actions', async () => {
     await renderPanel({ role: 'doctor' });
     expect(container.querySelector('[data-testid="finance-create-invoice-form"]')).toBeNull();
-    expect(container.querySelector('[data-testid="finance-record-payment-form"]')).toBeNull();
+    expect(container.querySelector('[data-testid="patient-finance-prepayment-open"]')).toBeNull();
     await act(async () => { root.render(<PatientFinancePanel tenantId={tenantId} patientId={patientId} role="registrar" repository={createRepository()} rpcClient={createRpcClient()} />); });
     await flush();
     expect(container.querySelector('[data-testid="finance-allocation-form"]')).toBeNull();
@@ -259,10 +260,11 @@ describe('PatientFinancePanel', () => {
     await flush();
   });
 
-  it('record payment and allocation forms validate required fields', async () => {
+  it('prepayment and allocation forms validate required fields', async () => {
     const { rpcClient } = await renderPanel();
-    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="finance-record-payment-submit"]')?.click(); });
-    expect(container.textContent).toContain('Сумма должна быть больше 0.');
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="patient-finance-prepayment-open"]')?.click(); });
+    await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="patient-finance-prepayment-submit"]')?.click(); });
+    expect(container.textContent).toContain('Введите сумму больше нуля.');
     await act(async () => { container.querySelector<HTMLButtonElement>('[data-testid="finance-allocation-submit"]')?.click(); });
     expect(container.textContent).toContain('Платёж не выбран.');
     expect(rpcClient.recordPayment).not.toHaveBeenCalled();

--- a/src/components/finance/PatientFinancePanel.tsx
+++ b/src/components/finance/PatientFinancePanel.tsx
@@ -3,6 +3,7 @@ import type { FinanceRepository } from '../../data/repositories/FinanceRepositor
 import type { FinanceRpcClient } from '../../data/repositories/FinanceRpcClient';
 import { useFinanceActions } from '../../data/hooks/useFinanceActions';
 import { usePatientFinance } from '../../data/hooks/usePatientFinance';
+import { AcceptPatientPrepaymentDialog } from '../cashier/AcceptPatientPrepaymentDialog';
 import { AllocationActions } from './AllocationActions';
 import { InvoiceDetail } from './InvoiceDetail';
 import { InvoiceList } from './InvoiceList';
@@ -14,6 +15,7 @@ import { getFinanceRoleCapabilities, type FinanceUserRole } from './financePermi
 interface PatientFinancePanelProps {
   tenantId?: string | null;
   patientId?: string | null;
+  patientName?: string | null;
   role?: FinanceUserRole;
   repository?: FinanceRepository;
   rpcClient?: FinanceRpcClient;
@@ -28,7 +30,7 @@ function safeFinanceMessage(error: unknown) {
   return 'Не удалось загрузить финансовые данные.';
 }
 
-export function PatientFinancePanel({ tenantId, patientId, role, repository, rpcClient }: PatientFinancePanelProps) {
+export function PatientFinancePanel({ tenantId, patientId, patientName, role, repository, rpcClient }: PatientFinancePanelProps) {
   const [selectedInvoiceId, setSelectedInvoiceId] = useState<string | null>(null);
   const [invoiceNotes, setInvoiceNotes] = useState('');
   const [invoiceDueDate, setInvoiceDueDate] = useState('');
@@ -105,6 +107,24 @@ export function PatientFinancePanel({ tenantId, patientId, role, repository, rpc
 
       {!finance.isError && (
         <>
+          <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="font-semibold text-slate-900">Новые деньги пациента</h3>
+              <p className="mt-1 text-sm text-slate-500">Предоплата создаёт обычный платёж и доступный кредит без счёта, распределения или депозита.</p>
+            </div>
+            <AcceptPatientPrepaymentDialog
+              tenantId={tenantId}
+              patient={{ id: patientId, fullName: patientName?.trim() || `Пациент #${patientId.slice(0, 8)}` }}
+              role={role}
+              summary={finance.summary}
+              operationStatus={actions.patientCreditOperationStatus}
+              operationResult={actions.patientCreditOperationResult}
+              operationError={actions.actionError}
+              onSubmit={actions.recordPayment}
+              onResetOperation={actions.resetPatientCreditOperation}
+              testIdPrefix="patient-finance-prepayment"
+            />
+          </div>
           <PatientFinanceSummaryCard summary={finance.summary} />
           <PatientFundReservationsPanel
             tenantId={tenantId}
@@ -121,7 +141,7 @@ export function PatientFinancePanel({ tenantId, patientId, role, repository, rpc
             <InvoiceList invoices={finance.invoices} selectedInvoiceId={selectedInvoice?.id ?? null} role={role} actionLoading={actions.actionLoading} onSelectInvoice={setSelectedInvoiceId} onIssueInvoice={actions.issueInvoice} onVoidInvoice={actions.voidInvoice} />
             <InvoiceDetail tenantId={tenantId} invoice={selectedInvoice} items={finance.invoiceItems} completedServiceBillingEligibility={finance.completedServiceBillingEligibility} role={role} repository={repository} rpcClient={rpcClient} canAddItem={capabilities.canAddInvoiceItem} actionLoading={actions.actionLoading} onChanged={finance.refresh} onAddItem={actions.addInvoiceItem} />
           </div>
-          <PaymentList tenantId={tenantId} payments={finance.payments} role={role} repository={repository} rpcClient={rpcClient} actionLoading={actions.actionLoading} onRecordPayment={actions.recordPayment} onVoidPayment={actions.voidPayment} onChanged={finance.refresh} />
+          <PaymentList tenantId={tenantId} payments={finance.payments} role={role} repository={repository} rpcClient={rpcClient} actionLoading={actions.actionLoading} onVoidPayment={actions.voidPayment} onChanged={finance.refresh} />
           <AllocationActions invoices={finance.invoices} invoiceItems={finance.invoiceItems} payments={finance.payments} allocations={finance.paymentAllocations} role={role} actionLoading={actions.actionLoading} onAllocatePayment={actions.allocatePayment} onVoidAllocation={actions.voidPaymentAllocation} />
         </>
       )}

--- a/src/components/finance/PaymentActions.tsx
+++ b/src/components/finance/PaymentActions.tsx
@@ -1,70 +1,22 @@
-import { useState, type FormEvent } from 'react';
-import type { Payment, PaymentMethod } from '../../data/repositories/FinanceRepository';
-import type { FinanceActionName, RecordPaymentActionInput } from '../../data/hooks/useFinanceActions';
+import { useState } from 'react';
+import type { Payment } from '../../data/repositories/FinanceRepository';
+import type { FinanceActionName } from '../../data/hooks/useFinanceActions';
 import { paymentMethodLabels } from './financeLabels';
 import { getFinanceRoleCapabilities, type FinanceUserRole } from './financePermissions';
-
-const PAYMENT_METHODS: PaymentMethod[] = ['cash', 'kaspi', 'halyk_terminal', 'card', 'bank_transfer', 'insurance', 'osms', 'mixed', 'other'];
 
 interface PaymentActionsProps {
   payments: Payment[];
   role: FinanceUserRole;
   actionLoading: FinanceActionName | null;
-  onRecordPayment: (input: RecordPaymentActionInput) => Promise<void>;
   onVoidPayment: (paymentId: string, reason: string) => Promise<void>;
 }
 
-export function PaymentActions({ payments, role, actionLoading, onRecordPayment, onVoidPayment }: PaymentActionsProps) {
+export function PaymentActions({ payments, role, actionLoading, onVoidPayment }: PaymentActionsProps) {
   const capabilities = getFinanceRoleCapabilities(role);
-  const [amount, setAmount] = useState('');
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('cash');
-  const [currency, setCurrency] = useState('KZT');
-  const [receivedAt, setReceivedAt] = useState('');
-  const [externalReference, setExternalReference] = useState('');
-  const [payerName, setPayerName] = useState('');
-  const [notes, setNotes] = useState('');
   const [voidPaymentId, setVoidPaymentId] = useState('');
   const [voidReason, setVoidReason] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
   const isBusy = actionLoading !== null;
-
-  const resetPaymentForm = () => {
-    setAmount('');
-    setPaymentMethod('cash');
-    setCurrency('KZT');
-    setReceivedAt('');
-    setExternalReference('');
-    setPayerName('');
-    setNotes('');
-  };
-
-  const handleRecord = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setFormError(null);
-    const parsedAmount = Number(amount);
-    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
-      setFormError('Сумма должна быть больше 0.');
-      return;
-    }
-    if (!paymentMethod) {
-      setFormError('Способ оплаты обязателен.');
-      return;
-    }
-    try {
-      await onRecordPayment({
-        amount: parsedAmount,
-        paymentMethod,
-        currency: currency.trim() || 'KZT',
-        receivedAt: receivedAt || null,
-        externalReference,
-        payerName,
-        notes,
-      });
-      resetPaymentForm();
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : 'Не удалось выполнить финансовую операцию.');
-    }
-  };
 
   const handleVoid = async () => {
     setFormError(null);
@@ -85,40 +37,22 @@ export function PaymentActions({ payments, role, actionLoading, onRecordPayment,
     }
   };
 
-  if (!capabilities.canRecordPayment && !capabilities.canVoid) return null;
+  if (!capabilities.canVoid || payments.length === 0) return null;
 
   return (
     <div className="mt-5 space-y-4">
-      {capabilities.canRecordPayment && (
-        <form data-testid="finance-record-payment-form" onSubmit={handleRecord} className="rounded-2xl border border-slate-100 bg-slate-50 p-4">
-          <h4 className="text-sm font-semibold text-slate-800">Принять оплату</h4>
-          <div className="mt-4 grid gap-3 md:grid-cols-3">
-            <label className="text-sm font-medium text-slate-700">Сумма<input data-testid="finance-payment-amount" type="number" min="0" step="0.01" value={amount} onChange={(event) => setAmount(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Способ оплаты<select data-testid="finance-payment-method" value={paymentMethod} onChange={(event) => setPaymentMethod(event.target.value as PaymentMethod)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">{PAYMENT_METHODS.map((method) => <option key={method} value={method}>{paymentMethodLabels[method]}</option>)}</select></label>
-            <label className="text-sm font-medium text-slate-700">Валюта<input value={currency} onChange={(event) => setCurrency(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Дата оплаты<input type="datetime-local" value={receivedAt} onChange={(event) => setReceivedAt(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Внешняя ссылка<input data-testid="finance-payment-external-reference" value={externalReference} onChange={(event) => setExternalReference(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700">Плательщик<input value={payerName} onChange={(event) => setPayerName(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-            <label className="text-sm font-medium text-slate-700 md:col-span-3">Примечание<input value={notes} onChange={(event) => setNotes(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm" /></label>
-          </div>
-          {formError && <p data-testid="finance-payment-form-error" className="mt-3 text-sm font-medium text-rose-600">{formError}</p>}
-          <button type="submit" data-testid="finance-record-payment-submit" disabled={isBusy} className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-60">{actionLoading === 'recordPayment' ? 'Сохраняем...' : 'Сохранить оплату'}</button>
-        </form>
-      )}
-
-      {capabilities.canVoid && payments.length > 0 && (
-        <div data-testid="finance-void-payment-box" className="rounded-2xl border border-rose-100 bg-rose-50 p-4">
-          <h4 className="text-sm font-semibold text-rose-800">Аннулировать оплату</h4>
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <select data-testid="finance-void-payment-select" value={voidPaymentId} onChange={(event) => setVoidPaymentId(event.target.value)} className="rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm">
-              <option value="">Выберите оплату</option>
-              {payments.filter((payment) => !['voided', 'archived'].includes(payment.status)).map((payment) => <option key={payment.id} value={payment.id}>{paymentMethodLabels[payment.paymentMethod]} · {payment.amount} {payment.currency}</option>)}
-            </select>
-            <input data-testid="finance-void-payment-reason" value={voidReason} onChange={(event) => setVoidReason(event.target.value)} placeholder="Причина аннулирования" className="rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm" />
-          </div>
-          <button type="button" data-testid="finance-void-payment-submit" disabled={isBusy || !voidPaymentId || !voidReason.trim()} onClick={() => { void handleVoid(); }} className="mt-3 rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-700 disabled:opacity-60">Аннулировать оплату</button>
+      <div data-testid="finance-void-payment-box" className="rounded-2xl border border-rose-100 bg-rose-50 p-4">
+        <h4 className="text-sm font-semibold text-rose-800">Аннулировать оплату</h4>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <select data-testid="finance-void-payment-select" value={voidPaymentId} onChange={(event) => setVoidPaymentId(event.target.value)} className="rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm">
+            <option value="">Выберите оплату</option>
+            {payments.filter((payment) => !['voided', 'archived'].includes(payment.status)).map((payment) => <option key={payment.id} value={payment.id}>{paymentMethodLabels[payment.paymentMethod]} · {payment.amount} {payment.currency}</option>)}
+          </select>
+          <input data-testid="finance-void-payment-reason" value={voidReason} onChange={(event) => setVoidReason(event.target.value)} placeholder="Причина аннулирования" className="rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm" />
         </div>
-      )}
+        {formError && <p data-testid="finance-void-payment-error" className="mt-3 text-sm font-medium text-rose-600">{formError}</p>}
+        <button type="button" data-testid="finance-void-payment-submit" disabled={isBusy || !voidPaymentId || !voidReason.trim()} onClick={() => { void handleVoid(); }} className="mt-3 rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-700 disabled:opacity-60">Аннулировать оплату</button>
+      </div>
     </div>
   );
 }

--- a/src/components/finance/PaymentList.tsx
+++ b/src/components/finance/PaymentList.tsx
@@ -1,6 +1,6 @@
 import type { FinanceRepository, Payment } from '../../data/repositories/FinanceRepository';
 import type { FinanceRpcClient } from '../../data/repositories/FinanceRpcClient';
-import type { FinanceActionName, RecordPaymentActionInput } from '../../data/hooks/useFinanceActions';
+import type { FinanceActionName } from '../../data/hooks/useFinanceActions';
 import { FinanceStatusBadge } from './FinanceStatusBadge';
 import { formatFinanceDateTime, formatFinanceMoney, paymentMethodLabels, shortFinanceId } from './financeLabels';
 import type { FinanceUserRole } from './financePermissions';
@@ -14,7 +14,6 @@ interface PaymentListProps {
   repository?: FinanceRepository;
   rpcClient?: FinanceRpcClient;
   actionLoading: FinanceActionName | null;
-  onRecordPayment: (input: RecordPaymentActionInput) => Promise<void>;
   onVoidPayment: (paymentId: string, reason: string) => Promise<void>;
   onChanged?: () => Promise<void> | void;
 }
@@ -28,11 +27,11 @@ function PaymentField({ label, value }: { label: string; value?: string | number
   );
 }
 
-export function PaymentList({ tenantId, payments, role, repository, rpcClient, actionLoading, onRecordPayment, onVoidPayment, onChanged }: PaymentListProps) {
+export function PaymentList({ tenantId, payments, role, repository, rpcClient, actionLoading, onVoidPayment, onChanged }: PaymentListProps) {
   return (
     <section data-testid="finance-payment-list" className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
       <h3 className="text-lg font-semibold text-slate-900">Оплаты</h3>
-      <PaymentActions payments={payments} role={role} actionLoading={actionLoading} onRecordPayment={onRecordPayment} onVoidPayment={onVoidPayment} />
+      <PaymentActions payments={payments} role={role} actionLoading={actionLoading} onVoidPayment={onVoidPayment} />
       {payments.length === 0 && <p data-testid="finance-payments-empty" className="mt-4 text-sm text-slate-500">Оплат пока нет.</p>}
       <div className="mt-4 space-y-3">
         {payments.map((payment) => (

--- a/src/data/hooks/useFinanceActions.test.tsx
+++ b/src/data/hooks/useFinanceActions.test.tsx
@@ -11,15 +11,26 @@ vi.mock('../../lib/supabaseClient', () => ({ supabase: {}, isSupabaseConfigured:
 const tenantId = 'tenant-1';
 const patientId = 'patient-1';
 
-function completedPatientCreditOperation(operationId = 'patient-credit-operation-1'): PatientCreditPaymentOperationResult {
+function completedPatientCreditOperation(operationId = 'patient-credit-operation-1', nextPatientId = patientId, nextTenantId = tenantId): PatientCreditPaymentOperationResult {
   return {
     status: 'completed',
     operationId,
-    tenantId,
-    patientId,
+    tenantId: nextTenantId,
+    patientId: nextPatientId,
     payment: { id: 'payment-1' } as PatientCreditPaymentOperationResult['payment'],
     capacity: { availableCreditAmount: 1000 } as PatientCreditPaymentOperationResult['capacity'],
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolver, rejecter) => { resolve = resolver; reject = rejecter; });
+  return { promise, resolve, reject };
+}
+
+async function flush() {
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
 }
 
 function createRpcClient(): FinanceRpcClient {
@@ -162,7 +173,7 @@ describe('useFinanceActions', () => {
     await act(async () => {
       try { await latest?.recordPayment({ amount: 2000, paymentMethod: 'cash' }); } catch (error) { changedError = error; }
     });
-    expect((changedError as Error).message).toContain('предыдущую оплату');
+    expect((changedError as Error).message).toBe('Не удалось подтвердить результат операции. Повторите попытку с теми же данными.');
     expect(rpcClient.recordPayment).toHaveBeenCalledOnce();
   });
 
@@ -186,6 +197,118 @@ describe('useFinanceActions', () => {
     expect(first.patientId).toBe(patientId);
     expect(second.patientId).toBe('patient-2');
     expect(first.idempotencyKey).not.toBe(second.idempotencyKey);
+  });
+
+  it('shows submitting, reconciling and succeeded states for one operation', async () => {
+    const rpcClient = createRpcClient();
+    const write = deferred<PatientCreditPaymentOperationResult>();
+    const recovery = deferred<PatientCreditPaymentOperationResult>();
+    vi.mocked(rpcClient.recordPayment).mockReturnValueOnce(write.promise);
+    vi.mocked(rpcClient.getPatientCreditPaymentOperation).mockReturnValueOnce(recovery.promise);
+    await renderHook(rpcClient);
+
+    let operationPromise!: Promise<PatientCreditPaymentOperationResult>;
+    act(() => { operationPromise = latest!.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
+    expect(latest?.patientCreditOperationStatus).toBe('submitting');
+
+    write.reject(new FinanceRpcClientError({ operation: 'recordPayment', category: 'operation_uncertain', message: 'network' }));
+    await flush();
+    expect(latest?.patientCreditOperationStatus).toBe('reconciling');
+
+    recovery.resolve(completedPatientCreditOperation());
+    await act(async () => { await operationPromise; });
+    expect(latest?.patientCreditOperationStatus).toBe('succeeded');
+    expect(latest?.patientCreditOperationResult?.payment?.id).toBe('payment-1');
+  });
+
+  it('clears a completed operation so a new payload gets a new key', async () => {
+    const rpcClient = await renderHook();
+    await act(async () => { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
+    await act(async () => { await latest?.recordPayment({ amount: 2000, paymentMethod: 'cash' }); });
+    const first = vi.mocked(rpcClient.recordPayment).mock.calls[0][0].idempotencyKey;
+    const second = vi.mocked(rpcClient.recordPayment).mock.calls[1][0].idempotencyKey;
+    expect(second).not.toBe(first);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears pending identity after a permission failure', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment)
+      .mockRejectedValueOnce(new FinanceRpcClientError({ operation: 'recordPayment', category: 'permission', message: 'denied' }))
+      .mockImplementationOnce(async (input) => completedPatientCreditOperation(input.idempotencyKey));
+    await renderHook(rpcClient);
+    await act(async () => { try { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); } catch { /* expected */ } });
+    await act(async () => { await latest?.recordPayment({ amount: 2000, paymentMethod: 'cash' }); });
+    expect(rpcClient.recordPayment).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears pending identity after a validation failure', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment)
+      .mockRejectedValueOnce(new FinanceRpcClientError({ operation: 'recordPayment', category: 'validation', message: 'invalid amount' }))
+      .mockImplementationOnce(async (input) => completedPatientCreditOperation(input.idempotencyKey));
+    await renderHook(rpcClient);
+    await act(async () => { try { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); } catch { /* expected */ } });
+    await act(async () => { await latest?.recordPayment({ amount: 2000, paymentMethod: 'cash' }); });
+    expect(rpcClient.recordPayment).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a late success after patient context changes', async () => {
+    const rpcClient = createRpcClient();
+    const write = deferred<PatientCreditPaymentOperationResult>();
+    vi.mocked(rpcClient.recordPayment).mockReturnValueOnce(write.promise);
+    await renderHook(rpcClient);
+    let operationPromise!: Promise<PatientCreditPaymentOperationResult>;
+    act(() => { operationPromise = latest!.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
+    await act(async () => { root.render(<Probe rpcClient={rpcClient} patient="patient-2" />); });
+    write.resolve(completedPatientCreditOperation('operation-a'));
+    await act(async () => { await operationPromise; });
+    expect(latest?.patientCreditOperationStatus).toBe('idle');
+    expect(latest?.patientCreditOperationResult).toBeNull();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('ignores a late success after tenant context changes', async () => {
+    const rpcClient = createRpcClient();
+    const write = deferred<PatientCreditPaymentOperationResult>();
+    vi.mocked(rpcClient.recordPayment).mockReturnValueOnce(write.promise);
+    await renderHook(rpcClient);
+    let operationPromise!: Promise<PatientCreditPaymentOperationResult>;
+    act(() => { operationPromise = latest!.recordPayment({ amount: 1000, paymentMethod: 'cash' }); });
+    await act(async () => { root.render(<Probe rpcClient={rpcClient} tenant="tenant-2" />); });
+    write.resolve(completedPatientCreditOperation('operation-a'));
+    await act(async () => { await operationPromise; });
+    expect(latest?.patientCreditOperationStatus).toBe('idle');
+    expect(latest?.patientCreditOperationResult).toBeNull();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh after an unresolved failure', async () => {
+    const rpcClient = createRpcClient();
+    vi.mocked(rpcClient.recordPayment).mockRejectedValue(new FinanceRpcClientError({ operation: 'recordPayment', category: 'operation_uncertain', message: 'network' }));
+    vi.mocked(rpcClient.getPatientCreditPaymentOperation).mockRejectedValue(new FinanceRpcClientError({ operation: 'getPatientCreditPaymentOperation', category: 'operation_uncertain', message: 'network' }));
+    await renderHook(rpcClient);
+    await act(async () => { try { await latest?.recordPayment({ amount: 1000, paymentMethod: 'cash' }); } catch { /* expected */ } });
+    expect(latest?.patientCreditOperationStatus).toBe('uncertain');
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates rapid concurrent submits inside the hook', async () => {
+    const rpcClient = createRpcClient();
+    const write = deferred<PatientCreditPaymentOperationResult>();
+    vi.mocked(rpcClient.recordPayment).mockReturnValueOnce(write.promise);
+    await renderHook(rpcClient);
+    let first!: Promise<PatientCreditPaymentOperationResult>;
+    let second!: Promise<PatientCreditPaymentOperationResult>;
+    act(() => {
+      first = latest!.recordPayment({ amount: 1000, paymentMethod: 'cash' });
+      second = latest!.recordPayment({ amount: 1000, paymentMethod: 'cash' });
+    });
+    expect(first).toBe(second);
+    expect(rpcClient.recordPayment).toHaveBeenCalledOnce();
+    write.resolve(completedPatientCreditOperation());
+    await act(async () => { await Promise.all([first, second]); });
+    expect(refresh).toHaveBeenCalledOnce();
   });
 
   it('calls allocatePayment', async () => {

--- a/src/data/hooks/useFinanceActions.ts
+++ b/src/data/hooks/useFinanceActions.ts
@@ -1,9 +1,17 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { createFinanceRpcClient, FinanceRpcClientError, type FinanceRpcClient, type RecordPaymentInput } from '../repositories/FinanceRpcClient';
+/* eslint-disable react-hooks/set-state-in-effect -- tenant/patient changes must clear visible operation state before late responses can render */
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  createFinanceRpcClient,
+  FinanceRpcClientError,
+  type FinanceRpcClient,
+  type PatientCreditPaymentOperationResult,
+  type RecordPaymentInput,
+} from '../repositories/FinanceRpcClient';
 import type { PaymentMethod } from '../repositories/FinanceRepository';
 import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
 export type FinanceActionName = 'createInvoice' | 'addInvoiceItem' | 'issueInvoice' | 'voidInvoice' | 'recordPayment' | 'allocatePayment' | 'voidPaymentAllocation' | 'voidPayment';
+export type PatientCreditOperationStatus = 'idle' | 'submitting' | 'reconciling' | 'succeeded' | 'failed' | 'uncertain';
 
 export interface CreateInvoiceActionInput {
   currency?: string;
@@ -54,20 +62,24 @@ export interface UseFinanceActionsResult {
   loading: boolean;
   actionError: Error | null;
   error: Error | null;
+  patientCreditOperationStatus: PatientCreditOperationStatus;
+  patientCreditOperationResult: PatientCreditPaymentOperationResult | null;
   createInvoice: (input?: CreateInvoiceActionInput) => Promise<void>;
   addInvoiceItem: (input: AddInvoiceItemActionInput) => Promise<void>;
   issueInvoice: (invoiceId: string) => Promise<void>;
   voidInvoice: (invoiceId: string, reason: string) => Promise<void>;
-  recordPayment: (input: RecordPaymentActionInput) => Promise<void>;
+  recordPayment: (input: RecordPaymentActionInput) => Promise<PatientCreditPaymentOperationResult>;
   allocatePayment: (input: AllocatePaymentActionInput) => Promise<void>;
   voidPaymentAllocation: (allocationId: string, reason: string) => Promise<void>;
   voidPayment: (paymentId: string, reason: string) => Promise<void>;
   clearError: () => void;
+  resetPatientCreditOperation: () => void;
 }
 
 const ACTION_METADATA = { source: 'patient_finance_ui' };
 const COMPLETED_SERVICE_ALREADY_BILLED_ERROR = 'Эта выполненная услуга уже включена в другой счёт.';
 const COMPLETED_SERVICE_ALREADY_BILLED_REFRESHED_ERROR = 'Услуга уже была включена в другой счёт. Данные обновлены.';
+const PATIENT_CREDIT_UNCERTAIN_MESSAGE = 'Не удалось подтвердить результат операции. Повторите попытку с теми же данными.';
 
 function normalizeOptionalText(value?: string | null) {
   const trimmed = value?.trim();
@@ -86,6 +98,36 @@ function safeFinanceError(error: unknown): Error {
     }
   }
   return new Error('Не удалось выполнить финансовую операцию.');
+}
+
+function safePatientCreditError(error: unknown): FinanceRpcClientError {
+  if (error instanceof FinanceRpcClientError) {
+    const category = error.category ?? 'operation_failed';
+    const lower = error.message.toLowerCase();
+    if (category === 'permission') {
+      return new FinanceRpcClientError({ operation: 'recordPayment', category, message: 'Недостаточно прав для приёма предоплаты.' });
+    }
+    if (category === 'duplicate_conflict') {
+      return new FinanceRpcClientError({ operation: 'recordPayment', category, message: 'Эта операция уже была выполнена с другими параметрами.' });
+    }
+    if (category === 'stale_patient') {
+      return new FinanceRpcClientError({ operation: 'recordPayment', category, message: 'Операция относится к другому пациенту. Данные обновлены.' });
+    }
+    if (category === 'operation_uncertain') {
+      return new FinanceRpcClientError({ operation: 'recordPayment', category, message: PATIENT_CREDIT_UNCERTAIN_MESSAGE });
+    }
+    if (category === 'validation' && (lower.includes('kzt') || lower.includes('currency') || lower.includes('валют'))) {
+      return new FinanceRpcClientError({ operation: 'recordPayment', category, message: 'Предоплата принимается только в KZT.' });
+    }
+    if (category === 'validation') {
+      return new FinanceRpcClientError({ operation: 'recordPayment', category, message: error.message.length <= 160 && !error.message.includes('{') ? error.message : 'Проверьте данные предоплаты.' });
+    }
+  }
+  return new FinanceRpcClientError({
+    operation: 'recordPayment',
+    category: 'operation_uncertain',
+    message: 'Не удалось принять предоплату. Проверьте текущее состояние операции.',
+  });
 }
 
 function isCompletedServiceDuplicate(error: unknown) {
@@ -115,9 +157,25 @@ function createPatientCreditOperationKey(tenantId: string, patientId: string): s
 }
 
 export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: UseFinanceActionsOptions): UseFinanceActionsResult {
+  const contextKey = tenantId && patientId ? `${tenantId}:${patientId}` : null;
+  const contextRef = useRef({ tenantId: tenantId ?? null, patientId: patientId ?? null, contextKey });
   const [actionLoading, setActionLoading] = useState<FinanceActionName | null>(null);
   const [actionError, setActionError] = useState<Error | null>(null);
+  const [patientCreditOperationStatus, setPatientCreditOperationStatus] = useState<PatientCreditOperationStatus>('idle');
+  const [patientCreditOperationResult, setPatientCreditOperationResult] = useState<PatientCreditPaymentOperationResult | null>(null);
   const pendingPatientCreditOperations = useRef(new Map<string, PendingPatientCreditOperation>());
+  const inFlightPatientCreditOperations = useRef(new Map<string, Promise<PatientCreditPaymentOperationResult>>());
+
+  useLayoutEffect(() => {
+    contextRef.current = { tenantId: tenantId ?? null, patientId: patientId ?? null, contextKey };
+  }, [contextKey, patientId, tenantId]);
+
+  useEffect(() => {
+    setPatientCreditOperationStatus('idle');
+    setPatientCreditOperationResult(null);
+    setActionError(null);
+    setActionLoading(null);
+  }, [contextKey]);
 
   const client = useMemo(() => {
     if (rpcClient) return rpcClient;
@@ -197,91 +255,121 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
     });
   }, [requireClient, runAction, tenantId]);
 
-  const recordPayment = useCallback(async (input: RecordPaymentActionInput) => {
-    await runAction('recordPayment', async () => {
-      const actionClient = requireClient();
-      if (!patientId) throw new Error('Пациент не выбран.');
+  const recordPayment = useCallback((input: RecordPaymentActionInput): Promise<PatientCreditPaymentOperationResult> => {
+    if (!tenantId) return Promise.reject(new Error('Клиника не выбрана.'));
+    if (!patientId) return Promise.reject(new Error('Пациент не выбран.'));
+    if (!client) return Promise.reject(new Error('Не удалось принять предоплату. Проверьте текущее состояние операции.'));
 
-      const normalizedInput = {
-        amount: input.amount,
-        paymentMethod: input.paymentMethod,
-        currency: input.currency?.trim() || 'KZT',
-        receivedAt: normalizeOptionalText(input.receivedAt),
-        externalReference: normalizeOptionalText(input.externalReference),
-        payerName: normalizeOptionalText(input.payerName),
-        notes: normalizeOptionalText(input.notes),
-        metadata: ACTION_METADATA,
-      } satisfies Omit<RecordPaymentInput, 'tenantId' | 'patientId' | 'idempotencyKey'>;
-      const fingerprint = patientCreditFingerprint(normalizedInput);
-      const operationScope = `${tenantId}:${patientId}`;
-      const pending = pendingPatientCreditOperations.current.get(operationScope);
+    const operationScope = `${tenantId}:${patientId}`;
+    const normalizedInput = {
+      amount: input.amount,
+      paymentMethod: input.paymentMethod,
+      currency: input.currency?.trim() || 'KZT',
+      receivedAt: normalizeOptionalText(input.receivedAt),
+      externalReference: normalizeOptionalText(input.externalReference),
+      payerName: normalizeOptionalText(input.payerName),
+      notes: normalizeOptionalText(input.notes),
+      metadata: ACTION_METADATA,
+    } satisfies Omit<RecordPaymentInput, 'tenantId' | 'patientId' | 'idempotencyKey'>;
+    const fingerprint = patientCreditFingerprint(normalizedInput);
+    const pending = pendingPatientCreditOperations.current.get(operationScope);
 
-      if (pending && pending.fingerprint !== fingerprint) {
+    if (pending && pending.fingerprint !== fingerprint) {
+      const conflict = new FinanceRpcClientError({
+        operation: 'recordPayment',
+        category: 'operation_uncertain',
+        message: PATIENT_CREDIT_UNCERTAIN_MESSAGE,
+      });
+      if (contextRef.current.contextKey === operationScope) {
+        setPatientCreditOperationStatus('uncertain');
+        setActionError(conflict);
+      }
+      return Promise.reject(conflict);
+    }
+
+    const existingInFlight = inFlightPatientCreditOperations.current.get(operationScope);
+    if (existingInFlight) return existingInFlight;
+
+    const idempotencyKey = pending?.idempotencyKey ?? createPatientCreditOperationKey(tenantId, patientId);
+    pendingPatientCreditOperations.current.set(operationScope, { idempotencyKey, fingerprint });
+    const request: RecordPaymentInput = {
+      tenantId,
+      patientId,
+      idempotencyKey,
+      ...normalizedInput,
+    };
+
+    const isCurrentContext = () => contextRef.current.contextKey === operationScope;
+    const confirmSuccess = async (result: PatientCreditPaymentOperationResult) => {
+      if (!result.payment || result.tenantId !== tenantId || result.patientId !== patientId) {
         throw new FinanceRpcClientError({
           operation: 'recordPayment',
-          category: 'operation_uncertain',
-          message: 'Сначала повторите предыдущую оплату с теми же параметрами, чтобы проверить её результат.',
+          category: 'stale_patient',
+          message: 'Операция относится к другому пациенту. Данные обновлены.',
         });
       }
+      pendingPatientCreditOperations.current.delete(operationScope);
+      if (isCurrentContext()) {
+        setPatientCreditOperationResult(result);
+        setPatientCreditOperationStatus('succeeded');
+        setActionError(null);
+        try {
+          await refresh?.();
+        } catch {
+          // The payment is committed and the returned capacity remains authoritative for the success view.
+        }
+      }
+      return result;
+    };
 
-      const idempotencyKey = pending?.idempotencyKey ?? createPatientCreditOperationKey(tenantId!, patientId);
-      pendingPatientCreditOperations.current.set(operationScope, { idempotencyKey, fingerprint });
-      const request: RecordPaymentInput = {
-        tenantId: tenantId!,
-        patientId,
-        idempotencyKey,
-        ...normalizedInput,
-      };
+    const operationPromise = (async () => {
+      if (isCurrentContext()) {
+        setActionLoading('recordPayment');
+        setActionError(null);
+        setPatientCreditOperationResult(null);
+        setPatientCreditOperationStatus('submitting');
+      }
 
       try {
-        const result = await actionClient.recordPayment(request);
-        if (!result.payment || result.tenantId !== tenantId || result.patientId !== patientId) {
-          throw new FinanceRpcClientError({
-            operation: 'recordPayment',
-            category: 'stale_patient',
-            message: 'Ответ операции относится к другому пациенту или клинике.',
-          });
+        try {
+          return await confirmSuccess(await client.recordPayment(request));
+        } catch (error) {
+          if (!(error instanceof FinanceRpcClientError) || error.category !== 'operation_uncertain') throw error;
         }
-        pendingPatientCreditOperations.current.delete(operationScope);
-        return;
-      } catch (error) {
-        if (!(error instanceof FinanceRpcClientError) || error.category !== 'operation_uncertain') {
-          pendingPatientCreditOperations.current.delete(operationScope);
+
+        if (isCurrentContext()) setPatientCreditOperationStatus('reconciling');
+        try {
+          const recovered = await client.getPatientCreditPaymentOperation({ tenantId, patientId, idempotencyKey });
+          if (recovered.status !== 'not_found') return await confirmSuccess(recovered);
+          return await confirmSuccess(await client.recordPayment(request));
+        } catch (error) {
+          if (error instanceof FinanceRpcClientError && error.category === 'operation_uncertain') {
+            const unresolved = safePatientCreditError(error);
+            if (isCurrentContext()) {
+              setPatientCreditOperationStatus('uncertain');
+              setActionError(unresolved);
+            }
+            throw unresolved;
+          }
           throw error;
         }
-      }
-
-      try {
-        const recovered = await actionClient.getPatientCreditPaymentOperation({ tenantId: tenantId!, patientId, idempotencyKey });
-        if (recovered.status !== 'not_found') {
-          if (!recovered.payment || recovered.tenantId !== tenantId || recovered.patientId !== patientId) {
-            throw new FinanceRpcClientError({
-              operation: 'getPatientCreditPaymentOperation',
-              category: 'stale_patient',
-              message: 'Восстановленная операция относится к другому пациенту или клинике.',
-            });
-          }
-          pendingPatientCreditOperations.current.delete(operationScope);
-          return;
-        }
-
-        const retried = await actionClient.recordPayment(request);
-        if (!retried.payment || retried.tenantId !== tenantId || retried.patientId !== patientId) {
-          throw new FinanceRpcClientError({
-            operation: 'recordPayment',
-            category: 'stale_patient',
-            message: 'Повторная операция относится к другому пациенту или клинике.',
-          });
-        }
-        pendingPatientCreditOperations.current.delete(operationScope);
       } catch (error) {
-        if (!(error instanceof FinanceRpcClientError) || error.category !== 'operation_uncertain') {
-          pendingPatientCreditOperations.current.delete(operationScope);
+        const safeError = safePatientCreditError(error);
+        if (safeError.category !== 'operation_uncertain') pendingPatientCreditOperations.current.delete(operationScope);
+        if (isCurrentContext()) {
+          setPatientCreditOperationStatus(safeError.category === 'operation_uncertain' ? 'uncertain' : 'failed');
+          setActionError(safeError);
         }
-        throw error;
+        throw safeError;
+      } finally {
+        inFlightPatientCreditOperations.current.delete(operationScope);
+        if (isCurrentContext()) setActionLoading(null);
       }
-    });
-  }, [patientId, requireClient, runAction, tenantId]);
+    })();
+
+    inFlightPatientCreditOperations.current.set(operationScope, operationPromise);
+    return operationPromise;
+  }, [client, patientId, refresh, tenantId]);
 
   const allocatePayment = useCallback(async (input: AllocatePaymentActionInput) => {
     await runAction('allocatePayment', async () => {
@@ -308,11 +396,19 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
     });
   }, [requireClient, runAction, tenantId]);
 
+  const resetPatientCreditOperation = useCallback(() => {
+    setPatientCreditOperationStatus('idle');
+    setPatientCreditOperationResult(null);
+    setActionError(null);
+  }, []);
+
   return {
     actionLoading,
     loading: actionLoading !== null,
     actionError,
     error: actionError,
+    patientCreditOperationStatus,
+    patientCreditOperationResult,
     createInvoice,
     addInvoiceItem,
     issueInvoice,
@@ -322,7 +418,12 @@ export function useFinanceActions({ tenantId, patientId, refresh, rpcClient }: U
     voidPaymentAllocation,
     voidPayment,
     clearError: () => setActionError(null),
+    resetPatientCreditOperation,
   };
 }
 
-export { COMPLETED_SERVICE_ALREADY_BILLED_ERROR, COMPLETED_SERVICE_ALREADY_BILLED_REFRESHED_ERROR };
+export {
+  COMPLETED_SERVICE_ALREADY_BILLED_ERROR,
+  COMPLETED_SERVICE_ALREADY_BILLED_REFRESHED_ERROR,
+  PATIENT_CREDIT_UNCERTAIN_MESSAGE,
+};

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -264,6 +264,7 @@ export function PatientCardPage() {
             <PatientFinancePanel
               tenantId={activeTenant?.tenantId}
               patientId={patient.id}
+              patientName={patient.fullName}
               role={activeTenant?.role}
             />
           </div>


### PR DESCRIPTION
## Summary

Adds one reusable operational prepayment dialog to the cashier patient workspace and patient Finance tab. The UI uses the hardened migration 0023 patient-credit intake and recovery contract, preserves one idempotency key through uncertainty, blocks duplicate submits, isolates stale patient and tenant responses, and keeps invoice payment, reserved-credit use, and deposit reservation visually distinct. No prepayment table, migration, direct payment insert, service role, cloud write, automatic invoice, allocation, deposit, cash shift, fiscal receipt, or provider integration was added. Final PR head: 986f27273ecff99545731f0e068b56c08884f1f7. Fresh CI #690, run ID 29156786522, succeeded on that exact commit.

## Checks

- 38 required dialog component tests passed
- 21 finance hook tests passed
- 14 cashier panel tests passed, including success-view persistence during refresh
- 80 test files / 864 tests passed
- ESLint and production build passed
- Real browser role, normal, duplicate, recovery, conflict, stale-context, deposit and allocated-flow smoke completed
- Gateway logs confirm hardened intake and recovery RPCs; legacy record_payment and direct payments inserts absent
- 0023, cashier, deposit and refund/write-off SQL/concurrency regressions passed
- All browser fixtures, QA users, network shim, logs and screenshots removed; final local DB is empty
- Final CI #690 succeeded on PR head 986f27273ecff99545731f0e068b56c08884f1f7

## Limitations

- Durable unresolved-operation identity across a full browser restart remains outside this UI task
- Existing unrelated React act warnings and Vite bundle-size warning remain
