### PR TITLE
APPOINTMENT-CONFLICT-HARDENING-001: prevent double booking and unsafe retries

### DIFF
--- a/_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md
+++ b/_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md
@@ -1,0 +1,590 @@
+# APPOINTMENT-CONFLICT-HARDENING-001: authoritative appointment conflict protection
+
+## Final verdict
+
+APPOINTMENT CONFLICT HARDENING IMPLEMENTED AND VERIFIED
+
+## Summary
+
+Appointment creation and protected appointment mutation now cross transactional PostgreSQL RPCs. The database serializes tenant-scoped doctor and patient resources with deterministic advisory locks, uses half-open overlap checks, rejects invalid intervals and changed-payload retries, preserves one logical appointment per operation key, and provides operation recovery after an uncertain response.
+
+Configured Supabase mode no longer performs direct appointment INSERT or protected UPDATE from the frontend. The legacy grants matrix remains intact for compatibility with `0024`, while a database trigger rejects ordinary authenticated INSERT/UPDATE. Current hard delete remains under the existing owner/admin RLS policy, as required by scope.
+
+## Branch
+
+`feature/appointment-conflict-hardening-001`
+
+## PR URL
+
+Pending publication.
+
+## Baseline
+
+- repository: `NckNA/codex-test`;
+- required baseline: `8dfa46d27a7e192a3c949c7515bb94fb72345dee`;
+- verified `origin/main`: `8dfa46d27a7e192a3c949c7515bb94fb72345dee`;
+- PR #346 was merged into that exact commit;
+- worktree was created cleanly from current `main`/`origin/main`.
+
+## PR head reviewed before final report update
+
+Pending implementation commit, PR publication, and fresh CI.
+
+## Report update commit
+
+N/A because the final report commit cannot reference itself.
+
+## Changed files
+
+- `supabase/migrations/0025_harden_appointment_conflicts.sql`
+- `supabase/tests/0025_appointment_conflict_hardening_test.sql`
+- `supabase/tests/0025_appointment_conflict_concurrency.ps1`
+- `supabase/tests/0024_legacy_core_table_grants_test.sql`
+- `supabase/tests/0021_completed_service_billing_guard_test.sql`
+- `supabase/tests/0022_patient_credit_deposits_foundation_test.sql`
+- `src/data/repositories/AppointmentRepository.ts`
+- `src/data/repositories/AppointmentRepository.test.ts`
+- `src/data/hooks/useScheduleAppointments.ts`
+- `src/data/hooks/useScheduleAppointments.test.tsx`
+- `src/components/schedule/AppointmentModal.tsx`
+- `src/components/schedule/AppointmentModal.test.tsx`
+- `src/pages/SchedulePage.tsx`
+- `src/types/index.ts`
+- `_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md`
+
+No historical migration, generated type, package, lock file, finance implementation, clinical implementation, reminder, waitlist, room/chair, confirmation workflow, or cloud state changed.
+
+The three older SQL tests changed only to align fixtures/expectations with the new appointment boundary:
+
+- `0021`: adds a tenant-valid doctor to its appointment side-effect fixture;
+- `0022`: adds a tenant-valid doctor to its two appointment fixtures;
+- `0024`: preserves the grants matrix but validates RPC writes and direct-write denial instead of the superseded direct CRUD contract.
+
+## Pre-read
+
+Reviewed before implementation:
+
+- `_ai_work/REPORTS/SCHEDULE-OPERATIONS-RECON-001_recon.md`
+- `_ai_work/REPORTS/LEGACY-CORE-TABLE-GRANTS-RECOVERY-001_recovery.md`
+- `_ai_work/SOURCES/02_ROLES_AND_PERMISSIONS.md`
+- `_ai_work/SOURCES/03_MULTI_TENANT_ARCHITECTURE_RULES.md`
+- `_ai_work/SOURCES/04_DATA_ISOLATION_AND_SECURITY.md`
+- `_ai_work/SOURCES/05_MEDICAL_DOMAIN_MODEL.md`
+- `_ai_work/SOURCES/08_APPOINTMENTS_AND_SCHEDULE.md`
+- `_ai_work/SOURCES/11_BACKEND_AND_API_ARCHITECTURE.md`
+- `_ai_work/SOURCES/18_TESTING_AND_QUALITY_ASSURANCE_STRATEGY.md`
+- migrations `0001` through `0024`, with appointment, audit, activity, encounter, finance, and grants sections;
+- SchedulePage, AppointmentModal, AppointmentRepository, schedule hooks/context, role helpers, appointment types, and existing tests.
+
+## Previous write contract
+
+Before this task:
+
+- `SupabaseAppointmentRepository.createAppointment` performed direct `POST /rest/v1/appointments` through `.insert(...)`;
+- `updateAppointment` performed a full direct `.update(...)` and could change patient, doctor, start, end, status, and details together;
+- reschedule was not a dedicated operation;
+- modal quick validation checked doctor and text cabinet only;
+- patient overlap was not checked;
+- edit excluded its own appointment in the modal check;
+- modal submit was not disabled and rapid duplicate submit could send multiple writes;
+- hook exposed an internal saving state but SchedulePage/modal did not consume it;
+- no operation key, replay identity, recovery read, or optimistic version check existed;
+- the database accepted concurrent conflicting writes.
+
+After this task, the only direct appointment table calls in the production repository are tenant-scoped SELECT and the existing DELETE. Create, reschedule, details/status update, and recovery use RPCs.
+
+## Active-slot policy
+
+The shared database rule is:
+
+- `cancelled`: does not block and releases doctor/patient slots;
+- `new`, `confirmed`, `arrived`, `in_progress`, `completed`, `no_show`, `blocked`: block slots.
+
+This preserves the current product semantics: only cancellation made an appointment non-conflicting in the prior client check. `completed` and `no_show` remain historical schedule facts occupying their original interval. `blocked` remains a doctor-only schedule block and may have no patient.
+
+## Interval semantics
+
+All overlap checks use half-open intervals:
+
+```text
+existing.start_time < proposed.end_time
+AND existing.end_time > proposed.start_time
+```
+
+Therefore:
+
+- exact overlap: rejected;
+- partial overlap: rejected;
+- contained interval: rejected;
+- surrounding interval: rejected;
+- back-to-back intervals: allowed;
+- zero and negative duration: rejected;
+- overnight intervals remain valid when `end_time > start_time`;
+- comparison is performed on `timestamptz` values.
+
+Migration `0025` adds `appointments_valid_interval_check` with `end_time > start_time`.
+
+## Historical-data precheck
+
+Before adding constraints/indexes, migration `0025` fails clearly if existing rows contain:
+
+- invalid intervals;
+- missing doctor;
+- missing patient on a non-`blocked` appointment;
+- missing/cross-tenant patient references;
+- missing/cross-tenant doctor references;
+- duplicate active logical groups;
+- active doctor overlap pairs;
+- active patient overlap pairs.
+
+The migration never deletes, rewrites, cancels, or archives historical appointments.
+
+## Chosen enforcement design
+
+Chosen design: transactional `SECURITY DEFINER` RPCs with deterministic advisory locking and explicit overlap queries.
+
+Why:
+
+- it supports both doctor and patient resources;
+- it supports one ignored status (`cancelled`) without duplicating complicated exclusion predicates;
+- create/reschedule/recovery/idempotency can share one transaction boundary;
+- safe domain errors can be returned deliberately;
+- it does not require a new slot/resource model;
+- current PostgreSQL/Supabase extensions already provide advisory locks and `pgcrypto` digest.
+
+PostgreSQL exclusion constraints were not chosen because two resource dimensions, replay/recovery semantics, current status behavior, and safe error mapping would still require a substantial RPC boundary. A slot serialization table was larger than the represented domain.
+
+## Lock strategy
+
+Create acquires locks in this order:
+
+1. tenant + operation key;
+2. sorted tenant + doctor and tenant + patient resource keys.
+
+Reschedule acquires:
+
+1. tenant + operation key;
+2. target appointment row `FOR UPDATE`;
+3. sorted distinct old doctor, old patient, new doctor, and new patient resource keys.
+
+All resource keys are tenant-scoped and hashed with `hashtextextended`. Locks are held through overlap validation, mutation, audit/activity creation, and operation recording. The concurrency suite observed zero deadlocks.
+
+## Idempotency design
+
+`public.appointment_operations` stores:
+
+- tenant ID;
+- operation key;
+- operation type (`create` or `reschedule`);
+- SHA-256 fingerprint;
+- appointment ID when still present;
+- patient/doctor/start/end/status;
+- safe appointment result snapshot;
+- actor and timestamp.
+
+Uniqueness is `tenant_id + operation_key`.
+
+Create fingerprint includes all business-significant fields:
+
+- tenant, patient, doctor;
+- cabinet, service, status;
+- payment type, source, price, comment;
+- start and end epoch values.
+
+Reschedule additionally includes appointment ID and expected version.
+
+Rules verified:
+
+- same tenant + same key + same payload returns the same result with `replayed=true`;
+- no duplicate row/event is produced;
+- same key + changed patient/doctor/time/details is rejected;
+- same key in another tenant is independent;
+- malformed keys are rejected;
+- concurrent same-key calls resolve to one appointment;
+- hard delete sets operation `appointment_id` to null but preserves the result snapshot and key, preventing key reuse/amnesia.
+
+## Create RPC
+
+Signature:
+
+```sql
+public.create_appointment(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_doctor_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_cabinet text,
+  p_service text,
+  p_status text,
+  p_payment_type text,
+  p_source text,
+  p_price numeric,
+  p_comment text,
+  p_operation_key text
+) returns jsonb
+```
+
+It authenticates, validates tenant membership/current role policy, validates tenant patient/doctor ownership, interval and enum values, normalizes strings/key, resolves replay, locks resources, checks doctor and patient conflicts, inserts one appointment, emits one success audit/activity pair, records operation identity, and returns appointment plus replay/recovery metadata.
+
+## Reschedule RPC
+
+Signature:
+
+```sql
+public.reschedule_appointment(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_patient_id uuid,
+  p_doctor_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_cabinet text,
+  p_service text,
+  p_status text,
+  p_payment_type text,
+  p_source text,
+  p_price numeric,
+  p_comment text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) returns jsonb
+```
+
+It locks the target row, verifies tenant and optimistic `updated_at`, locks old/new resources in deterministic order, excludes the target appointment from overlap checks, updates protected and detail fields atomically, emits one reschedule event pair, and records replay identity.
+
+## Recovery RPC
+
+Signature:
+
+```sql
+public.get_appointment_operation(
+  p_tenant_id uuid,
+  p_operation_key text
+) returns jsonb
+```
+
+It returns safe found/type/appointment/replay/recovered data. Fingerprints, lock keys, SQLSTATE, function names, and raw database objects are not returned. Cross-tenant recovery is denied.
+
+## Non-time update handling
+
+`public.update_appointment_details(...)` controls:
+
+- cabinet;
+- service;
+- status;
+- payment type;
+- source;
+- price;
+- comment.
+
+It accepts `p_expected_updated_at` and cannot change patient, doctor, start, or end. Status reactivation from `cancelled` obtains the same doctor/patient resource locks and rechecks overlap before making the row active.
+
+## Direct-write protection
+
+Migration `0024` established an explicit authenticated CRUD grant matrix for appointments. Migration `0025` preserves that matrix for compatibility but installs `appointments_authoritative_write_guard`:
+
+- SECURITY DEFINER RPCs execute as `postgres` and pass;
+- guarded local service-role setup/cleanup passes;
+- ordinary authenticated direct INSERT or UPDATE receives the safe permission error;
+- SELECT remains available through RLS;
+- DELETE remains available only where the existing owner/admin RLS policy permits it.
+
+The frontend contains no protected `.insert(...)` or `.update(...)` appointment path. Browser network capture showed zero direct POST/PATCH requests to `/rest/v1/appointments`.
+
+## Role enforcement
+
+Current appointment role semantics were preserved rather than redesigned:
+
+- clinic owner: create/update via RPC; delete allowed by existing RLS;
+- clinic admin: create/update via RPC; delete allowed;
+- registrar: create/update via RPC; delete denied;
+- doctor: create/update via RPC under current broad policy;
+- cashier: create/update via RPC under current broad policy;
+- no-tenant/unknown/anonymous: denied.
+
+A doctor permission redesign is intentionally deferred.
+
+## Tenant and relationship integrity
+
+Verified:
+
+- patient and doctor must belong to the appointment tenant;
+- composite patient/doctor tenant foreign keys remain present;
+- cross-tenant create and reschedule are rejected;
+- tenant B cannot read or recover tenant A operation data;
+- operation keys are tenant-scoped;
+- RLS remains enabled on appointments and appointment operations;
+- operation table has no authenticated direct SELECT grant.
+
+## Audit and activity
+
+Successful first execution emits:
+
+- `appointment_created`; or
+- `appointment_rescheduled`.
+
+Events contain tenant, appointment, patient, doctor, actor, operation reference, current status, and old/new start/end for reschedule. Replay emits no duplicate event; conflicts emit no success event.
+
+No parallel audit subsystem was added.
+
+## Repository migration
+
+`SupabaseAppointmentRepository` now exposes:
+
+- `createAppointment`;
+- `rescheduleAppointment`;
+- `updateAppointmentDetails`;
+- `recoverAppointmentOperation`;
+- tenant-scoped list methods;
+- existing hard delete.
+
+It generates/receives one operation key per logical attempt, preserves it during ambiguous retry, invokes the four scheduling RPCs, maps database rows, normalizes time values, maps safe Russian errors, and attempts recovery only for ambiguous outcomes.
+
+Production frontend source contains no `service_role` reference and no Supabase localStorage fallback.
+
+## Hook/modal integration
+
+`useScheduleAppointments` now:
+
+- chooses Supabase/local backend as before;
+- uses a tenant/auth context query key;
+- generates one UUID per logical create/reschedule attempt;
+- shares one in-flight promise for rapid duplicate submission;
+- retains the key after ambiguous failure;
+- routes patient/doctor/start/end changes to reschedule RPC;
+- routes details/status-only changes to details RPC;
+- exposes saving/reconciliation/safe error states;
+- refreshes once after confirmed success;
+- ignores stale success/error from an old tenant context.
+
+AppointmentModal now:
+
+- has an immediate ref-based submit lock;
+- disables inputs, close, delete, cancel, and submit while saving;
+- shows `Сохраняем запись…`;
+- shows `Проверяем, была ли запись сохранена…` during recovery;
+- keeps form data open on conflict;
+- performs quick doctor and patient half-open checks;
+- ignores cancelled appointments in the quick check;
+- validates zero/negative intervals;
+- does not close before confirmed success.
+
+No visual schedule redesign was made.
+
+## SQL tests
+
+`0025_appointment_conflict_hardening_test.sql` passed after a clean reset.
+
+It covers role matrix, anonymous/no-tenant, tenant relationships, interval cases, doctor/patient overlap shapes, different resources, cancelled/completed/no-show/blocked behavior, idempotent create/recovery, changed-payload rejection, tenant-scoped keys, free/conflicting/self/back-to-back/cross-tenant reschedule, optimistic concurrency, details/status reactivation, direct-write denial, read/delete behavior, grants/trigger/RLS/FKs, zero overlap queries, hard-delete operation history, and clinical/financial non-side-effects.
+
+Relevant SQL regressions passed:
+
+- `0018_refund_writeoff_rpc_test.sql`
+- `0019_cashier_payment_hardening_test.sql`
+- `0021_completed_service_billing_guard_test.sql`
+- `0022_patient_credit_deposits_foundation_test.sql`
+- `0023_patient_credit_intake_hardening_test.sql`
+- `0024_legacy_core_table_grants_test.sql`
+- `0025_appointment_conflict_hardening_test.sql`
+
+## Concurrency tests
+
+`0025_appointment_conflict_concurrency.ps1` passed:
+
+- exact same doctor: one success, one conflict, one row;
+- partial doctor overlap: one success, one conflict;
+- same patient/different doctor: one success, one patient conflict;
+- different patient/doctor: two successes;
+- back-to-back: two successes;
+- same key/same payload: both calls resolve, one appointment ID, one replay;
+- same key/different payload: one success, one idempotency conflict;
+- concurrent reschedule: one winner;
+- create vs reschedule: one slot owner;
+- tenant isolation: two independent successes;
+- invalid intervals: zero rows;
+- final doctor overlap pairs: 0;
+- final patient overlap pairs: 0;
+- invalid intervals: 0;
+- audit/activity: 13/13;
+- deadlocks: 0.
+
+All current concurrency regressions also passed:
+
+- refund/write-off;
+- cashier payment;
+- completed-service billing;
+- patient fund reservations;
+- patient credit intake;
+- appointment conflicts.
+
+## TypeScript tests
+
+Targeted scheduling tests: 37 passed.
+
+Full suite:
+
+- test files: 80 passed;
+- tests: 884 passed.
+
+Coverage added for RPC invocation, unchanged operation keys, ambiguous recovery, direct-write source guards, safe errors, replay mapping, tenant scope, stale response suppression, duplicate submit, recovery UI, doctor/patient conflicts, back-to-back, cancelled quick-check behavior, interval validation, form preservation, and one refresh after success.
+
+## Browser smoke
+
+Real local Supabase mode was used with ordinary Supabase Auth and two isolated browser sessions.
+
+Verified:
+
+- normal create persisted after reload;
+- simultaneous exact doctor conflict produced one winner and one safe conflict;
+- partial doctor conflict produced one winner and one safe conflict;
+- same patient/different doctor produced one winner and one safe patient conflict;
+- back-to-back UI bookings both succeeded;
+- rapid same-key duplicate calls returned one appointment ID and one replay;
+- a deliberately discarded successful response was recovered by the original key;
+- two appointments concurrently rescheduled into one slot produced one winner;
+- an active appointment was cancelled through the details RPC and its slot reused;
+- tenant B could not see tenant A appointments or recover tenant A operation.
+
+Rejected RPCs appear in Chrome as the expected `400 Bad Request` resource entry. There were no unhandled promises, raw SQL/constraint/function text in the UI, fatal console errors, or visible secrets.
+
+## Network validation
+
+Captured local Kong/PostgREST requests:
+
+- `POST /rest/v1/rpc/create_appointment`: success and expected conflict responses;
+- `POST /rest/v1/rpc/reschedule_appointment`: success and expected conflict response;
+- `POST /rest/v1/rpc/update_appointment_details`: success;
+- `POST /rest/v1/rpc/get_appointment_operation`: success and tenant denial;
+- direct `POST /rest/v1/appointments`: 0;
+- direct protected `PATCH /rest/v1/appointments`: 0.
+
+No service-role credential was sent by browser code.
+
+## Database validation
+
+After browser smoke:
+
+- active doctor overlap pairs: 0;
+- active patient overlap pairs: 0;
+- invalid intervals: 0;
+- duplicate tenant operation keys: 0;
+- successful operation rows: 11;
+- distinct operation appointment IDs: 11;
+- appointment-created audits/activities: 10/10;
+- appointment-rescheduled audits/activities: 1/1;
+- RLS enabled on appointments and appointment operations.
+
+After final clean reset and transactional SQL validation, all QA tables returned zero rows.
+
+## Side-effect validation
+
+Appointment create/reschedule produced no:
+
+- visit;
+- clinical encounter;
+- completed service;
+- treatment plan;
+- finding;
+- dental-chart mutation;
+- invoice;
+- payment;
+- refund;
+- write-off/financial adjustment;
+- document.
+
+Patient balances remained unchanged. No stock, reminder, waitlist, confirmation, or amoCRM data was created.
+
+## Cleanup
+
+Removed:
+
+- QA auth users, tenants, memberships, patients, doctors, appointments, and operation rows;
+- temporary same-origin recovery page;
+- Vite process;
+- screenshots and network log extracts;
+- temporary patch scripts.
+
+Final command:
+
+```text
+npx supabase db reset --no-seed
+```
+
+Final counters:
+
+```text
+auth.users | tenants | profiles | tenant_users | patients | doctors | appointments | appointment_operations | audit_events | activity_events
+0          | 0       | 0        | 0            | 0        | 0       | 0            | 0                      | 0            | 0
+```
+
+## Checks
+
+- baseline and merged dependency verified;
+- clean forward migration `0001–0025`: passed;
+- SQL hardening test: passed;
+- grants regression: passed;
+- relevant SQL regressions: passed;
+- all six concurrency suites: passed;
+- targeted TypeScript tests: passed;
+- real two-session Supabase browser smoke: passed;
+- RPC-only protected browser network path: verified;
+- database overlap/invalid/key counts: zero;
+- cleanup counters: zero;
+- `git diff --check`: passed;
+- production frontend service-role scan: clean;
+- temporary file scan: clean.
+
+## Lint/test/build
+
+- `npm run lint`: passed;
+- `npm run test -- --run`: 80 files / 884 tests passed;
+- `npm run build`: passed.
+
+Existing unrelated React `act(...)` test warnings and the existing Vite bundle-size warning remain.
+
+## Fresh CI
+
+Pending PR publication and a fresh GitHub Actions run on the final PR head.
+
+Required final confirmation:
+
+- CI tested the exact final PR head;
+- ESLint passed;
+- tests passed;
+- build passed;
+- PR remains open and unmerged.
+
+## Known limitations
+
+- Cabinet remains untrusted free text and is not an authoritative conflict resource.
+- Current broad doctor/cashier appointment mutation policy is preserved; permission redesign is deferred.
+- Expected rejected PostgREST RPCs appear as HTTP 400 resource entries in Chrome, although the UI receives only safe domain text.
+- Hard delete remains; the idempotency operation snapshot/key is preserved after deletion.
+- LocalStorage development mode remains available by explicit backend selection; configured Supabase mode uses RPCs.
+
+## What was intentionally not implemented
+
+- week/month schedule views;
+- lifecycle redesign;
+- cancellation reasons;
+- no-show metadata redesign;
+- confirmation workflow;
+- reminders;
+- waitlist;
+- room/chair/assistant/equipment models;
+- public booking;
+- hard-delete removal;
+- source-of-truth consolidation;
+- finance or clinical changes;
+- cloud migration apply;
+- generated types;
+- HEP-V2.
+
+## Recommended next task
+
+`SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001`
+
+Reason: appointment writes are now authoritative and conflict-safe. The next task should make all patient-card and summary appointment readers consume the same Supabase-backed facts instead of mixing them with localStorage-only readers.
+
+This task was not started.

--- a/_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md
+++ b/_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md
@@ -2,6 +2,8 @@
 
 ## Final verdict
 
+Final verdict: **PASS**
+
 APPOINTMENT CONFLICT HARDENING IMPLEMENTED AND VERIFIED
 
 ## Summary
@@ -16,7 +18,7 @@ Configured Supabase mode no longer performs direct appointment INSERT or protect
 
 ## PR URL
 
-Pending publication.
+https://github.com/NckNA/codex-test/pull/347
 
 ## Baseline
 
@@ -28,11 +30,17 @@ Pending publication.
 
 ## PR head reviewed before final report update
 
-Pending implementation commit, PR publication, and fresh CI.
+- implementation head reviewed: `da3cc2815c32a2df54fd33c8400ff4d0d058dfa9`;
+- workflow: `CI`;
+- run: `#698`;
+- run ID: `29170706995`;
+- conclusion: `success`;
+- tested commit matched the reviewed PR head.
 
 ## Report update commit
 
-N/A because the final report commit cannot reference itself.
+- Report update commit: N/A (the report commit cannot reference itself; use the finalization receipt).
+- The final PR head and CI run are recorded after final CI in an immutable local finalization receipt.
 
 ## Changed files
 
@@ -545,17 +553,20 @@ Existing unrelated React `act(...)` test warnings and the existing Vite bundle-s
 
 ## Fresh CI
 
-Pending PR publication and a fresh GitHub Actions run on the final PR head.
+Initial implementation CI:
 
-Required final confirmation:
+- workflow: `CI`;
+- run: `#698`;
+- run ID: `29170706995`;
+- conclusion: `success`;
+- tested commit: `da3cc2815c32a2df54fd33c8400ff4d0d058dfa9`;
+- ESLint: passed;
+- tests: passed;
+- build: passed.
 
-- CI tested the exact final PR head;
-- ESLint passed;
-- tests passed;
-- build passed;
-- PR remains open and unmerged.
+A fresh CI run on the final metadata-only PR head is required after this report update. The PR must remain open and unmerged.
 
-## Known limitations
+## Limitations
 
 - Cabinet remains untrusted free text and is not an authoritative conflict resource.
 - Current broad doctor/cashier appointment mutation policy is preserved; permission redesign is deferred.

--- a/src/components/schedule/AppointmentModal.test.tsx
+++ b/src/components/schedule/AppointmentModal.test.tsx
@@ -1,85 +1,260 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { describe, it, expect, vi } from 'vitest';
+
 import { act } from 'react';
-import { createRoot } from 'react-dom/client';
-import { AppointmentModal } from './AppointmentModal';
+import { createRoot, type Root } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Appointment } from '../../types';
+import { AppointmentModal } from './AppointmentModal';
 
-describe('AppointmentModal', () => {
-  const doctors = [{ id: 'd1', fullName: 'Dr. Test', specialization: 'Dentist', cabinet: 'Cab 1', active: true, color: 'blue' }];
-  const patients = [{ id: 'p1', fullName: 'Patient Test', phone: '123', source: 'walk_in', status: 'active', createdAt: '' } as any];
-  
-  it('new appointment uses crypto.randomUUID()', async () => {
-    const onSave = vi.fn();
-    const container = document.createElement('div');
-    const root = createRoot(container);
-    
-    await act(async () => {
-      root.render(
-        <MemoryRouter>
-          <AppointmentModal 
-            isOpen={true} 
-            onClose={() => {}} 
-            onSave={onSave}
-            initialData={{ doctorId: 'd1', start: '2023-01-01T10:00', end: '2023-01-01T11:00' }}
-            appointments={[]}
-            doctors={doctors}
-            patients={patients}
-          />
-        </MemoryRouter>
-      );
-    });
+const doctors = [
+  { id: 'd1', fullName: 'Doctor One', specialization: 'Dentist', cabinet: 'A1', active: true, color: 'blue' },
+  { id: 'd2', fullName: 'Doctor Two', specialization: 'Surgeon', cabinet: 'A2', active: true, color: 'green' },
+];
 
-    const form = container.querySelector('form') as HTMLFormElement;
-    
-    await act(async () => {
-      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-    });
-    
-    expect(onSave).toHaveBeenCalled();
-    const savedAppt = onSave.mock.calls[0][0];
-    
-    expect(savedAppt.id.length).toBe(36);
-    expect(savedAppt.patientId).toBe('');
-    expect(savedAppt.doctorId).toBe('d1');
+const patients = [
+  { id: 'p1', fullName: 'Patient One', phone: '111', source: 'walk_in', status: 'active', createdAt: '' } as any,
+  { id: 'p2', fullName: 'Patient Two', phone: '222', source: 'phone', status: 'active', createdAt: '' } as any,
+];
 
-    await act(async () => { root.unmount(); });
+const baseInitial: Partial<Appointment> = {
+  patientId: 'p1',
+  doctorId: 'd1',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'new',
+  paymentType: 'unpaid',
+  source: 'phone',
+  start: '2026-08-01T10:00:00',
+  end: '2026-08-01T11:00:00',
+};
+
+interface RenderOptions {
+  initialData?: Partial<Appointment>;
+  appointments?: Appointment[];
+  onSave?: any;
+  onClose?: any;
+  isSaving?: boolean;
+  isReconciling?: boolean;
+  serverError?: string | null;
+}
+
+const renderModal = async (options: RenderOptions = {}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onSave = options.onSave || vi.fn().mockResolvedValue(true);
+  const onClose = options.onClose || vi.fn();
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <AppointmentModal
+          isOpen
+          onClose={onClose}
+          onSave={onSave}
+          initialData={{ ...baseInitial, ...options.initialData }}
+          appointments={options.appointments || []}
+          doctors={doctors}
+          patients={patients}
+          isSaving={options.isSaving}
+          isReconciling={options.isReconciling}
+          serverError={options.serverError}
+        />
+      </MemoryRouter>,
+    );
   });
 
-  it('existing appointment preserves existing id', async () => {
-    const onSave = vi.fn();
-    const container = document.createElement('div');
-    const root = createRoot(container);
-    
-    await act(async () => {
-      root.render(
-        <MemoryRouter>
-          <AppointmentModal 
-            isOpen={true} 
-            onClose={() => {}} 
-            onSave={onSave}
-            initialData={{ id: 'existing-id', doctorId: 'd1', start: '2023-01-01T10:00', end: '2023-01-01T11:00' }}
-            appointments={[]}
-            doctors={doctors}
-            patients={patients}
-          />
-        </MemoryRouter>
-      );
+  return { container, root, onSave, onClose };
+};
+
+const submit = async (container: HTMLElement) => {
+  const form = container.querySelector('#appointment-form') as HTMLFormElement;
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+};
+
+const cleanup = async (root: Root, container: HTMLElement) => {
+  await act(async () => root.unmount());
+  container.remove();
+};
+
+describe('AppointmentModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates one appointment with a generated id and selected patient', async () => {
+    const { container, root, onSave } = await renderModal();
+
+    await submit(container);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as Appointment;
+    expect(saved.id).toHaveLength(36);
+    expect(saved.patientId).toBe('p1');
+    expect(saved.doctorId).toBe('d1');
+    await cleanup(root, container);
+  });
+
+  it('preserves existing appointment id and updatedAt for optimistic reschedule', async () => {
+    const { container, root, onSave } = await renderModal({
+      initialData: {
+        id: 'existing-id',
+        createdAt: '2026-07-01T09:00:00',
+        updatedAt: '2026-07-01T09:30:00+00:00',
+      },
     });
 
-    const form = container.querySelector('form') as HTMLFormElement;
-    
+    await submit(container);
+
+    const saved = onSave.mock.calls[0][0] as Appointment;
+    expect(saved.id).toBe('existing-id');
+    expect(saved.updatedAt).toBe('2026-07-01T09:30:00+00:00');
+    await cleanup(root, container);
+  });
+
+  it('uses an immediate submit lock so rapid duplicate submits call onSave once', async () => {
+    let resolveSave: ((value: boolean) => void) | undefined;
+    const pending = new Promise<boolean>((resolve) => { resolveSave = resolve; });
+    const onSave = vi.fn(() => pending);
+    const { container, root } = await renderModal({ onSave });
+    const form = container.querySelector('#appointment-form') as HTMLFormElement;
+
     await act(async () => {
       form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
     });
-    
-    expect(onSave).toHaveBeenCalled();
-    const savedAppt = onSave.mock.calls[0][0];
-    
-    expect(savedAppt.id).toBe('existing-id');
 
-    await act(async () => { root.unmount(); });
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect((container.querySelector('button[form="appointment-form"]') as HTMLButtonElement).disabled).toBe(true);
+    expect(container.textContent).toContain('Сохраняем запись…');
+
+    await act(async () => resolveSave?.(true));
+    await cleanup(root, container);
+  });
+
+  it('shows reconciliation state and disables dismissal while checking uncertain result', async () => {
+    const onClose = vi.fn();
+    const { container, root } = await renderModal({
+      onClose,
+      isSaving: true,
+      isReconciling: true,
+    });
+
+    expect(container.textContent).toContain('Проверяем, была ли запись сохранена…');
+    expect(container.textContent).toContain('Сохраняем запись…');
+    const closeButton = container.querySelector('button[aria-label="Закрыть"]') as HTMLButtonElement;
+    expect(closeButton.disabled).toBe(true);
+
+    await act(async () => closeButton.click());
+    expect(onClose).not.toHaveBeenCalled();
+    await cleanup(root, container);
+  });
+
+  it('shows safe server doctor and patient conflicts without closing form', async () => {
+    const doctor = await renderModal({ serverError: 'У врача уже есть запись на это время.' });
+    expect(doctor.container.textContent).toContain('У врача уже есть запись на это время.');
+    expect(doctor.container.querySelector('#appointment-form')).not.toBeNull();
+    await cleanup(doctor.root, doctor.container);
+
+    const patient = await renderModal({ serverError: 'У пациента уже есть другая запись на это время.' });
+    expect(patient.container.textContent).toContain('У пациента уже есть другая запись на это время.');
+    expect(patient.container.querySelector('#appointment-form')).not.toBeNull();
+    await cleanup(patient.root, patient.container);
+  });
+
+  it('blocks doctor overlap using half-open client check', async () => {
+    const existing: Appointment = {
+      ...baseInitial,
+      id: 'existing-doctor',
+      patientId: 'p2',
+      start: '2026-08-01T10:00:00',
+      end: '2026-08-01T11:00:00',
+      createdAt: '2026-07-01T09:00:00',
+    } as Appointment;
+    const { container, root, onSave } = await renderModal({
+      initialData: { start: '2026-08-01T10:30:00', end: '2026-08-01T11:30:00' },
+      appointments: [existing],
+    });
+
+    await submit(container);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('У врача уже есть запись на это время.');
+    await cleanup(root, container);
+  });
+
+  it('blocks patient overlap even when doctors differ', async () => {
+    const existing: Appointment = {
+      ...baseInitial,
+      id: 'existing-patient',
+      doctorId: 'd2',
+      patientId: 'p1',
+      createdAt: '2026-07-01T09:00:00',
+    } as Appointment;
+    const { container, root, onSave } = await renderModal({ appointments: [existing] });
+
+    await submit(container);
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('У пациента уже есть другая запись на это время.');
+    await cleanup(root, container);
+  });
+
+  it('allows back-to-back interval and ignores cancelled appointments in quick check', async () => {
+    const active: Appointment = {
+      ...baseInitial,
+      id: 'active',
+      patientId: 'p2',
+      start: '2026-08-01T10:00:00',
+      end: '2026-08-01T11:00:00',
+      createdAt: '2026-07-01T09:00:00',
+    } as Appointment;
+    const adjacent = await renderModal({
+      initialData: { start: '2026-08-01T11:00:00', end: '2026-08-01T12:00:00' },
+      appointments: [active],
+    });
+    await submit(adjacent.container);
+    expect(adjacent.onSave).toHaveBeenCalledTimes(1);
+    await cleanup(adjacent.root, adjacent.container);
+
+    const cancelled = await renderModal({
+      appointments: [{ ...active, status: 'cancelled', patientId: 'p1' }],
+    });
+    await submit(cancelled.container);
+    expect(cancelled.onSave).toHaveBeenCalledTimes(1);
+    await cleanup(cancelled.root, cancelled.container);
+  });
+
+  it('rejects zero and negative intervals before repository call', async () => {
+    const zero = await renderModal({ initialData: { end: '2026-08-01T10:00:00' } });
+    await submit(zero.container);
+    expect(zero.onSave).not.toHaveBeenCalled();
+    expect(zero.container.textContent).toContain('Время окончания должно быть позже времени начала.');
+    await cleanup(zero.root, zero.container);
+
+    const negative = await renderModal({ initialData: { end: '2026-08-01T09:00:00' } });
+    await submit(negative.container);
+    expect(negative.onSave).not.toHaveBeenCalled();
+    expect(negative.container.textContent).toContain('Время окончания должно быть позже времени начала.');
+    await cleanup(negative.root, negative.container);
+  });
+
+  it('keeps form data open when save rejects', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('У врача уже есть запись на это время.'));
+    const { container, root } = await renderModal({ onSave });
+
+    await submit(container);
+
+    expect(container.querySelector('#appointment-form')).not.toBeNull();
+    expect(container.textContent).toContain('У врача уже есть запись на это время.');
+    const service = container.querySelector('input[name="service"]') as HTMLInputElement;
+    expect(service.value).toBe('Осмотр');
+    await cleanup(root, container);
   });
 });

--- a/src/components/schedule/AppointmentModal.tsx
+++ b/src/components/schedule/AppointmentModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X, AlertCircle, ExternalLink } from 'lucide-react';
 import type { Appointment, AppointmentStatus, PaymentType, Source, Doctor, Patient } from '../../types';
@@ -6,13 +6,30 @@ import type { Appointment, AppointmentStatus, PaymentType, Source, Doctor, Patie
 interface AppointmentModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (appointment: Appointment) => void;
-  onDelete?: (id: string) => void;
+  onSave: (appointment: Appointment) => Promise<boolean>;
+  onDelete?: (id: string) => Promise<boolean>;
   initialData?: Partial<Appointment>;
   appointments: Appointment[];
   doctors: Doctor[];
   patients: Patient[];
+  isSaving?: boolean;
+  isReconciling?: boolean;
+  serverError?: string | null;
 }
+
+const defaultForm = (): Partial<Appointment> => ({
+  patientId: '',
+  doctorId: '',
+  cabinet: '',
+  service: '',
+  start: '',
+  end: '',
+  status: 'new',
+  paymentType: 'unpaid',
+  source: 'walk_in',
+  price: 0,
+  comment: '',
+});
 
 export function AppointmentModal({
   isOpen,
@@ -23,96 +40,100 @@ export function AppointmentModal({
   appointments,
   doctors,
   patients,
+  isSaving = false,
+  isReconciling = false,
+  serverError = null,
 }: AppointmentModalProps) {
-  const isEditing = !!initialData?.id;
+  const isEditing = Boolean(initialData?.id);
   const navigate = useNavigate();
-
+  const submitLockRef = useRef(false);
+  const [isSubmittingLocally, setIsSubmittingLocally] = useState(false);
   const [formData, setFormData] = useState<Partial<Appointment>>({
-    patientId: '',
-    doctorId: '',
-    cabinet: '',
-    service: '',
-    start: '',
-    end: '',
-    status: 'new',
-    paymentType: 'unpaid',
-    source: 'walk_in',
-    price: 0,
-    comment: '',
+    ...defaultForm(),
     ...initialData,
   });
+  const [localError, setLocalError] = useState<string | null>(null);
+  const isBusy = isSaving || isSubmittingLocally;
+  const visibleError = localError || serverError;
 
-  const [error, setError] = useState<string | null>(null);
-
-  // Reset form when opened with new data
-    useEffect(() => {
+  useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-                setFormData({
-      patientId: '',
-      doctorId: '',
-      cabinet: '',
-      start: '',
-      end: '',
-      status: 'new',
-      paymentType: 'unpaid',
-      source: 'walk_in',
-      price: 0,
-      service: '',
-      comment: '',
+    setFormData({
+      ...defaultForm(),
       ...initialData,
     });
-    setError(null);
+    setLocalError(null);
+    setIsSubmittingLocally(false);
+    submitLockRef.current = false;
   }, [isOpen, initialData]);
 
   if (!isOpen) return null;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-
-          setFormData(prev => ({ ...prev, [name]: name === 'price' ? Number(value) : value }));
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({
+      ...previous,
+      [name]: name === 'price' ? Number(value) : value,
+    }));
+    setLocalError(null);
   };
 
   const handleStatusChange = (status: AppointmentStatus) => {
-
-          setFormData(prev => ({ ...prev, status }));
+    setFormData((previous) => ({ ...previous, status }));
+    setLocalError(null);
   };
 
-  const checkConflicts = () => {
+  const checkConflicts = (): boolean => {
     if (formData.status === 'cancelled') return false;
 
-    const allAppointments = appointments;
-    const newStart = new Date(formData.start as string).getTime();
-    const newEnd = new Date(formData.end as string).getTime();
+    const proposedStart = new Date(formData.start as string).getTime();
+    const proposedEnd = new Date(formData.end as string).getTime();
 
-    for (const appt of allAppointments) {
-      if (appt.id === formData.id) continue; // Skip self
-      if (appt.status === 'cancelled') continue;
+    for (const appointment of appointments) {
+      if (appointment.id === formData.id || appointment.status === 'cancelled') continue;
 
-      const apptStart = new Date(appt.start).getTime();
-      const apptEnd = new Date(appt.end).getTime();
+      const existingStart = new Date(appointment.start).getTime();
+      const existingEnd = new Date(appointment.end).getTime();
+      const overlaps = proposedStart < existingEnd && proposedEnd > existingStart;
+      if (!overlaps) continue;
 
-      // Check overlap
-      if (newStart < apptEnd && newEnd > apptStart) {
-        if (appt.doctorId === formData.doctorId) {
-          setError('Врач занят в это время.');
-          return true;
-        }
-        if (appt.cabinet === formData.cabinet) {
-          setError('Кабинет занят в это время.');
-          return true;
-        }
+      if (appointment.doctorId === formData.doctorId) {
+        setLocalError('У врача уже есть запись на это время.');
+        return true;
+      }
+
+      if (
+        formData.patientId
+        && appointment.patientId
+        && appointment.patientId === formData.patientId
+      ) {
+        setLocalError('У пациента уже есть другая запись на это время.');
+        return true;
       }
     }
+
     return false;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (submitLockRef.current || isSaving) return;
+    setLocalError(null);
 
-    // Basic validation
     if (!formData.doctorId || !formData.start || !formData.end) {
-      setError('Заполните обязательные поля (Врач, Время).');
+      setLocalError('Заполните обязательные поля: врач, начало и окончание.');
+      return;
+    }
+
+    if (!formData.patientId && formData.status !== 'blocked') {
+      setLocalError('Выберите пациента.');
+      return;
+    }
+
+    const startTime = new Date(formData.start).getTime();
+    const endTime = new Date(formData.end).getTime();
+    if (!Number.isFinite(startTime) || !Number.isFinite(endTime) || endTime <= startTime) {
+      setLocalError('Время окончания должно быть позже времени начала.');
       return;
     }
 
@@ -120,21 +141,54 @@ export function AppointmentModal({
 
     const appointmentToSave: Appointment = {
       id: formData.id || crypto.randomUUID(),
-      patientId: formData.patientId,
-      doctorId: formData.doctorId as string,
-      cabinet: formData.cabinet || doctors.find(d => d.id === formData.doctorId)?.cabinet || 'Каб. 1',
+      patientId: formData.patientId || undefined,
+      doctorId: formData.doctorId,
+      cabinet: formData.cabinet || doctors.find((doctor) => doctor.id === formData.doctorId)?.cabinet || 'Каб. 1',
       service: formData.service || '',
-      start: formData.start as string,
-      end: formData.end as string,
+      start: formData.start,
+      end: formData.end,
       status: formData.status as AppointmentStatus,
       paymentType: formData.paymentType as PaymentType,
       source: formData.source as Source,
       price: formData.price,
       comment: formData.comment,
       createdAt: formData.createdAt || new Date().toISOString(),
+      updatedAt: formData.updatedAt,
     };
 
-    onSave(appointmentToSave);
+    submitLockRef.current = true;
+    setIsSubmittingLocally(true);
+    try {
+      await onSave(appointmentToSave);
+    } catch (error) {
+      setLocalError(error instanceof Error
+        ? error.message
+        : 'Не удалось сохранить запись. Обновите расписание и проверьте результат.');
+    } finally {
+      submitLockRef.current = false;
+      setIsSubmittingLocally(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!onDelete || !formData.id || submitLockRef.current || isSaving) return;
+    submitLockRef.current = true;
+    setIsSubmittingLocally(true);
+    setLocalError(null);
+    try {
+      await onDelete(formData.id);
+    } catch (error) {
+      setLocalError(error instanceof Error
+        ? error.message
+        : 'Не удалось удалить запись. Обновите расписание.');
+    } finally {
+      submitLockRef.current = false;
+      setIsSubmittingLocally(false);
+    }
+  };
+
+  const closeSafely = () => {
+    if (!isBusy) onClose();
   };
 
   return (
@@ -145,188 +199,195 @@ export function AppointmentModal({
             {isEditing ? 'Редактирование записи' : 'Новая запись'}
             {isEditing && formData.patientId && (
               <button
+                type="button"
+                disabled={isBusy}
                 onClick={() => {
+                  if (isBusy) return;
                   onClose();
                   navigate(`/patients/${formData.patientId}`);
                 }}
-                className="text-xs font-medium text-blue-600 hover:text-blue-800 bg-blue-50 px-2 py-1 rounded-md flex items-center gap-1 transition-colors"
+                className="text-xs font-medium text-blue-600 hover:text-blue-800 bg-blue-50 px-2 py-1 rounded-md flex items-center gap-1 transition-colors disabled:opacity-50"
               >
                 <ExternalLink className="w-3 h-3" />
                 Карточка пациента
               </button>
             )}
           </h2>
-          <button onClick={onClose} className="p-1 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100">
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={closeSafely}
+            aria-label="Закрыть"
+            className="p-1 text-slate-400 hover:text-slate-600 rounded-lg hover:bg-slate-100 disabled:opacity-50"
+          >
             <X className="w-5 h-5" />
           </button>
         </div>
 
         <div className="flex-1 overflow-y-auto p-4">
-          {error && (
-            <div className="mb-4 p-3 bg-red-50 text-red-700 rounded-lg flex items-center gap-2 text-sm border border-red-200">
+          {visibleError && (
+            <div className="mb-4 p-3 bg-red-50 text-red-700 rounded-lg flex items-center gap-2 text-sm border border-red-200" role="alert">
               <AlertCircle className="w-4 h-4 shrink-0" />
-              {error}
+              {visibleError}
+            </div>
+          )}
+
+          {isReconciling && (
+            <div className="mb-4 p-3 bg-blue-50 text-blue-700 rounded-lg text-sm border border-blue-200" role="status">
+              Проверяем, была ли запись сохранена…
             </div>
           )}
 
           <form id="appointment-form" onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              {/* Пациент */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Пациент (демо)</label>
-                <select
-                  name="patientId"
-                  value={formData.patientId || ''}
-                  onChange={handleChange}
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                >
-                  <option value="">-- Выберите пациента --</option>
-                  {patients.map(p => (
-                    <option key={p.id} value={p.id}>{p.fullName} ({p.phone})</option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Услуга */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Услуга</label>
-                <input
-                  type="text"
-                  name="service"
-                  value={formData.service || ''}
-                  onChange={handleChange}
-                  placeholder="Например, Осмотр"
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                />
-              </div>
-
-              {/* Врач */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Врач</label>
-                <select
-                  name="doctorId"
-                  value={formData.doctorId || ''}
-                  onChange={handleChange}
-                  required
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                >
-                  <option value="">-- Выберите врача --</option>
-                  {doctors.map(d => (
-                    <option key={d.id} value={d.id}>{d.fullName} ({d.specialization})</option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Кабинет */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Кабинет</label>
-                <input
-                  type="text"
-                  name="cabinet"
-                  value={formData.cabinet || ''}
-                  onChange={handleChange}
-                  placeholder="Каб. 1"
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                />
-              </div>
-
-              {/* Время начала */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Начало</label>
-                <input
-                  type="datetime-local"
-                  name="start"
-                  value={formData.start ? formData.start.slice(0, 16) : ''}
-                  onChange={handleChange}
-                  required
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                />
-              </div>
-
-              {/* Время конца */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Окончание</label>
-                <input
-                  type="datetime-local"
-                  name="end"
-                  value={formData.end ? formData.end.slice(0, 16) : ''}
-                  onChange={handleChange}
-                  required
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                />
-              </div>
-
-               {/* Цена */}
-               <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Цена (₸)</label>
-                <input
-                  type="number"
-                  name="price"
-                  value={formData.price || 0}
-                  onChange={handleChange}
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                />
-              </div>
-
-              {/* Источник */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Источник</label>
-                <select
-                  name="source"
-                  value={formData.source || 'walk_in'}
-                  onChange={handleChange}
-                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
-                >
-                  <option value="phone">Телефон</option>
-                  <option value="whatsapp">WhatsApp</option>
-                  <option value="instagram">Instagram</option>
-                  <option value="walk_in">С улицы</option>
-                  <option value="repeat">Повторный</option>
-                  <option value="referral">По рекомендации</option>
-                </select>
-              </div>
-            </div>
-
-            {/* Комментарий */}
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">Комментарий</label>
-              <textarea
-                name="comment"
-                value={formData.comment || ''}
-                onChange={handleChange}
-                rows={2}
-                className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm resize-none"
-              ></textarea>
-            </div>
-
-            {/* Быстрые статусы */}
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-2">Статус</label>
-              <div className="flex flex-wrap gap-2">
-                {[
-                  { value: 'new', label: 'Новая' },
-                  { value: 'confirmed', label: 'Подтвержден' },
-                  { value: 'arrived', label: 'Пришел' },
-                  { value: 'in_progress', label: 'В работе' },
-                  { value: 'completed', label: 'Завершен' },
-                  { value: 'no_show', label: 'Не пришел' },
-                  { value: 'cancelled', label: 'Отменен' },
-                ].map(status => (
-                  <button
-                    key={status.value}
-                    type="button"
-                    onClick={() => handleStatusChange(status.value as AppointmentStatus)}
-                    className={`px-3 py-1 text-sm rounded-md border ${
-                      formData.status === status.value
-                        ? 'bg-blue-50 border-blue-500 text-blue-700 font-medium'
-                        : 'bg-white border-slate-200 text-slate-600 hover:bg-slate-50'
-                    }`}
+            <fieldset disabled={isBusy} className="space-y-4 disabled:opacity-70">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Пациент</label>
+                  <select
+                    name="patientId"
+                    value={formData.patientId || ''}
+                    onChange={handleChange}
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
                   >
-                    {status.label}
-                  </button>
-                ))}
+                    <option value="">-- Выберите пациента --</option>
+                    {patients.map((patient) => (
+                      <option key={patient.id} value={patient.id}>{patient.fullName} ({patient.phone})</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Услуга</label>
+                  <input
+                    type="text"
+                    name="service"
+                    value={formData.service || ''}
+                    onChange={handleChange}
+                    placeholder="Например, Осмотр"
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Врач</label>
+                  <select
+                    name="doctorId"
+                    value={formData.doctorId || ''}
+                    onChange={handleChange}
+                    required
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  >
+                    <option value="">-- Выберите врача --</option>
+                    {doctors.map((doctor) => (
+                      <option key={doctor.id} value={doctor.id}>{doctor.fullName} ({doctor.specialization})</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Кабинет</label>
+                  <input
+                    type="text"
+                    name="cabinet"
+                    value={formData.cabinet || ''}
+                    onChange={handleChange}
+                    placeholder="Каб. 1"
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Начало</label>
+                  <input
+                    type="datetime-local"
+                    name="start"
+                    value={formData.start ? formData.start.slice(0, 16) : ''}
+                    onChange={handleChange}
+                    required
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Окончание</label>
+                  <input
+                    type="datetime-local"
+                    name="end"
+                    value={formData.end ? formData.end.slice(0, 16) : ''}
+                    onChange={handleChange}
+                    required
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Цена (₸)</label>
+                  <input
+                    type="number"
+                    name="price"
+                    value={formData.price || 0}
+                    onChange={handleChange}
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Источник</label>
+                  <select
+                    name="source"
+                    value={formData.source || 'walk_in'}
+                    onChange={handleChange}
+                    className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                  >
+                    <option value="phone">Телефон</option>
+                    <option value="whatsapp">WhatsApp</option>
+                    <option value="instagram">Instagram</option>
+                    <option value="walk_in">С улицы</option>
+                    <option value="repeat">Повторный</option>
+                    <option value="referral">По рекомендации</option>
+                  </select>
+                </div>
               </div>
-            </div>
+
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Комментарий</label>
+                <textarea
+                  name="comment"
+                  value={formData.comment || ''}
+                  onChange={handleChange}
+                  rows={2}
+                  className="w-full p-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm resize-none"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-2">Статус</label>
+                <div className="flex flex-wrap gap-2">
+                  {[
+                    { value: 'new', label: 'Новая' },
+                    { value: 'confirmed', label: 'Подтвержден' },
+                    { value: 'arrived', label: 'Пришел' },
+                    { value: 'in_progress', label: 'В работе' },
+                    { value: 'completed', label: 'Завершен' },
+                    { value: 'no_show', label: 'Не пришел' },
+                    { value: 'cancelled', label: 'Отменен' },
+                  ].map((status) => (
+                    <button
+                      key={status.value}
+                      type="button"
+                      onClick={() => handleStatusChange(status.value as AppointmentStatus)}
+                      className={`px-3 py-1 text-sm rounded-md border ${
+                        formData.status === status.value
+                          ? 'bg-blue-50 border-blue-500 text-blue-700 font-medium'
+                          : 'bg-white border-slate-200 text-slate-600 hover:bg-slate-50'
+                      }`}
+                    >
+                      {status.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </fieldset>
           </form>
         </div>
 
@@ -335,8 +396,9 @@ export function AppointmentModal({
             {isEditing && onDelete && (
               <button
                 type="button"
-                onClick={() => onDelete(formData.id as string)}
-                className="px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                disabled={isBusy}
+                onClick={() => void handleDelete()}
+                className="px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
               >
                 Удалить
               </button>
@@ -345,17 +407,19 @@ export function AppointmentModal({
           <div className="flex gap-2">
             <button
               type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200 bg-slate-100 rounded-lg transition-colors"
+              disabled={isBusy}
+              onClick={closeSafely}
+              className="px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200 bg-slate-100 rounded-lg transition-colors disabled:opacity-50"
             >
               Отмена
             </button>
             <button
               type="submit"
               form="appointment-form"
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
+              disabled={isBusy}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Сохранить
+              {isBusy ? 'Сохраняем запись…' : 'Сохранить'}
             </button>
           </div>
         </div>

--- a/src/data/hooks/useScheduleAppointments.test.tsx
+++ b/src/data/hooks/useScheduleAppointments.test.tsx
@@ -1,141 +1,295 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+
 import { act } from 'react';
-import { createRoot } from 'react-dom/client';
-import { useScheduleAppointments } from './useScheduleAppointments';
+import { createRoot, type Root } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Appointment } from '../../types';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
+import {
+  AppointmentRepositoryError,
+  type IAppointmentRepository,
+  type AppointmentWriteOptions,
+} from '../repositories/AppointmentRepository';
 import * as AppointmentRepo from '../repositories/AppointmentRepository';
+import { useScheduleAppointments } from './useScheduleAppointments';
 
 vi.mock('../../contexts/AuthContext');
 vi.mock('../../contexts/TenantContext');
 vi.mock('../../lib/supabaseClient', () => ({
   isSupabaseConfigured: true,
-  supabase: {}
+  supabase: {},
 }));
+
+const refetchMock = vi.fn().mockResolvedValue(undefined);
 vi.mock('./useAsyncQuery', () => ({
   useAsyncQuery: () => ({
     data: [],
     isLoading: false,
     isError: false,
     error: null,
-    refetch: vi.fn(),
-  })
+    refetch: refetchMock,
+  }),
 }));
 
+const appointment: Appointment = {
+  id: '11111111-1111-4111-8111-111111111111',
+  patientId: '22222222-2222-4222-8222-222222222222',
+  doctorId: '33333333-3333-4333-8333-333333333333',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'new',
+  paymentType: 'unpaid',
+  source: 'phone',
+  price: 1000,
+  comment: 'Test',
+  start: '2026-08-01T10:00:00',
+  end: '2026-08-01T11:00:00',
+  createdAt: '2026-07-01T09:00:00',
+  updatedAt: '2026-07-01T09:00:00+00:00',
+};
+
+const writeResult = (value: Appointment = appointment, operationType: 'create' | 'reschedule' | 'details' = 'create') => ({
+  appointment: value,
+  replayed: false,
+  recovered: false,
+  operationType,
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const makeRepository = (): IAppointmentRepository => ({
+  listAppointmentsByPatient: vi.fn().mockResolvedValue([]),
+  listAppointments: vi.fn().mockResolvedValue([]),
+  createAppointment: vi.fn().mockResolvedValue(writeResult()),
+  rescheduleAppointment: vi.fn().mockResolvedValue(writeResult(appointment, 'reschedule')),
+  updateAppointmentDetails: vi.fn().mockResolvedValue(writeResult(appointment, 'details')),
+  recoverAppointmentOperation: vi.fn().mockResolvedValue({ found: false }),
+  deleteAppointment: vi.fn().mockResolvedValue(undefined),
+});
+
+interface HookHarness {
+  getResult: () => ReturnType<typeof useScheduleAppointments>;
+  root: Root;
+  rerender: () => Promise<void>;
+  unmount: () => Promise<void>;
+}
+
+const renderHook = async (): Promise<HookHarness> => {
+  let result: ReturnType<typeof useScheduleAppointments> | undefined;
+  const TestComponent = () => {
+    result = useScheduleAppointments();
+    return null;
+  };
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const rerender = async () => {
+    await act(async () => root.render(<TestComponent />));
+  };
+  await rerender();
+
+  return {
+    getResult: () => {
+      if (!result) throw new Error('Hook not rendered');
+      return result;
+    },
+    root,
+    rerender,
+    unmount: async () => act(async () => root.unmount()),
+  };
+};
+
 describe('useScheduleAppointments', () => {
-  const mockCreateRepo = vi.spyOn(AppointmentRepo, 'createAppointmentRepository');
+  const createRepositorySpy = vi.spyOn(AppointmentRepo, 'createAppointmentRepository');
+  let repository: IAppointmentRepository;
+  let activeTenant: { tenantId: string } | null;
+  let authMode: 'dev' | 'supabase-active';
 
   beforeEach(() => {
     vi.clearAllMocks();
+    refetchMock.mockResolvedValue(undefined);
+    repository = makeRepository();
+    createRepositorySpy.mockReturnValue(repository);
+    activeTenant = { tenantId: 'tenant-a' };
+    authMode = 'supabase-active';
+    vi.mocked(useAuth).mockImplementation(() => ({ authMode } as any));
+    vi.mocked(useTenant).mockImplementation(() => ({ activeTenant } as any));
   });
 
-  const renderTestHook = async () => {
-    let hookResult: ReturnType<typeof useScheduleAppointments> | undefined;
-    const TestComponent = () => {
-      hookResult = useScheduleAppointments();
-      return null;
-    };
-    const container = document.createElement('div');
-    const root = createRoot(container);
+  it('selects Supabase only for active configured tenant and exposes hardened mutation state', async () => {
+    const harness = await renderHook();
+
+    expect(createRepositorySpy).toHaveBeenCalledWith({ backend: 'supabase', tenantId: 'tenant-a' });
+    expect(harness.getResult()).toMatchObject({
+      appointments: [],
+      isSaving: false,
+      isReconciling: false,
+      saveError: null,
+    });
+    expect(harness.getResult()).toHaveProperty('createAppointment');
+    expect(harness.getResult()).toHaveProperty('updateAppointment');
+    await harness.unmount();
+
+    authMode = 'dev';
+    activeTenant = null;
+    const localHarness = await renderHook();
+    expect(createRepositorySpy).toHaveBeenLastCalledWith({ backend: 'local', tenantId: undefined });
+    await localHarness.unmount();
+  });
+
+  it('rapid duplicate create calls share one logical operation, one key, and one refetch', async () => {
+    const save = deferred<ReturnType<typeof writeResult>>();
+    const create = vi.fn((value: Appointment, options: AppointmentWriteOptions) => {
+      void value;
+      void options;
+      return save.promise;
+    });
+    repository.createAppointment = create;
+    const harness = await renderHook();
+
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
     await act(async () => {
-      root.render(<TestComponent />);
+      first = harness.getResult().createAppointment(appointment);
+      second = harness.getResult().createAppointment(appointment);
+      await Promise.resolve();
     });
-    return { hookResult, root };
-  };
 
-  it('routes to local when authMode is dev', async () => {
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as any);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1' } } as any);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(create.mock.calls[0][1].operationKey).toMatch(/^[0-9a-f-]{36}$/);
+    expect(harness.getResult().isSaving).toBe(true);
 
-    const { root } = await renderTestHook();
-    
-    expect(mockCreateRepo).toHaveBeenCalledWith({
-      backend: 'local',
-      tenantId: 't1'
-    });
-    
-    await act(async () => { root.unmount(); });
+    await act(async () => save.resolve(writeResult()));
+    await expect(first).resolves.toMatchObject({ appointment: { id: appointment.id } });
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    expect(harness.getResult().isSaving).toBe(false);
+    await harness.unmount();
   });
 
-  it('routes to supabase when authMode is supabase-active with tenant and config', async () => {
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as any);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1' } } as any);
+  it('retains the same operation key when an ambiguous attempt is retried', async () => {
+    const keys: string[] = [];
+    const create = vi.fn()
+      .mockImplementationOnce((_value: Appointment, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        return Promise.reject(new AppointmentRepositoryError(
+          'generic',
+          'Не удалось сохранить запись. Обновите расписание и проверьте результат.',
+          true,
+        ));
+      })
+      .mockImplementationOnce((_value: Appointment, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        return Promise.resolve(writeResult());
+      });
+    repository.createAppointment = create;
+    const harness = await renderHook();
 
-    const { root } = await renderTestHook();
-    
-    expect(mockCreateRepo).toHaveBeenCalledWith({
-      backend: 'supabase',
-      tenantId: 't1'
-    });
-    
-    await act(async () => { root.unmount(); });
-  });
-
-  it('routes to local when authMode is supabase-active but no tenant', async () => {
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as any);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as any);
-
-    const { root } = await renderTestHook();
-    
-    expect(mockCreateRepo).toHaveBeenCalledWith({
-      backend: 'local',
-      tenantId: undefined
-    });
-    
-    await act(async () => { root.unmount(); });
-  });
-
-  it('returns expected API', async () => {
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as any);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as any);
-
-    const { hookResult, root } = await renderTestHook();
-    
-    expect(hookResult).toBeDefined();
-    expect(hookResult).toHaveProperty('appointments');
-    expect(hookResult).toHaveProperty('createAppointment');
-    expect(hookResult).toHaveProperty('updateAppointment');
-    expect(hookResult).toHaveProperty('deleteAppointment');
-    expect(hookResult).toHaveProperty('isLoading');
-    expect(hookResult).toHaveProperty('isSaving');
-    
-    await act(async () => { root.unmount(); });
-  });
-
-  it('memoizes repository and does not recreate on re-render if dependencies are stable', async () => {
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as any);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1' } } as any);
-
-    let renderCount = 0;
-    const TestComponent = () => {
-      renderCount++;
-      useScheduleAppointments();
-      return null;
-    };
-    
-    const container = document.createElement('div');
-    const root = createRoot(container);
-    
     await act(async () => {
-      root.render(<TestComponent />);
+      await expect(harness.getResult().createAppointment(appointment)).rejects.toMatchObject({ ambiguous: true });
     });
-    
-    // Initial render creates the repository once
-    const initialCallCount = mockCreateRepo.mock.calls.length;
-    expect(initialCallCount).toBeGreaterThan(0);
-    
-    // Force a re-render
     await act(async () => {
-      root.render(<TestComponent />);
+      await expect(harness.getResult().createAppointment(appointment)).resolves.toMatchObject({ appointment: { id: appointment.id } });
     });
-    
-    expect(renderCount).toBe(2);
-    // Factory should NOT be called again since dependencies haven't changed
-    expect(mockCreateRepo.mock.calls.length).toBe(initialCallCount);
-    
-    await act(async () => { root.unmount(); });
+
+    expect(keys).toHaveLength(2);
+    expect(keys[1]).toBe(keys[0]);
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    await harness.unmount();
+  });
+
+  it('routes protected changes to reschedule RPC and details-only changes to details RPC', async () => {
+    const reschedule = vi.fn().mockResolvedValue(writeResult(appointment, 'reschedule'));
+    const details = vi.fn().mockResolvedValue(writeResult(appointment, 'details'));
+    repository.rescheduleAppointment = reschedule;
+    repository.updateAppointmentDetails = details;
+    const harness = await renderHook();
+
+    const moved = { ...appointment, start: '2026-08-01T11:00:00', end: '2026-08-01T12:00:00' };
+    await act(async () => {
+      await harness.getResult().updateAppointment(appointment, moved);
+    });
+    expect(reschedule).toHaveBeenCalledTimes(1);
+    expect(reschedule.mock.calls[0][2].operationKey).toMatch(/^[0-9a-f-]{36}$/);
+    expect(details).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await harness.getResult().updateAppointment(appointment, { ...appointment, comment: 'Details' });
+    });
+    expect(details).toHaveBeenCalledTimes(1);
+    expect(reschedule).toHaveBeenCalledTimes(1);
+    expect(refetchMock).toHaveBeenCalledTimes(2);
+    await harness.unmount();
+  });
+
+  it('shows reconciliation state while repository checks an uncertain result', async () => {
+    const recovery = deferred<ReturnType<typeof writeResult>>();
+    repository.createAppointment = vi.fn((_value, options) => {
+      options.onRecoveryStateChange?.(true);
+      return recovery.promise.finally(() => options.onRecoveryStateChange?.(false));
+    });
+    const harness = await renderHook();
+
+    let pending!: Promise<unknown>;
+    await act(async () => {
+      pending = harness.getResult().createAppointment(appointment);
+      await Promise.resolve();
+    });
+    expect(harness.getResult().isSaving).toBe(true);
+    expect(harness.getResult().isReconciling).toBe(true);
+
+    await act(async () => recovery.resolve({ ...writeResult(), recovered: true, replayed: true }));
+    await pending;
+    expect(harness.getResult().isSaving).toBe(false);
+    expect(harness.getResult().isReconciling).toBe(false);
+    await harness.unmount();
+  });
+
+  it('ignores stale success after tenant context changes and does not refresh the new tenant', async () => {
+    const save = deferred<ReturnType<typeof writeResult>>();
+    repository.createAppointment = vi.fn(() => save.promise);
+    const harness = await renderHook();
+
+    let pending!: Promise<unknown>;
+    await act(async () => {
+      pending = harness.getResult().createAppointment(appointment);
+      await Promise.resolve();
+    });
+
+    activeTenant = { tenantId: 'tenant-b' };
+    await harness.rerender();
+    expect(createRepositorySpy).toHaveBeenLastCalledWith({ backend: 'supabase', tenantId: 'tenant-b' });
+    expect(harness.getResult().isSaving).toBe(false);
+
+    await act(async () => save.resolve(writeResult()));
+    await expect(pending).resolves.toBeNull();
+    expect(refetchMock).not.toHaveBeenCalled();
+    expect(harness.getResult().saveError).toBeNull();
+    await harness.unmount();
+  });
+
+  it('stores safe server conflict and does not refresh after failure', async () => {
+    repository.createAppointment = vi.fn().mockRejectedValue(
+      new AppointmentRepositoryError('patient_conflict', 'У пациента уже есть другая запись на это время.'),
+    );
+    const harness = await renderHook();
+
+    await act(async () => {
+      await expect(harness.getResult().createAppointment(appointment)).rejects.toThrow('У пациента уже есть другая запись');
+    });
+
+    expect(harness.getResult().saveError?.message).toBe('У пациента уже есть другая запись на это время.');
+    expect(refetchMock).not.toHaveBeenCalled();
+    await harness.unmount();
   });
 });

--- a/src/data/hooks/useScheduleAppointments.ts
+++ b/src/data/hooks/useScheduleAppointments.ts
@@ -1,28 +1,83 @@
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
 import type { Appointment } from '../../types';
-import { createAppointmentRepository } from '../repositories/AppointmentRepository';
+import {
+  AppointmentRepositoryError,
+  createAppointmentRepository,
+  isProtectedAppointmentChange,
+  type AppointmentWriteResult,
+} from '../repositories/AppointmentRepository';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
+interface OperationAttempt {
+  contextKey: string;
+  signature: string;
+  operationKey: string;
+}
+
+interface MutationState {
+  contextKey: string;
+  isSaving: boolean;
+  isReconciling: boolean;
+  error: Error | null;
+}
+
+const appointmentBusinessSignature = (appointment: Appointment) => JSON.stringify({
+  patientId: appointment.patientId || null,
+  doctorId: appointment.doctorId,
+  cabinet: appointment.cabinet || '',
+  service: appointment.service || '',
+  status: appointment.status,
+  paymentType: appointment.paymentType || null,
+  source: appointment.source || null,
+  price: appointment.price ?? null,
+  comment: appointment.comment || null,
+  start: appointment.start,
+  end: appointment.end,
+});
+
+const safeMutationError = (error: unknown): Error => (
+  error instanceof Error
+    ? error
+    : new Error('Не удалось сохранить запись. Обновите расписание и проверьте результат.')
+);
+
 export function useScheduleAppointments() {
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveError, setSaveError] = useState<Error | null>(null);
-  
   const { authMode } = useAuth();
   const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const contextKey = `${authMode}:${tenantId || 'no-tenant'}`;
+  const currentContextRef = useRef(contextKey);
+  useLayoutEffect(() => {
+    currentContextRef.current = contextKey;
+  }, [contextKey]);
 
-  const repository = useMemo(() => {
-    return createAppointmentRepository({
-      backend: (authMode === 'supabase-active' && activeTenant?.tenantId && isSupabaseConfigured) ? 'supabase' : 'local',
-      tenantId: activeTenant?.tenantId,
-    });
-  }, [authMode, activeTenant?.tenantId]);
+  const [mutationState, setMutationState] = useState<MutationState>({
+    contextKey,
+    isSaving: false,
+    isReconciling: false,
+    error: null,
+  });
+
+  const createAttemptRef = useRef<OperationAttempt | null>(null);
+  const rescheduleAttemptRef = useRef<OperationAttempt | null>(null);
+  const inFlightRef = useRef<{
+    contextKey: string;
+    signature: string;
+    token: symbol;
+    promise: Promise<AppointmentWriteResult | null>;
+  } | null>(null);
+
+  const repository = useMemo(() => createAppointmentRepository({
+    backend: (authMode === 'supabase-active' && tenantId && isSupabaseConfigured) ? 'supabase' : 'local',
+    tenantId,
+  }), [authMode, tenantId]);
 
   const queryFn = useCallback(
     () => repository.listAppointments(),
-    [repository]
+    [repository],
   );
 
   const {
@@ -35,63 +90,172 @@ export function useScheduleAppointments() {
     queryFn,
     initialData: [],
     enabled: true,
+    queryKey: contextKey,
   });
 
-  const createAppointment = async (appointment: Appointment): Promise<void> => {
-    setIsSaving(true);
-    setSaveError(null);
-    try {
-      await repository.createAppointment(appointment);
-      await refetch();
-    } catch (e) {
-      const parsedError = e instanceof Error ? e : new Error(String(e));
-      setSaveError(parsedError);
-      throw parsedError;
-    } finally {
-      setIsSaving(false);
+  const getOperationKey = useCallback((
+    ref: MutableRefObject<OperationAttempt | null>,
+    signature: string,
+  ): string => {
+    if (
+      ref.current
+      && ref.current.contextKey === contextKey
+      && ref.current.signature === signature
+    ) {
+      return ref.current.operationKey;
     }
-  };
 
-  const updateAppointment = async (appointment: Appointment): Promise<void> => {
-    setIsSaving(true);
-    setSaveError(null);
-    try {
-      await repository.updateAppointment(appointment);
-      await refetch();
-    } catch (e) {
-      const parsedError = e instanceof Error ? e : new Error(String(e));
-      setSaveError(parsedError);
-      throw parsedError;
-    } finally {
-      setIsSaving(false);
+    const operationKey = crypto.randomUUID();
+    ref.current = { contextKey, signature, operationKey };
+    return operationKey;
+  }, [contextKey]);
+
+  const runMutation = useCallback((
+    signature: string,
+    write: (onRecoveryStateChange: (recovering: boolean) => void) => Promise<AppointmentWriteResult>,
+    attemptRef?: MutableRefObject<OperationAttempt | null>,
+  ): Promise<AppointmentWriteResult | null> => {
+    const existing = inFlightRef.current;
+    if (existing && existing.contextKey === contextKey) return existing.promise;
+
+    const capturedContext = contextKey;
+    setMutationState({
+      contextKey: capturedContext,
+      isSaving: true,
+      isReconciling: false,
+      error: null,
+    });
+
+    const operationToken = Symbol(signature);
+    const promise = (async (): Promise<AppointmentWriteResult | null> => {
+      try {
+        const result = await write((recovering) => {
+          if (currentContextRef.current !== capturedContext) return;
+          setMutationState((current) => ({
+            contextKey: capturedContext,
+            isSaving: true,
+            isReconciling: recovering,
+            error: current.contextKey === capturedContext ? current.error : null,
+          }));
+        });
+
+        if (currentContextRef.current !== capturedContext) return null;
+        if (attemptRef) attemptRef.current = null;
+        await refetch();
+        if (currentContextRef.current !== capturedContext) return null;
+        return result;
+      } catch (error) {
+        const parsedError = safeMutationError(error);
+        if (
+          attemptRef
+          && (!(parsedError instanceof AppointmentRepositoryError) || !parsedError.ambiguous)
+        ) {
+          attemptRef.current = null;
+        }
+
+        if (currentContextRef.current === capturedContext) {
+          setMutationState({
+            contextKey: capturedContext,
+            isSaving: false,
+            isReconciling: false,
+            error: parsedError,
+          });
+        }
+        throw parsedError;
+      } finally {
+        if (currentContextRef.current === capturedContext) {
+          setMutationState((current) => ({
+            contextKey: capturedContext,
+            isSaving: false,
+            isReconciling: false,
+            error: current.contextKey === capturedContext ? current.error : null,
+          }));
+        }
+        if (inFlightRef.current?.token === operationToken) inFlightRef.current = null;
+      }
+    })();
+
+    inFlightRef.current = { contextKey: capturedContext, signature, token: operationToken, promise };
+    return promise;
+  }, [contextKey, refetch]);
+
+  const createAppointment = useCallback((appointment: Appointment) => {
+    const signature = `create:${contextKey}:${appointmentBusinessSignature(appointment)}`;
+    const operationKey = getOperationKey(createAttemptRef, signature);
+
+    return runMutation(
+      signature,
+      (onRecoveryStateChange) => repository.createAppointment(appointment, {
+        operationKey,
+        onRecoveryStateChange,
+      }),
+      createAttemptRef,
+    );
+  }, [contextKey, getOperationKey, repository, runMutation]);
+
+  const updateAppointment = useCallback((current: Appointment, next: Appointment) => {
+    if (isProtectedAppointmentChange(current, next)) {
+      const signature = `reschedule:${contextKey}:${current.id}:${current.updatedAt || ''}:${appointmentBusinessSignature(next)}`;
+      const operationKey = getOperationKey(rescheduleAttemptRef, signature);
+      return runMutation(
+        signature,
+        (onRecoveryStateChange) => repository.rescheduleAppointment(current, next, {
+          operationKey,
+          onRecoveryStateChange,
+        }),
+        rescheduleAttemptRef,
+      );
     }
-  };
 
-  const deleteAppointment = async (appointmentId: string): Promise<void> => {
-    setIsSaving(true);
-    setSaveError(null);
+    const signature = `details:${contextKey}:${current.id}:${current.updatedAt || ''}:${appointmentBusinessSignature(next)}`;
+    return runMutation(
+      signature,
+      () => repository.updateAppointmentDetails(current, next),
+    );
+  }, [contextKey, getOperationKey, repository, runMutation]);
+
+  const deleteAppointment = useCallback(async (appointmentId: string): Promise<boolean> => {
+    const capturedContext = contextKey;
+    if (inFlightRef.current?.contextKey === capturedContext) return false;
+
+    setMutationState({ contextKey: capturedContext, isSaving: true, isReconciling: false, error: null });
     try {
       await repository.deleteAppointment(appointmentId);
+      if (currentContextRef.current !== capturedContext) return false;
       await refetch();
-    } catch (e) {
-      const parsedError = e instanceof Error ? e : new Error(String(e));
-      setSaveError(parsedError);
+      return currentContextRef.current === capturedContext;
+    } catch (error) {
+      const parsedError = safeMutationError(error);
+      if (currentContextRef.current === capturedContext) {
+        setMutationState({ contextKey: capturedContext, isSaving: false, isReconciling: false, error: parsedError });
+      }
       throw parsedError;
     } finally {
-      setIsSaving(false);
+      if (currentContextRef.current === capturedContext) {
+        setMutationState((current) => ({
+          contextKey: capturedContext,
+          isSaving: false,
+          isReconciling: false,
+          error: current.contextKey === capturedContext ? current.error : null,
+        }));
+      }
     }
-  };
+  }, [contextKey, refetch, repository]);
 
-  const isError = isQueryError || saveError !== null;
-  const error = saveError || queryError;
+  const mutationForCurrentContext = mutationState.contextKey === contextKey
+    ? mutationState
+    : { contextKey, isSaving: false, isReconciling: false, error: null };
+  const isError = isQueryError || mutationForCurrentContext.error !== null;
+  const error = mutationForCurrentContext.error || queryError;
 
   return {
     appointments: appointments || [],
     isLoading,
     isError,
     error,
-    isSaving,
-    saveError,
+    isSaving: mutationForCurrentContext.isSaving,
+    isReconciling: mutationForCurrentContext.isReconciling,
+    saveError: mutationForCurrentContext.error,
     createAppointment,
     updateAppointment,
     deleteAppointment,

--- a/src/data/repositories/AppointmentRepository.test.ts
+++ b/src/data/repositories/AppointmentRepository.test.ts
@@ -1,170 +1,331 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { 
-  createAppointmentRepository, 
-  SupabaseAppointmentRepository, 
-  LocalStorageAppointmentRepository 
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import repositorySource from './AppointmentRepository.ts?raw';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Appointment } from '../../types';
+import {
+  AppointmentRepositoryError,
+  LocalStorageAppointmentRepository,
+  SupabaseAppointmentRepository,
+  createAppointmentRepository,
+  isProtectedAppointmentChange,
+  toSafeAppointmentError,
 } from './AppointmentRepository';
 import { supabase } from '../../lib/supabaseClient';
-import type { Appointment } from '../../types';
-import type { SupabaseClient } from '@supabase/supabase-js';
 
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: {
     from: vi.fn(),
+    rpc: vi.fn(),
   },
 }));
+
+const tenantId = '11111111-1111-4111-8111-111111111111';
+const appointmentId = '22222222-2222-4222-8222-222222222222';
+const patientId = '33333333-3333-4333-8333-333333333333';
+const doctorId = '44444444-4444-4444-8444-444444444444';
+const operationKey = 'appointment-test-operation-001';
+
+const appointment: Appointment = {
+  id: appointmentId,
+  patientId,
+  doctorId,
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'new',
+  paymentType: 'unpaid',
+  source: 'phone',
+  price: 1500,
+  comment: 'Комментарий',
+  start: '2026-08-01T10:00:00',
+  end: '2026-08-01T11:00:00',
+  createdAt: '2026-07-01T09:00:00',
+  updatedAt: '2026-07-01T09:00:00+00:00',
+};
+
+const databaseRow = (overrides: Record<string, unknown> = {}) => ({
+  id: appointmentId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  doctor_id: doctorId,
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'new',
+  payment_type: 'unpaid',
+  source: 'phone',
+  price: '1500.00',
+  comment: 'Комментарий',
+  start_time: '2026-08-01T10:00:00+00:00',
+  end_time: '2026-08-01T11:00:00+00:00',
+  created_at: '2026-07-01T09:00:00+00:00',
+  updated_at: '2026-07-01T09:00:00+00:00',
+  ...overrides,
+});
+
+const rpcResult = (
+  operationType: 'create' | 'reschedule' | 'details' = 'create',
+  overrides: Record<string, unknown> = {},
+) => ({
+  appointment: databaseRow(overrides),
+  replayed: false,
+  recovered: false,
+  operationType,
+});
+
+const createClient = () => {
+  const rpc = vi.fn();
+  const from = vi.fn();
+  return {
+    client: { rpc, from } as unknown as SupabaseClient,
+    rpc,
+    from,
+  };
+};
 
 describe('AppointmentRepository', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('Factory', () => {
-    it('returns LocalStorageAppointmentRepository when backend is local', () => {
-      const repo = createAppointmentRepository({ backend: 'local' });
-      expect(repo).toBe(LocalStorageAppointmentRepository);
+  describe('factory', () => {
+    it('uses local storage only when local backend is selected', () => {
+      expect(createAppointmentRepository({ backend: 'local' })).toBe(LocalStorageAppointmentRepository);
+      expect(createAppointmentRepository({ backend: 'supabase', tenantId: null })).toBe(LocalStorageAppointmentRepository);
     });
 
-    it('returns LocalStorageAppointmentRepository when backend is supabase but no tenantId', () => {
-      const repo = createAppointmentRepository({ backend: 'supabase', tenantId: null });
-      expect(repo).toBe(LocalStorageAppointmentRepository);
-    });
-
-    it('returns SupabaseAppointmentRepository when backend is supabase with tenantId', () => {
-      const repo = createAppointmentRepository({ backend: 'supabase', tenantId: 't1' });
-      expect(repo).toBeInstanceOf(SupabaseAppointmentRepository);
+    it('creates Supabase repository for configured tenant backend', () => {
+      const repository = createAppointmentRepository({ backend: 'supabase', tenantId });
+      expect(repository).toBeInstanceOf(SupabaseAppointmentRepository);
+      expect(supabase).toBeTruthy();
     });
   });
 
-  describe('SupabaseAppointmentRepository', () => {
-    const tenantId = 'test-tenant';
-    const client = supabase as unknown as SupabaseClient;
-    const repo = new SupabaseAppointmentRepository(tenantId, client);
-    
-    const mockSelect = vi.fn();
-    const mockEq = vi.fn();
-    const mockOrder = vi.fn();
-    const mockInsert = vi.fn();
-    const mockUpdate = vi.fn();
-    const mockDelete = vi.fn();
+  it('reads appointments through tenant-scoped table SELECT', async () => {
+    const { client, from } = createClient();
+    const order = vi.fn().mockResolvedValue({ data: [databaseRow()], error: null });
+    const secondEq = vi.fn().mockReturnValue({ order });
+    const firstEq = vi.fn().mockReturnValue({ eq: secondEq, order });
+    const select = vi.fn().mockReturnValue({ eq: firstEq });
+    from.mockReturnValue({ select });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
 
-    beforeEach(() => {
-      vi.mocked(client.from).mockReturnValue({
-        select: mockSelect,
-        insert: mockInsert,
-        update: mockUpdate,
-        delete: mockDelete,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+    const all = await repository.listAppointments();
+    const byPatient = await repository.listAppointmentsByPatient(patientId);
 
-      mockSelect.mockReturnValue({ eq: mockEq });
-      mockEq.mockReturnValue({ eq: mockEq, order: mockOrder, maybeSingle: vi.fn() });
-      mockOrder.mockResolvedValue({ data: [], error: null });
-      mockInsert.mockResolvedValue({ error: null });
-      mockUpdate.mockReturnValue({ eq: mockEq });
-      mockDelete.mockReturnValue({ eq: mockEq });
-      
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockEq.mockImplementation((...args: any[]) => {
-        void args;
-        const chain = { eq: mockEq, order: mockOrder };
-        return Object.assign(Promise.resolve({ error: null }), chain);
+    expect(from).toHaveBeenCalledWith('appointments');
+    expect(firstEq).toHaveBeenCalledWith('tenant_id', tenantId);
+    expect(secondEq).toHaveBeenCalledWith('patient_id', patientId);
+    expect(all[0]).toMatchObject({
+      id: appointmentId,
+      patientId,
+      doctorId,
+      start: '2026-08-01T10:00:00',
+      end: '2026-08-01T11:00:00',
+      updatedAt: '2026-07-01T09:00:00+00:00',
+      price: 1500,
+    });
+    expect(byPatient).toHaveLength(1);
+  });
+
+  it('creates through create_appointment RPC and preserves operation key unchanged', async () => {
+    const { client, rpc, from } = createClient();
+    rpc.mockResolvedValue({ data: rpcResult('create'), error: null });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const result = await repository.createAppointment(appointment, { operationKey });
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith('create_appointment', expect.objectContaining({
+      p_tenant_id: tenantId,
+      p_patient_id: patientId,
+      p_doctor_id: doctorId,
+      p_start_time: '2026-08-01T10:00:00Z',
+      p_end_time: '2026-08-01T11:00:00Z',
+      p_operation_key: operationKey,
+    }));
+    expect(from).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ operationType: 'create', replayed: false, recovered: false });
+  });
+
+  it('reschedules through reschedule_appointment RPC with optimistic version and unchanged key', async () => {
+    const { client, rpc, from } = createClient();
+    rpc.mockResolvedValue({
+      data: rpcResult('reschedule', {
+        doctor_id: '55555555-5555-4555-8555-555555555555',
+        start_time: '2026-08-01T12:00:00+00:00',
+        end_time: '2026-08-01T13:00:00+00:00',
+      }),
+      error: null,
+    });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+    const next: Appointment = {
+      ...appointment,
+      doctorId: '55555555-5555-4555-8555-555555555555',
+      start: '2026-08-01T12:00:00',
+      end: '2026-08-01T13:00:00',
+    };
+
+    const result = await repository.rescheduleAppointment(appointment, next, { operationKey });
+
+    expect(rpc).toHaveBeenCalledWith('reschedule_appointment', expect.objectContaining({
+      p_tenant_id: tenantId,
+      p_appointment_id: appointmentId,
+      p_patient_id: patientId,
+      p_doctor_id: next.doctorId,
+      p_expected_updated_at: appointment.updatedAt,
+      p_operation_key: operationKey,
+    }));
+    expect(from).not.toHaveBeenCalled();
+    expect(result.appointment.start).toBe('2026-08-01T12:00:00');
+  });
+
+  it('updates non-protected details only through update_appointment_details RPC', async () => {
+    const { client, rpc, from } = createClient();
+    rpc.mockResolvedValue({ data: rpcResult('details', { comment: 'Новый комментарий' }), error: null });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+    const next = { ...appointment, comment: 'Новый комментарий' };
+
+    await repository.updateAppointmentDetails(appointment, next);
+
+    expect(rpc).toHaveBeenCalledWith('update_appointment_details', expect.objectContaining({
+      p_tenant_id: tenantId,
+      p_appointment_id: appointmentId,
+      p_comment: 'Новый комментарий',
+      p_expected_updated_at: appointment.updatedAt,
+    }));
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('recovers operation through scoped recovery RPC without exposing fingerprint', async () => {
+    const { client, rpc } = createClient();
+    rpc.mockResolvedValue({
+      data: {
+        found: true,
+        operationType: 'create',
+        appointment: databaseRow(),
+        replayed: true,
+        recovered: true,
+      },
+      error: null,
+    });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const recovered = await repository.recoverAppointmentOperation(operationKey);
+
+    expect(rpc).toHaveBeenCalledWith('get_appointment_operation', {
+      p_tenant_id: tenantId,
+      p_operation_key: operationKey,
+    });
+    expect(recovered).toMatchObject({
+      found: true,
+      operationType: 'create',
+      replayed: true,
+      recovered: true,
+      appointment: { id: appointmentId },
+    });
+    expect(JSON.stringify(recovered)).not.toContain('fingerprint');
+  });
+
+  it('recovers an uncertain create with the original operation key and reports reconciliation state', async () => {
+    const { client, rpc } = createClient();
+    rpc
+      .mockResolvedValueOnce({ data: null, error: { message: 'Failed to fetch' } })
+      .mockResolvedValueOnce({
+        data: {
+          found: true,
+          operationType: 'create',
+          appointment: databaseRow(),
+          replayed: true,
+          recovered: true,
+        },
+        error: null,
       });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+    const recoveryStates: boolean[] = [];
+
+    const result = await repository.createAppointment(appointment, {
+      operationKey,
+      onRecoveryStateChange: (recovering) => recoveryStates.push(recovering),
     });
 
-    it('listAppointments filters by tenant_id and orders asc', async () => {
-      await repo.listAppointments();
-      expect(client.from).toHaveBeenCalledWith('appointments');
-      expect(mockSelect).toHaveBeenCalledWith('*');
-      expect(mockEq).toHaveBeenCalledWith('tenant_id', tenantId);
-      expect(mockOrder).toHaveBeenCalledWith('start_time', { ascending: true });
+    expect(rpc.mock.calls[0]).toEqual(['create_appointment', expect.objectContaining({ p_operation_key: operationKey })]);
+    expect(rpc.mock.calls[1]).toEqual(['get_appointment_operation', {
+      p_tenant_id: tenantId,
+      p_operation_key: operationKey,
+    }]);
+    expect(recoveryStates).toEqual([true, false]);
+    expect(result).toMatchObject({ recovered: true, replayed: true, appointment: { id: appointmentId } });
+  });
+
+  it.each([
+    ['У врача уже есть запись на это время.', 'doctor_conflict', 'У врача уже есть запись на это время.'],
+    ['У пациента уже есть другая запись на это время.', 'patient_conflict', 'У пациента уже есть другая запись на это время.'],
+    ['Время окончания должно быть позже времени начала.', 'invalid_interval', 'Время окончания должно быть позже времени начала.'],
+    ['Пациент недоступен в этой клинике.', 'patient_unavailable', 'Пациент недоступен в этой клинике.'],
+    ['Врач недоступен в этой клинике.', 'doctor_unavailable', 'Врач недоступен в этой клинике.'],
+    ['Операция с этим идентификатором уже выполнена с другими параметрами.', 'idempotency_conflict', 'Операция с этим идентификатором уже выполнена с другими параметрами.'],
+    ['Запись была изменена другим пользователем. Обновите расписание.', 'concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.'],
+    ['permission denied for function', 'permission', 'Недостаточно прав для изменения записи.'],
+  ])('maps server error safely: %s', (rawMessage, code, safeMessage) => {
+    const mapped = toSafeAppointmentError({
+      message: rawMessage,
+      details: 'SQLSTATE 23505 appointment_operations_tenant_key_key',
+      hint: 'public.create_appointment',
     });
 
-    it('listAppointmentsByPatient filters by tenant_id and patient_id and orders desc', async () => {
-      await repo.listAppointmentsByPatient('p1');
-      expect(client.from).toHaveBeenCalledWith('appointments');
-      expect(mockSelect).toHaveBeenCalledWith('*');
-      expect(mockEq).toHaveBeenCalledWith('tenant_id', tenantId);
-      expect(mockEq).toHaveBeenCalledWith('patient_id', 'p1');
-      expect(mockOrder).toHaveBeenCalledWith('start_time', { ascending: false });
-    });
+    expect(mapped).toBeInstanceOf(AppointmentRepositoryError);
+    expect(mapped.code).toBe(code);
+    expect(mapped.message).toBe(safeMessage);
+    expect(mapped.message).not.toContain('SQLSTATE');
+    expect(mapped.message).not.toContain('appointment_operations');
+    expect(mapped.message).not.toContain('create_appointment');
+  });
 
-    it('createAppointment inserts tenant_id and generates UUID if missing', async () => {
-      const appt: Appointment = {
-        id: 'a123',
-        doctorId: 'd1',
-        patientId: '',
-        cabinet: '1',
-        service: 'test',
-        status: 'new',
-        start: '2023-01-01T10:00',
-        end: '2023-01-01T11:00',
-        createdAt: '2023-01-01T09:00',
-      };
-      
-      await repo.createAppointment(appt);
-      expect(mockInsert).toHaveBeenCalled();
-      const insertArg = mockInsert.mock.calls[0][0];
-      
-      expect(insertArg.tenant_id).toBe(tenantId);
-      expect(insertArg.id).not.toBe('a123');
-      expect(insertArg.id.length).toBe(36);
-      expect(insertArg.patient_id).toBeNull();
-      expect(insertArg.payment_type).toBeNull();
-      expect(insertArg.start_time).toBe('2023-01-01T10:00:00Z');
-    });
+  it('does not attempt recovery for deterministic doctor conflict', async () => {
+    const { client, rpc } = createClient();
+    rpc.mockResolvedValue({ data: null, error: { message: 'У врача уже есть запись на это время.' } });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
 
-    it('updateAppointment updates by tenant_id and id', async () => {
-      const appt: Appointment = {
-        id: 'uuid-123',
-        doctorId: 'd1',
-        cabinet: '1',
-        service: 'test',
-        status: 'new',
-        start: '2023-01-01T10:00',
-        end: '2023-01-01T11:00',
-        createdAt: '2023-01-01T09:00',
-      };
-      
-      await repo.updateAppointment(appt);
-      expect(mockUpdate).toHaveBeenCalled();
-      expect(mockEq).toHaveBeenCalledWith('tenant_id', tenantId);
-      expect(mockEq).toHaveBeenCalledWith('id', 'uuid-123');
-    });
+    await expect(repository.createAppointment(appointment, { operationKey }))
+      .rejects.toMatchObject({ code: 'doctor_conflict' });
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
 
-    it('deleteAppointment deletes by tenant_id and id', async () => {
-      await repo.deleteAppointment('uuid-123');
-      expect(mockDelete).toHaveBeenCalled();
-      expect(mockEq).toHaveBeenCalledWith('tenant_id', tenantId);
-      expect(mockEq).toHaveBeenCalledWith('id', 'uuid-123');
-    });
+  it('marks protected scheduling changes and ignores details-only edits', () => {
+    expect(isProtectedAppointmentChange(appointment, { ...appointment, comment: 'Другое' })).toBe(false);
+    expect(isProtectedAppointmentChange(appointment, { ...appointment, start: '2026-08-01T10:30:00' })).toBe(true);
+    expect(isProtectedAppointmentChange(appointment, { ...appointment, patientId: 'other' })).toBe(true);
+    expect(isProtectedAppointmentChange(appointment, { ...appointment, doctorId: 'other' })).toBe(true);
+  });
 
-    it('strips UTC timezone offset when reading from DB to preserve wall-clock time', async () => {
-      mockOrder.mockResolvedValueOnce({
-        data: [{
-          id: 'uuid-123',
-          doctor_id: 'd1',
-          cabinet: '1',
-          service: 'test',
-          status: 'new',
-          start_time: '2026-06-10T09:00:00Z',
-          end_time: '2026-06-10T10:00:00+00:00',
-          created_at: '2026-06-10T08:00:00Z',
-        }],
-        error: null
-      });
+  it('retains direct DELETE only under current hard-delete policy', async () => {
+    const { client, from } = createClient();
+    const finalEq = vi.fn().mockResolvedValue({ error: null });
+    const firstEq = vi.fn().mockReturnValue({ eq: finalEq });
+    const deleteCall = vi.fn().mockReturnValue({ eq: firstEq });
+    from.mockReturnValue({ delete: deleteCall });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
 
-      const apps = await repo.listAppointments();
-      expect(apps).toHaveLength(1);
-      expect(apps[0].start).toBe('2026-06-10T09:00:00');
-      expect(apps[0].end).toBe('2026-06-10T10:00:00');
-      expect(apps[0].createdAt).toBe('2026-06-10T08:00:00');
-    });
+    await repository.deleteAppointment(appointmentId);
 
-    it('throws Supabase errors', async () => {
-      mockInsert.mockResolvedValueOnce({ error: new Error('DB Error') });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await expect(repo.createAppointment({} as any)).rejects.toThrow('DB Error');
-    });
+    expect(from).toHaveBeenCalledWith('appointments');
+    expect(deleteCall).toHaveBeenCalledTimes(1);
+    expect(firstEq).toHaveBeenCalledWith('tenant_id', tenantId);
+    expect(finalEq).toHaveBeenCalledWith('id', appointmentId);
+  });
+
+  it('source contains no protected direct INSERT/UPDATE, service role, or Supabase localStorage fallback', () => {
+    const supabaseClass = repositorySource.slice(
+      repositorySource.indexOf('export class SupabaseAppointmentRepository'),
+      repositorySource.indexOf('export function createAppointmentRepository'),
+    );
+
+    expect(supabaseClass).not.toContain('.insert(');
+    expect(supabaseClass).not.toContain('.update(');
+    expect(supabaseClass).not.toContain('service_role');
+    expect(supabaseClass).not.toContain('localStorage');
+    expect(supabaseClass).not.toContain('storage.');
+    expect(supabaseClass).toContain("rpc('create_appointment'");
+    expect(supabaseClass).toContain("rpc('reschedule_appointment'");
+    expect(supabaseClass).toContain("rpc('get_appointment_operation'");
   });
 });

--- a/src/data/repositories/AppointmentRepository.ts
+++ b/src/data/repositories/AppointmentRepository.ts
@@ -3,11 +3,57 @@ import { storage } from '../../utils/storage';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+export type AppointmentOperationType = 'create' | 'reschedule' | 'details';
+export type AppointmentRepositoryErrorCode =
+  | 'doctor_conflict'
+  | 'patient_conflict'
+  | 'invalid_interval'
+  | 'patient_unavailable'
+  | 'doctor_unavailable'
+  | 'idempotency_conflict'
+  | 'concurrent_change'
+  | 'permission'
+  | 'generic';
+
+export class AppointmentRepositoryError extends Error {
+  readonly code: AppointmentRepositoryErrorCode;
+  readonly ambiguous: boolean;
+
+  constructor(code: AppointmentRepositoryErrorCode, message: string, ambiguous = false) {
+    super(message);
+    this.name = 'AppointmentRepositoryError';
+    this.code = code;
+    this.ambiguous = ambiguous;
+  }
+}
+
+export interface AppointmentWriteOptions {
+  operationKey: string;
+  onRecoveryStateChange?: (isRecovering: boolean) => void;
+}
+
+export interface AppointmentWriteResult {
+  appointment: Appointment;
+  replayed: boolean;
+  recovered: boolean;
+  operationType: AppointmentOperationType;
+}
+
+export interface AppointmentRecoveryResult {
+  found: boolean;
+  operationType?: 'create' | 'reschedule';
+  appointment?: Appointment;
+  replayed?: boolean;
+  recovered?: boolean;
+}
+
 export interface IAppointmentRepository {
   listAppointmentsByPatient(patientId: string): Promise<Appointment[]>;
   listAppointments(): Promise<Appointment[]>;
-  createAppointment(appointment: Appointment): Promise<void>;
-  updateAppointment(appointment: Appointment): Promise<void>;
+  createAppointment(appointment: Appointment, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
+  rescheduleAppointment(current: Appointment, next: Appointment, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
+  updateAppointmentDetails(current: Appointment, next: Appointment): Promise<AppointmentWriteResult>;
+  recoverAppointmentOperation(operationKey: string): Promise<AppointmentRecoveryResult>;
   deleteAppointment(appointmentId: string): Promise<void>;
 }
 
@@ -18,29 +64,106 @@ export interface CreateAppointmentRepositoryOptions {
   backend: AppointmentRepositoryBackend;
 }
 
+const genericSaveError = () => new AppointmentRepositoryError(
+  'generic',
+  'Не удалось сохранить запись. Обновите расписание и проверьте результат.',
+  true,
+);
+
+const errorText = (error: unknown): string => {
+  if (!error) return '';
+  if (error instanceof Error) return error.message.toLowerCase();
+  if (typeof error !== 'object') return String(error).toLowerCase();
+
+  const candidate = error as {
+    message?: unknown;
+    details?: unknown;
+    hint?: unknown;
+    code?: unknown;
+  };
+
+  return [candidate.message, candidate.details, candidate.hint, candidate.code]
+    .filter((part): part is string => typeof part === 'string')
+    .join(' ')
+    .toLowerCase();
+};
+
+export const toSafeAppointmentError = (error: unknown): AppointmentRepositoryError => {
+  if (error instanceof AppointmentRepositoryError) return error;
+  const text = errorText(error);
+
+  if (text.includes('у врача уже есть запись на это время')) {
+    return new AppointmentRepositoryError('doctor_conflict', 'У врача уже есть запись на это время.');
+  }
+  if (text.includes('у пациента уже есть другая запись на это время')) {
+    return new AppointmentRepositoryError('patient_conflict', 'У пациента уже есть другая запись на это время.');
+  }
+  if (text.includes('время окончания должно быть позже времени начала') || text.includes('appointments_valid_interval_check')) {
+    return new AppointmentRepositoryError('invalid_interval', 'Время окончания должно быть позже времени начала.');
+  }
+  if (text.includes('пациент недоступен в этой клинике')) {
+    return new AppointmentRepositoryError('patient_unavailable', 'Пациент недоступен в этой клинике.');
+  }
+  if (text.includes('врач недоступен в этой клинике')) {
+    return new AppointmentRepositoryError('doctor_unavailable', 'Врач недоступен в этой клинике.');
+  }
+  if (text.includes('запись была изменена другим пользователем')) {
+    return new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+  }
+  if (text.includes('недостаточно прав для изменения записи') || text.includes('permission denied') || text.includes('42501')) {
+    return new AppointmentRepositoryError('permission', 'Недостаточно прав для изменения записи.');
+  }
+  if (text.includes('операция с этим идентификатором уже выполнена с другими параметрами') || text.includes('appointment_operations_tenant_key_key')) {
+    return new AppointmentRepositoryError('idempotency_conflict', 'Операция с этим идентификатором уже выполнена с другими параметрами.');
+  }
+
+  return genericSaveError();
+};
+
+export const isProtectedAppointmentChange = (current: Appointment, next: Appointment): boolean => (
+  (current.patientId || '') !== (next.patientId || '')
+  || current.doctorId !== next.doctorId
+  || current.start !== next.start
+  || current.end !== next.end
+);
+
+const localWriteResult = (appointment: Appointment, operationType: AppointmentOperationType): AppointmentWriteResult => ({
+  appointment: {
+    ...appointment,
+    updatedAt: new Date().toISOString(),
+  },
+  replayed: false,
+  recovered: false,
+  operationType,
+});
+
 export const LocalStorageAppointmentRepository: IAppointmentRepository = {
-  listAppointmentsByPatient: async (patientId: string): Promise<Appointment[]> => {
-    // Mimics the sorting behavior from the UI component directly in the repository
-    const appointments = storage.getAppointments()
-      .filter(a => a.patientId === patientId)
-      .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
-    return Promise.resolve(appointments);
-  },
-  listAppointments: async (): Promise<Appointment[]> => {
-    return Promise.resolve(storage.getAppointments());
-  },
-  createAppointment: async (appointment: Appointment): Promise<void> => {
+  listAppointmentsByPatient: async (patientId: string): Promise<Appointment[]> => storage.getAppointments()
+    .filter((appointment) => appointment.patientId === patientId)
+    .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime()),
+
+  listAppointments: async (): Promise<Appointment[]> => storage.getAppointments(),
+
+  createAppointment: async (appointment: Appointment): Promise<AppointmentWriteResult> => {
     storage.addAppointment(appointment);
-    return Promise.resolve();
+    return localWriteResult(appointment, 'create');
   },
-  updateAppointment: async (appointment: Appointment): Promise<void> => {
-    storage.updateAppointment(appointment);
-    return Promise.resolve();
+
+  rescheduleAppointment: async (_current: Appointment, next: Appointment): Promise<AppointmentWriteResult> => {
+    storage.updateAppointment(next);
+    return localWriteResult(next, 'reschedule');
   },
+
+  updateAppointmentDetails: async (_current: Appointment, next: Appointment): Promise<AppointmentWriteResult> => {
+    storage.updateAppointment(next);
+    return localWriteResult(next, 'details');
+  },
+
+  recoverAppointmentOperation: async (): Promise<AppointmentRecoveryResult> => ({ found: false }),
+
   deleteAppointment: async (appointmentId: string): Promise<void> => {
     storage.deleteAppointment(appointmentId);
-    return Promise.resolve();
-  }
+  },
 };
 
 export class SupabaseAppointmentRepository implements IAppointmentRepository {
@@ -60,7 +183,7 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
       .eq('patient_id', patientId)
       .order('start_time', { ascending: false });
 
-    if (error) throw error;
+    if (error) throw toSafeAppointmentError(error);
     return (data || []).map(this.mapToAppointment);
   }
 
@@ -71,31 +194,116 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
       .eq('tenant_id', this.tenantId)
       .order('start_time', { ascending: true });
 
-    if (error) throw error;
+    if (error) throw toSafeAppointmentError(error);
     return (data || []).map(this.mapToAppointment);
   }
 
-  async createAppointment(appointment: Appointment): Promise<void> {
-    const id = this.normalizeId(appointment.id);
-    const mappedRow = this.mapToRow({ ...appointment, id });
-    const { error } = await this.client
-      .from('appointments')
-      .insert({
-        ...mappedRow,
-        tenant_id: this.tenantId
+  async createAppointment(appointment: Appointment, options: AppointmentWriteOptions): Promise<AppointmentWriteResult> {
+    return this.executeRecoverableWrite(options, async () => {
+      const { data, error } = await this.client.rpc('create_appointment', {
+        p_tenant_id: this.tenantId,
+        p_patient_id: appointment.patientId || null,
+        p_doctor_id: appointment.doctorId,
+        p_start_time: this.normalizeTimeForDb(appointment.start),
+        p_end_time: this.normalizeTimeForDb(appointment.end),
+        p_cabinet: appointment.cabinet || '',
+        p_service: appointment.service || '',
+        p_status: appointment.status,
+        p_payment_type: appointment.paymentType || null,
+        p_source: appointment.source || null,
+        p_price: appointment.price ?? null,
+        p_comment: appointment.comment || null,
+        p_operation_key: options.operationKey,
       });
 
-    if (error) throw error;
+      if (error) throw error;
+      return this.parseWriteResult(data, 'create');
+    });
   }
 
-  async updateAppointment(appointment: Appointment): Promise<void> {
-    const { error } = await this.client
-      .from('appointments')
-      .update(this.mapToRow(appointment))
-      .eq('tenant_id', this.tenantId)
-      .eq('id', appointment.id);
+  async rescheduleAppointment(
+    current: Appointment,
+    next: Appointment,
+    options: AppointmentWriteOptions,
+  ): Promise<AppointmentWriteResult> {
+    if (!current.updatedAt) {
+      throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+    }
 
-    if (error) throw error;
+    return this.executeRecoverableWrite(options, async () => {
+      const { data, error } = await this.client.rpc('reschedule_appointment', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: current.id,
+        p_patient_id: next.patientId || null,
+        p_doctor_id: next.doctorId,
+        p_start_time: this.normalizeTimeForDb(next.start),
+        p_end_time: this.normalizeTimeForDb(next.end),
+        p_cabinet: next.cabinet || '',
+        p_service: next.service || '',
+        p_status: next.status,
+        p_payment_type: next.paymentType || null,
+        p_source: next.source || null,
+        p_price: next.price ?? null,
+        p_comment: next.comment || null,
+        p_expected_updated_at: current.updatedAt,
+        p_operation_key: options.operationKey,
+      });
+
+      if (error) throw error;
+      return this.parseWriteResult(data, 'reschedule');
+    });
+  }
+
+  async updateAppointmentDetails(current: Appointment, next: Appointment): Promise<AppointmentWriteResult> {
+    if (!current.updatedAt) {
+      throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+    }
+
+    try {
+      const { data, error } = await this.client.rpc('update_appointment_details', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: current.id,
+        p_cabinet: next.cabinet || '',
+        p_service: next.service || '',
+        p_status: next.status,
+        p_payment_type: next.paymentType || null,
+        p_source: next.source || null,
+        p_price: next.price ?? null,
+        p_comment: next.comment || null,
+        p_expected_updated_at: current.updatedAt,
+      });
+
+      if (error) throw error;
+      return this.parseWriteResult(data, 'details');
+    } catch (error) {
+      throw toSafeAppointmentError(error);
+    }
+  }
+
+  async recoverAppointmentOperation(operationKey: string): Promise<AppointmentRecoveryResult> {
+    try {
+      const { data, error } = await this.client.rpc('get_appointment_operation', {
+        p_tenant_id: this.tenantId,
+        p_operation_key: operationKey,
+      });
+
+      if (error) throw error;
+      if (!data || typeof data !== 'object') return { found: false };
+
+      const payload = data as Record<string, unknown>;
+      if (payload.found !== true) return { found: false };
+      if (!payload.appointment || typeof payload.appointment !== 'object') return { found: false };
+
+      return {
+        found: true,
+        operationType: payload.operationType === 'reschedule' ? 'reschedule' : 'create',
+        appointment: this.mapToAppointment(payload.appointment as Record<string, unknown>),
+        replayed: payload.replayed === true,
+        recovered: payload.recovered === true,
+      };
+    } catch (error) {
+      throw toSafeAppointmentError(error);
+    }
   }
 
   async deleteAppointment(appointmentId: string): Promise<void> {
@@ -105,66 +313,87 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
       .eq('tenant_id', this.tenantId)
       .eq('id', appointmentId);
 
-    if (error) throw error;
+    if (error) throw toSafeAppointmentError(error);
   }
 
-  private normalizeId(id?: string): string {
-    if (!id || id.length !== 36) {
-      return crypto.randomUUID();
+  private async executeRecoverableWrite(
+    options: AppointmentWriteOptions,
+    write: () => Promise<AppointmentWriteResult>,
+  ): Promise<AppointmentWriteResult> {
+    try {
+      return await write();
+    } catch (error) {
+      const safeError = toSafeAppointmentError(error);
+      if (!safeError.ambiguous) throw safeError;
+
+      options.onRecoveryStateChange?.(true);
+      try {
+        const recovered = await this.recoverAppointmentOperation(options.operationKey);
+        if (recovered.found && recovered.appointment && recovered.operationType) {
+          return {
+            appointment: recovered.appointment,
+            replayed: recovered.replayed === true,
+            recovered: true,
+            operationType: recovered.operationType,
+          };
+        }
+      } catch (recoveryError) {
+        const recoverySafeError = toSafeAppointmentError(recoveryError);
+        if (!recoverySafeError.ambiguous) throw recoverySafeError;
+      } finally {
+        options.onRecoveryStateChange?.(false);
+      }
+
+      throw safeError;
     }
-    return id;
+  }
+
+  private parseWriteResult(data: unknown, fallbackType: AppointmentOperationType): AppointmentWriteResult {
+    if (!data || typeof data !== 'object') throw genericSaveError();
+    const payload = data as Record<string, unknown>;
+    if (!payload.appointment || typeof payload.appointment !== 'object') throw genericSaveError();
+
+    const operationType = payload.operationType === 'create'
+      || payload.operationType === 'reschedule'
+      || payload.operationType === 'details'
+      ? payload.operationType
+      : fallbackType;
+
+    return {
+      appointment: this.mapToAppointment(payload.appointment as Record<string, unknown>),
+      replayed: payload.replayed === true,
+      recovered: payload.recovered === true,
+      operationType,
+    };
   }
 
   private normalizeTimeForDb(timeStr: string): string {
     if (!timeStr) return timeStr;
-    if (timeStr.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(timeStr)) {
-      return timeStr;
-    }
-    // Force UTC storage of local digits to prevent timezone shifting in UI
+    if (timeStr.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(timeStr)) return timeStr;
     return timeStr.length === 16 ? `${timeStr}:00Z` : `${timeStr}Z`;
-  }
-
-  private mapToRow(appointment: Appointment): Record<string, unknown> {
-    return {
-      id: appointment.id,
-      patient_id: appointment.patientId || null,
-      doctor_id: appointment.doctorId || null,
-      cabinet: appointment.cabinet || '',
-      service: appointment.service || '',
-      status: appointment.status,
-      payment_type: appointment.paymentType || null,
-      source: appointment.source || null,
-      price: appointment.price === undefined ? null : appointment.price,
-      comment: appointment.comment || null,
-      start_time: this.normalizeTimeForDb(appointment.start),
-      end_time: this.normalizeTimeForDb(appointment.end),
-      created_at: appointment.createdAt ? this.normalizeTimeForDb(appointment.createdAt) : undefined,
-    };
   }
 
   private normalizeTimeFromDb(timeStr: string): string {
     if (!timeStr) return timeStr;
-    // Strip trailing Z or timezone offset (e.g. +00:00) so UI treats it as local wall-clock time
     return timeStr.replace(/(Z|[+-]\d{2}:\d{2})$/, '');
   }
 
-  private mapToAppointment = (row: Record<string, unknown>): Appointment => {
-    return {
-      id: row.id as string,
-      patientId: (row.patient_id as string) || undefined,
-      doctorId: row.doctor_id as string,
-      cabinet: (row.cabinet as string) || '',
-      service: (row.service as string) || '',
-      status: row.status as AppointmentStatus,
-      paymentType: (row.payment_type as PaymentType) || undefined,
-      source: (row.source as Source) || undefined,
-      price: row.price !== null ? Number(row.price) : undefined,
-      comment: (row.comment as string) || undefined,
-      start: this.normalizeTimeFromDb(row.start_time as string),
-      end: this.normalizeTimeFromDb(row.end_time as string),
-      createdAt: this.normalizeTimeFromDb(row.created_at as string),
-    };
-  };
+  private mapToAppointment = (row: Record<string, unknown>): Appointment => ({
+    id: row.id as string,
+    patientId: (row.patient_id as string) || undefined,
+    doctorId: row.doctor_id as string,
+    cabinet: (row.cabinet as string) || '',
+    service: (row.service as string) || '',
+    status: row.status as AppointmentStatus,
+    paymentType: (row.payment_type as PaymentType) || undefined,
+    source: (row.source as Source) || undefined,
+    price: row.price !== null && row.price !== undefined ? Number(row.price) : undefined,
+    comment: (row.comment as string) || undefined,
+    start: this.normalizeTimeFromDb(row.start_time as string),
+    end: this.normalizeTimeFromDb(row.end_time as string),
+    createdAt: this.normalizeTimeFromDb(row.created_at as string),
+    updatedAt: row.updated_at as string,
+  });
 }
 
 export function createAppointmentRepository(options: CreateAppointmentRepositoryOptions): IAppointmentRepository {

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -61,6 +61,9 @@ export function SchedulePage() {
     createAppointment,
     updateAppointment,
     deleteAppointment,
+    isSaving,
+    isReconciling,
+    saveError,
   } = useScheduleAppointments();
   
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -112,25 +115,28 @@ export function SchedulePage() {
     setIsModalOpen(true);
   };
 
-  const handleSaveAppointment = async (saved: Appointment) => {
+  const handleSaveAppointment = async (saved: Appointment): Promise<boolean> => {
     try {
-      if (editingAppointment?.id) {
-        await updateAppointment(saved);
-      } else {
-        await createAppointment(saved);
-      }
+      const result = editingAppointment?.id
+        ? await updateAppointment(editingAppointment as Appointment, saved)
+        : await createAppointment(saved);
+
+      if (!result) return false;
       setIsModalOpen(false);
-    } catch (e) {
-      console.error(e);
+      return true;
+    } catch {
+      return false;
     }
   };
 
-  const handleDeleteAppointment = async (id: string) => {
+  const handleDeleteAppointment = async (id: string): Promise<boolean> => {
     try {
-      await deleteAppointment(id);
+      const deleted = await deleteAppointment(id);
+      if (!deleted) return false;
       setIsModalOpen(false);
-    } catch (e) {
-      console.error(e);
+      return true;
+    } catch {
+      return false;
     }
   };
 
@@ -302,6 +308,9 @@ export function SchedulePage() {
         appointments={appointments}
         doctors={allDoctors}
         patients={patients}
+        isSaving={isSaving}
+        isReconciling={isReconciling}
+        serverError={saveError?.message || null}
       />
     </div>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,7 @@ export interface Appointment {
   comment?: string;
   price?: number;
   createdAt: string;
+  updatedAt?: string;
 }
 
 export type ToothNumber =

--- a/supabase/migrations/0025_harden_appointment_conflicts.sql
+++ b/supabase/migrations/0025_harden_appointment_conflicts.sql
@@ -1,0 +1,911 @@
+-- 0025_harden_appointment_conflicts.sql
+-- APPOINTMENT-CONFLICT-HARDENING-001
+-- Authoritative conflict-safe appointment write boundary.
+
+-- Historical precheck.  Existing incompatible rows are never silently changed.
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM public.appointments
+  WHERE end_time <= start_time;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % appointment rows have invalid intervals', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.appointments
+  WHERE doctor_id IS NULL;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % appointment rows have no doctor', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.appointments
+  WHERE patient_id IS NULL
+    AND status <> 'blocked';
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % non-blocked appointment rows have no patient', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.appointments a
+  WHERE a.patient_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.patients p
+      WHERE p.id = a.patient_id
+        AND p.tenant_id = a.tenant_id
+    );
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % appointment rows have cross-tenant or missing patients', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.appointments a
+  WHERE a.doctor_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.doctors d
+      WHERE d.id = a.doctor_id
+        AND d.tenant_id = a.tenant_id
+    );
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % appointment rows have cross-tenant or missing doctors', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM (
+    SELECT tenant_id, patient_id, doctor_id, start_time, end_time, count(*)
+    FROM public.appointments
+    WHERE status <> 'cancelled'
+    GROUP BY tenant_id, patient_id, doctor_id, start_time, end_time
+    HAVING count(*) > 1
+  ) duplicate_groups;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % duplicate active appointment groups exist', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.appointments a
+  JOIN public.appointments b
+    ON b.tenant_id = a.tenant_id
+   AND b.id > a.id
+   AND b.doctor_id = a.doctor_id
+   AND b.status <> 'cancelled'
+   AND a.status <> 'cancelled'
+   AND b.start_time < a.end_time
+   AND b.end_time > a.start_time;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % active doctor overlap pairs exist', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.appointments a
+  JOIN public.appointments b
+    ON b.tenant_id = a.tenant_id
+   AND b.id > a.id
+   AND b.patient_id = a.patient_id
+   AND a.patient_id IS NOT NULL
+   AND b.status <> 'cancelled'
+   AND a.status <> 'cancelled'
+   AND b.start_time < a.end_time
+   AND b.end_time > a.start_time;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'APPOINTMENT-CONFLICT-HARDENING-001: % active patient overlap pairs exist', v_count;
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_valid_interval_check
+  CHECK (end_time > start_time);
+
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_doctor_required_check
+  CHECK (doctor_id IS NOT NULL);
+
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_patient_required_unless_blocked_check
+  CHECK (patient_id IS NOT NULL OR status = 'blocked');
+
+CREATE INDEX idx_appointments_active_doctor_interval
+  ON public.appointments (tenant_id, doctor_id, start_time, end_time)
+  WHERE status <> 'cancelled';
+
+CREATE INDEX idx_appointments_active_patient_interval
+  ON public.appointments (tenant_id, patient_id, start_time, end_time)
+  WHERE status <> 'cancelled' AND patient_id IS NOT NULL;
+
+CREATE TABLE public.appointment_operations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  operation_key text NOT NULL,
+  operation_type text NOT NULL CHECK (operation_type IN ('create', 'reschedule')),
+  fingerprint text NOT NULL,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL,
+  patient_id uuid,
+  doctor_id uuid NOT NULL,
+  start_time timestamptz NOT NULL,
+  end_time timestamptz NOT NULL,
+  status text NOT NULL,
+  result_appointment jsonb NOT NULL,
+  actor_user_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT appointment_operations_key_check CHECK (
+    length(operation_key) BETWEEN 8 AND 160
+    AND operation_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  CONSTRAINT appointment_operations_fingerprint_check CHECK (fingerprint ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT appointment_operations_interval_check CHECK (end_time > start_time),
+  CONSTRAINT appointment_operations_result_object_check CHECK (jsonb_typeof(result_appointment) = 'object'),
+  CONSTRAINT appointment_operations_tenant_key_key UNIQUE (tenant_id, operation_key),
+  CONSTRAINT appointment_operations_patient_fk
+    FOREIGN KEY (tenant_id, patient_id)
+    REFERENCES public.patients(tenant_id, id)
+    ON DELETE CASCADE,
+  CONSTRAINT appointment_operations_doctor_fk
+    FOREIGN KEY (tenant_id, doctor_id)
+    REFERENCES public.doctors(tenant_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_appointment_operations_appointment
+  ON public.appointment_operations (tenant_id, appointment_id, created_at DESC);
+
+ALTER TABLE public.appointment_operations ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.appointment_operations FROM PUBLIC;
+REVOKE ALL ON TABLE public.appointment_operations FROM anon;
+REVOKE ALL ON TABLE public.appointment_operations FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.appointment_operations TO service_role;
+
+CREATE OR REPLACE FUNCTION public.set_appointment_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at := clock_timestamp();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS appointments_set_updated_at ON public.appointments;
+CREATE TRIGGER appointments_set_updated_at
+BEFORE UPDATE ON public.appointments
+FOR EACH ROW
+EXECUTE FUNCTION public.set_appointment_updated_at();
+
+CREATE OR REPLACE FUNCTION public.guard_appointment_authoritative_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $guard$
+BEGIN
+  -- RPC functions are SECURITY DEFINER and therefore execute as postgres.
+  -- service_role remains available for guarded local setup/cleanup. Ordinary
+  -- authenticated PostgREST INSERT/UPDATE retains the legacy grant matrix but
+  -- cannot cross this mutation boundary.
+  IF current_user IN ('postgres', 'service_role') THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+END;
+$guard$;
+
+DROP TRIGGER IF EXISTS appointments_authoritative_write_guard ON public.appointments;
+CREATE TRIGGER appointments_authoritative_write_guard
+BEFORE INSERT OR UPDATE ON public.appointments
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_appointment_authoritative_write();
+
+CREATE OR REPLACE FUNCTION public.normalize_appointment_operation_key(p_operation_key text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_key text := btrim(p_operation_key);
+BEGIN
+  IF v_key IS NULL
+     OR length(v_key) < 8
+     OR length(v_key) > 160
+     OR v_key !~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$' THEN
+    RAISE EXCEPTION 'Операция с этим идентификатором уже выполнена с другими параметрами.';
+  END IF;
+  RETURN v_key;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.appointment_row_json(p_appointment public.appointments)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT to_jsonb(p_appointment);
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_appointment(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_doctor_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_cabinet text,
+  p_service text,
+  p_status text,
+  p_payment_type text,
+  p_source text,
+  p_price numeric,
+  p_comment text,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_key text;
+  v_status text := COALESCE(NULLIF(btrim(p_status), ''), 'new');
+  v_cabinet text := COALESCE(btrim(p_cabinet), '');
+  v_service text := COALESCE(btrim(p_service), '');
+  v_comment text := NULLIF(btrim(p_comment), '');
+  v_payment_type text := NULLIF(btrim(p_payment_type), '');
+  v_source text := NULLIF(btrim(p_source), '');
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_appointment public.appointments%ROWTYPE;
+  v_lock_key text;
+  v_audit_id uuid;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF p_end_time IS NULL OR p_start_time IS NULL OR p_end_time <= p_start_time THEN
+    RAISE EXCEPTION 'Время окончания должно быть позже времени начала.';
+  END IF;
+
+  IF v_status NOT IN ('new', 'confirmed', 'arrived', 'in_progress', 'completed', 'cancelled', 'no_show', 'blocked') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_payment_type IS NOT NULL AND v_payment_type NOT IN ('cash', 'card', 'kaspi', 'insurance', 'installment', 'unpaid') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_source IS NOT NULL AND v_source NOT IN ('phone', 'whatsapp', 'instagram', 'walk_in', 'repeat', 'referral') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF p_patient_id IS NULL AND v_status <> 'blocked' THEN
+    RAISE EXCEPTION 'Пациент недоступен в этой клинике.';
+  END IF;
+
+  IF p_patient_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.patients p
+    WHERE p.id = p_patient_id AND p.tenant_id = p_tenant_id
+  ) THEN
+    RAISE EXCEPTION 'Пациент недоступен в этой клинике.';
+  END IF;
+
+  IF p_doctor_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.doctors d
+    WHERE d.id = p_doctor_id AND d.tenant_id = p_tenant_id
+  ) THEN
+    RAISE EXCEPTION 'Врач недоступен в этой клинике.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'create',
+    'tenantId', p_tenant_id,
+    'patientId', p_patient_id,
+    'doctorId', p_doctor_id,
+    'cabinet', v_cabinet,
+    'service', v_service,
+    'status', v_status,
+    'paymentType', v_payment_type,
+    'source', v_source,
+    'price', p_price,
+    'comment', v_comment,
+    'startEpoch', extract(epoch FROM p_start_time),
+    'endEpoch', extract(epoch FROM p_end_time)
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0));
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'create' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Операция с этим идентификатором уже выполнена с другими параметрами.';
+    END IF;
+    RETURN jsonb_build_object(
+      'appointment', v_operation.result_appointment,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'create'
+    );
+  END IF;
+
+  FOR v_lock_key IN
+    SELECT resource_key
+    FROM (
+      VALUES
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || p_doctor_id::text),
+        (CASE WHEN p_patient_id IS NOT NULL THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || p_patient_id::text END)
+    ) AS resources(resource_key)
+    WHERE resource_key IS NOT NULL
+    ORDER BY resource_key
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_lock_key, 0));
+  END LOOP;
+
+  IF v_status <> 'cancelled' THEN
+    IF EXISTS (
+      SELECT 1
+      FROM public.appointments a
+      WHERE a.tenant_id = p_tenant_id
+        AND a.doctor_id = p_doctor_id
+        AND a.status <> 'cancelled'
+        AND a.start_time < p_end_time
+        AND a.end_time > p_start_time
+    ) THEN
+      RAISE EXCEPTION 'У врача уже есть запись на это время.';
+    END IF;
+
+    IF p_patient_id IS NOT NULL AND EXISTS (
+      SELECT 1
+      FROM public.appointments a
+      WHERE a.tenant_id = p_tenant_id
+        AND a.patient_id = p_patient_id
+        AND a.status <> 'cancelled'
+        AND a.start_time < p_end_time
+        AND a.end_time > p_start_time
+    ) THEN
+      RAISE EXCEPTION 'У пациента уже есть другая запись на это время.';
+    END IF;
+  END IF;
+
+  INSERT INTO public.appointments (
+    tenant_id, patient_id, doctor_id, cabinet, service, status,
+    payment_type, source, price, comment, start_time, end_time
+  ) VALUES (
+    p_tenant_id, p_patient_id, p_doctor_id, v_cabinet, v_service, v_status,
+    v_payment_type, v_source, p_price, v_comment, p_start_time, p_end_time
+  )
+  RETURNING * INTO v_appointment;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => 'appointment_created',
+    p_category => 'appointment',
+    p_target_type => 'appointment',
+    p_target_id => v_appointment.id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_actor_role,
+    p_patient_id => p_patient_id,
+    p_appointment_id => v_appointment.id::text,
+    p_after_data => jsonb_build_object(
+      'patientId', p_patient_id,
+      'doctorId', p_doctor_id,
+      'startTime', p_start_time,
+      'endTime', p_end_time,
+      'status', v_status
+    ),
+    p_request_id => v_key,
+    p_metadata => jsonb_build_object('operationKey', v_key, 'replayed', false)
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'appointment',
+    p_type => 'appointment_created',
+    p_title => 'Запись создана',
+    p_source_type => 'appointment',
+    p_source_id => v_appointment.id::text,
+    p_patient_id => p_patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_source_status => v_status,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', v_appointment.id,
+      'doctorId', p_doctor_id,
+      'operationKey', v_key,
+      'replayed', false
+    )
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id
+  ) VALUES (
+    p_tenant_id, v_key, 'create', v_fingerprint, v_appointment.id,
+    p_patient_id, p_doctor_id, p_start_time, p_end_time, v_status,
+    public.appointment_row_json(v_appointment), v_actor
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_appointment),
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'create'
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reschedule_appointment(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_patient_id uuid,
+  p_doctor_id uuid,
+  p_start_time timestamptz,
+  p_end_time timestamptz,
+  p_cabinet text,
+  p_service text,
+  p_status text,
+  p_payment_type text,
+  p_source text,
+  p_price numeric,
+  p_comment text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_key text;
+  v_status text := COALESCE(NULLIF(btrim(p_status), ''), 'new');
+  v_cabinet text := COALESCE(btrim(p_cabinet), '');
+  v_service text := COALESCE(btrim(p_service), '');
+  v_comment text := NULLIF(btrim(p_comment), '');
+  v_payment_type text := NULLIF(btrim(p_payment_type), '');
+  v_source text := NULLIF(btrim(p_source), '');
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_lock_key text;
+  v_audit_id uuid;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF p_end_time IS NULL OR p_start_time IS NULL OR p_end_time <= p_start_time THEN
+    RAISE EXCEPTION 'Время окончания должно быть позже времени начала.';
+  END IF;
+
+  IF v_status NOT IN ('new', 'confirmed', 'arrived', 'in_progress', 'completed', 'cancelled', 'no_show', 'blocked') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_payment_type IS NOT NULL AND v_payment_type NOT IN ('cash', 'card', 'kaspi', 'insurance', 'installment', 'unpaid') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_source IS NOT NULL AND v_source NOT IN ('phone', 'whatsapp', 'instagram', 'walk_in', 'repeat', 'referral') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF p_patient_id IS NULL AND v_status <> 'blocked' THEN
+    RAISE EXCEPTION 'Пациент недоступен в этой клинике.';
+  END IF;
+
+  IF p_patient_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.patients p
+    WHERE p.id = p_patient_id AND p.tenant_id = p_tenant_id
+  ) THEN
+    RAISE EXCEPTION 'Пациент недоступен в этой клинике.';
+  END IF;
+
+  IF p_doctor_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.doctors d
+    WHERE d.id = p_doctor_id AND d.tenant_id = p_tenant_id
+  ) THEN
+    RAISE EXCEPTION 'Врач недоступен в этой клинике.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'reschedule',
+    'tenantId', p_tenant_id,
+    'appointmentId', p_appointment_id,
+    'patientId', p_patient_id,
+    'doctorId', p_doctor_id,
+    'cabinet', v_cabinet,
+    'service', v_service,
+    'status', v_status,
+    'paymentType', v_payment_type,
+    'source', v_source,
+    'price', p_price,
+    'comment', v_comment,
+    'startEpoch', extract(epoch FROM p_start_time),
+    'endEpoch', extract(epoch FROM p_end_time),
+    'expectedUpdatedEpoch', extract(epoch FROM p_expected_updated_at)
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0));
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'reschedule' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Операция с этим идентификатором уже выполнена с другими параметрами.';
+    END IF;
+    RETURN jsonb_build_object(
+      'appointment', v_operation.result_appointment,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'reschedule'
+    );
+  END IF;
+
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF p_expected_updated_at IS NULL OR v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  FOR v_lock_key IN
+    SELECT DISTINCT resource_key
+    FROM (
+      VALUES
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || v_before.doctor_id::text),
+        (CASE WHEN v_before.patient_id IS NOT NULL THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || v_before.patient_id::text END),
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || p_doctor_id::text),
+        (CASE WHEN p_patient_id IS NOT NULL THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || p_patient_id::text END)
+    ) AS resources(resource_key)
+    WHERE resource_key IS NOT NULL
+    ORDER BY resource_key
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_lock_key, 0));
+  END LOOP;
+
+  IF v_status <> 'cancelled' THEN
+    IF EXISTS (
+      SELECT 1
+      FROM public.appointments a
+      WHERE a.tenant_id = p_tenant_id
+        AND a.id <> p_appointment_id
+        AND a.doctor_id = p_doctor_id
+        AND a.status <> 'cancelled'
+        AND a.start_time < p_end_time
+        AND a.end_time > p_start_time
+    ) THEN
+      RAISE EXCEPTION 'У врача уже есть запись на это время.';
+    END IF;
+
+    IF p_patient_id IS NOT NULL AND EXISTS (
+      SELECT 1
+      FROM public.appointments a
+      WHERE a.tenant_id = p_tenant_id
+        AND a.id <> p_appointment_id
+        AND a.patient_id = p_patient_id
+        AND a.status <> 'cancelled'
+        AND a.start_time < p_end_time
+        AND a.end_time > p_start_time
+    ) THEN
+      RAISE EXCEPTION 'У пациента уже есть другая запись на это время.';
+    END IF;
+  END IF;
+
+  UPDATE public.appointments
+  SET patient_id = p_patient_id,
+      doctor_id = p_doctor_id,
+      cabinet = v_cabinet,
+      service = v_service,
+      status = v_status,
+      payment_type = v_payment_type,
+      source = v_source,
+      price = p_price,
+      comment = v_comment,
+      start_time = p_start_time,
+      end_time = p_end_time
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => 'appointment_rescheduled',
+    p_category => 'appointment',
+    p_target_type => 'appointment',
+    p_target_id => p_appointment_id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_actor_role,
+    p_patient_id => p_patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_before_data => jsonb_build_object(
+      'patientId', v_before.patient_id,
+      'doctorId', v_before.doctor_id,
+      'startTime', v_before.start_time,
+      'endTime', v_before.end_time,
+      'status', v_before.status
+    ),
+    p_after_data => jsonb_build_object(
+      'patientId', p_patient_id,
+      'doctorId', p_doctor_id,
+      'startTime', p_start_time,
+      'endTime', p_end_time,
+      'status', v_status
+    ),
+    p_request_id => v_key,
+    p_metadata => jsonb_build_object('operationKey', v_key, 'replayed', false)
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'appointment',
+    p_type => 'appointment_rescheduled',
+    p_title => 'Запись перенесена',
+    p_source_type => 'appointment',
+    p_source_id => p_appointment_id::text,
+    p_patient_id => p_patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_source_status => v_status,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_appointment_id,
+      'oldStartTime', v_before.start_time,
+      'oldEndTime', v_before.end_time,
+      'newStartTime', p_start_time,
+      'newEndTime', p_end_time,
+      'doctorId', p_doctor_id,
+      'operationKey', v_key,
+      'replayed', false
+    )
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id
+  ) VALUES (
+    p_tenant_id, v_key, 'reschedule', v_fingerprint, p_appointment_id,
+    p_patient_id, p_doctor_id, p_start_time, p_end_time, v_status,
+    public.appointment_row_json(v_after), v_actor
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'reschedule'
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_appointment_details(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_cabinet text,
+  p_service text,
+  p_status text,
+  p_payment_type text,
+  p_source text,
+  p_price numeric,
+  p_comment text,
+  p_expected_updated_at timestamptz
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_status text := COALESCE(NULLIF(btrim(p_status), ''), 'new');
+  v_cabinet text := COALESCE(btrim(p_cabinet), '');
+  v_service text := COALESCE(btrim(p_service), '');
+  v_comment text := NULLIF(btrim(p_comment), '');
+  v_payment_type text := NULLIF(btrim(p_payment_type), '');
+  v_source text := NULLIF(btrim(p_source), '');
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_lock_key text;
+BEGIN
+  IF v_actor IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.tenant_users tu
+    WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor
+  ) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_status NOT IN ('new', 'confirmed', 'arrived', 'in_progress', 'completed', 'cancelled', 'no_show', 'blocked') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_payment_type IS NOT NULL AND v_payment_type NOT IN ('cash', 'card', 'kaspi', 'insurance', 'installment', 'unpaid') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_source IS NOT NULL AND v_source NOT IN ('phone', 'whatsapp', 'instagram', 'walk_in', 'repeat', 'referral') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF p_expected_updated_at IS NULL OR v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  IF v_before.patient_id IS NULL AND v_status <> 'blocked' THEN
+    RAISE EXCEPTION 'Пациент недоступен в этой клинике.';
+  END IF;
+
+  FOR v_lock_key IN
+    SELECT resource_key
+    FROM (
+      VALUES
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || v_before.doctor_id::text),
+        (CASE WHEN v_before.patient_id IS NOT NULL THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || v_before.patient_id::text END)
+    ) AS resources(resource_key)
+    WHERE resource_key IS NOT NULL
+    ORDER BY resource_key
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_lock_key, 0));
+  END LOOP;
+
+  IF v_status <> 'cancelled' THEN
+    IF EXISTS (
+      SELECT 1 FROM public.appointments a
+      WHERE a.tenant_id = p_tenant_id
+        AND a.id <> p_appointment_id
+        AND a.doctor_id = v_before.doctor_id
+        AND a.status <> 'cancelled'
+        AND a.start_time < v_before.end_time
+        AND a.end_time > v_before.start_time
+    ) THEN
+      RAISE EXCEPTION 'У врача уже есть запись на это время.';
+    END IF;
+
+    IF v_before.patient_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM public.appointments a
+      WHERE a.tenant_id = p_tenant_id
+        AND a.id <> p_appointment_id
+        AND a.patient_id = v_before.patient_id
+        AND a.status <> 'cancelled'
+        AND a.start_time < v_before.end_time
+        AND a.end_time > v_before.start_time
+    ) THEN
+      RAISE EXCEPTION 'У пациента уже есть другая запись на это время.';
+    END IF;
+  END IF;
+
+  UPDATE public.appointments
+  SET cabinet = v_cabinet,
+      service = v_service,
+      status = v_status,
+      payment_type = v_payment_type,
+      source = v_source,
+      price = p_price,
+      comment = v_comment
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'details'
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_appointment_operation(
+  p_tenant_id uuid,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_key text;
+  v_operation public.appointment_operations%ROWTYPE;
+BEGIN
+  IF v_actor IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.tenant_users tu
+    WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor
+  ) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('found', false);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'found', true,
+    'operationType', v_operation.operation_type,
+    'appointment', v_operation.result_appointment,
+    'replayed', true,
+    'recovered', true
+  );
+END;
+$$;
+
+-- Keep the explicit legacy table-grant matrix from migration 0024 intact.
+-- The authoritative-write trigger blocks ordinary authenticated INSERT/UPDATE,
+-- while hard delete remains under its existing owner/admin RLS policy.
+
+REVOKE ALL ON FUNCTION public.set_appointment_updated_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.guard_appointment_authoritative_write() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.normalize_appointment_operation_key(text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.appointment_row_json(public.appointments) FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.create_appointment(uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reschedule_appointment(uuid,uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.update_appointment_details(uuid,uuid,text,text,text,text,text,numeric,text,timestamptz) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_appointment_operation(uuid,text) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_appointment(uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.reschedule_appointment(uuid,uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.update_appointment_details(uuid,uuid,text,text,text,text,text,numeric,text,timestamptz) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_appointment_operation(uuid,text) TO authenticated, service_role;

--- a/supabase/tests/0021_completed_service_billing_guard_test.sql
+++ b/supabase/tests/0021_completed_service_billing_guard_test.sql
@@ -43,6 +43,7 @@ $$;
 \set registrar_a 'a9230000-0000-4000-8000-000000000005'
 \set notenant 'a9230000-0000-4000-8000-000000000006'
 \set admin_b 'b9230000-0000-4000-8000-000000000001'
+\set appointment_doctor_a 'a9260000-0000-4000-8000-000000000001'
 \set invoice_a1 'a9240000-0000-4000-8000-000000000001'
 \set invoice_a2 'a9240000-0000-4000-8000-000000000002'
 \set invoice_a_patient2 'a9240000-0000-4000-8000-000000000003'
@@ -81,8 +82,10 @@ INSERT INTO public.patients(id, tenant_id, full_name, phone, source, balance) VA
   (:'patient_a', :'tenant_a', 'Billing Guard Patient A', '+77009220001', 'phone', 777),
   (:'patient_a2', :'tenant_a', 'Billing Guard Patient A2', '+77009220002', 'phone', 0),
   (:'patient_b', :'tenant_b', 'Billing Guard Patient B', '+77009220003', 'phone', 0);
-INSERT INTO public.appointments(tenant_id, patient_id, service, status, start_time, end_time)
-VALUES (:'tenant_a', :'patient_a', 'No billing side effect fixture', 'completed', now() - interval '1 hour', now());
+INSERT INTO public.doctors(id, tenant_id, full_name)
+VALUES (:'appointment_doctor_a', :'tenant_a', 'Billing guard fixture doctor');
+INSERT INTO public.appointments(tenant_id, patient_id, doctor_id, service, status, start_time, end_time)
+VALUES (:'tenant_a', :'patient_a', :'appointment_doctor_a', 'No billing side effect fixture', 'completed', now() - interval '1 hour', now());
 INSERT INTO public.invoices(id, tenant_id, patient_id, invoice_number, status, currency, subtotal_amount, total_amount, balance_amount, created_by, metadata) VALUES
   (:'invoice_a1', :'tenant_a', :'patient_a', 'CSBG-A1', 'draft', 'KZT', 0, 0, 0, :'admin_a', '{}'),
   (:'invoice_a2', :'tenant_a', :'patient_a', 'CSBG-A2', 'draft', 'KZT', 0, 0, 0, :'admin_a', '{}'),

--- a/supabase/tests/0022_patient_credit_deposits_foundation_test.sql
+++ b/supabase/tests/0022_patient_credit_deposits_foundation_test.sql
@@ -41,6 +41,7 @@ $$;
 \set registrar_a 'e2230000-0000-4000-8000-000000000005'
 \set notenant 'e2230000-0000-4000-8000-000000000006'
 \set admin_b 'e2230000-0000-4000-8000-000000000007'
+\set appointment_doctor_a 'e2230000-0000-4000-8000-000000000099'
 \set appointment_a 'e2270000-0000-4000-8000-000000000001'
 \set appointment_a2 'e2270000-0000-4000-8000-000000000002'
 \set plan_a 'e2280000-0000-4000-8000-000000000001'
@@ -97,9 +98,11 @@ INSERT INTO public.patients(id, tenant_id, full_name, phone, source, balance) VA
   (:'patient_a2', :'tenant_a', 'Deposit Patient A2', '+77002220002', 'phone', 0),
   (:'patient_b', :'tenant_b', 'Deposit Patient B', '+77002220003', 'phone', 0);
 
-INSERT INTO public.appointments(id, tenant_id, patient_id, service, status, start_time, end_time) VALUES
-  (:'appointment_a', :'tenant_a', :'patient_a', 'Deposit appointment', 'confirmed', now() + interval '1 day', now() + interval '1 day 1 hour'),
-  (:'appointment_a2', :'tenant_a', :'patient_a2', 'Other patient appointment', 'confirmed', now() + interval '2 days', now() + interval '2 days 1 hour');
+INSERT INTO public.doctors(id, tenant_id, full_name)
+VALUES (:'appointment_doctor_a', :'tenant_a', 'Deposit fixture doctor');
+INSERT INTO public.appointments(id, tenant_id, patient_id, doctor_id, service, status, start_time, end_time) VALUES
+  (:'appointment_a', :'tenant_a', :'patient_a', :'appointment_doctor_a', 'Deposit appointment', 'confirmed', now() + interval '1 day', now() + interval '1 day 1 hour'),
+  (:'appointment_a2', :'tenant_a', :'patient_a2', :'appointment_doctor_a', 'Other patient appointment', 'confirmed', now() + interval '2 days', now() + interval '2 days 1 hour');
 INSERT INTO public.treatment_plans(id, tenant_id, patient_id, title, status, total_price) VALUES
   (:'plan_a', :'tenant_a', :'patient_a', 'Deposit treatment plan', 'approved', 5000);
 

--- a/supabase/tests/0024_legacy_core_table_grants_test.sql
+++ b/supabase/tests/0024_legacy_core_table_grants_test.sql
@@ -336,44 +336,36 @@ SELECT pg_temp.expect_error(
   'permission denied'
 );
 
--- Current AppointmentRepository direct CRUD remains reachable through RLS.
-INSERT INTO public.appointments(id, tenant_id, patient_id, doctor_id, service, status, start_time, end_time)
-VALUES (:'appointment_created', :'tenant_a', :'patient_a', :'doctor_a', 'Created by admin', 'new', '2026-08-01T10:00:00Z', '2026-08-01T11:00:00Z');
-UPDATE public.appointments SET status = 'confirmed', comment = 'updated by admin' WHERE id = :'appointment_created';
-SELECT pg_temp.assert_true(
-  (SELECT status = 'confirmed' AND comment = 'updated by admin' FROM public.appointments WHERE id = :'appointment_created'),
-  'appointment create and update succeed under current RLS'
+-- Migration 0025 preserves the legacy grants matrix but closes direct appointment
+-- INSERT/UPDATE through an authoritative trigger. Current members write via RPC.
+SELECT pg_temp.expect_error(
+  format('insert into public.appointments(id,tenant_id,patient_id,doctor_id,status,start_time,end_time) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,%L::timestamptz,%L::timestamptz)', 'a9244000-0000-4000-8000-000000000097', :'tenant_a', :'patient_a', :'doctor_a', 'new', '2026-08-01T10:00:00Z', '2026-08-01T11:00:00Z'),
+  'Недостаточно прав'
+);
+SELECT (public.create_appointment(:'tenant_a', :'patient_a', :'doctor_a', '2026-08-01T10:00:00Z', '2026-08-01T11:00:00Z', '', 'Created by admin', 'new', NULL, NULL, NULL, NULL, 'legacy-grants-admin-create')->'appointment'->>'id') AS appointment_created \gset
+SELECT pg_temp.expect_error(
+  format('update public.appointments set status=%L where id=%L::uuid', 'confirmed', :'appointment_created'),
+  'Недостаточно прав'
 );
 SELECT pg_temp.expect_error(
   format('insert into public.appointments(id,tenant_id,patient_id,doctor_id,status,start_time,end_time) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,%L::timestamptz,%L::timestamptz)', 'b9244000-0000-4000-8000-000000000099', :'tenant_b', :'patient_b', :'doctor_b', 'new', '2026-08-01T10:00:00Z', '2026-08-01T11:00:00Z'),
-  'row-level security'
-);
-SELECT pg_temp.expect_error(
-  format('insert into public.appointments(id,tenant_id,patient_id,doctor_id,status,start_time,end_time) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,%L::timestamptz,%L::timestamptz)', 'a9244000-0000-4000-8000-000000000099', :'tenant_a', :'patient_b', :'doctor_a', 'new', '2026-08-01T11:00:00Z', '2026-08-01T12:00:00Z'),
-  'appointments_tenant_id_patient_id_fkey'
-);
-SELECT pg_temp.expect_error(
-  format('insert into public.appointments(id,tenant_id,patient_id,doctor_id,status,start_time,end_time) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,%L::timestamptz,%L::timestamptz)', 'a9244000-0000-4000-8000-000000000098', :'tenant_a', :'patient_a', :'doctor_b', 'new', '2026-08-01T11:00:00Z', '2026-08-01T12:00:00Z'),
-  'appointments_tenant_id_doctor_id_fkey'
-);
-SELECT pg_temp.expect_error(
-  format('update public.appointments set patient_id=%L::uuid where id=%L::uuid', :'patient_b', :'appointment_created'),
-  'appointments_tenant_id_patient_id_fkey'
-);
-SELECT pg_temp.expect_error(
-  format('update public.appointments set doctor_id=%L::uuid where id=%L::uuid', :'doctor_b', :'appointment_created'),
-  'appointments_tenant_id_doctor_id_fkey'
+  'Недостаточно прав'
 );
 
--- Current broad appointment policies allow doctor and cashier create/update.
+-- Current broad appointment role policy is now enforced through RPC, while
+-- direct table mutations remain blocked for doctor and cashier as well.
 SELECT set_config('request.jwt.claim.sub', :'doctor_user_a', true);
-INSERT INTO public.appointments(id, tenant_id, patient_id, doctor_id, service, status, start_time, end_time)
-VALUES (:'appointment_doctor_created', :'tenant_a', :'patient_a', :'doctor_a', 'Doctor policy evidence', 'new', '2026-08-01T12:00:00Z', '2026-08-01T13:00:00Z');
-UPDATE public.appointments SET status = 'arrived' WHERE id = :'appointment_doctor_created';
+SELECT (public.create_appointment(:'tenant_a', :'patient_a', :'doctor_a', '2026-08-01T12:00:00Z', '2026-08-01T13:00:00Z', '', 'Doctor policy evidence', 'new', NULL, NULL, NULL, NULL, 'legacy-grants-doctor-create')->'appointment'->>'id') AS appointment_doctor_created \gset
+SELECT pg_temp.expect_error(
+  format('update public.appointments set status=%L where id=%L::uuid', 'arrived', :'appointment_doctor_created'),
+  'Недостаточно прав'
+);
 SELECT set_config('request.jwt.claim.sub', :'cashier_a', true);
-INSERT INTO public.appointments(id, tenant_id, patient_id, doctor_id, service, status, start_time, end_time)
-VALUES (:'appointment_cashier_created', :'tenant_a', :'patient_a', :'doctor_a', 'Cashier policy evidence', 'new', '2026-08-01T13:00:00Z', '2026-08-01T14:00:00Z');
-UPDATE public.appointments SET status = 'confirmed' WHERE id = :'appointment_cashier_created';
+SELECT (public.create_appointment(:'tenant_a', :'patient_a', :'doctor_a', '2026-08-01T13:00:00Z', '2026-08-01T14:00:00Z', '', 'Cashier policy evidence', 'new', NULL, NULL, NULL, NULL, 'legacy-grants-cashier-create')->'appointment'->>'id') AS appointment_cashier_created \gset
+SELECT pg_temp.expect_error(
+  format('update public.appointments set status=%L where id=%L::uuid', 'confirmed', :'appointment_cashier_created'),
+  'Недостаточно прав'
+);
 
 -- Registrar has DELETE table privilege but existing RLS prevents deletion.
 SELECT set_config('request.jwt.claim.sub', :'registrar_a', true);

--- a/supabase/tests/0025_appointment_conflict_concurrency.ps1
+++ b/supabase/tests/0025_appointment_conflict_concurrency.ps1
@@ -1,0 +1,269 @@
+$ErrorActionPreference = 'Stop'
+
+# APPOINTMENT-CONFLICT-HARDENING-001 local-only concurrency validation.
+$container = (docker ps --format '{{.Names}}' | Where-Object { $_ -like 'supabase_db_*' } | Select-Object -First 1)
+if (-not $container) { throw 'Local Supabase DB container is not running.' }
+
+$tenantA = 'c2510000-0000-4000-8000-000000000001'
+$tenantB = 'c2510000-0000-4000-8000-000000000002'
+$adminA = 'c2520000-0000-4000-8000-000000000001'
+$adminB = 'c2520000-0000-4000-8000-000000000002'
+$patientA1 = 'c2530000-0000-4000-8000-000000000001'
+$patientA2 = 'c2530000-0000-4000-8000-000000000002'
+$patientA3 = 'c2530000-0000-4000-8000-000000000003'
+$patientA4 = 'c2530000-0000-4000-8000-000000000004'
+$patientB1 = 'c2530000-0000-4000-8000-000000000005'
+$doctorA1 = 'c2540000-0000-4000-8000-000000000001'
+$doctorA2 = 'c2540000-0000-4000-8000-000000000002'
+$doctorA3 = 'c2540000-0000-4000-8000-000000000003'
+$doctorB1 = 'c2540000-0000-4000-8000-000000000004'
+$moveH1 = 'c2550000-0000-4000-8000-000000000001'
+$moveH2 = 'c2550000-0000-4000-8000-000000000002'
+$moveI = 'c2550000-0000-4000-8000-000000000003'
+
+function Invoke-Sql([string]$sql) {
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $previousPreference
+  if ($code -ne 0) { throw "SQL failed:`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $previousPreference
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return (($output | Where-Object { $_ -ne $null -and $_.ToString().Trim() -ne '' } | Select-Object -Last 1).ToString().Trim())
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function AuthContext([string]$userId) {
+  return "BEGIN; SET LOCAL ROLE authenticated; SET LOCAL `"request.jwt.claim.sub`"='$userId'; "
+}
+
+function CreateSql(
+  [string]$userId,
+  [string]$tenantId,
+  [string]$patientId,
+  [string]$doctorId,
+  [string]$startTime,
+  [string]$endTime,
+  [string]$service,
+  [string]$operationKey
+) {
+  $context = AuthContext $userId
+  return $context + "SELECT (r#>>'{appointment,id}') || '|' || (r->>'replayed') FROM (SELECT public.create_appointment('$tenantId','$patientId','$doctorId','$startTime','$endTime','QA','$service','new','unpaid','phone',100,null,'$operationKey') r) q; COMMIT;"
+}
+
+function InvalidCreateSql([string]$startTime, [string]$endTime, [string]$key) {
+  return (AuthContext $adminA) + "SELECT public.create_appointment('$tenantA','$patientA1','$doctorA1','$startTime','$endTime','QA','Invalid','new','unpaid','phone',1,null,'$key'); COMMIT;"
+}
+
+function Assert-OneWinner([object[]]$results, [string]$name) {
+  $success = @($results | Where-Object { $_.Code -eq 0 }).Count
+  $conflict = @($results | Where-Object { $_.Code -ne 0 }).Count
+  if ($success -ne 1 -or $conflict -ne 1) {
+    throw "$name expected one success and one conflict; success=$success conflict=$conflict outputs=$($results.Text -join ' || ')"
+  }
+  return [pscustomobject]@{ Success = $success; Conflict = $conflict }
+}
+
+function Count-Deadlocks([object[]]$results) {
+  return @($results | Where-Object { $_.Text -match 'deadlock detected' }).Count
+}
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id IN ('$tenantA'::uuid,'$tenantB'::uuid);
+DELETE FROM auth.users WHERE id IN ('$adminA'::uuid,'$adminB'::uuid);
+"@
+
+$setup = @"
+BEGIN;
+$cleanup
+INSERT INTO public.tenants(id,name) VALUES
+ ('$tenantA','ACH concurrency A'),
+ ('$tenantB','ACH concurrency B');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+ ('$adminA','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-concurrency-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+ ('$adminB','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-concurrency-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$adminA'),('$adminB');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+ ('$tenantA','$adminA','clinic_admin'),
+ ('$tenantB','$adminB','clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status) VALUES
+ ('$patientA1','$tenantA','Concurrent A1','+77002531001','phone','active'),
+ ('$patientA2','$tenantA','Concurrent A2','+77002531002','phone','active'),
+ ('$patientA3','$tenantA','Concurrent A3','+77002531003','phone','active'),
+ ('$patientA4','$tenantA','Concurrent A4','+77002531004','phone','active'),
+ ('$patientB1','$tenantB','Concurrent B1','+77002531005','phone','active');
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+ ('$doctorA1','$tenantA','Concurrent Doctor A1','General','A1','#111111',true),
+ ('$doctorA2','$tenantA','Concurrent Doctor A2','General','A2','#222222',true),
+ ('$doctorA3','$tenantA','Concurrent Doctor A3','General','A3','#333333',true),
+ ('$doctorB1','$tenantB','Concurrent Doctor B1','General','B1','#444444',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,payment_type,source,price,start_time,end_time) VALUES
+ ('$moveH1','$tenantA','$patientA1','$doctorA1','A1','Move H1','new','unpaid','phone',1,'2026-09-08 08:00+00','2026-09-08 09:00+00'),
+ ('$moveH2','$tenantA','$patientA2','$doctorA2','A2','Move H2','new','unpaid','phone',1,'2026-09-08 09:00+00','2026-09-08 10:00+00'),
+ ('$moveI','$tenantA','$patientA3','$doctorA3','A3','Move I','new','unpaid','phone',1,'2026-09-09 08:00+00','2026-09-09 09:00+00');
+COMMIT;
+"@
+
+$allResults = @()
+
+try {
+  Invoke-Sql $setup | Out-Null
+  $moveH1Updated = Invoke-Scalar "select updated_at from public.appointments where id='$moveH1'"
+  $moveH2Updated = Invoke-Scalar "select updated_at from public.appointments where id='$moveH2'"
+  $moveIUpdated = Invoke-Scalar "select updated_at from public.appointments where id='$moveI'"
+
+  # A. Same doctor, exact interval.
+  $a = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA1 '2026-09-01 10:00+00' '2026-09-01 11:00+00' 'A-exact-1' 'ach-conc-a1') `
+    (CreateSql $adminA $tenantA $patientA2 $doctorA1 '2026-09-01 10:00+00' '2026-09-01 11:00+00' 'A-exact-2' 'ach-conc-a2'))
+  $allResults += $a
+  $ar = Assert-OneWinner $a 'A exact doctor'
+  Write-Output "A_EXACT_DOCTOR success=$($ar.Success) conflict=$($ar.Conflict) rows=$(Invoke-Scalar "select count(*) from public.appointments where tenant_id='$tenantA' and start_time='2026-09-01 10:00+00'")"
+
+  # B. Same doctor, partial overlap.
+  $b = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA1 '2026-09-02 10:00+00' '2026-09-02 11:00+00' 'B-partial-1' 'ach-conc-b1') `
+    (CreateSql $adminA $tenantA $patientA2 $doctorA1 '2026-09-02 10:30+00' '2026-09-02 11:30+00' 'B-partial-2' 'ach-conc-b2'))
+  $allResults += $b
+  $br = Assert-OneWinner $b 'B partial doctor'
+  Write-Output "B_PARTIAL_DOCTOR success=$($br.Success) conflict=$($br.Conflict)"
+
+  # C. Same patient, different doctors.
+  $c = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA3 $doctorA1 '2026-09-03 10:00+00' '2026-09-03 11:00+00' 'C-patient-1' 'ach-conc-c1') `
+    (CreateSql $adminA $tenantA $patientA3 $doctorA2 '2026-09-03 10:00+00' '2026-09-03 11:00+00' 'C-patient-2' 'ach-conc-c2'))
+  $allResults += $c
+  $cr = Assert-OneWinner $c 'C patient conflict'
+  Write-Output "C_PATIENT_CONFLICT success=$($cr.Success) conflict=$($cr.Conflict)"
+
+  # D. Different doctor and patient resources.
+  $d = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA1 '2026-09-04 10:00+00' '2026-09-04 11:00+00' 'D-free-1' 'ach-conc-d1') `
+    (CreateSql $adminA $tenantA $patientA2 $doctorA2 '2026-09-04 10:00+00' '2026-09-04 11:00+00' 'D-free-2' 'ach-conc-d2'))
+  $allResults += $d
+  $dSuccess = @($d | Where-Object { $_.Code -eq 0 }).Count
+  if ($dSuccess -ne 2) { throw "D different resources expected two successes: $($d.Text -join ' || ')" }
+  Write-Output "D_DIFFERENT_RESOURCES success=$dSuccess conflict=0"
+
+  # E. Back-to-back on the same doctor.
+  $e = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA1 '2026-09-05 10:00+00' '2026-09-05 11:00+00' 'E-adjacent-1' 'ach-conc-e1') `
+    (CreateSql $adminA $tenantA $patientA2 $doctorA1 '2026-09-05 11:00+00' '2026-09-05 12:00+00' 'E-adjacent-2' 'ach-conc-e2'))
+  $allResults += $e
+  $eSuccess = @($e | Where-Object { $_.Code -eq 0 }).Count
+  if ($eSuccess -ne 2) { throw "E back-to-back expected two successes: $($e.Text -join ' || ')" }
+  Write-Output "E_BACK_TO_BACK success=$eSuccess conflict=0"
+
+  # F. Same operation key and same payload.
+  $fSql = CreateSql $adminA $tenantA $patientA4 $doctorA3 '2026-09-06 10:00+00' '2026-09-06 11:00+00' 'F-replay' 'ach-conc-f-same'
+  $f = @(Invoke-ConcurrentPair $fSql $fSql)
+  $allResults += $f
+  if (@($f | Where-Object { $_.Code -ne 0 }).Count -ne 0) { throw "F same-key replay failed: $($f.Text -join ' || ')" }
+  $fIds = @($f | ForEach-Object { ($_.Text -split '\|')[0].Trim() } | Select-Object -Unique)
+  $fReplay = @($f | Where-Object { $_.Text -match '\|true' }).Count
+  if ($fIds.Count -ne 1 -or $fReplay -ne 1) { throw "F replay invariant failed ids=$($fIds.Count) replay=$fReplay outputs=$($f.Text -join ' || ')" }
+  Write-Output "F_SAME_KEY success=2 replay=$fReplay uniqueAppointmentIds=$($fIds.Count)"
+
+  # G. Same key with changed payload.
+  $g = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA2 '2026-09-07 10:00+00' '2026-09-07 11:00+00' 'G-first' 'ach-conc-g-conflict') `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA2 '2026-09-07 11:00+00' '2026-09-07 12:00+00' 'G-second' 'ach-conc-g-conflict'))
+  $allResults += $g
+  $gr = Assert-OneWinner $g 'G changed payload'
+  Write-Output "G_CHANGED_PAYLOAD success=$($gr.Success) conflict=$($gr.Conflict) operationRows=$(Invoke-Scalar "select count(*) from public.appointment_operations where tenant_id='$tenantA' and operation_key='ach-conc-g-conflict'")"
+
+  # H. Two different appointments rescheduled into one doctor slot.
+  $hContext = AuthContext $adminA
+  $h1 = $hContext + "SELECT (r#>>'{appointment,id}') || '|' || (r->>'replayed') FROM (SELECT public.reschedule_appointment('$tenantA','$moveH1','$patientA1','$doctorA3','2026-09-08 12:00+00','2026-09-08 13:00+00','A3','Move H1','new','unpaid','phone',1,null,'$moveH1Updated','ach-conc-h1') r) q; COMMIT;"
+  $h2 = $hContext + "SELECT (r#>>'{appointment,id}') || '|' || (r->>'replayed') FROM (SELECT public.reschedule_appointment('$tenantA','$moveH2','$patientA2','$doctorA3','2026-09-08 12:00+00','2026-09-08 13:00+00','A3','Move H2','new','unpaid','phone',1,null,'$moveH2Updated','ach-conc-h2') r) q; COMMIT;"
+  $h = @(Invoke-ConcurrentPair $h1 $h2)
+  $allResults += $h
+  $hr = Assert-OneWinner $h 'H concurrent reschedule'
+  Write-Output "H_RESCHEDULE success=$($hr.Success) conflict=$($hr.Conflict) slotRows=$(Invoke-Scalar "select count(*) from public.appointments where tenant_id='$tenantA' and doctor_id='$doctorA3' and start_time='2026-09-08 12:00+00' and status<>'cancelled'")"
+
+  # I. Create versus reschedule race.
+  $iCreate = CreateSql $adminA $tenantA $patientA4 $doctorA2 '2026-09-09 12:00+00' '2026-09-09 13:00+00' 'I-create' 'ach-conc-i-create'
+  $iRes = (AuthContext $adminA) + "SELECT (r#>>'{appointment,id}') || '|' || (r->>'replayed') FROM (SELECT public.reschedule_appointment('$tenantA','$moveI','$patientA3','$doctorA2','2026-09-09 12:00+00','2026-09-09 13:00+00','A2','Move I','new','unpaid','phone',1,null,'$moveIUpdated','ach-conc-i-reschedule') r) q; COMMIT;"
+  $i = @(Invoke-ConcurrentPair $iCreate $iRes)
+  $allResults += $i
+  $ir = Assert-OneWinner $i 'I create versus reschedule'
+  Write-Output "I_CREATE_VS_RESCHEDULE success=$($ir.Success) conflict=$($ir.Conflict) slotRows=$(Invoke-Scalar "select count(*) from public.appointments where tenant_id='$tenantA' and doctor_id='$doctorA2' and start_time='2026-09-09 12:00+00' and status<>'cancelled'")"
+
+  # J. Tenant-scoped keys/resources remain independent.
+  $j = @(Invoke-ConcurrentPair `
+    (CreateSql $adminA $tenantA $patientA1 $doctorA1 '2026-09-10 10:00+00' '2026-09-10 11:00+00' 'J-tenant-A' 'ach-conc-j-same-key') `
+    (CreateSql $adminB $tenantB $patientB1 $doctorB1 '2026-09-10 10:00+00' '2026-09-10 11:00+00' 'J-tenant-B' 'ach-conc-j-same-key'))
+  $allResults += $j
+  $jSuccess = @($j | Where-Object { $_.Code -eq 0 }).Count
+  if ($jSuccess -ne 2) { throw "J tenant isolation expected two successes: $($j.Text -join ' || ')" }
+  Write-Output "J_TENANT_ISOLATION success=$jSuccess operationRows=$(Invoke-Scalar "select count(*) from public.appointment_operations where operation_key='ach-conc-j-same-key'")"
+
+  # K. Invalid interval race never creates a row.
+  $k = @(Invoke-ConcurrentPair `
+    (InvalidCreateSql '2026-09-11 10:00+00' '2026-09-11 10:00+00' 'ach-conc-k-zero') `
+    (InvalidCreateSql '2026-09-11 11:00+00' '2026-09-11 10:00+00' 'ach-conc-k-negative'))
+  $allResults += $k
+  $kRejected = @($k | Where-Object { $_.Code -ne 0 }).Count
+  if ($kRejected -ne 2) { throw "K invalid intervals expected two rejections: $($k.Text -join ' || ')" }
+  Write-Output "K_INVALID_INTERVAL success=0 conflict=$kRejected invalidRows=$(Invoke-Scalar "select count(*) from public.appointments where end_time<=start_time")"
+
+  $doctorOverlaps = [int](Invoke-Scalar "select count(*) from public.appointments a join public.appointments b on b.id>a.id and b.tenant_id=a.tenant_id and b.doctor_id=a.doctor_id and a.status<>'cancelled' and b.status<>'cancelled' and b.start_time<a.end_time and b.end_time>a.start_time where a.tenant_id in ('$tenantA','$tenantB')")
+  $patientOverlaps = [int](Invoke-Scalar "select count(*) from public.appointments a join public.appointments b on b.id>a.id and b.tenant_id=a.tenant_id and b.patient_id=a.patient_id and a.patient_id is not null and a.status<>'cancelled' and b.status<>'cancelled' and b.start_time<a.end_time and b.end_time>a.start_time where a.tenant_id in ('$tenantA','$tenantB')")
+  $invalidIntervals = [int](Invoke-Scalar "select count(*) from public.appointments where tenant_id in ('$tenantA','$tenantB') and end_time<=start_time")
+  $operationRows = [int](Invoke-Scalar "select count(*) from public.appointment_operations where tenant_id in ('$tenantA','$tenantB') and operation_key like 'ach-conc-%'")
+  $appointmentRows = [int](Invoke-Scalar "select count(*) from public.appointments where tenant_id in ('$tenantA','$tenantB')")
+  $uniqueAppointmentIds = [int](Invoke-Scalar "select count(distinct appointment_id) from public.appointment_operations where tenant_id in ('$tenantA','$tenantB') and operation_key like 'ach-conc-%'")
+  $auditCount = [int](Invoke-Scalar "select count(*) from public.audit_events where tenant_id in ('$tenantA','$tenantB') and request_id like 'ach-conc-%' and action in ('appointment_created','appointment_rescheduled')")
+  $activityCount = [int](Invoke-Scalar "select count(*) from public.activity_events where tenant_id in ('$tenantA','$tenantB') and metadata->>'operationKey' like 'ach-conc-%' and type in ('appointment_created','appointment_rescheduled')")
+  $deadlocks = Count-Deadlocks $allResults
+
+  if ($doctorOverlaps -ne 0 -or $patientOverlaps -ne 0 -or $invalidIntervals -ne 0) {
+    throw "Final invariants failed doctorOverlaps=$doctorOverlaps patientOverlaps=$patientOverlaps invalidIntervals=$invalidIntervals"
+  }
+  if ($operationRows -ne 13 -or $auditCount -ne 13 -or $activityCount -ne 13) {
+    throw "Event/idempotency totals failed operations=$operationRows audit=$auditCount activity=$activityCount"
+  }
+  if ($deadlocks -ne 0) { throw "Deadlocks detected: $deadlocks" }
+
+  Write-Output "FINAL successOperations=$operationRows appointmentRows=$appointmentRows uniqueAppointmentIds=$uniqueAppointmentIds doctorOverlapPairs=$doctorOverlaps patientOverlapPairs=$patientOverlaps invalidIntervals=$invalidIntervals audit=$auditCount activity=$activityCount deadlocks=$deadlocks"
+  Write-Output 'APPOINTMENT-CONFLICT-HARDENING-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remaining = Invoke-Scalar "select (select count(*) from public.tenants where id in ('$tenantA','$tenantB')) + (select count(*) from auth.users where id in ('$adminA','$adminB'))"
+  if ([int]$remaining -ne 0) { throw "Concurrency cleanup failed: remaining=$remaining" }
+}

--- a/supabase/tests/0025_appointment_conflict_hardening_test.sql
+++ b/supabase/tests/0025_appointment_conflict_hardening_test.sql
@@ -1,0 +1,269 @@
+\set ON_ERROR_STOP on
+\echo 'APPOINTMENT-CONFLICT-HARDENING-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+\set tenant_a 'a2510000-0000-4000-8000-000000000001'
+\set tenant_b 'b2510000-0000-4000-8000-000000000001'
+\set owner_a 'a2520000-0000-4000-8000-000000000001'
+\set admin_a 'a2520000-0000-4000-8000-000000000002'
+\set registrar_a 'a2520000-0000-4000-8000-000000000003'
+\set doctor_user_a 'a2520000-0000-4000-8000-000000000004'
+\set cashier_a 'a2520000-0000-4000-8000-000000000005'
+\set no_tenant 'a2520000-0000-4000-8000-000000000006'
+\set unknown_user 'a2520000-0000-4000-8000-000000000007'
+\set admin_b 'b2520000-0000-4000-8000-000000000001'
+\set patient_a1 'a2530000-0000-4000-8000-000000000001'
+\set patient_a2 'a2530000-0000-4000-8000-000000000002'
+\set patient_a3 'a2530000-0000-4000-8000-000000000003'
+\set patient_b1 'b2530000-0000-4000-8000-000000000001'
+\set doctor_a1 'a2540000-0000-4000-8000-000000000001'
+\set doctor_a2 'a2540000-0000-4000-8000-000000000002'
+\set doctor_b1 'b2540000-0000-4000-8000-000000000001'
+
+INSERT INTO public.tenants(id,name) VALUES
+  (:'tenant_a','Appointment hardening A'),
+  (:'tenant_b','Appointment hardening B');
+
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+  (:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-owner@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-admin@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-registrar@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'doctor_user_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-doctor@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-cashier@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'no_tenant','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-notenant@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'unknown_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-unknown@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ach-admin-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id) VALUES
+  (:'owner_a'),(:'admin_a'),(:'registrar_a'),(:'doctor_user_a'),(:'cashier_a'),(:'no_tenant'),(:'unknown_user'),(:'admin_b');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+  (:'tenant_a',:'owner_a','clinic_owner'),
+  (:'tenant_a',:'admin_a','clinic_admin'),
+  (:'tenant_a',:'registrar_a','registrar'),
+  (:'tenant_a',:'doctor_user_a','doctor'),
+  (:'tenant_a',:'cashier_a','cashier'),
+  (:'tenant_b',:'admin_b','clinic_admin');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+  (:'patient_a1',:'tenant_a','ACH Patient A1','+77002530001','phone','active',77),
+  (:'patient_a2',:'tenant_a','ACH Patient A2','+77002530002','phone','active',0),
+  (:'patient_a3',:'tenant_a','ACH Patient A3','+77002530003','phone','active',0),
+  (:'patient_b1',:'tenant_b','ACH Patient B1','+77002530004','phone','active',0);
+
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+  (:'doctor_a1',:'tenant_a','ACH Doctor A1','General','A1','#111111',true),
+  (:'doctor_a2',:'tenant_a','ACH Doctor A2','Surgery','A2','#222222',true),
+  (:'doctor_b1',:'tenant_b','ACH Doctor B1','General','B1','#333333',true);
+
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS plans_before FROM public.treatment_plans \gset
+SELECT count(*)::text AS findings_before FROM public.findings \gset
+SELECT count(*)::text AS charts_before FROM public.dental_charts \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments \gset
+SELECT count(*)::text AS documents_before FROM public.documents \gset
+SELECT balance::text AS balance_before FROM public.patients WHERE id=:'patient_a1' \gset
+
+SET LOCAL ROLE authenticated;
+
+-- Current role policy: every valid tenant member may create/update; delete stays owner/admin only.
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-01 08:00+00','2026-08-01 09:00+00','A1','Owner','new','unpaid','phone',100,NULL,'ach-role-owner')->'appointment'->>'id' AS owner_appointment \gset
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a2','2026-08-01 09:00+00','2026-08-01 10:00+00','A2','Admin','confirmed','card','phone',200,NULL,'ach-role-admin')->'appointment'->>'id' AS admin_appointment \gset
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-01 10:00+00','2026-08-01 11:00+00','A1','Registrar','new','unpaid','walk_in',300,NULL,'ach-role-registrar')->'appointment'->>'id' AS registrar_appointment \gset
+SELECT set_config('request.jwt.claim.sub',:'doctor_user_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-01 11:00+00','2026-08-01 12:00+00','A1','Doctor','arrived','unpaid','repeat',400,NULL,'ach-role-doctor')->'appointment'->>'id' AS doctor_appointment \gset
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-01 12:00+00','2026-08-01 13:00+00','A1','Cashier','in_progress','cash','phone',500,NULL,'ach-role-cashier')->'appointment'->>'id' AS cashier_appointment \gset
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id IN (:'owner_appointment'::uuid,:'admin_appointment'::uuid,:'registrar_appointment'::uuid,:'doctor_appointment'::uuid,:'cashier_appointment'::uuid))=5,'all current member roles create through RPC');
+
+SELECT set_config('request.jwt.claim.sub',:'no_tenant',true);
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-01 14:00+00','2026-08-01 15:00+00','A1','No tenant','new','unpaid','phone','1','','ach-no-tenant'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'unknown_user',true);
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-01 14:00+00','2026-08-01 15:00+00','A1','Unknown role','new','unpaid','phone','1','','ach-unknown-role'),'Недостаточно прав');
+
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_b1',:'doctor_a1','2026-08-02 08:00+00','2026-08-02 09:00+00','A1','Cross patient','new','unpaid','phone','1','','ach-cross-patient'),'Пациент недоступен');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_b1','2026-08-02 08:00+00','2026-08-02 09:00+00','A1','Cross doctor','new','unpaid','phone','1','','ach-cross-doctor'),'Врач недоступен');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-02 08:00+00','2026-08-02 08:00+00','A1','Zero','new','unpaid','phone','1','','ach-zero'),'Время окончания');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-02 09:00+00','2026-08-02 08:00+00','A1','Negative','new','unpaid','phone','1','','ach-negative'),'Время окончания');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-02 08:00+00','2026-08-02 09:00+00','A1','Bad key','new','unpaid','phone','1','','bad'),'идентификатором');
+
+-- Half-open doctor overlap semantics.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-02 10:00+00','2026-08-02 11:00+00','A1','Doctor anchor','new','unpaid','phone',1,NULL,'ach-doctor-anchor')->'appointment'->>'id' AS doctor_anchor \gset
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-02 10:00+00','2026-08-02 11:00+00','A1','Exact','new','unpaid','phone','1','','ach-doctor-exact'),'У врача уже есть запись');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-02 10:30+00','2026-08-02 11:30+00','A1','Partial','new','unpaid','phone','1','','ach-doctor-partial'),'У врача уже есть запись');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-02 10:15+00','2026-08-02 10:45+00','A1','Contained','new','unpaid','phone','1','','ach-doctor-contained'),'У врача уже есть запись');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-02 09:30+00','2026-08-02 11:30+00','A1','Surrounding','new','unpaid','phone','1','','ach-doctor-surround'),'У врача уже есть запись');
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-02 11:00+00','2026-08-02 12:00+00','A1','Back to back','new','unpaid','phone',1,NULL,'ach-doctor-adjacent')->'appointment'->>'id' AS doctor_adjacent \gset
+SELECT pg_temp.assert_true(:'doctor_adjacent' IS NOT NULL,'back-to-back create allowed');
+
+-- Patient overlap is independent from doctor overlap.
+SELECT public.create_appointment(:'tenant_a',:'patient_a3',:'doctor_a1','2026-08-03 10:00+00','2026-08-03 11:00+00','A1','Patient anchor','new','unpaid','phone',1,NULL,'ach-patient-anchor')->'appointment'->>'id' AS patient_anchor \gset
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a3',:'doctor_a2','2026-08-03 10:00+00','2026-08-03 11:00+00','A2','Patient exact','new','unpaid','phone','1','','ach-patient-exact'),'У пациента уже есть другая запись');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a3',:'doctor_a2','2026-08-03 10:30+00','2026-08-03 11:30+00','A2','Patient partial','new','unpaid','phone','1','','ach-patient-partial'),'У пациента уже есть другая запись');
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a2','2026-08-03 10:00+00','2026-08-03 11:00+00','A2','Different resources','new','unpaid','phone',1,NULL,'ach-different-resources')->'appointment'->>'id' AS different_resources \gset
+SELECT pg_temp.assert_true(:'different_resources' IS NOT NULL,'different doctor and patient may share interval');
+
+-- Cancelled releases slots; every other current status blocks.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 08:00+00','2026-08-04 09:00+00','A1','Cancelled','cancelled','unpaid','phone',1,NULL,'ach-cancelled-anchor');
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-04 08:00+00','2026-08-04 09:00+00','A1','Cancelled released','new','unpaid','phone',1,NULL,'ach-cancelled-reuse')->'appointment'->>'id' AS cancelled_reuse \gset
+SELECT pg_temp.assert_true(:'cancelled_reuse' IS NOT NULL,'cancelled appointment releases doctor slot');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 10:00+00','2026-08-04 11:00+00','A1','Completed','completed','unpaid','phone',1,NULL,'ach-completed-anchor');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-04 10:00+00','2026-08-04 11:00+00','A1','Completed blocks','new','unpaid','phone','1','','ach-completed-overlap'),'У врача уже есть запись');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 11:00+00','2026-08-04 12:00+00','A1','No show','no_show','unpaid','phone',1,NULL,'ach-noshow-anchor');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-04 11:00+00','2026-08-04 12:00+00','A1','No show blocks','new','unpaid','phone','1','','ach-noshow-overlap'),'У врача уже есть запись');
+SELECT public.create_appointment(:'tenant_a',NULL,:'doctor_a2','2026-08-04 12:00+00','2026-08-04 13:00+00','A2','Blocked','blocked',NULL,NULL,NULL,NULL,'ach-blocked-anchor');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a3',:'doctor_a2','2026-08-04 12:00+00','2026-08-04 13:00+00','A2','Blocked blocks','new','unpaid','phone','1','','ach-blocked-overlap'),'У врача уже есть запись');
+
+-- Create idempotency and recovery.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-05 08:00+00','2026-08-05 09:00+00','A1','Idempotent','new','unpaid','phone',100,'same','ach-create-replay')::text AS create_first \gset
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-05 08:00+00','2026-08-05 09:00+00','A1','Idempotent','new','unpaid','phone',100,'same','ach-create-replay')::text AS create_second \gset
+SELECT pg_temp.assert_true((:'create_first'::jsonb#>>'{appointment,id}') = (:'create_second'::jsonb#>>'{appointment,id}'),'same create key returns same appointment');
+SELECT pg_temp.assert_true((:'create_second'::jsonb->>'replayed')::boolean,'same create key marks replay');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=(:'create_first'::jsonb#>>'{appointment,id}')::uuid)=1,'same create key creates one row');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE request_id='ach-create-replay' AND action='appointment_created')=1,'create replay emits one audit');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type='appointment_created' AND metadata->>'operationKey'='ach-create-replay')=1,'create replay emits one activity');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-05 09:00+00','2026-08-05 10:00+00','A1','Idempotent','new','unpaid','phone','100','same','ach-create-replay'),'другими параметрами');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-05 08:00+00','2026-08-05 09:00+00','A1','Idempotent','new','unpaid','phone','100','same','ach-create-replay'),'другими параметрами');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a2','2026-08-05 08:00+00','2026-08-05 09:00+00','A2','Idempotent','new','unpaid','phone','100','same','ach-create-replay'),'другими параметрами');
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','ach-create-replay')->>'found')::boolean,'recovery finds create operation');
+SELECT pg_temp.assert_true(NOT (public.get_appointment_operation(:'tenant_a','ach-unknown-key')->>'found')::boolean,'unknown recovery returns found=false');
+
+-- Same key is tenant-scoped.
+SELECT set_config('request.jwt.claim.sub',:'admin_b',true);
+SELECT public.create_appointment(:'tenant_b',:'patient_b1',:'doctor_b1','2026-08-05 08:00+00','2026-08-05 09:00+00','B1','Tenant B same key','new','unpaid','phone',1,NULL,'ach-create-replay')->'appointment'->>'id' AS tenant_b_same_key \gset
+SELECT pg_temp.assert_true(:'tenant_b_same_key' IS NOT NULL,'same key is independent in another tenant');
+SELECT pg_temp.expect_error(format('select public.get_appointment_operation(%L::uuid,%L)',:'tenant_a','ach-create-replay'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+
+-- Reschedule uses optimistic target version plus old/new resource locks.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-06 08:00+00','2026-08-06 09:00+00','A1','Move me','new','unpaid','phone',10,'before','ach-res-create')::text AS res_created \gset
+SELECT (:'res_created'::jsonb#>>'{appointment,id}') AS res_id \gset
+SELECT (:'res_created'::jsonb#>>'{appointment,updated_at}') AS res_updated \gset
+SELECT public.reschedule_appointment(:'tenant_a',:'res_id',:'patient_a1',:'doctor_a2','2026-08-06 09:00+00','2026-08-06 10:00+00','A2','Moved','confirmed','card','repeat',20,'after',:'res_updated','ach-res-free')::text AS res_free \gset
+SELECT pg_temp.assert_true((:'res_free'::jsonb#>>'{appointment,start_time}')::timestamptz='2026-08-06 09:00+00','free reschedule updates time');
+SELECT pg_temp.assert_true((:'res_free'::jsonb#>>'{appointment,doctor_id}')::uuid=:'doctor_a2','free reschedule updates doctor');
+SELECT public.reschedule_appointment(:'tenant_a',:'res_id',:'patient_a1',:'doctor_a2','2026-08-06 09:00+00','2026-08-06 10:00+00','A2','Moved','confirmed','card','repeat',20,'after',:'res_updated','ach-res-free')::text AS res_free_replay \gset
+SELECT pg_temp.assert_true((:'res_free_replay'::jsonb->>'replayed')::boolean,'reschedule replay marked');
+SELECT pg_temp.assert_true((:'res_free'::jsonb#>>'{appointment,id}') = (:'res_free_replay'::jsonb#>>'{appointment,id}'),'reschedule replay returns same appointment');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE request_id='ach-res-free' AND action='appointment_rescheduled')=1,'reschedule replay emits one audit');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type='appointment_rescheduled' AND metadata->>'operationKey'='ach-res-free')=1,'reschedule replay emits one activity');
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','ach-res-free')->>'found')::boolean,'recovery finds reschedule operation');
+
+SELECT (:'res_free'::jsonb#>>'{appointment,updated_at}') AS res_after_updated \gset
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-06 11:00+00','2026-08-06 12:00+00','A1','Res conflict anchor','new','unpaid','phone',1,NULL,'ach-res-anchor');
+SELECT pg_temp.expect_error(format('select public.reschedule_appointment(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz,%L)',:'tenant_a',:'res_id',:'patient_a1',:'doctor_a1','2026-08-06 11:00+00','2026-08-06 12:00+00','A1','Exact move','new','unpaid','phone','1','',:'res_after_updated','ach-res-exact'),'У врача уже есть запись');
+SELECT pg_temp.expect_error(format('select public.reschedule_appointment(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz,%L)',:'tenant_a',:'res_id',:'patient_a1',:'doctor_a1','2026-08-06 11:30+00','2026-08-06 12:30+00','A1','Partial move','new','unpaid','phone','1','',:'res_after_updated','ach-res-partial'),'У врача уже есть запись');
+SELECT public.reschedule_appointment(:'tenant_a',:'res_id',:'patient_a1',:'doctor_a2','2026-08-06 09:00+00','2026-08-06 10:00+00','A2','Self exclude','confirmed','card','repeat',20,'self',:'res_after_updated','ach-res-self')::text AS res_self \gset
+SELECT pg_temp.assert_true((:'res_self'::jsonb#>>'{appointment,id}')=:'res_id','reschedule excludes itself');
+SELECT (:'res_self'::jsonb#>>'{appointment,updated_at}') AS res_self_updated \gset
+SELECT public.reschedule_appointment(:'tenant_a',:'res_id',:'patient_a1',:'doctor_a1','2026-08-06 12:00+00','2026-08-06 13:00+00','A1','Adjacent move','new','unpaid','phone',1,NULL,:'res_self_updated','ach-res-adjacent')::text AS res_adjacent \gset
+SELECT pg_temp.assert_true((:'res_adjacent'::jsonb#>>'{appointment,start_time}')::timestamptz='2026-08-06 12:00+00','back-to-back reschedule allowed');
+SELECT (:'res_adjacent'::jsonb#>>'{appointment,updated_at}') AS res_adjacent_updated \gset
+SELECT pg_temp.expect_error(format('select public.reschedule_appointment(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz,%L)',:'tenant_b',:'res_id',:'patient_b1',:'doctor_b1','2026-08-06 14:00+00','2026-08-06 15:00+00','B1','Cross tenant res','new','unpaid','phone','1','',:'res_adjacent_updated','ach-cross-res'),'Недостаточно прав');
+
+-- Details/status update cannot mutate protected fields and reactivation checks conflicts.
+SELECT public.update_appointment_details(:'tenant_a',:'res_id','A1','Details only','cancelled','unpaid','phone',30,'cancelled',:'res_adjacent_updated')::text AS details_cancel \gset
+SELECT pg_temp.assert_true((:'details_cancel'::jsonb#>>'{appointment,status}')='cancelled','details RPC updates status');
+SELECT (:'details_cancel'::jsonb#>>'{appointment,updated_at}') AS details_cancel_updated \gset
+SELECT public.create_appointment(:'tenant_a',:'patient_a3',:'doctor_a1','2026-08-06 12:00+00','2026-08-06 13:00+00','A1','Released by cancel','new','unpaid','phone',1,NULL,'ach-released-after-cancel')->'appointment'->>'id' AS released_after_cancel \gset
+SELECT pg_temp.assert_true(:'released_after_cancel' IS NOT NULL,'controlled cancellation releases slot');
+SELECT pg_temp.expect_error(format('select public.update_appointment_details(%L::uuid,%L::uuid,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz)',:'tenant_a',:'res_id','A1','Reactivate','new','unpaid','phone','30','reactivate',:'details_cancel_updated'),'У врача уже есть запись');
+
+-- Concurrent-change message from optimistic expected_updated_at.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a2','2026-08-07 08:00+00','2026-08-07 09:00+00','A2','Concurrent version','new','unpaid','phone',1,NULL,'ach-version-create')::text AS version_create \gset
+SELECT (:'version_create'::jsonb#>>'{appointment,id}') AS version_id \gset
+SELECT (:'version_create'::jsonb#>>'{appointment,updated_at}') AS version_old \gset
+SELECT public.update_appointment_details(:'tenant_a',:'version_id','A2','Changed elsewhere','confirmed','unpaid','phone',1,NULL,:'version_old')::text AS version_changed \gset
+SELECT pg_temp.expect_error(format('select public.reschedule_appointment(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz,%L)',:'tenant_a',:'version_id',:'patient_a1',:'doctor_a2','2026-08-07 09:00+00','2026-08-07 10:00+00','A2','Stale move','new','unpaid','phone','1','',:'version_old','ach-version-stale'),'Запись была изменена другим пользователем');
+
+-- Direct protected writes are closed; read and current hard-delete behavior remain.
+SELECT pg_temp.expect_error(format('insert into public.appointments(tenant_id,patient_id,doctor_id,start_time,end_time,status) values(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-08 08:00+00','2026-08-08 09:00+00','new'),'Недостаточно прав');
+SELECT pg_temp.expect_error(format('update public.appointments set start_time=%L::timestamptz where id=%L::uuid','2026-08-01 07:00+00',:'owner_appointment'),'Недостаточно прав');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE tenant_id=:'tenant_a')>0,'authenticated read access remains');
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+DELETE FROM public.appointments WHERE id=:'owner_appointment';
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=:'owner_appointment')=1,'registrar cannot hard delete');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+DELETE FROM public.appointments WHERE id=:'owner_appointment';
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=:'owner_appointment')=0,'admin current hard delete remains');
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','ach-role-owner')->>'found')::boolean,'hard-deleted appointment operation remains recoverable without key reuse');
+
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-09 08:00+00','2026-08-09 09:00+00','A1','Anon','new','unpaid','phone','1','','ach-anon'),'permission denied');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointment_operations WHERE tenant_id=:'tenant_a' AND operation_key='ach-role-owner' AND appointment_id IS NULL)=1,'hard delete preserves operation-key history');
+
+-- Catalog and invariant assertions.
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointments'::regclass),'appointments RLS remains enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointment_operations'::regclass),'operation table RLS enabled');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointments','SELECT'),'authenticated appointment read granted');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointments','DELETE'),'authenticated delete grant retained for RLS');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointments','INSERT'),'authenticated legacy insert grant preserved');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointments','UPDATE'),'authenticated legacy update grant preserved');
+SELECT pg_temp.assert_true(EXISTS(SELECT 1 FROM pg_trigger WHERE tgrelid='public.appointments'::regclass AND tgname='appointments_authoritative_write_guard' AND NOT tgisinternal),'authoritative direct-write trigger installed');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_operations','SELECT'),'operations hidden from browser');
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.create_appointment(uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,text)','EXECUTE'),'create RPC executable');
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.reschedule_appointment(uuid,uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,timestamptz,text)','EXECUTE'),'reschedule RPC executable');
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.update_appointment_details(uuid,uuid,text,text,text,text,text,numeric,text,timestamptz)','EXECUTE'),'details RPC executable');
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.get_appointment_operation(uuid,text)','EXECUTE'),'recovery RPC executable');
+SELECT pg_temp.assert_true(NOT has_function_privilege('anon','public.create_appointment(uuid,uuid,uuid,timestamptz,timestamptz,text,text,text,text,text,numeric,text,text)','EXECUTE'),'anon create execute denied');
+SELECT pg_temp.assert_true(EXISTS(SELECT 1 FROM pg_constraint WHERE conrelid='public.appointments'::regclass AND conname='appointments_tenant_id_patient_id_fkey' AND contype='f'),'patient composite tenant FK preserved');
+SELECT pg_temp.assert_true(EXISTS(SELECT 1 FROM pg_constraint WHERE conrelid='public.appointments'::regclass AND conname='appointments_tenant_id_doctor_id_fkey' AND contype='f'),'doctor composite tenant FK preserved');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE end_time<=start_time)=0,'no invalid intervals');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointment_operations GROUP BY tenant_id,operation_key HAVING count(*)>1 LIMIT 1) IS NULL,'no duplicate operation keys');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a JOIN public.appointments b ON b.id>a.id AND b.tenant_id=a.tenant_id AND b.doctor_id=a.doctor_id AND a.status<>'cancelled' AND b.status<>'cancelled' AND b.start_time<a.end_time AND b.end_time>a.start_time)=0,'zero active doctor overlap pairs');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a JOIN public.appointments b ON b.id>a.id AND b.tenant_id=a.tenant_id AND b.patient_id=a.patient_id AND a.patient_id IS NOT NULL AND a.status<>'cancelled' AND b.status<>'cancelled' AND b.start_time<a.end_time AND b.end_time>a.start_time)=0,'zero active patient overlap pairs');
+
+-- Appointment is not a clinical or financial fact.
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.patient_visits)=:'visits_before'::integer,'no visit created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.clinical_encounters)=:'encounters_before'::integer,'no encounter created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.completed_services)=:'services_before'::integer,'no completed service created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.treatment_plans)=:'plans_before'::integer,'no treatment plan mutation');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.findings)=:'findings_before'::integer,'no finding mutation');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.dental_charts)=:'charts_before'::integer,'no dental chart mutation');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoices)=:'invoices_before'::integer,'no invoice created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments)=:'payments_before'::integer,'no payment created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.refunds)=:'refunds_before'::integer,'no refund created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.financial_adjustments)=:'adjustments_before'::integer,'no write-off created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.documents)=:'documents_before'::integer,'no document created');
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id=:'patient_a1')=:'balance_before'::numeric,'patient balance unchanged');
+
+ROLLBACK;
+\echo 'APPOINTMENT-CONFLICT-HARDENING-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Moves appointment creation and protected mutation behind authoritative transactional PostgreSQL RPCs. Migration 0025 adds historical-data prechecks, valid-interval/doctor/patient invariants, tenant-scoped operation identity, deterministic advisory locking, half-open doctor and patient overlap checks, optimistic reschedule versioning, safe recovery by operation key, safe Russian errors, and one audit/activity event pair per successful logical operation. The legacy appointment grants matrix remains intact, while an authoritative trigger blocks ordinary authenticated INSERT/UPDATE; existing owner/admin hard delete remains. Supabase repository/hook/modal integration uses create/reschedule/details/recovery RPCs, keeps one key through ambiguous retry, prevents rapid duplicate submit, exposes recovery state, preserves form data on conflict, refreshes once after confirmed success, and ignores stale tenant responses. Final PR head 90da963153dc433d220ac8b2c080910b6b8d1c68; CI #699, run ID 29170846498, succeeded on that exact commit.

## Checks

- Baseline origin/main = 8dfa46d27a7e192a3c949c7515bb94fb72345dee with PR #346 merged
- One forward migration 0025; historical migrations unchanged
- Clean npx supabase db reset --no-seed applied migrations 0001-0025
- SQL tests 0018, 0019, 0021, 0022, 0023, 0024, 0025 passed
- All six concurrency suites passed
- Appointment concurrency final: operations=13, doctor overlaps=0, patient overlaps=0, invalid intervals=0, audit/activity=13/13, deadlocks=0
- Targeted scheduling tests 37/37 passed
- Full lint passed
- 80 test files / 884 tests passed
- Production build passed
- Real two-session local Supabase browser smoke passed for create, exact/partial doctor conflict, patient conflict, back-to-back, duplicate replay, uncertain recovery, concurrent reschedule, cancelled slot reuse, and tenant isolation
- Network used create/reschedule/details/recovery RPCs; direct POST/PATCH /rest/v1/appointments = 0
- No clinical or financial side effects; patient balances unchanged
- Final local cleanup counters 0|0|0|0|0|0|0|0|0|0
- Final CI #699 passed on exact final head 90da963153dc433d220ac8b2c080910b6b8d1c68

## Limitations

- Cabinet remains non-authoritative free text and is not locked
- Current broad doctor/cashier appointment mutation policy is preserved
- Expected rejected RPCs appear as HTTP 400 resource entries in Chrome while UI shows only safe domain messages
- Hard delete remains; operation key and result snapshot survive with nullable appointment_id
- Cloud Supabase was not inspected or modified
