### PR TITLE
SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001: unify appointment readers on Supabase

### DIFF
--- a/_ai_work/REPORTS/SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001_consolidation.md
+++ b/_ai_work/REPORTS/SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001_consolidation.md
@@ -1,0 +1,563 @@
+# SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001: unify appointment readers on Supabase
+
+## Final verdict
+
+Final verdict: **PASS**
+
+SCHEDULE SOURCE OF TRUTH CONSOLIDATED AND VERIFIED
+
+## Summary
+
+All reachable appointment readers used by the current UI now select one explicit backend. In configured `supabase-active` mode, appointment facts come only from the tenant-scoped `SupabaseAppointmentRepository`; missing session or tenant context disables the read instead of selecting localStorage. Explicit `dev` mode retains the local repository intentionally.
+
+Patient history, patient-list previous/next summaries, patient-card medical summary, patient timeline, and SchedulePage now share the same appointment rows and deterministic date/status semantics. Stale tenant, user, and patient responses are discarded through query identity and request-generation checks. Configured bootstrap no longer creates demo `df_appointments` data.
+
+No migration, new table, RPC, package, generated type, appointment write redesign, lifecycle redesign, cloud apply, finance mutation, or clinical mutation was introduced.
+
+## Branch
+
+`feature/schedule-source-of-truth-consolidation-001`
+
+## PR URL
+
+https://github.com/NckNA/codex-test/pull/348
+
+## Baseline
+
+- repository: `NckNA/codex-test`;
+- required baseline: `7ba0b725acf21992a36f0185130f6bb6e8dbc791`;
+- verified `origin/main`: `7ba0b725acf21992a36f0185130f6bb6e8dbc791`;
+- PR #347 was present in that exact baseline;
+- the source checkout was clean;
+- the task worktree was created directly from `origin/main`.
+
+## PR head reviewed before final report update
+
+- implementation head reviewed: `35046311399ad973142a3f8427aeed56853aa81e`;
+- workflow: `CI`;
+- run: `#701`;
+- run ID: `29183273692`;
+- conclusion: `success`;
+- tested commit matched the reviewed implementation head exactly;
+- PR state: open, non-draft, mergeable;
+- PR was not merged.
+
+## Report update commit
+
+- Report update commit: N/A because the final report commit cannot reference itself.
+- The final report head and the fresh CI run after this update are recorded by the immutable local finalization receipt.
+
+## Changed files
+
+Implementation:
+
+- `src/components/patients/patient-card/PatientHistoryTab.tsx`
+- `src/components/patients/patient-card/PatientHistoryTab.test.tsx`
+- `src/components/patients/patient-card/PatientOverviewTab.tsx`
+- `src/components/patients/patient-card/PatientOverviewTab.test.tsx`
+- `src/components/schedule/AppointmentModal.tsx`
+- `src/data/aggregators/ClinicalSummaryAggregator.ts`
+- `src/data/aggregators/ClinicalSummaryAggregator.test.ts`
+- `src/data/aggregators/PatientListVisitSummaryAggregator.ts`
+- `src/data/aggregators/PatientListVisitSummaryAggregator.test.ts`
+- `src/data/hooks/usePatientAppointments.ts`
+- `src/data/hooks/usePatientAppointments.test.tsx`
+- `src/data/hooks/usePatientListVisitSummary.ts`
+- `src/data/hooks/usePatientListVisitSummary.test.tsx`
+- `src/data/hooks/usePatientMedicalSummary.ts`
+- `src/data/hooks/usePatientMedicalSummary.test.tsx`
+- `src/data/hooks/usePatientTimeline.ts`
+- `src/data/hooks/usePatientTimeline.test.tsx`
+- `src/data/hooks/useScheduleAppointments.ts`
+- `src/data/hooks/useScheduleAppointments.test.tsx`
+- `src/data/repositories/AppointmentRepository.ts`
+- `src/data/repositories/AppointmentRepository.test.ts`
+- `src/domain/appointmentSummary.ts`
+- `src/main.tsx`
+- `src/pages/PatientsPage.tsx`
+- `src/pages/PatientsPage.test.tsx`
+- `src/pages/SchedulePage.tsx`
+- `src/utils/storage.ts`
+- `src/utils/storage.test.ts`
+
+Report:
+
+- `_ai_work/REPORTS/SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001_consolidation.md`
+
+## Pre-read
+
+Primary reports reviewed:
+
+- `_ai_work/REPORTS/SCHEDULE-OPERATIONS-RECON-001_recon.md`
+- `_ai_work/REPORTS/LEGACY-CORE-TABLE-GRANTS-RECOVERY-001_recovery.md`
+- `_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md`
+
+Architecture reviewed:
+
+- `_ai_work/SOURCES/03_MULTI_TENANT_ARCHITECTURE_RULES.md`
+- `_ai_work/SOURCES/04_DATA_ISOLATION_AND_SECURITY.md`
+- `_ai_work/SOURCES/05_MEDICAL_DOMAIN_MODEL.md`
+- `_ai_work/SOURCES/08_APPOINTMENTS_AND_SCHEDULE.md`
+- `_ai_work/SOURCES/11_BACKEND_AND_API_ARCHITECTURE.md`
+- `_ai_work/SOURCES/14_UI_UX_RULES.md`
+- `_ai_work/SOURCES/18_TESTING_AND_QUALITY_ASSURANCE_STRATEGY.md`
+
+The repository, hooks, aggregators, components, storage bootstrap, every `storage.getAppointments` call, every appointment repository method, and all current appointment-derived UI consumers were inspected before code changes.
+
+## Original reader inventory
+
+| Reader / consumer | Original source | Tenant scope | Patient scope | Original behavior | Classification | Reachable |
+|---|---|---:|---:|---|---|---:|
+| `SchedulePage` / `useScheduleAppointments` | selected repository | Supabase repository scoped when tenant existed | no | ascending schedule list; no-tenant Supabase could resolve local repository | mixed with latent fallback | yes |
+| `PatientHistoryTab` / `usePatientAppointments` | `LocalStorageAppointmentRepository` | no | local filter only | descending history, including cancelled rows | localStorage only | yes |
+| `PatientsPage` / `usePatientListVisitSummary` / aggregator | `LocalStorageAppointmentRepository` | no | grouped in memory | previous/next from browser-local array | localStorage only | yes |
+| patient overview / `usePatientMedicalSummary` | configured repository | mixed | fetched all appointments, then filtered | duplicated previous/next logic; Supabase no-tenant selected local | mixed | yes |
+| patient timeline / `usePatientTimeline` | configured repository | yes when Supabase tenant existed | yes | repository-backed, but no tenant/patient query identity | Supabase authoritative with stale-context gap | yes |
+| `/appointments` placeholder | none | n/a | n/a | no operational reader | dead/placeholder | yes, but no appointment data |
+| local repository tests and explicit dev mode | localStorage | browser-local | optional local filter | intentional development backend | local-only/test-only | yes in dev only |
+| `storage.ts` appointment mutation helpers | `df_appointments` | no | n/a | explicit local adapter support | local backend implementation | reachable only in dev |
+
+No other reachable production component directly called `storage.getAppointments()` outside the local repository adapter after consolidation.
+
+## Original contradictions
+
+- SchedulePage could show Supabase rows while patient history showed unrelated browser-local demo rows.
+- Patient-list previous/next values could disagree with SchedulePage after create, edit, cancel, reload, or tenant change.
+- Medical summary fetched all clinic appointments and calculated another copy of previous/next semantics.
+- Supabase-active readers could silently select local storage when tenant context was absent.
+- Timeline and patient summary queries did not consistently bind visible data to user, tenant, and patient identity.
+- `storage.init()` created `df_appointments` in a fresh configured browser even though writes and schedule reads used Supabase.
+- Status/date rules were duplicated, including inconsistent cancelled handling and unstable equal-time ordering.
+
+## Chosen authoritative read contract
+
+The existing repository contract was sufficient. No RPC or schema change was required.
+
+- `listAppointments()` returns all rows for the active tenant, ordered by `start_time ASC, id ASC`.
+- `listAppointmentsByPatient(patientId)` returns rows matching both active `tenant_id` and `patient_id`, ordered by `start_time DESC, id ASC`.
+- Both methods preserve cancelled appointments as historical facts.
+- Supabase read failures are mapped to safe domain text and never trigger another backend.
+- The local repository implements the same interface only for explicit `dev` mode.
+- The repository factory throws `Клиника не выбрана.` when asked for Supabase without a tenant instead of returning the local adapter.
+
+Simple previous/next summaries are calculated in typed application code from one authoritative fetch. Query-specific next/latest RPCs were not added because current dataset and architecture did not justify another database contract.
+
+## Backend-selection behavior
+
+Configured `supabase-active` mode:
+
+- authenticated user + active tenant: Supabase repository;
+- no user or no tenant: query disabled, empty current-context state, no local fallback;
+- read error: safe error state, no local merge or fallback.
+
+Explicit `dev` mode:
+
+- local repository selected;
+- local demo appointments remain supported intentionally;
+- no Supabase appointment request occurs.
+
+Supabase and local appointment arrays are never merged.
+
+## Patient appointment hook
+
+`usePatientAppointments(patientId)` now binds the query to:
+
+- auth mode;
+- authenticated user ID;
+- tenant ID;
+- patient ID.
+
+Its query identity is `authMode:userId:tenantId:patientId`. Missing patient disables the query. Missing session or tenant in Supabase-active mode disables the query. Identity changes reset visible data before the replacement request resolves. Late patient, tenant, session, route, and unmount responses cannot commit to the new context.
+
+Cancelled rows remain returned for history. Errors expose only `Не удалось загрузить записи пациента.`
+
+## Patient history integration
+
+`PatientHistoryTab` consumes the authoritative patient appointment hook.
+
+Verified behavior:
+
+- a SchedulePage-created row appears in patient history;
+- edited time and status replace the prior values;
+- cancelled rows remain visible;
+- hard-deleted rows remain subject to the existing delete behavior and would disappear on refetch;
+- tenant and patient changes clear prior rows before new results;
+- loading, empty, and safe error states are rendered;
+- appointment history remains distinct from visits, encounters, and completed services.
+
+## Patient-list summary integration
+
+`usePatientListVisitSummary` creates one repository for the current context, calls `listAppointments()` once, and passes the resulting tenant array to the pure `PatientListVisitSummaryAggregator`.
+
+The aggregator performs one in-memory grouping operation for all patient rows. It has no storage or repository dependency and therefore cannot cause per-patient requests. UI values show `…` while loading and neutral `Недоступно` on failure; local stale dates are not displayed.
+
+The labels were corrected from visit terminology to `Предыдущая запись` and `Следующая запись` because an appointment is not a visit or encounter.
+
+## Patient-card and medical summaries
+
+`ClinicalSummaryAggregator` now requests `listAppointmentsByPatient(patientId)` rather than reading every tenant appointment and filtering afterward. It uses the same shared selector as the patient-list summary.
+
+`usePatientMedicalSummary` now binds to auth mode, user, tenant, and patient identity, disables Supabase reads without tenant/session, and exposes a safe summary error without local fallback.
+
+The overview labels are `Записи`, `Предыдущая`, and `Следующая`. Timeline appointment events continue to use the authoritative patient-scoped repository and now receive full stale-context protection.
+
+## Date and status semantics
+
+The shared selector in `src/domain/appointmentSummary.ts` defines the policy:
+
+- comparison uses JavaScript `Date` epoch values derived from database timestamptz/application timestamps;
+- exact `start == now` is upcoming;
+- a row with `start < now` is a previous appointment fact;
+- an ongoing row whose start is already past is therefore treated as previous under the explicit start-time policy;
+- cancelled rows are excluded from both previous and upcoming summary values but remain in history;
+- future cancelled, completed, no-show, and blocked rows are excluded from upcoming as terminal or non-patient-actionable facts;
+- past no-show rows are included as previous appointment facts;
+- blocked rows and rows without `patientId` are ignored for patient summaries;
+- earliest eligible future row is next;
+- latest eligible past row is previous;
+- equal start times use appointment ID as a stable tie-breaker;
+- no database status or lifecycle was modified.
+
+## Storage bootstrap behavior
+
+`storage.init()` accepts `includeAppointments`. `main.tsx` passes `false` when Supabase is configured and `true` only for explicit local/dev mode.
+
+Configured mode:
+
+- does not create `df_appointments` in a fresh browser;
+- does not read, merge, or mutate `df_appointments` during Supabase appointment CRUD;
+- leaves any pre-existing user browser data untouched rather than deleting it automatically;
+- may continue initializing unrelated legacy demo domains, which were outside this task.
+
+Explicit local mode continues to initialize and use demo appointments.
+
+## Stale-context protection
+
+Appointment-related asynchronous readers now use query keys containing all material context:
+
+- schedule: auth mode + user ID + tenant ID;
+- patient appointments: auth mode + user ID + tenant ID + patient ID;
+- patient-list summary: auth mode + user ID + tenant ID;
+- medical summary: auth mode + user ID + tenant ID + patient ID;
+- timeline: auth mode + user ID + tenant ID + patient ID + archived filter.
+
+The existing `useAsyncQuery` generation guard rejects results after identity changes, disable, unmount, overlapping refetch, or route change. Visible data is reset immediately on key change, preventing tenant-A or patient-A flashes in tenant-B or patient-B views.
+
+## Error handling
+
+Safe user-visible errors:
+
+- schedule: `Не удалось загрузить расписание.`
+- patient history: `Не удалось загрузить записи пациента.`
+- patient-list summary: neutral `Недоступно`
+- medical summary: `Не удалось загрузить сводку пациента.`
+
+No SQLSTATE, PostgREST payload, table name, policy name, stack trace, service-role token, or raw server error is rendered. Error handling never switches to localStorage.
+
+## Checks
+
+- reader inventory completed before implementation;
+- no reachable Supabase-active localStorage appointment reader remains;
+- no silent fallback or Supabase/local array merge;
+- tenant and patient stale-response protection passed unit and browser checks;
+- targeted suite: 12 files / 85 tests passed;
+- full suite: 86 files / 922 tests passed;
+- lint passed;
+- production build passed;
+- `0024` grants regression passed;
+- `0025` appointment hardening SQL and concurrency passed;
+- authenticated browser smoke passed;
+- Chrome DevTools MCP configured-mode validation passed;
+- cleanup and final zero-row verification passed;
+- implementation CI on exact reviewed head passed.
+
+## Repository tests
+
+Repository coverage verifies:
+
+- tenant filter on full list;
+- tenant + patient filters on patient list;
+- deterministic two-column ordering;
+- empty results map to empty arrays;
+- safe schedule and patient read errors;
+- no localStorage reference inside the Supabase repository;
+- local repository remains functional when explicitly selected;
+- cancelled rows are returned;
+- mapping preserves status and `updatedAt`;
+- cross-tenant data cannot be introduced by repository filters;
+- Supabase-without-tenant cannot silently return the local adapter;
+- existing hardened write RPC and hard-delete behavior remains unchanged.
+
+## Hook tests
+
+Hook tests verify:
+
+- Supabase-active mode selects Supabase with tenant scope;
+- dev mode selects the local repository;
+- missing tenant, session, or patient prevents fetch;
+- tenant and patient changes refetch;
+- stale tenant and patient responses are ignored;
+- errors do not trigger local fallback;
+- loading, empty, disabled, and safe-error states;
+- cancelled history rows are retained;
+- late unmount results are ignored;
+- schedule, medical summary, and timeline compatibility.
+
+## Aggregator tests
+
+Aggregator tests verify:
+
+- earliest eligible future row;
+- cancelled future exclusion;
+- completed/no-show future exclusion;
+- latest eligible past row;
+- exact-now boundary;
+- no-show past inclusion;
+- cancelled past exclusion;
+- multiple-patient grouping;
+- stable equal-time ID ordering;
+- blocked/no-patient exclusion;
+- no-appointment null state;
+- one supplied appointment array supports all patient rows without repository calls or N+1 behavior.
+
+## UI tests
+
+UI tests verify:
+
+- Supabase appointment row rendering in patient history;
+- cancelled history rendering;
+- loading, empty, and safe error states;
+- authoritative previous/next dates in the patient list;
+- neutral unavailable state after summary failure;
+- patient overview uses appointment terminology and the same dates;
+- SchedulePage and AppointmentModal retain compatibility with the hardened write flow.
+
+Final targeted result: 12 files / 85 tests passed.
+
+## Browser smoke
+
+Environment:
+
+- clean local Supabase after migrations `0001` through `0025`;
+- real local Supabase Auth users;
+- tenant A and tenant B;
+- tenant-scoped patients and doctors;
+- configured Supabase Vite application;
+- isolated Chromium browser sessions;
+- no committed fixtures.
+
+Full authenticated Chromium/Playwright smoke through Hermes verified:
+
+1. **Create consistency**
+   - SchedulePage created one appointment through the existing hardened RPC.
+   - authoritative appointment ID: `a2744fa4-ca25-4abf-b0ad-5652a07e3f88`;
+   - the same unique row appeared in schedule, patient-list summary, patient overview, and patient history;
+   - all views remained consistent after reload.
+
+2. **Edit consistency**
+   - the same appointment ID moved from 19:00 to 18:00 and status changed to `arrived`;
+   - schedule, summary, and history reflected the new values after refetch/reload;
+   - no duplicate appointment was created.
+
+3. **Cancellation**
+   - the same row changed to `cancelled`;
+   - it remained visible in patient history and schedule;
+   - it disappeared from upcoming summary;
+   - no lifecycle redesign or replacement row occurred.
+
+4. **Tenant isolation**
+   - tenant B schedule, patient list, card, and history showed only tenant-B markers;
+   - tenant-A markers never appeared;
+   - delayed tenant-A results did not flash after switching to tenant B.
+
+5. **Patient switch**
+   - patient-A response was deliberately delayed;
+   - the UI switched to patient A2 before A completed;
+   - A rows never appeared in A2, before or after the delayed response resolved.
+
+6. **Configured localStorage proof**
+   - fresh configured browser: `df_appointments=null`;
+   - after real create/edit/cancel/details operations: `df_appointments=null`;
+   - Supabase CRUD did not mutate the key.
+
+7. **Explicit local mode**
+   - a separate unconfigured Vite instance displayed demo appointments from `df_appointments`;
+   - no Supabase appointment request occurred.
+
+No fatal console errors, raw SQL, stack traces, secrets, or service-role material appeared. Temporary delay shims, probe pages, screenshots, logs, and browser processes were removed.
+
+## Chrome DevTools MCP validation
+
+The mandatory Chrome DevTools MCP check was executed with:
+
+- server: `chrome_devtools`;
+- title: `Chrome DevTools MCP server`;
+- version: `1.5.0`;
+- headless isolated Chrome context;
+- configured app URL: `http://127.0.0.1:5207/`;
+- local Supabase URL resolved by the application client: `http://127.0.0.1:54321`.
+
+MCP confirmed before any diagnostic request:
+
+- configured login UI rendered;
+- `df_initialized="true"`;
+- `df_appointments=null`;
+- no `/rest/v1/appointments` request occurred without authenticated tenant context;
+- console error/issue list was empty;
+- no external `supabase.co` endpoint, SQLSTATE, or service_role text appeared.
+
+A separate deliberate anonymous diagnostic call through the configured Supabase client completed against the local endpoint and received the expected authorization error. That post-snapshot QA request was not an application fallback or production reader call and was kept separate from the clean-console assertion.
+
+## Network validation
+
+Authenticated network probes verified:
+
+- patient-list summary performs one appointments GET with `tenant_id=eq.<active tenant>` and no patient filter;
+- patient history performs one appointments GET with both `tenant_id=eq.<active tenant>` and `patient_id=eq.<patient>`;
+- one tenant-wide fetch supports multiple patient rows;
+- no per-patient request flood occurred;
+- no service_role was present;
+- no unexpected direct INSERT or UPDATE replaced the existing hardened RPC writes;
+- create, reschedule, details, and delete behavior remained on the pre-existing appointment write contract.
+
+## Database validation
+
+Before cleanup:
+
+- three QA appointment rows had three distinct IDs;
+- the main browser-created ID existed exactly once;
+- the main row had the final `cancelled` status and edited time;
+- tenant, patient, doctor, status, and time matched UI assertions;
+- operation rows for the main appointment were one `create` and one `reschedule`;
+- audit rows were one `appointment_created` and one `appointment_rescheduled`;
+- activity rows matched those two events;
+- readers created no duplicate appointment and performed no database mutation.
+
+The unique main ID and deterministic SchedulePage test selector were used to trace the edited/cancelled schedule card; patient views read the same unique tenant/patient database row.
+
+## No-localStorage proof
+
+Evidence from unit tests, configured browser sessions, network probes, and Chrome DevTools MCP agrees:
+
+- all `storage.getAppointments()` calls remain inside `storage.ts` and the explicit local repository adapter;
+- no reachable Supabase-active reader imports the local appointment repository directly;
+- fresh configured browser does not receive demo appointment facts;
+- configured reads and writes leave `df_appointments` absent;
+- Supabase errors do not trigger a local read or array merge;
+- explicit dev mode still uses local appointments intentionally.
+
+## Side-effect validation
+
+The following remained unchanged and had zero QA rows before cleanup:
+
+- patient visits;
+- clinical encounters;
+- completed services;
+- treatment plans;
+- findings;
+- dental charts;
+- invoices and invoice items;
+- payments and allocations;
+- refunds;
+- financial adjustments;
+- documents.
+
+Appointment write RPC definitions, appointment operation records, conflict locks, grants, RLS behavior, hard delete, reminders, waitlist, documents, finance, amoCRM, and all adjacent clinical workflows were not redesigned.
+
+## Cleanup
+
+Removed:
+
+- QA Auth users;
+- tenant A and tenant B;
+- memberships;
+- patients and doctors;
+- appointments and operation rows;
+- audit/activity rows;
+- temporary response-delay and network probe code;
+- temporary HTML harnesses;
+- screenshots and logs;
+- configured and dev Vite processes;
+- Chrome DevTools MCP temporary clients and isolated browser data.
+
+Final command:
+
+`npx supabase db reset --no-seed`
+
+Final zero-row verification:
+
+- auth users: 0;
+- tenants: 0;
+- patients: 0;
+- doctors: 0;
+- appointments: 0;
+- appointment operations: 0;
+- audit events: 0;
+- activity events: 0.
+
+## Lint, tests, and build
+
+Final implementation checks:
+
+- `npm run lint`: passed;
+- `npm run test -- --run`: 86 files / 922 tests passed;
+- `npm run build`: passed;
+- targeted appointment reader/UI suite: 12 files / 85 tests passed.
+
+Existing unrelated React `act(...)` warnings and the existing Vite bundle-size warning remain. They did not fail the test or build commands and were not introduced by this task.
+
+Appointment regression checks:
+
+- `0024_legacy_core_table_grants_test.sql`: passed;
+- `0025_appointment_conflict_hardening_test.sql`: passed;
+- `0025_appointment_conflict_concurrency.ps1`: passed;
+- final concurrency result: 0 doctor overlaps, 0 patient overlaps, 0 invalid intervals, 0 deadlocks.
+
+One preliminary SQL invocation through a PowerShell text pipe corrupted Cyrillic expectations. The unchanged test files were rerun by copying their original UTF-8 bytes into the database container and passed. This was a command-encoding issue, not a repository failure.
+
+## Fresh CI
+
+Implementation CI:
+
+- workflow: `CI`;
+- run: `#701`;
+- run ID: `29183273692`;
+- conclusion: `success`;
+- tested commit: `35046311399ad973142a3f8427aeed56853aa81e`;
+- validate job passed ESLint, tests, and build.
+
+A fresh CI run on the final report-only PR head is required after this report update. The PR must remain open and unmerged.
+
+## Issues / limitations
+
+- Internal compatibility field names `lastVisit` and `nextVisit` remain in some component contracts, although the UI and documented semantics now correctly call them appointments.
+- Patient-list summary intentionally performs one tenant-wide appointment fetch. This removes N+1 behavior but may eventually justify a server-side read model if tenant appointment volume becomes large.
+- Summary semantics are start-time based; ongoing appointment classification is not a lifecycle engine.
+- Existing broad appointment role policies, cabinet free text, hard delete, and schedule filtering behavior remain unchanged.
+- Existing unrelated React test warnings and bundle-size warning remain.
+
+## What was intentionally not implemented
+
+- no migration or new table;
+- no new RPC;
+- no appointment write change;
+- no status lifecycle redesign;
+- no hard-delete redesign;
+- no confirmation workflow;
+- no cancellation/no-show reason model;
+- no reminders;
+- no waitlist;
+- no week/month view;
+- no role-policy redesign;
+- no clinic resource model;
+- no finance or clinical mutation;
+- no cloud Supabase apply;
+- no generated types;
+- no package change;
+- no HEP-V2 work.
+
+## Recommended next task
+
+**APPOINTMENT-CANCELLATION-NOSHOW-001**
+
+Reason: all operational screens now read the same appointment facts, so cancellation and no-show can add reasons, actor, timestamps, and audit history without different parts of the application disagreeing about the underlying row.

--- a/src/components/patients/patient-card/PatientHistoryTab.test.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.test.tsx
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PatientHistoryTab } from './PatientHistoryTab';
+import { usePatientAppointments } from '../../../data/hooks/usePatientAppointments';
+import { useClinicDoctors } from '../../../data/hooks/useClinicDoctors';
+import type { Appointment } from '../../../types';
+
+vi.mock('../../../data/hooks/usePatientAppointments', () => ({ usePatientAppointments: vi.fn() }));
+vi.mock('../../../data/hooks/useClinicDoctors', () => ({ useClinicDoctors: vi.fn() }));
+
+const row = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: 'appointment-1',
+  patientId: 'patient-1',
+  doctorId: 'doctor-1',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'confirmed',
+  start: '2026-08-01T10:00:00',
+  end: '2026-08-01T11:00:00',
+  createdAt: '2026-07-01T10:00:00',
+  updatedAt: '2026-07-01T10:00:00+00:00',
+  ...overrides,
+});
+
+describe('PatientHistoryTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useClinicDoctors).mockReturnValue({
+      doctors: [{ id: 'doctor-1', fullName: 'Доктор Один', specialization: '', cabinet: 'A1', color: '', active: true }],
+      isLoading: false,
+      isError: false,
+    } as any);
+  });
+
+  const render = async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => root.render(<PatientHistoryTab patientId="patient-1" />));
+    return { container, root };
+  };
+
+  it('displays authoritative appointment facts including doctor, time and status', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({
+      appointments: [row()],
+      isLoading: false,
+      isError: false,
+    } as any);
+    const { container, root } = await render();
+
+    expect(container.textContent).toContain('Осмотр');
+    expect(container.textContent).toContain('Доктор Один');
+    expect(container.textContent).toContain('Подтвержден');
+    expect(container.textContent).toContain('10:00');
+    await act(async () => root.unmount());
+  });
+
+  it('keeps cancelled appointments visible as history facts', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({
+      appointments: [row({ status: 'cancelled', service: 'Отменённый приём' })],
+      isLoading: false,
+      isError: false,
+    } as any);
+    const { container, root } = await render();
+
+    expect(container.textContent).toContain('Отменённый приём');
+    expect(container.textContent).toContain('Отменен');
+    await act(async () => root.unmount());
+  });
+
+  it('shows loading and empty states without demo rows', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({ appointments: [], isLoading: true, isError: false } as any);
+    const loading = await render();
+    expect(loading.container.textContent).toContain('Загрузка истории приёмов...');
+    await act(async () => loading.root.unmount());
+
+    vi.mocked(usePatientAppointments).mockReturnValue({ appointments: [], isLoading: false, isError: false } as any);
+    const empty = await render();
+    expect(empty.container.textContent).toContain('У пациента еще не было приёмов.');
+    await act(async () => empty.root.unmount());
+  });
+
+  it('shows only the safe patient appointment error', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({
+      appointments: [],
+      isLoading: false,
+      isError: true,
+      error: new Error('SQLSTATE 42501 public.appointments'),
+    } as any);
+    const { container, root } = await render();
+
+    expect(container.textContent).toContain('Не удалось загрузить записи пациента.');
+    expect(container.textContent).not.toContain('SQLSTATE');
+    expect(container.textContent).not.toContain('appointments');
+    await act(async () => root.unmount());
+  });
+
+  it('reflects edited appointment time and status on rerender', async () => {
+    let appointments = [row()];
+    vi.mocked(usePatientAppointments).mockImplementation(() => ({
+      appointments,
+      isLoading: false,
+      isError: false,
+    } as any));
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => root.render(<PatientHistoryTab patientId="patient-1" />));
+    expect(container.textContent).toContain('10:00');
+
+    appointments = [row({ start: '2026-08-01T12:30:00', end: '2026-08-01T13:30:00', status: 'arrived' })];
+    await act(async () => root.render(<PatientHistoryTab patientId="patient-1" />));
+
+    expect(container.textContent).toContain('12:30');
+    expect(container.textContent).toContain('Пришел');
+    await act(async () => root.unmount());
+  });
+});

--- a/src/components/patients/patient-card/PatientHistoryTab.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.tsx
@@ -44,7 +44,7 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
   if (isError) {
     return (
       <div className="bg-white rounded-xl border border-red-200 shadow-sm p-8 text-center text-red-500">
-        <p>Ошибка при загрузке истории приёмов.</p>
+        <p>Не удалось загрузить записи пациента.</p>
       </div>
     );
   }

--- a/src/components/patients/patient-card/PatientOverviewTab.test.tsx
+++ b/src/components/patients/patient-card/PatientOverviewTab.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import type { Patient } from '../../../types';
+import { PatientOverviewTab } from './PatientOverviewTab';
+
+const patient: Patient = {
+  id: 'patient-1',
+  fullName: 'Authoritative Patient',
+  phone: '+7 700 000 00 00',
+  birthDate: '1990-01-01',
+  source: 'phone',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const dentalSummary = {
+  needsTreatment: 0,
+  missing: 0,
+  activePlans: 0,
+  totalAmount: 0,
+  chiefComplaintText: '',
+  highUrgentFindings: 0,
+  notIncludedFindings: 0,
+  monitoringFindings: 0,
+};
+
+describe('PatientOverviewTab appointment summary', () => {
+  it('renders previous and next appointment values as appointment facts, not visits', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => root.render(
+      <PatientOverviewTab
+        patient={patient}
+        dentalSummary={dentalSummary}
+        lastVisit={new Date('2026-07-10T10:00:00.000Z')}
+        nextVisit={new Date('2026-07-15T10:00:00.000Z')}
+        onNavigateToSchedule={vi.fn()}
+      />,
+    ));
+
+    expect(container.textContent).toContain('Записи');
+    expect(container.textContent).toContain('Предыдущая');
+    expect(container.textContent).toContain('Следующая');
+    expect(container.textContent).toContain('10.07.2026');
+    expect(container.textContent).toContain('15.07.2026');
+    expect(container.textContent).not.toContain('Визиты');
+
+    act(() => root.unmount());
+  });
+});

--- a/src/components/patients/patient-card/PatientOverviewTab.tsx
+++ b/src/components/patients/patient-card/PatientOverviewTab.tsx
@@ -268,15 +268,15 @@ export function PatientOverviewTab({
         {/* Visits Info */}
         <div className="bg-white rounded-xl border border-slate-200 shadow-sm p-5 space-y-4">
            <h3 className="font-semibold text-slate-800 flex items-center gap-2">
-            <ClipboardList className="w-4 h-4 text-slate-400" /> Визиты
+            <ClipboardList className="w-4 h-4 text-slate-400" /> Записи
            </h3>
            <div className="space-y-3">
              <div className="flex justify-between items-center text-sm">
-               <span className="text-slate-500">Последний</span>
+               <span className="text-slate-500">Предыдущая</span>
                <span className="font-medium text-slate-800">{lastVisit ? lastVisit.toLocaleDateString('ru-RU') : '-'}</span>
              </div>
              <div className="flex justify-between items-center text-sm">
-               <span className="text-slate-500">Следующий</span>
+               <span className="text-slate-500">Следующая</span>
                <span className="font-medium text-slate-800">{nextVisit ? nextVisit.toLocaleDateString('ru-RU') : '-'}</span>
              </div>
            </div>

--- a/src/components/schedule/AppointmentModal.tsx
+++ b/src/components/schedule/AppointmentModal.tsx
@@ -375,6 +375,7 @@ export function AppointmentModal({
                     <button
                       key={status.value}
                       type="button"
+                      data-testid={`appointment-status-${status.value}`}
                       onClick={() => handleStatusChange(status.value as AppointmentStatus)}
                       className={`px-3 py-1 text-sm rounded-md border ${
                         formData.status === status.value

--- a/src/data/aggregators/ClinicalSummaryAggregator.test.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.test.ts
@@ -119,6 +119,29 @@ describe('ClinicalSummaryAggregator', () => {
       // It should not have queried local storage or anything
     });
 
+    it('uses the patient-scoped appointment read contract', async () => {
+      vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository').mockReturnValue({
+        listFindingsByPatient: vi.fn().mockResolvedValue([]),
+      } as unknown as ReturnType<typeof FindingsRepositoryModule.createFindingsRepository>);
+      vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository').mockReturnValue({
+        getDentalChart: vi.fn().mockResolvedValue({ teeth: [] }),
+      } as unknown as ReturnType<typeof DentalChartRepositoryModule.createDentalChartRepository>);
+      vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository').mockReturnValue({
+        listTreatmentPlansByPatient: vi.fn().mockResolvedValue([]),
+      } as unknown as ReturnType<typeof TreatmentPlansRepositoryModule.createTreatmentPlansRepository>);
+      vi.spyOn(ChiefComplaintRepositoryModule, 'createChiefComplaintRepository').mockReturnValue({
+        getChiefComplaint: vi.fn().mockResolvedValue(null),
+      } as unknown as ReturnType<typeof ChiefComplaintRepositoryModule.createChiefComplaintRepository>);
+      const listAppointmentsByPatient = vi.fn().mockResolvedValue([]);
+      vi.spyOn(AppointmentRepositoryModule, 'createAppointmentRepository').mockReturnValue({
+        listAppointmentsByPatient,
+      } as unknown as ReturnType<typeof AppointmentRepositoryModule.createAppointmentRepository>);
+
+      await getPatientMedicalSummary('patient_1', { backend: 'supabase', tenantId: 't1' });
+
+      expect(listAppointmentsByPatient).toHaveBeenCalledWith('patient_1');
+    });
+
     it('propagates Supabase errors instead of falling back to local storage', async () => {
       vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository').mockReturnValue({
         listFindingsByPatient: vi.fn().mockRejectedValue(new Error('Supabase network error')),
@@ -137,7 +160,7 @@ describe('ClinicalSummaryAggregator', () => {
       } as unknown as ReturnType<typeof ChiefComplaintRepositoryModule.createChiefComplaintRepository>);
 
       vi.spyOn(AppointmentRepositoryModule, 'createAppointmentRepository').mockReturnValue({
-        listAppointments: vi.fn().mockResolvedValue([]),
+        listAppointmentsByPatient: vi.fn().mockResolvedValue([]),
       } as unknown as ReturnType<typeof AppointmentRepositoryModule.createAppointmentRepository>);
 
       await expect(getPatientMedicalSummary('patient_1', { backend: 'supabase', tenantId: 't1' })).rejects.toThrow('Supabase network error');

--- a/src/data/aggregators/ClinicalSummaryAggregator.ts
+++ b/src/data/aggregators/ClinicalSummaryAggregator.ts
@@ -3,6 +3,7 @@ import { createTreatmentPlansRepository } from '../repositories/TreatmentPlansRe
 import { createChiefComplaintRepository } from '../repositories/ChiefComplaintRepository';
 import { createFindingsRepository } from '../repositories/FindingsRepository';
 import { createAppointmentRepository } from '../repositories/AppointmentRepository';
+import { getPatientAppointmentSummary } from '../../domain/appointmentSummary';
 import { isActiveFindingStatus } from '../../domain/findingStatus';
 
 export interface PatientDentalSummary {
@@ -58,17 +59,13 @@ export async function getPatientMedicalSummary(patientId: string, config: Clinic
   const findingsRepo = createFindingsRepository(config);
   const appointmentRepo = createAppointmentRepository(config);
 
-  const [chart, plans, complaint, findings, allAppointments] = await Promise.all([
+  const [chart, plans, complaint, findings, patientAppointments] = await Promise.all([
     chartRepo.getDentalChart(patientId),
     plansRepo.listTreatmentPlansByPatient(patientId),
     complaintRepo.getChiefComplaint(patientId),
     findingsRepo.listFindingsByPatient(patientId),
-    appointmentRepo.listAppointments(),
+    appointmentRepo.listAppointmentsByPatient(patientId),
   ]);
-
-  const patientAppointments = allAppointments
-    .filter(a => a.patientId === patientId)
-    .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
 
   const needsTreatment = chart.teeth.filter(t => ['needs_treatment', 'caries', 'pulpitis', 'periodontitis'].includes(t.condition)).length;
   const missing = chart.teeth.filter(t => t.condition === 'missing').length;
@@ -81,21 +78,13 @@ export async function getPatientMedicalSummary(patientId: string, config: Clinic
   const notIncludedFindings = activeFindings.filter(f => f.status === 'discovered').length;
   const monitoringFindings = activeFindings.filter(f => f.status === 'monitoring').length;
 
-  let lastVisit: Date | undefined;
-  let nextVisit: Date | undefined;
-  const now = new Date();
-
-  const sortedAsc = [...patientAppointments].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
-
-  for (const appt of sortedAsc) {
-    if (appt.status === 'blocked' || appt.status === 'cancelled') continue;
-    const apptDate = new Date(appt.start);
-    if (apptDate < now) {
-      lastVisit = apptDate;
-    } else {
-      if (!nextVisit) nextVisit = apptDate;
-    }
-  }
+  const appointmentSummary = getPatientAppointmentSummary(patientAppointments, patientId);
+  const lastVisit = appointmentSummary.previousAppointment
+    ? new Date(appointmentSummary.previousAppointment.start)
+    : undefined;
+  const nextVisit = appointmentSummary.nextAppointment
+    ? new Date(appointmentSummary.nextAppointment.start)
+    : undefined;
 
   return {
     dentalSummary: {

--- a/src/data/aggregators/PatientListVisitSummaryAggregator.test.ts
+++ b/src/data/aggregators/PatientListVisitSummaryAggregator.test.ts
@@ -1,78 +1,102 @@
-// @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { PatientListVisitSummaryAggregator } from './PatientListVisitSummaryAggregator';
-import type { Appointment } from '../../types';
+import type { Appointment, AppointmentStatus } from '../../types';
+
+const appointment = (
+  id: string,
+  patientId: string | undefined,
+  start: string,
+  status: AppointmentStatus = 'confirmed',
+): Appointment => ({
+  id,
+  patientId,
+  doctorId: 'doctor-1',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  start,
+  end: new Date(new Date(start).getTime() + 60 * 60 * 1000).toISOString(),
+  status,
+  createdAt: '2026-01-01T00:00:00.000Z',
+});
 
 describe('PatientListVisitSummaryAggregator', () => {
-  beforeEach(() => {
-    localStorage.clear();
+  const now = new Date('2026-01-10T12:00:00.000Z');
+
+  it('selects the latest past and earliest actionable future appointment', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('past-1', 'patient-1', '2026-01-08T10:00:00.000Z', 'completed'),
+      appointment('past-2', 'patient-1', '2026-01-09T10:00:00.000Z', 'no_show'),
+      appointment('future-2', 'patient-1', '2026-01-12T10:00:00.000Z'),
+      appointment('future-1', 'patient-1', '2026-01-11T10:00:00.000Z'),
+    ], now);
+
+    expect(summary['patient-1'].lastVisit?.toISOString()).toBe('2026-01-09T10:00:00.000Z');
+    expect(summary['patient-1'].nextVisit?.toISOString()).toBe('2026-01-11T10:00:00.000Z');
   });
 
-  it('calculates lastVisit and nextVisit per patient', async () => {
-    const now = new Date('2026-01-10T12:00:00.000Z');
-    const past = new Date('2026-01-09T12:00:00.000Z').toISOString();
-    const future = new Date('2026-01-11T12:00:00.000Z').toISOString();
+  it('excludes cancelled and malformed future terminal rows from upcoming', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('cancelled', 'patient-1', '2026-01-11T09:00:00.000Z', 'cancelled'),
+      appointment('completed-future', 'patient-1', '2026-01-11T10:00:00.000Z', 'completed'),
+      appointment('no-show-future', 'patient-1', '2026-01-11T11:00:00.000Z', 'no_show'),
+      appointment('confirmed', 'patient-1', '2026-01-11T12:00:00.000Z', 'confirmed'),
+    ], now);
 
-    const appts: Appointment[] = [
-      { id: '1', patientId: 'patient_1', doctorId: 'd1', cabinet: 'c1', service: 's1', start: past, end: past, status: 'completed', createdAt: 'now' },
-      { id: '2', patientId: 'patient_1', doctorId: 'd1', cabinet: 'c1', service: 's1', start: future, end: future, status: 'confirmed', createdAt: 'now' },
-      { id: '3', patientId: 'patient_2', doctorId: 'd1', cabinet: 'c1', service: 's1', start: future, end: future, status: 'confirmed', createdAt: 'now' }
-    ];
-    localStorage.setItem('df_appointments', JSON.stringify(appts));
-
-    const summaryMap = await PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(now);
-
-    expect(summaryMap['patient_1'].lastVisit?.toISOString()).toBe(past);
-    expect(summaryMap['patient_1'].nextVisit?.toISOString()).toBe(future);
-
-    expect(summaryMap['patient_2'].lastVisit).toBeUndefined();
-    expect(summaryMap['patient_2'].nextVisit?.toISOString()).toBe(future);
+    expect(summary['patient-1'].nextVisit?.toISOString()).toBe('2026-01-11T12:00:00.000Z');
   });
 
-  it('ignores appointments without patientId', async () => {
-    const now = new Date('2026-01-10T12:00:00.000Z');
-    const appts = [
-      { id: '1', doctorId: 'd1', cabinet: 'c1', service: 's1', start: now.toISOString(), end: now.toISOString(), status: 'confirmed', createdAt: 'now' }
-    ] as Appointment[];
-    
-    localStorage.setItem('df_appointments', JSON.stringify(appts));
+  it('does not treat a cancelled past appointment as the previous visit', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('completed', 'patient-1', '2026-01-08T10:00:00.000Z', 'completed'),
+      appointment('cancelled', 'patient-1', '2026-01-09T10:00:00.000Z', 'cancelled'),
+    ], now);
 
-    const summaryMap = await PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(now);
-    expect(Object.keys(summaryMap)).toHaveLength(0);
+    expect(summary['patient-1'].lastVisit?.toISOString()).toBe('2026-01-08T10:00:00.000Z');
   });
 
-  it('ignores blocked and cancelled appointments', async () => {
-    const now = new Date('2026-01-10T12:00:00.000Z');
-    const past = new Date('2026-01-09T12:00:00.000Z').toISOString();
+  it('uses start >= now as the deterministic upcoming boundary', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('exact-now', 'patient-1', now.toISOString(), 'confirmed'),
+      appointment('one-ms-past', 'patient-1', '2026-01-10T11:59:59.999Z', 'arrived'),
+    ], now);
 
-    const appts: Appointment[] = [
-      { id: '1', patientId: 'patient_2', doctorId: 'd1', cabinet: 'c1', service: 's1', start: past, end: past, status: 'cancelled', createdAt: 'now' },
-      { id: '2', patientId: 'patient_2', doctorId: 'd1', cabinet: 'c1', service: 's1', start: past, end: past, status: 'blocked', createdAt: 'now' }
-    ];
-    localStorage.setItem('df_appointments', JSON.stringify(appts));
-
-    const summaryMap = await PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(now);
-    // Current behavior returns empty object if no valid appts
-    expect(summaryMap['patient_2']).toBeUndefined();
+    expect(summary['patient-1'].lastVisit?.toISOString()).toBe('2026-01-10T11:59:59.999Z');
+    expect(summary['patient-1'].nextVisit?.toISOString()).toBe(now.toISOString());
   });
 
-  it('handles patients without appointments', async () => {
-    const now = new Date('2026-01-10T12:00:00.000Z');
-    localStorage.setItem('df_appointments', JSON.stringify([]));
+  it('groups multiple patients independently from one appointment array', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('a', 'patient-a', '2026-01-11T10:00:00.000Z'),
+      appointment('b', 'patient-b', '2026-01-09T10:00:00.000Z', 'completed'),
+      appointment('c', 'patient-b', '2026-01-13T10:00:00.000Z'),
+    ], now);
 
-    const summaryMap = await PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(now);
-    expect(summaryMap['patient_3']).toBeUndefined();
+    expect(summary['patient-a'].lastVisit).toBeUndefined();
+    expect(summary['patient-a'].nextVisit?.toISOString()).toBe('2026-01-11T10:00:00.000Z');
+    expect(summary['patient-b'].lastVisit?.toISOString()).toBe('2026-01-09T10:00:00.000Z');
+    expect(summary['patient-b'].nextVisit?.toISOString()).toBe('2026-01-13T10:00:00.000Z');
   });
 
-  it('does not mutate appointments storage', async () => {
-    const now = new Date('2026-01-10T12:00:00.000Z');
-    const apptsData = JSON.stringify([
-      { id: '1', patientId: 'patient_1', doctorId: 'd1', cabinet: 'c1', service: 's1', start: now.toISOString(), end: now.toISOString(), status: 'completed', createdAt: 'now' }
-    ]);
-    localStorage.setItem('df_appointments', apptsData);
+  it('uses appointment id as a stable tie-breaker for equal start times', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('z-id', 'patient-1', '2026-01-11T10:00:00.000Z'),
+      appointment('a-id', 'patient-1', '2026-01-11T10:00:00.000Z'),
+    ], now);
 
-    await PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(now);
+    expect(summary['patient-1'].nextVisit?.toISOString()).toBe('2026-01-11T10:00:00.000Z');
+  });
 
-    expect(localStorage.getItem('df_appointments')).toBe(apptsData);
+  it('ignores blocked rows and rows without a patient', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([
+      appointment('blocked', undefined, '2026-01-11T10:00:00.000Z', 'blocked'),
+      appointment('missing-patient', undefined, '2026-01-11T11:00:00.000Z', 'confirmed'),
+    ], now);
+
+    expect(summary).toEqual({});
+  });
+
+  it('returns no state for a patient without appointments', () => {
+    const summary = PatientListVisitSummaryAggregator.getVisitSummaryByPatientId([], now);
+    expect(summary['patient-none']).toBeUndefined();
   });
 });

--- a/src/data/aggregators/PatientListVisitSummaryAggregator.ts
+++ b/src/data/aggregators/PatientListVisitSummaryAggregator.ts
@@ -1,4 +1,5 @@
-import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
+import type { Appointment } from '../../types';
+import { buildPatientAppointmentSummaryByPatientId } from '../../domain/appointmentSummary';
 
 export interface PatientVisitSummary {
   lastVisit?: Date;
@@ -8,29 +9,22 @@ export interface PatientVisitSummary {
 export type PatientVisitSummaryByPatientId = Record<string, PatientVisitSummary>;
 
 export const PatientListVisitSummaryAggregator = {
-  async getVisitSummaryByPatientId(now = new Date()): Promise<PatientVisitSummaryByPatientId> {
+  getVisitSummaryByPatientId(
+    appointments: Appointment[],
+    now = new Date(),
+  ): PatientVisitSummaryByPatientId {
+    const summaries = buildPatientAppointmentSummaryByPatientId(appointments, now);
     const visits: PatientVisitSummaryByPatientId = {};
-    const appointments = await LocalStorageAppointmentRepository.listAppointments();
 
-    const sortedAppts = [...appointments].sort(
-      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
-    );
-
-    for (const appt of sortedAppts) {
-      if (!appt.patientId || appt.status === 'blocked' || appt.status === 'cancelled') continue;
-
-      const apptDate = new Date(appt.start);
-      if (!visits[appt.patientId]) {
-        visits[appt.patientId] = {};
-      }
-
-      if (apptDate < now) {
-        visits[appt.patientId].lastVisit = apptDate;
-      } else {
-        if (!visits[appt.patientId].nextVisit) {
-          visits[appt.patientId].nextVisit = apptDate;
-        }
-      }
+    for (const [patientId, summary] of Object.entries(summaries)) {
+      visits[patientId] = {
+        lastVisit: summary.previousAppointment
+          ? new Date(summary.previousAppointment.start)
+          : undefined,
+        nextVisit: summary.nextAppointment
+          ? new Date(summary.nextAppointment.start)
+          : undefined,
+      };
     }
 
     return visits;

--- a/src/data/hooks/usePatientAppointments.test.tsx
+++ b/src/data/hooks/usePatientAppointments.test.tsx
@@ -1,0 +1,205 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Appointment } from '../../types';
+import { usePatientAppointments } from './usePatientAppointments';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { createAppointmentRepository } from '../repositories/AppointmentRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  isSupabaseConfigured: true,
+  supabase: {},
+}));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../repositories/AppointmentRepository', () => ({
+  createAppointmentRepository: vi.fn(),
+}));
+
+const makeAppointment = (id: string, patientId: string, status: Appointment['status'] = 'confirmed'): Appointment => ({
+  id,
+  patientId,
+  doctorId: 'doctor-1',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status,
+  start: '2026-08-01T10:00:00',
+  end: '2026-08-01T11:00:00',
+  createdAt: '2026-07-01T09:00:00',
+  updatedAt: '2026-07-01T09:00:00+00:00',
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('usePatientAppointments', () => {
+  let authState: any;
+  let tenantState: any;
+  let current: ReturnType<typeof usePatientAppointments> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A' } };
+    vi.mocked(useAuth).mockImplementation(() => authState);
+    vi.mocked(useTenant).mockImplementation(() => tenantState);
+  });
+
+  const mount = async (patientId: string) => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const Harness = ({ id, tick = 0 }: { id: string; tick?: number }) => {
+      void tick;
+      current = usePatientAppointments(id);
+      return null;
+    };
+    await act(async () => {
+      root.render(<Harness id={patientId} />);
+    });
+    return { root, Harness };
+  };
+
+  it('uses the Supabase repository with tenant scope and retains cancelled history rows', async () => {
+    const list = vi.fn().mockResolvedValue([makeAppointment('cancelled', 'patient-a', 'cancelled')]);
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: list } as any);
+
+    const { root } = await mount('patient-a');
+
+    expect(createAppointmentRepository).toHaveBeenCalledWith({ backend: 'supabase', tenantId: 'tenant-a' });
+    expect(list).toHaveBeenCalledWith('patient-a');
+    expect(current?.appointments[0].status).toBe('cancelled');
+    await act(async () => root.unmount());
+  });
+
+  it('uses local repository only in explicit dev mode', async () => {
+    authState = { authMode: 'dev', user: { id: 'dev-user' } };
+    tenantState = { activeTenant: null };
+    const list = vi.fn().mockResolvedValue([]);
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: list } as any);
+
+    const { root } = await mount('patient-a');
+
+    expect(createAppointmentRepository).toHaveBeenCalledWith({ backend: 'local' });
+    expect(list).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('does not create a repository or fetch without tenant in Supabase mode', async () => {
+    tenantState = { activeTenant: null };
+    const { root } = await mount('patient-a');
+
+    expect(createAppointmentRepository).not.toHaveBeenCalled();
+    expect(current).toMatchObject({ appointments: [], isLoading: false, isError: false });
+    await act(async () => root.unmount());
+  });
+
+  it('does not fetch without a patient id', async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: list } as any);
+    const { root } = await mount('');
+
+    expect(list).not.toHaveBeenCalled();
+    expect(current?.appointments).toEqual([]);
+    await act(async () => root.unmount());
+  });
+
+  it('refetches on patient change and clears the previous patient immediately', async () => {
+    const list = vi.fn((patientId: string) => Promise.resolve([makeAppointment(patientId, patientId)]));
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: list } as any);
+    const { root, Harness } = await mount('patient-a');
+    expect(current?.appointments[0].patientId).toBe('patient-a');
+
+    await act(async () => {
+      root.render(<Harness id="patient-b" tick={1} />);
+    });
+
+    expect(list).toHaveBeenLastCalledWith('patient-b');
+    expect(current?.appointments[0].patientId).toBe('patient-b');
+    await act(async () => root.unmount());
+  });
+
+  it('ignores a stale patient response that arrives after navigation', async () => {
+    const patientA = deferred<Appointment[]>();
+    const patientB = deferred<Appointment[]>();
+    const list = vi.fn((patientId: string) => patientId === 'patient-a' ? patientA.promise : patientB.promise);
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: list } as any);
+    const { root, Harness } = await mount('patient-a');
+
+    await act(async () => {
+      root.render(<Harness id="patient-b" tick={1} />);
+    });
+    expect(current?.appointments).toEqual([]);
+
+    await act(async () => patientA.resolve([makeAppointment('a', 'patient-a')]));
+    expect(current?.appointments).toEqual([]);
+
+    await act(async () => patientB.resolve([makeAppointment('b', 'patient-b')]));
+    expect(current?.appointments[0].patientId).toBe('patient-b');
+    await act(async () => root.unmount());
+  });
+
+  it('ignores a stale tenant response and loads the new tenant repository', async () => {
+    const tenantA = deferred<Appointment[]>();
+    const tenantB = deferred<Appointment[]>();
+    const listA = vi.fn(() => tenantA.promise);
+    const listB = vi.fn(() => tenantB.promise);
+    vi.mocked(createAppointmentRepository).mockImplementation(({ tenantId }) => (
+      { listAppointmentsByPatient: tenantId === 'tenant-a' ? listA : listB } as any
+    ));
+    const { root, Harness } = await mount('patient-a');
+
+    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B' } };
+    await act(async () => root.render(<Harness id="patient-a" tick={1} />));
+    expect(current?.appointments).toEqual([]);
+
+    await act(async () => tenantA.resolve([makeAppointment('a', 'patient-a')]));
+    expect(current?.appointments).toEqual([]);
+
+    await act(async () => tenantB.resolve([makeAppointment('b', 'patient-a')]));
+    expect(current?.appointments[0].id).toBe('b');
+    expect(createAppointmentRepository).toHaveBeenLastCalledWith({ backend: 'supabase', tenantId: 'tenant-b' });
+    await act(async () => root.unmount());
+  });
+
+  it('exposes a safe error and never falls back to local data', async () => {
+    const list = vi.fn().mockRejectedValue({ message: 'SQLSTATE 42501 public.appointments' });
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: list } as any);
+    const { root } = await mount('patient-a');
+
+    expect(current?.isError).toBe(true);
+    expect(current?.error?.message).toBe('Не удалось загрузить записи пациента.');
+    expect(createAppointmentRepository).toHaveBeenCalledTimes(1);
+    expect(createAppointmentRepository).not.toHaveBeenCalledWith({ backend: 'local' });
+    await act(async () => root.unmount());
+  });
+
+  it('reports loading and empty states without stale data', async () => {
+    const pending = deferred<Appointment[]>();
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: () => pending.promise } as any);
+    const { root } = await mount('patient-a');
+    expect(current).toMatchObject({ appointments: [], isLoading: true, isError: false });
+
+    await act(async () => pending.resolve([]));
+    expect(current).toMatchObject({ appointments: [], isLoading: false, isError: false });
+    await act(async () => root.unmount());
+  });
+
+  it('ignores a late result after unmount', async () => {
+    const pending = deferred<Appointment[]>();
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointmentsByPatient: () => pending.promise } as any);
+    const { root } = await mount('patient-a');
+    await act(async () => root.unmount());
+    await expect(act(async () => pending.resolve([makeAppointment('late', 'patient-a')]))).resolves.toBeUndefined();
+  });
+});

--- a/src/data/hooks/usePatientAppointments.ts
+++ b/src/data/hooks/usePatientAppointments.ts
@@ -1,12 +1,43 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { Appointment } from '../../types';
-import { LocalStorageAppointmentRepository } from '../repositories/AppointmentRepository';
+import { createAppointmentRepository } from '../repositories/AppointmentRepository';
 import { useAsyncQuery } from './useAsyncQuery';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+
+const PATIENT_APPOINTMENTS_ERROR = 'Не удалось загрузить записи пациента.';
 
 export function usePatientAppointments(patientId: string) {
-  const queryFn = useCallback(() => {
-    return LocalStorageAppointmentRepository.listAppointmentsByPatient(patientId);
-  }, [patientId]);
+  const { authMode, user } = useAuth();
+  const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
+
+  const repository = useMemo(() => {
+    if (authMode === 'dev') {
+      return createAppointmentRepository({ backend: 'local' });
+    }
+    if (isSupabaseMode && user?.id && tenantId) {
+      return createAppointmentRepository({ backend: 'supabase', tenantId });
+    }
+    return null;
+  }, [authMode, isSupabaseMode, tenantId, user?.id]);
+
+  const queryFn = useCallback(async (): Promise<Appointment[]> => {
+    if (!patientId || !repository) return [];
+    try {
+      return await repository.listAppointmentsByPatient(patientId);
+    } catch {
+      throw new Error(PATIENT_APPOINTMENTS_ERROR);
+    }
+  }, [patientId, repository]);
+
+  const enabled = Boolean(patientId) && (
+    authMode === 'dev'
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId))
+  );
+  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${patientId || 'no-patient'}`;
 
   const {
     data: appointments,
@@ -17,14 +48,16 @@ export function usePatientAppointments(patientId: string) {
   } = useAsyncQuery<Appointment[]>({
     queryFn,
     initialData: [],
-    enabled: Boolean(patientId),
+    enabled,
+    queryKey,
+    resetOnDisable: true,
   });
 
   return {
-    appointments,
-    isLoading,
-    isError,
-    error,
+    appointments: enabled ? appointments : [],
+    isLoading: enabled ? isLoading : false,
+    isError: enabled ? isError : false,
+    error: enabled ? error : null,
     refetch,
   };
 }

--- a/src/data/hooks/usePatientListVisitSummary.test.tsx
+++ b/src/data/hooks/usePatientListVisitSummary.test.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Appointment } from '../../types';
+import { usePatientListVisitSummary } from './usePatientListVisitSummary';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { createAppointmentRepository } from '../repositories/AppointmentRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({ isSupabaseConfigured: true, supabase: {} }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../repositories/AppointmentRepository', () => ({ createAppointmentRepository: vi.fn() }));
+
+const appointment = (id: string, patientId: string, start: string): Appointment => ({
+  id,
+  patientId,
+  doctorId: 'doctor-1',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'confirmed',
+  start,
+  end: start,
+  createdAt: start,
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+};
+
+describe('usePatientListVisitSummary', () => {
+  let authState: any;
+  let tenantState: any;
+  let current: ReturnType<typeof usePatientListVisitSummary> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A' } };
+    vi.mocked(useAuth).mockImplementation(() => authState);
+    vi.mocked(useTenant).mockImplementation(() => tenantState);
+  });
+
+  const mount = async () => {
+    const root = createRoot(document.createElement('div'));
+    const Harness = ({ tick = 0 }: { tick?: number }) => {
+      void tick;
+      current = usePatientListVisitSummary();
+      return null;
+    };
+    await act(async () => root.render(<Harness />));
+    return { root, Harness };
+  };
+
+  it('loads all tenant appointments once and groups many patients without N+1 calls', async () => {
+    const list = vi.fn().mockResolvedValue([
+      appointment('past-a', 'patient-a', '2020-01-01T10:00:00.000Z'),
+      appointment('future-a', 'patient-a', '2099-01-01T10:00:00.000Z'),
+      appointment('future-b', 'patient-b', '2099-02-01T10:00:00.000Z'),
+    ]);
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointments: list } as any);
+
+    const { root } = await mount();
+
+    expect(createAppointmentRepository).toHaveBeenCalledWith({ backend: 'supabase', tenantId: 'tenant-a' });
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(current?.visitSummaryByPatientId['patient-a'].lastVisit?.toISOString()).toBe('2020-01-01T10:00:00.000Z');
+    expect(current?.visitSummaryByPatientId['patient-a'].nextVisit?.toISOString()).toBe('2099-01-01T10:00:00.000Z');
+    expect(current?.visitSummaryByPatientId['patient-b'].nextVisit?.toISOString()).toBe('2099-02-01T10:00:00.000Z');
+    await act(async () => root.unmount());
+  });
+
+  it('uses local backend only in explicit dev mode', async () => {
+    authState = { authMode: 'dev', user: { id: 'dev-user' } };
+    tenantState = { activeTenant: null };
+    vi.mocked(createAppointmentRepository).mockReturnValue({ listAppointments: vi.fn().mockResolvedValue([]) } as any);
+    const { root } = await mount();
+
+    expect(createAppointmentRepository).toHaveBeenCalledWith({ backend: 'local' });
+    await act(async () => root.unmount());
+  });
+
+  it('does not query or expose stale local values without tenant in Supabase mode', async () => {
+    tenantState = { activeTenant: null };
+    const { root } = await mount();
+
+    expect(createAppointmentRepository).not.toHaveBeenCalled();
+    expect(current).toMatchObject({ visitSummaryByPatientId: {}, isLoading: false, isError: false });
+    await act(async () => root.unmount());
+  });
+
+  it('clears tenant A data immediately and ignores its late response after switching to tenant B', async () => {
+    const a = deferred<Appointment[]>();
+    const b = deferred<Appointment[]>();
+    vi.mocked(createAppointmentRepository).mockImplementation(({ tenantId }) => ({
+      listAppointments: () => tenantId === 'tenant-a' ? a.promise : b.promise,
+    } as any));
+    const { root, Harness } = await mount();
+
+    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B' } };
+    await act(async () => root.render(<Harness tick={1} />));
+    expect(current?.visitSummaryByPatientId).toEqual({});
+
+    await act(async () => a.resolve([appointment('a', 'patient-a', '2099-01-01T10:00:00.000Z')]));
+    expect(current?.visitSummaryByPatientId).toEqual({});
+
+    await act(async () => b.resolve([appointment('b', 'patient-b', '2099-02-01T10:00:00.000Z')]));
+    expect(current?.visitSummaryByPatientId['patient-b'].nextVisit).toBeDefined();
+    expect(current?.visitSummaryByPatientId['patient-a']).toBeUndefined();
+    await act(async () => root.unmount());
+  });
+
+  it('shows a neutral safe error and does not retry through local storage', async () => {
+    vi.mocked(createAppointmentRepository).mockReturnValue({
+      listAppointments: vi.fn().mockRejectedValue({ message: 'SQLSTATE 42501 public.appointments' }),
+    } as any);
+    const { root } = await mount();
+
+    expect(current?.visitSummaryByPatientId).toEqual({});
+    expect(current?.isError).toBe(true);
+    expect(current?.error?.message).toBe('Не удалось загрузить сводку по записям.');
+    expect(createAppointmentRepository).toHaveBeenCalledTimes(1);
+    expect(createAppointmentRepository).not.toHaveBeenCalledWith({ backend: 'local' });
+    await act(async () => root.unmount());
+  });
+});

--- a/src/data/hooks/usePatientListVisitSummary.ts
+++ b/src/data/hooks/usePatientListVisitSummary.ts
@@ -1,25 +1,57 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
 import { PatientListVisitSummaryAggregator } from '../aggregators/PatientListVisitSummaryAggregator';
 import type { PatientVisitSummaryByPatientId } from '../aggregators/PatientListVisitSummaryAggregator';
+import { createAppointmentRepository } from '../repositories/AppointmentRepository';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+
+const SUMMARY_ERROR = 'Не удалось загрузить сводку по записям.';
 
 export function usePatientListVisitSummary() {
-  const queryFn = useCallback(
-    () => PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(),
-    []
-  );
+  const { authMode, user } = useAuth();
+  const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
+
+  const repository = useMemo(() => {
+    if (authMode === 'dev') {
+      return createAppointmentRepository({ backend: 'local' });
+    }
+    if (isSupabaseMode && user?.id && tenantId) {
+      return createAppointmentRepository({ backend: 'supabase', tenantId });
+    }
+    return null;
+  }, [authMode, isSupabaseMode, tenantId, user?.id]);
+
+  const queryFn = useCallback(async (): Promise<PatientVisitSummaryByPatientId> => {
+    if (!repository) return {};
+    try {
+      const appointments = await repository.listAppointments();
+      return PatientListVisitSummaryAggregator.getVisitSummaryByPatientId(appointments);
+    } catch {
+      throw new Error(SUMMARY_ERROR);
+    }
+  }, [repository]);
+
+  const enabled = authMode === 'dev'
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId));
+  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:patient-list-summary`;
 
   const { data, isLoading, isError, error, refetch } = useAsyncQuery<PatientVisitSummaryByPatientId>({
     queryFn,
     initialData: {},
-    enabled: true,
+    enabled,
+    queryKey,
+    resetOnDisable: true,
   });
 
   return {
-    visitSummaryByPatientId: data || {},
-    isLoading,
-    isError,
-    error,
+    visitSummaryByPatientId: enabled ? data : {},
+    isLoading: enabled ? isLoading : false,
+    isError: enabled ? isError : false,
+    error: enabled ? error : null,
     refetch,
   };
 }

--- a/src/data/hooks/usePatientMedicalSummary.test.tsx
+++ b/src/data/hooks/usePatientMedicalSummary.test.tsx
@@ -1,133 +1,148 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // @vitest-environment jsdom
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createRoot } from 'react-dom/client';
 import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePatientMedicalSummary } from './usePatientMedicalSummary';
-import * as ClinicalSummaryAggregatorModule from '../aggregators/ClinicalSummaryAggregator';
-import * as SupabaseClientModule from '../../lib/supabaseClient';
+import * as ClinicalSummary from '../aggregators/ClinicalSummaryAggregator';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 
-vi.mock('../../lib/supabaseClient', () => ({
-  supabase: {},
-  isSupabaseConfigured: true,
-}));
+vi.mock('../../lib/supabaseClient', () => ({ supabase: {}, isSupabaseConfigured: true }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
 
-vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: vi.fn(),
-}));
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+};
 
-vi.mock('../../contexts/TenantContext', () => ({
-  useTenant: vi.fn(),
-}));
+const summary = (amount: number): ClinicalSummary.PatientMedicalSummaryData => ({
+  dentalSummary: {
+    ...ClinicalSummary.EMPTY_PATIENT_DENTAL_SUMMARY,
+    totalAmount: amount,
+  },
+});
 
 describe('usePatientMedicalSummary', () => {
+  let authState: any;
+  let tenantState: any;
+  let current: ReturnType<typeof usePatientMedicalSummary> | undefined;
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A' } };
+    vi.mocked(useAuth).mockImplementation(() => authState);
+    vi.mocked(useTenant).mockImplementation(() => tenantState);
   });
 
-  it('routes to supabase backend when authMode is supabase-active, activeTenant exists, and supabase is configured', async () => {
-    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
-
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
-
-    const TestComponent = () => {
-      usePatientMedicalSummary('patient_1');
+  const mount = async (patientId: string) => {
+    const root = createRoot(document.createElement('div'));
+    const Harness = ({ id, tick = 0 }: { id: string; tick?: number }) => {
+      void tick;
+      current = usePatientMedicalSummary(id);
       return null;
     };
+    await act(async () => root.render(<Harness id={patientId} />));
+    return { root, Harness };
+  };
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
+  it('uses Supabase only with an authenticated tenant context', async () => {
+    const spy = vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary').mockResolvedValue(summary(100));
+    const { root } = await mount('patient-a');
 
-    await act(async () => {
-      root.render(<TestComponent />);
-    });
-
-    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'supabase', tenantId: 'real-tenant-id' }));
-
-    await act(async () => {
-      root.unmount();
-    });
+    expect(spy).toHaveBeenCalledWith('patient-a', { backend: 'supabase', tenantId: 'tenant-a' });
+    expect(current?.data.dentalSummary.totalAmount).toBe(100);
+    await act(async () => root.unmount());
   });
 
-  it('routes to local backend when authMode is supabase-active but activeTenant is missing', async () => {
-    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+  it('does not fall back to local storage without tenant in Supabase mode', async () => {
+    tenantState = { activeTenant: null };
+    const spy = vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary').mockResolvedValue(summary(999));
+    const { root } = await mount('patient-a');
 
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: null } as unknown as ReturnType<typeof useTenant>);
-
-    const TestComponent = () => {
-      usePatientMedicalSummary('patient_1');
-      return null;
-    };
-
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<TestComponent />);
+    expect(spy).not.toHaveBeenCalled();
+    expect(current).toMatchObject({
+      data: ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY,
+      isLoading: false,
+      isError: false,
     });
-
-    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'local' }));
-
-    await act(async () => {
-      root.unmount();
-    });
+    await act(async () => root.unmount());
   });
 
-  it('routes to local backend when authMode is dev', async () => {
-    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+  it('uses local backend only in explicit dev mode', async () => {
+    authState = { authMode: 'dev', user: { id: 'dev-user' } };
+    tenantState = { activeTenant: { tenantId: 'dev-tenant', tenantName: 'Dev' } };
+    const spy = vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary').mockResolvedValue(summary(200));
+    const { root } = await mount('patient-a');
 
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: '123', tenantName: 'Dev' } } as unknown as ReturnType<typeof useTenant>);
-
-    const TestComponent = () => {
-      usePatientMedicalSummary('patient_1');
-      return null;
-    };
-
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<TestComponent />);
-    });
-
-    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'local', tenantId: '123' }));
-
-    await act(async () => {
-      root.unmount();
-    });
+    expect(spy).toHaveBeenCalledWith('patient-a', { backend: 'local', tenantId: 'dev-tenant' });
+    await act(async () => root.unmount());
   });
 
-  it('routes to local backend when authMode is supabase-active but isSupabaseConfigured is false', async () => {
-    Object.defineProperty(SupabaseClientModule, 'isSupabaseConfigured', { value: false, configurable: true });
-    const aggregatorSpy = vi.spyOn(ClinicalSummaryAggregatorModule, 'getPatientMedicalSummary').mockResolvedValue(ClinicalSummaryAggregatorModule.EMPTY_PATIENT_MEDICAL_SUMMARY);
+  it('clears stale patient data and ignores a late response', async () => {
+    const a = deferred<ClinicalSummary.PatientMedicalSummaryData>();
+    const b = deferred<ClinicalSummary.PatientMedicalSummaryData>();
+    vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary')
+      .mockImplementation((patientId) => patientId === 'patient-a' ? a.promise : b.promise);
+    const { root, Harness } = await mount('patient-a');
 
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    await act(async () => root.render(<Harness id="patient-b" tick={1} />));
+    expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
 
-    const TestComponent = () => {
-      usePatientMedicalSummary('patient_1');
-      return null;
-    };
+    await act(async () => a.resolve(summary(111)));
+    expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
 
-    const container = document.createElement('div');
-    const root = createRoot(container);
+    await act(async () => b.resolve(summary(222)));
+    expect(current?.data.dentalSummary.totalAmount).toBe(222);
+    await act(async () => root.unmount());
+  });
 
-    await act(async () => {
-      root.render(<TestComponent />);
-    });
+  it('clears stale tenant data and ignores a late response', async () => {
+    const a = deferred<ClinicalSummary.PatientMedicalSummaryData>();
+    const b = deferred<ClinicalSummary.PatientMedicalSummaryData>();
+    vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary')
+      .mockImplementation((_patientId, config) => config.tenantId === 'tenant-a' ? a.promise : b.promise);
+    const { root, Harness } = await mount('patient-a');
 
-    expect(aggregatorSpy).toHaveBeenCalledWith('patient_1', expect.objectContaining({ backend: 'local', tenantId: 'real-tenant-id' }));
+    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B' } };
+    await act(async () => root.render(<Harness id="patient-a" tick={1} />));
+    expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
 
-    await act(async () => {
-      root.unmount();
-    });
-    
-    // Restore
-    Object.defineProperty(SupabaseClientModule, 'isSupabaseConfigured', { value: true, configurable: true });
+    await act(async () => a.resolve(summary(111)));
+    expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
+
+    await act(async () => b.resolve(summary(222)));
+    expect(current?.data.dentalSummary.totalAmount).toBe(222);
+    await act(async () => root.unmount());
+  });
+
+  it('clears data when the Supabase session ends during a request', async () => {
+    const pending = deferred<ClinicalSummary.PatientMedicalSummaryData>();
+    const spy = vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary').mockReturnValue(pending.promise);
+    const { root, Harness } = await mount('patient-a');
+
+    authState = { authMode: 'supabase-active', user: null };
+    await act(async () => root.render(<Harness id="patient-a" tick={1} />));
+    expect(current).toMatchObject({ data: ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY, isLoading: false });
+
+    await act(async () => pending.resolve(summary(999)));
+    expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
+    expect(spy).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('maps failures to a safe summary error without fallback', async () => {
+    vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary')
+      .mockRejectedValue({ message: 'SQLSTATE 42501 public.appointments' });
+    const { root } = await mount('patient-a');
+
+    expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
+    expect(current?.isError).toBe(true);
+    expect(current?.error?.message).toBe('Не удалось загрузить сводку пациента.');
+    await act(async () => root.unmount());
   });
 });

--- a/src/data/hooks/usePatientMedicalSummary.ts
+++ b/src/data/hooks/usePatientMedicalSummary.ts
@@ -4,28 +4,56 @@ import {
   getPatientMedicalSummary,
   EMPTY_PATIENT_MEDICAL_SUMMARY,
   type PatientMedicalSummaryData,
-  type ClinicalSummaryRepositoryConfig
+  type ClinicalSummaryRepositoryConfig,
 } from '../aggregators/ClinicalSummaryAggregator';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 import { isSupabaseConfigured } from '../../lib/supabaseClient';
 
 export function usePatientMedicalSummary(patientId: string) {
-  const { authMode } = useAuth();
+  const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
 
-  const config = useMemo<ClinicalSummaryRepositoryConfig>(() => {
-    return {
-      backend: authMode === 'supabase-active' && activeTenant?.tenantId && isSupabaseConfigured ? 'supabase' : 'local',
-      tenantId: activeTenant?.tenantId,
-    };
-  }, [authMode, activeTenant?.tenantId]);
+  const config = useMemo<ClinicalSummaryRepositoryConfig | null>(() => {
+    if (authMode === 'dev') {
+      return { backend: 'local', tenantId };
+    }
+    if (isSupabaseMode && user?.id && tenantId) {
+      return { backend: 'supabase', tenantId };
+    }
+    return null;
+  }, [authMode, isSupabaseMode, tenantId, user?.id]);
 
-  const queryFn = useCallback(() => getPatientMedicalSummary(patientId, config), [patientId, config]);
+  const queryFn = useCallback(async (): Promise<PatientMedicalSummaryData> => {
+    if (!patientId || !config) return EMPTY_PATIENT_MEDICAL_SUMMARY;
+    try {
+      return await getPatientMedicalSummary(patientId, config);
+    } catch {
+      throw new Error('Не удалось загрузить сводку пациента.');
+    }
+  }, [patientId, config]);
 
-  return useAsyncQuery<PatientMedicalSummaryData>({
+  const enabled = Boolean(patientId) && (
+    authMode === 'dev'
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId))
+  );
+  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${patientId || 'no-patient'}:medical-summary`;
+
+  const result = useAsyncQuery<PatientMedicalSummaryData>({
     queryFn,
     initialData: EMPTY_PATIENT_MEDICAL_SUMMARY,
-    enabled: Boolean(patientId),
+    enabled,
+    queryKey,
+    resetOnDisable: true,
   });
+
+  return {
+    ...result,
+    data: enabled ? result.data : EMPTY_PATIENT_MEDICAL_SUMMARY,
+    isLoading: enabled ? result.isLoading : false,
+    isError: enabled ? result.isError : false,
+    error: enabled ? result.error : null,
+  };
 }

--- a/src/data/hooks/usePatientTimeline.test.tsx
+++ b/src/data/hooks/usePatientTimeline.test.tsx
@@ -88,7 +88,7 @@ function renderHook(patientValue: Patient | null = patient, includeArchived = fa
 describe('usePatientTimeline', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active', user: { id: 'user-a' } } as unknown as ReturnType<typeof useAuth>);
     vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
     mocks.getChiefComplaint.mockResolvedValue(null);
     mocks.listFindingsByPatient.mockResolvedValue([]);
@@ -174,7 +174,7 @@ describe('usePatientTimeline', () => {
   });
 
   it('does not query activity repository in non-Supabase local mode and does not create a local fallback', async () => {
-    vi.mocked(useAuth).mockReturnValue({ authMode: 'local' } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue({ authMode: 'dev', user: { id: 'dev-user' } } as unknown as ReturnType<typeof useAuth>);
     const { root, render } = renderHook(patient);
     await render();
 

--- a/src/data/hooks/usePatientTimeline.ts
+++ b/src/data/hooks/usePatientTimeline.ts
@@ -23,26 +23,25 @@ interface UsePatientTimelineOptions {
 }
 
 export function usePatientTimeline({ patient, includeArchived = false }: UsePatientTimelineOptions) {
-  const { authMode } = useAuth();
+  const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
-
-  const isNoTenantSupabase = authMode === 'supabase-active' && isSupabaseConfigured && !activeTenant?.tenantId;
+  const tenantId = activeTenant?.tenantId;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
 
   const repositoryConfig = useMemo(() => {
-    const backend = authMode === 'supabase-active' && isSupabaseConfigured && activeTenant?.tenantId
-      ? 'supabase'
-      : 'local';
-
-    return {
-      backend,
-      tenantId: activeTenant?.tenantId,
-    } as const;
-  }, [authMode, activeTenant?.tenantId]);
+    if (authMode === 'dev') {
+      return { backend: 'local' as const, tenantId };
+    }
+    if (isSupabaseMode && user?.id && tenantId) {
+      return { backend: 'supabase' as const, tenantId };
+    }
+    return null;
+  }, [authMode, isSupabaseMode, tenantId, user?.id]);
 
   const queryFn = useCallback(async (): Promise<PatientTimelineEvent[]> => {
-    if (!patient?.id) return [];
-    if (isNoTenantSupabase || !activeTenant?.tenantId) return [];
+    if (!patient?.id || !repositoryConfig) return [];
 
+    const timelineTenantId = repositoryConfig.tenantId || '11111111-1111-1111-1111-111111111111';
     const chiefComplaintRepository = createChiefComplaintRepository(repositoryConfig);
     const findingsRepository = createFindingsRepository(repositoryConfig);
     const treatmentPlansRepository = createTreatmentPlansRepository(repositoryConfig);
@@ -62,7 +61,7 @@ export function usePatientTimeline({ patient, includeArchived = false }: UsePati
       dentalChartRepository.getDentalChart(patient.id),
       activityRepository
         ? activityRepository.listPatientActivityEvents({
-          tenantId: activeTenant.tenantId,
+          tenantId: timelineTenantId,
           patientId: patient.id,
           includeArchived,
         })
@@ -70,7 +69,7 @@ export function usePatientTimeline({ patient, includeArchived = false }: UsePati
     ]);
 
     const events = buildPatientTimeline({
-      tenantId: activeTenant.tenantId,
+      tenantId: timelineTenantId,
       patientId: patient.id,
       patient,
       chiefComplaint,
@@ -83,20 +82,28 @@ export function usePatientTimeline({ patient, includeArchived = false }: UsePati
       includeArchived,
     });
 
-    return events.filter((event) => canRoleSeePatientTimelineEvent(activeTenant.role, event));
-  }, [activeTenant, includeArchived, isNoTenantSupabase, patient, repositoryConfig]);
+    return events.filter((event) => canRoleSeePatientTimelineEvent(activeTenant?.role, event));
+  }, [activeTenant?.role, includeArchived, patient, repositoryConfig]);
+
+  const enabled = Boolean(patient?.id) && (
+    authMode === 'dev'
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId))
+  );
+  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${patient?.id || 'no-patient'}:${includeArchived ? 'archived' : 'active'}:timeline`;
 
   const { data, isLoading, isError, error, refetch } = useAsyncQuery<PatientTimelineEvent[]>({
     queryFn,
     initialData: [],
-    enabled: Boolean(patient?.id),
+    enabled,
+    queryKey,
+    resetOnDisable: true,
   });
 
   return {
-    events: isNoTenantSupabase ? [] : data,
-    isLoading: isNoTenantSupabase ? false : isLoading,
-    isError,
-    error,
+    events: enabled ? data : [],
+    isLoading: enabled ? isLoading : false,
+    isError: enabled ? isError : false,
+    error: enabled ? error : null,
     refresh: refetch,
   };
 }

--- a/src/data/hooks/useScheduleAppointments.test.tsx
+++ b/src/data/hooks/useScheduleAppointments.test.tsx
@@ -122,7 +122,7 @@ describe('useScheduleAppointments', () => {
     createRepositorySpy.mockReturnValue(repository);
     activeTenant = { tenantId: 'tenant-a' };
     authMode = 'supabase-active';
-    vi.mocked(useAuth).mockImplementation(() => ({ authMode } as any));
+    vi.mocked(useAuth).mockImplementation(() => ({ authMode, user: { id: 'user-a' } } as any));
     vi.mocked(useTenant).mockImplementation(() => ({ activeTenant } as any));
   });
 
@@ -143,8 +143,18 @@ describe('useScheduleAppointments', () => {
     authMode = 'dev';
     activeTenant = null;
     const localHarness = await renderHook();
-    expect(createRepositorySpy).toHaveBeenLastCalledWith({ backend: 'local', tenantId: undefined });
+    expect(createRepositorySpy).toHaveBeenLastCalledWith({ backend: 'local' });
     await localHarness.unmount();
+  });
+
+  it('does not select local storage when Supabase mode has no tenant', async () => {
+    activeTenant = null;
+    const harness = await renderHook();
+
+    expect(createRepositorySpy).not.toHaveBeenCalled();
+    expect(harness.getResult()).toMatchObject({ appointments: [], isLoading: false });
+    expect(() => harness.getResult().createAppointment(appointment)).toThrow('Клиника не выбрана.');
+    await harness.unmount();
   });
 
   it('rapid duplicate create calls share one logical operation, one key, and one refetch', async () => {

--- a/src/data/hooks/useScheduleAppointments.ts
+++ b/src/data/hooks/useScheduleAppointments.ts
@@ -6,6 +6,7 @@ import {
   createAppointmentRepository,
   isProtectedAppointmentChange,
   type AppointmentWriteResult,
+  type IAppointmentRepository,
 } from '../repositories/AppointmentRepository';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
@@ -45,10 +46,11 @@ const safeMutationError = (error: unknown): Error => (
 );
 
 export function useScheduleAppointments() {
-  const { authMode } = useAuth();
+  const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
   const tenantId = activeTenant?.tenantId;
-  const contextKey = `${authMode}:${tenantId || 'no-tenant'}`;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
+  const contextKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}`;
   const currentContextRef = useRef(contextKey);
   useLayoutEffect(() => {
     currentContextRef.current = contextKey;
@@ -70,15 +72,27 @@ export function useScheduleAppointments() {
     promise: Promise<AppointmentWriteResult | null>;
   } | null>(null);
 
-  const repository = useMemo(() => createAppointmentRepository({
-    backend: (authMode === 'supabase-active' && tenantId && isSupabaseConfigured) ? 'supabase' : 'local',
-    tenantId,
-  }), [authMode, tenantId]);
+  const repository = useMemo<IAppointmentRepository | null>(() => {
+    if (authMode === 'dev') {
+      return createAppointmentRepository({ backend: 'local' });
+    }
+    if (isSupabaseMode && user?.id && tenantId) {
+      return createAppointmentRepository({ backend: 'supabase', tenantId });
+    }
+    return null;
+  }, [authMode, isSupabaseMode, tenantId, user?.id]);
 
-  const queryFn = useCallback(
-    () => repository.listAppointments(),
-    [repository],
-  );
+  const queryEnabled = authMode === 'dev'
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId));
+
+  const queryFn = useCallback(async (): Promise<Appointment[]> => {
+    if (!repository) return [];
+    try {
+      return await repository.listAppointments();
+    } catch {
+      throw new Error('Не удалось загрузить расписание.');
+    }
+  }, [repository]);
 
   const {
     data: appointments,
@@ -89,9 +103,17 @@ export function useScheduleAppointments() {
   } = useAsyncQuery<Appointment[]>({
     queryFn,
     initialData: [],
-    enabled: true,
+    enabled: queryEnabled,
     queryKey: contextKey,
+    resetOnDisable: true,
   });
+
+  const requireRepository = useCallback((): IAppointmentRepository => {
+    if (!repository) {
+      throw new AppointmentRepositoryError('tenant_required', 'Клиника не выбрана.');
+    }
+    return repository;
+  }, [repository]);
 
   const getOperationKey = useCallback((
     ref: MutableRefObject<OperationAttempt | null>,
@@ -180,26 +202,28 @@ export function useScheduleAppointments() {
   }, [contextKey, refetch]);
 
   const createAppointment = useCallback((appointment: Appointment) => {
+    const activeRepository = requireRepository();
     const signature = `create:${contextKey}:${appointmentBusinessSignature(appointment)}`;
     const operationKey = getOperationKey(createAttemptRef, signature);
 
     return runMutation(
       signature,
-      (onRecoveryStateChange) => repository.createAppointment(appointment, {
+      (onRecoveryStateChange) => activeRepository.createAppointment(appointment, {
         operationKey,
         onRecoveryStateChange,
       }),
       createAttemptRef,
     );
-  }, [contextKey, getOperationKey, repository, runMutation]);
+  }, [contextKey, getOperationKey, requireRepository, runMutation]);
 
   const updateAppointment = useCallback((current: Appointment, next: Appointment) => {
+    const activeRepository = requireRepository();
     if (isProtectedAppointmentChange(current, next)) {
       const signature = `reschedule:${contextKey}:${current.id}:${current.updatedAt || ''}:${appointmentBusinessSignature(next)}`;
       const operationKey = getOperationKey(rescheduleAttemptRef, signature);
       return runMutation(
         signature,
-        (onRecoveryStateChange) => repository.rescheduleAppointment(current, next, {
+        (onRecoveryStateChange) => activeRepository.rescheduleAppointment(current, next, {
           operationKey,
           onRecoveryStateChange,
         }),
@@ -210,17 +234,18 @@ export function useScheduleAppointments() {
     const signature = `details:${contextKey}:${current.id}:${current.updatedAt || ''}:${appointmentBusinessSignature(next)}`;
     return runMutation(
       signature,
-      () => repository.updateAppointmentDetails(current, next),
+      () => activeRepository.updateAppointmentDetails(current, next),
     );
-  }, [contextKey, getOperationKey, repository, runMutation]);
+  }, [contextKey, getOperationKey, requireRepository, runMutation]);
 
   const deleteAppointment = useCallback(async (appointmentId: string): Promise<boolean> => {
+    const activeRepository = requireRepository();
     const capturedContext = contextKey;
     if (inFlightRef.current?.contextKey === capturedContext) return false;
 
     setMutationState({ contextKey: capturedContext, isSaving: true, isReconciling: false, error: null });
     try {
-      await repository.deleteAppointment(appointmentId);
+      await activeRepository.deleteAppointment(appointmentId);
       if (currentContextRef.current !== capturedContext) return false;
       await refetch();
       return currentContextRef.current === capturedContext;
@@ -240,7 +265,7 @@ export function useScheduleAppointments() {
         }));
       }
     }
-  }, [contextKey, refetch, repository]);
+  }, [contextKey, refetch, requireRepository]);
 
   const mutationForCurrentContext = mutationState.contextKey === contextKey
     ? mutationState
@@ -249,9 +274,9 @@ export function useScheduleAppointments() {
   const error = mutationForCurrentContext.error || queryError;
 
   return {
-    appointments: appointments || [],
-    isLoading,
-    isError,
+    appointments: queryEnabled ? appointments : [],
+    isLoading: queryEnabled ? isLoading : false,
+    isError: queryEnabled ? isError : mutationForCurrentContext.error !== null,
     error,
     isSaving: mutationForCurrentContext.isSaving,
     isReconciling: mutationForCurrentContext.isReconciling,

--- a/src/data/repositories/AppointmentRepository.test.ts
+++ b/src/data/repositories/AppointmentRepository.test.ts
@@ -87,9 +87,13 @@ describe('AppointmentRepository', () => {
   });
 
   describe('factory', () => {
-    it('uses local storage only when local backend is selected', () => {
+    it('uses local storage only when the explicit local backend is selected', () => {
       expect(createAppointmentRepository({ backend: 'local' })).toBe(LocalStorageAppointmentRepository);
-      expect(createAppointmentRepository({ backend: 'supabase', tenantId: null })).toBe(LocalStorageAppointmentRepository);
+    });
+
+    it('does not silently fall back when Supabase tenant context is missing', () => {
+      expect(() => createAppointmentRepository({ backend: 'supabase', tenantId: null }))
+        .toThrow('Клиника не выбрана.');
     });
 
     it('creates Supabase repository for configured tenant backend', () => {
@@ -99,9 +103,10 @@ describe('AppointmentRepository', () => {
     });
   });
 
-  it('reads appointments through tenant-scoped table SELECT', async () => {
+  it('reads appointments through tenant and patient scoped deterministic SELECTs', async () => {
     const { client, from } = createClient();
-    const order = vi.fn().mockResolvedValue({ data: [databaseRow()], error: null });
+    const result = Promise.resolve({ data: [databaseRow()], error: null });
+    const order = vi.fn().mockImplementation(() => Object.assign(result, { order }));
     const secondEq = vi.fn().mockReturnValue({ order });
     const firstEq = vi.fn().mockReturnValue({ eq: secondEq, order });
     const select = vi.fn().mockReturnValue({ eq: firstEq });
@@ -114,16 +119,60 @@ describe('AppointmentRepository', () => {
     expect(from).toHaveBeenCalledWith('appointments');
     expect(firstEq).toHaveBeenCalledWith('tenant_id', tenantId);
     expect(secondEq).toHaveBeenCalledWith('patient_id', patientId);
+    expect(order).toHaveBeenCalledWith('start_time', { ascending: true });
+    expect(order).toHaveBeenCalledWith('start_time', { ascending: false });
+    expect(order).toHaveBeenCalledWith('id', { ascending: true });
     expect(all[0]).toMatchObject({
       id: appointmentId,
       patientId,
       doctorId,
+      status: 'new',
       start: '2026-08-01T10:00:00',
       end: '2026-08-01T11:00:00',
       updatedAt: '2026-07-01T09:00:00+00:00',
       price: 1500,
     });
     expect(byPatient).toHaveLength(1);
+  });
+
+  it('maps empty reads to empty arrays and returns cancelled history rows unchanged', async () => {
+    const { client, from } = createClient();
+    const result = Promise.resolve({ data: [databaseRow({ status: 'cancelled' })], error: null });
+    const order = vi.fn().mockImplementation(() => Object.assign(result, { order }));
+    const secondEq = vi.fn().mockReturnValue({ order });
+    const firstEq = vi.fn().mockReturnValue({ eq: secondEq, order });
+    from.mockReturnValue({ select: vi.fn().mockReturnValue({ eq: firstEq }) });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const rows = await repository.listAppointmentsByPatient(patientId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('cancelled');
+
+    const emptyResult = Promise.resolve({ data: null, error: null });
+    order.mockImplementation(() => Object.assign(emptyResult, { order }));
+    await expect(repository.listAppointments()).resolves.toEqual([]);
+  });
+
+  it('maps Supabase read failures to safe consumer-specific messages', async () => {
+    const { client, from } = createClient();
+    const result = Promise.resolve({
+      data: null,
+      error: { message: 'permission denied', details: 'SQLSTATE 42501 public.appointments' },
+    });
+    const order = vi.fn().mockImplementation(() => Object.assign(result, { order }));
+    const secondEq = vi.fn().mockReturnValue({ order });
+    const firstEq = vi.fn().mockReturnValue({ eq: secondEq, order });
+    from.mockReturnValue({ select: vi.fn().mockReturnValue({ eq: firstEq }) });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    await expect(repository.listAppointments()).rejects.toMatchObject({
+      code: 'schedule_read_failed',
+      message: 'Не удалось загрузить расписание.',
+    });
+    await expect(repository.listAppointmentsByPatient(patientId)).rejects.toMatchObject({
+      code: 'patient_read_failed',
+      message: 'Не удалось загрузить записи пациента.',
+    });
   });
 
   it('creates through create_appointment RPC and preserves operation key unchanged', async () => {

--- a/src/data/repositories/AppointmentRepository.ts
+++ b/src/data/repositories/AppointmentRepository.ts
@@ -1,4 +1,5 @@
 import type { Appointment, AppointmentStatus, PaymentType, Source } from '../../types';
+import { compareAppointmentsByStartThenId } from '../../domain/appointmentSummary';
 import { storage } from '../../utils/storage';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -13,6 +14,9 @@ export type AppointmentRepositoryErrorCode =
   | 'idempotency_conflict'
   | 'concurrent_change'
   | 'permission'
+  | 'tenant_required'
+  | 'schedule_read_failed'
+  | 'patient_read_failed'
   | 'generic';
 
 export class AppointmentRepositoryError extends Error {
@@ -120,6 +124,13 @@ export const toSafeAppointmentError = (error: unknown): AppointmentRepositoryErr
   return genericSaveError();
 };
 
+export const toSafeAppointmentReadError = (
+  scope: 'schedule' | 'patient',
+): AppointmentRepositoryError => new AppointmentRepositoryError(
+  scope === 'schedule' ? 'schedule_read_failed' : 'patient_read_failed',
+  scope === 'schedule' ? 'Не удалось загрузить расписание.' : 'Не удалось загрузить записи пациента.',
+);
+
 export const isProtectedAppointmentChange = (current: Appointment, next: Appointment): boolean => (
   (current.patientId || '') !== (next.patientId || '')
   || current.doctorId !== next.doctorId
@@ -140,9 +151,13 @@ const localWriteResult = (appointment: Appointment, operationType: AppointmentOp
 export const LocalStorageAppointmentRepository: IAppointmentRepository = {
   listAppointmentsByPatient: async (patientId: string): Promise<Appointment[]> => storage.getAppointments()
     .filter((appointment) => appointment.patientId === patientId)
-    .sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime()),
+    .sort((left, right) => {
+      const startDifference = new Date(right.start).getTime() - new Date(left.start).getTime();
+      return startDifference !== 0 ? startDifference : left.id.localeCompare(right.id);
+    }),
 
-  listAppointments: async (): Promise<Appointment[]> => storage.getAppointments(),
+  listAppointments: async (): Promise<Appointment[]> => [...storage.getAppointments()]
+    .sort(compareAppointmentsByStartThenId),
 
   createAppointment: async (appointment: Appointment): Promise<AppointmentWriteResult> => {
     storage.addAppointment(appointment);
@@ -181,9 +196,10 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
       .select('*')
       .eq('tenant_id', this.tenantId)
       .eq('patient_id', patientId)
-      .order('start_time', { ascending: false });
+      .order('start_time', { ascending: false })
+      .order('id', { ascending: true });
 
-    if (error) throw toSafeAppointmentError(error);
+    if (error) throw toSafeAppointmentReadError('patient');
     return (data || []).map(this.mapToAppointment);
   }
 
@@ -192,9 +208,10 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
       .from('appointments')
       .select('*')
       .eq('tenant_id', this.tenantId)
-      .order('start_time', { ascending: true });
+      .order('start_time', { ascending: true })
+      .order('id', { ascending: true });
 
-    if (error) throw toSafeAppointmentError(error);
+    if (error) throw toSafeAppointmentReadError('schedule');
     return (data || []).map(this.mapToAppointment);
   }
 
@@ -397,8 +414,13 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
 }
 
 export function createAppointmentRepository(options: CreateAppointmentRepositoryOptions): IAppointmentRepository {
-  if (options.backend === 'supabase' && options.tenantId && supabase) {
-    return new SupabaseAppointmentRepository(options.tenantId, supabase as SupabaseClient);
+  if (options.backend === 'local') {
+    return LocalStorageAppointmentRepository;
   }
-  return LocalStorageAppointmentRepository;
+
+  if (!options.tenantId || !supabase) {
+    throw new AppointmentRepositoryError('tenant_required', 'Клиника не выбрана.');
+  }
+
+  return new SupabaseAppointmentRepository(options.tenantId, supabase as SupabaseClient);
 }

--- a/src/domain/appointmentSummary.ts
+++ b/src/domain/appointmentSummary.ts
@@ -1,0 +1,64 @@
+import type { Appointment } from '../types';
+
+export interface PatientAppointmentSummary {
+  previousAppointment?: Appointment;
+  nextAppointment?: Appointment;
+}
+
+export type PatientAppointmentSummaryByPatientId = Record<string, PatientAppointmentSummary>;
+
+const FUTURE_TERMINAL_STATUSES = new Set<Appointment['status']>([
+  'cancelled',
+  'completed',
+  'no_show',
+  'blocked',
+]);
+
+export const compareAppointmentsByStartThenId = (left: Appointment, right: Appointment): number => {
+  const startDifference = new Date(left.start).getTime() - new Date(right.start).getTime();
+  if (startDifference !== 0) return startDifference;
+  return left.id.localeCompare(right.id);
+};
+
+export function buildPatientAppointmentSummaryByPatientId(
+  appointments: Appointment[],
+  now = new Date(),
+): PatientAppointmentSummaryByPatientId {
+  const summaries: PatientAppointmentSummaryByPatientId = {};
+  const nowTime = now.getTime();
+
+  for (const appointment of [...appointments].sort(compareAppointmentsByStartThenId)) {
+    if (!appointment.patientId || appointment.status === 'blocked') continue;
+
+    const startTime = new Date(appointment.start).getTime();
+    if (!Number.isFinite(startTime)) continue;
+
+    const summary = summaries[appointment.patientId] ?? {};
+    summaries[appointment.patientId] = summary;
+
+    if (startTime < nowTime) {
+      // Cancelled appointments remain available in history, but are not treated as a prior visit.
+      // A past no-show remains the latest prior appointment fact and is intentionally included.
+      if (appointment.status !== 'cancelled') {
+        summary.previousAppointment = appointment;
+      }
+      continue;
+    }
+
+    // The exact now boundary is upcoming. Future terminal rows are malformed schedule facts,
+    // so they remain visible in history but never become the next actionable appointment.
+    if (!summary.nextAppointment && !FUTURE_TERMINAL_STATUSES.has(appointment.status)) {
+      summary.nextAppointment = appointment;
+    }
+  }
+
+  return summaries;
+}
+
+export function getPatientAppointmentSummary(
+  appointments: Appointment[],
+  patientId: string,
+  now = new Date(),
+): PatientAppointmentSummary {
+  return buildPatientAppointmentSummaryByPatientId(appointments, now)[patientId] ?? {};
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,14 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 
 import { storage } from './utils/storage';
+import { isSupabaseConfigured } from './lib/supabaseClient';
 
 import { AuthProvider } from './contexts/AuthContext';
 import { TenantProvider } from './contexts/TenantContext';
 import { App } from './App';
 
-// Initialize localStorage seed data if not present
-storage.init();
+// Seed demo appointment facts only for the explicit local/dev backend.
+storage.init({ includeAppointments: !isSupabaseConfigured });
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/PatientsPage.test.tsx
+++ b/src/pages/PatientsPage.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PatientsPage } from './PatientsPage';
+import { usePatientsCollection } from '../data/hooks/usePatientsCollection';
+import { usePatientListVisitSummary } from '../data/hooks/usePatientListVisitSummary';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../data/hooks/usePatientsCollection', () => ({ usePatientsCollection: vi.fn() }));
+vi.mock('../data/hooks/usePatientListVisitSummary', () => ({ usePatientListVisitSummary: vi.fn() }));
+vi.mock('../components/patients/PatientModal', () => ({ PatientModal: () => null }));
+
+const patient = {
+  id: 'patient-1',
+  fullName: 'Authoritative Patient',
+  phone: '+7 700 000 00 00',
+  birthDate: '1990-01-01',
+  source: 'phone',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+function renderPage() {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => root.render(<PatientsPage />));
+  return { container, root };
+}
+
+describe('PatientsPage appointment summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(usePatientsCollection).mockReturnValue({
+      patients: [patient],
+      isLoading: false,
+      isError: false,
+      createPatient: vi.fn(),
+      updatePatient: vi.fn(),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof usePatientsCollection>);
+  });
+
+  it('renders authoritative previous and next appointment dates for one patient row', () => {
+    vi.mocked(usePatientListVisitSummary).mockReturnValue({
+      visitSummaryByPatientId: {
+        'patient-1': {
+          lastVisit: new Date('2026-07-10T10:00:00.000Z'),
+          nextVisit: new Date('2026-07-15T10:00:00.000Z'),
+        },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof usePatientListVisitSummary>);
+
+    const { container, root } = renderPage();
+
+    expect(container.textContent).toContain('Предыдущая запись');
+    expect(container.textContent).toContain('Следующая запись');
+    expect(container.textContent).toContain('10.07.2026');
+    expect(container.textContent).toContain('15.07.2026');
+    expect(container.textContent).not.toContain('Недоступно');
+
+    act(() => root.unmount());
+  });
+
+  it('shows a neutral unavailable state instead of stale appointment dates after summary failure', () => {
+    vi.mocked(usePatientListVisitSummary).mockReturnValue({
+      visitSummaryByPatientId: {},
+      isLoading: false,
+      isError: true,
+      error: new Error('Не удалось загрузить сводку по записям.'),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof usePatientListVisitSummary>);
+
+    const { container, root } = renderPage();
+
+    expect(container.textContent?.match(/Недоступно/g)).toHaveLength(2);
+    expect(container.textContent).not.toContain('10.07.2026');
+    expect(container.textContent).not.toContain('15.07.2026');
+
+    act(() => root.unmount());
+  });
+});

--- a/src/pages/PatientsPage.tsx
+++ b/src/pages/PatientsPage.tsx
@@ -102,6 +102,8 @@ export function PatientsPage() {
 
   const {
     visitSummaryByPatientId,
+    isLoading: isVisitSummaryLoading,
+    isError: isVisitSummaryError,
   } = usePatientListVisitSummary();
 
   const filteredPatients = useMemo(() => {
@@ -230,8 +232,8 @@ export function PatientsPage() {
                 <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Дата рождения</th>
                 <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Источник</th>
                 <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Статус</th>
-                <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Последний визит</th>
-                <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Следующий визит</th>
+                <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Предыдущая запись</th>
+                <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Следующая запись</th>
                 <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Баланс</th>
                 <th className="py-3 px-4 font-semibold text-sm text-slate-600 border-b border-slate-200">Действия</th>
               </tr>
@@ -270,8 +272,12 @@ export function PatientsPage() {
                           {getStatusLabel(patient.status)}
                         </span>
                       </td>
-                      <td className="py-3 px-4 text-sm text-slate-600">{formatDate(visits.lastVisit)}</td>
-                      <td className="py-3 px-4 text-sm text-slate-600">{formatDate(visits.nextVisit)}</td>
+                      <td className="py-3 px-4 text-sm text-slate-600">
+                        {isVisitSummaryLoading ? '…' : isVisitSummaryError ? 'Недоступно' : formatDate(visits.lastVisit)}
+                      </td>
+                      <td className="py-3 px-4 text-sm text-slate-600">
+                        {isVisitSummaryLoading ? '…' : isVisitSummaryError ? 'Недоступно' : formatDate(visits.nextVisit)}
+                      </td>
                       <td className="py-3 px-4 text-sm font-medium text-slate-700">{patient.balance ? `${patient.balance} ₸` : '-'}</td>
                       <td className="py-3 px-4 text-sm">
                         <div className="flex items-center gap-3">

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -250,6 +250,7 @@ export function SchedulePage() {
                 {timeSlots.map((time, i) => (
                   <div
                     key={time}
+                    data-testid={`schedule-slot-${doctor.id}-${time.replace(':', '')}`}
                     onClick={() => handleOpenModal(doctor, time)}
                     className={clsx(
                       "group border-b border-slate-100 cursor-pointer hover:bg-blue-50/50 transition-colors flex items-center justify-center",
@@ -270,6 +271,7 @@ export function SchedulePage() {
                     return (
                       <div
                         key={apt.id}
+                        data-testid={`schedule-appointment-${apt.id}`}
                         onClick={() => handleEditAppointment(apt)}
                         className={clsx(
                           "absolute left-1 right-1 rounded-lg border p-1.5 text-xs shadow-sm transition-transform hover:-translate-y-0.5 cursor-pointer overflow-hidden flex flex-col",

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { storage } from './storage';
+
+describe('storage appointment bootstrap', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not create df_appointments when configured mode excludes appointment demo facts', () => {
+    storage.init({ includeAppointments: false });
+
+    expect(localStorage.getItem('df_initialized')).toBe('true');
+    expect(localStorage.getItem('df_patients')).not.toBeNull();
+    expect(localStorage.getItem('df_doctors')).not.toBeNull();
+    expect(localStorage.getItem('df_appointments')).toBeNull();
+  });
+
+  it('does not delete or overwrite an existing appointment key', () => {
+    const existing = JSON.stringify([{ id: 'user-owned-row' }]);
+    localStorage.setItem('df_appointments', existing);
+
+    storage.init({ includeAppointments: false });
+
+    expect(localStorage.getItem('df_appointments')).toBe(existing);
+  });
+
+  it('initializes appointment demo facts only for explicit local mode', () => {
+    storage.init({ includeAppointments: false });
+    expect(localStorage.getItem('df_appointments')).toBeNull();
+
+    storage.init({ includeAppointments: true });
+
+    expect(storage.getAppointments().length).toBeGreaterThan(0);
+  });
+
+  it('keeps explicit local appointment CRUD functional', () => {
+    storage.init({ includeAppointments: true });
+    const originalCount = storage.getAppointments().length;
+    const appointment = {
+      id: 'local-test',
+      patientId: 'patient-1',
+      doctorId: 'doctor-1',
+      cabinet: 'A1',
+      service: 'Осмотр',
+      status: 'new' as const,
+      start: '2026-08-01T10:00:00',
+      end: '2026-08-01T11:00:00',
+      createdAt: '2026-07-01T10:00:00',
+    };
+
+    storage.addAppointment(appointment);
+    expect(storage.getAppointments()).toHaveLength(originalCount + 1);
+
+    storage.updateAppointment({ ...appointment, status: 'confirmed' });
+    expect(storage.getAppointments().find((row) => row.id === appointment.id)?.status).toBe('confirmed');
+
+    storage.deleteAppointment(appointment.id);
+    expect(storage.getAppointments().some((row) => row.id === appointment.id)).toBe(false);
+  });
+});

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -14,21 +14,28 @@ const STORAGE_KEYS = {
 };
 
 export const storage = {
-  init: () => {
+  init: (options: { includeAppointments?: boolean } = {}) => {
+    const includeAppointments = options.includeAppointments ?? true;
     const initialized = localStorage.getItem(STORAGE_KEYS.INITIALIZED);
+
     if (!initialized) {
       localStorage.setItem(STORAGE_KEYS.DOCTORS, JSON.stringify(demoDoctors));
       localStorage.setItem(STORAGE_KEYS.PATIENTS, JSON.stringify(demoPatients));
-      localStorage.setItem(STORAGE_KEYS.APPOINTMENTS, JSON.stringify(demoAppointments));
       localStorage.setItem(STORAGE_KEYS.CHIEF_COMPLAINTS, JSON.stringify(demoChiefComplaints));
       localStorage.setItem(STORAGE_KEYS.DENTAL_FINDINGS, JSON.stringify(demoDentalFindings));
       localStorage.setItem(STORAGE_KEYS.INITIALIZED, 'true');
+    }
+
+    // Configured Supabase mode must not create demo appointment facts. Existing browser
+    // data is deliberately left untouched; explicit local/dev mode can still initialize it.
+    if (includeAppointments && localStorage.getItem(STORAGE_KEYS.APPOINTMENTS) === null) {
+      localStorage.setItem(STORAGE_KEYS.APPOINTMENTS, JSON.stringify(demoAppointments));
     }
   },
 
   reset: () => {
     localStorage.removeItem(STORAGE_KEYS.INITIALIZED);
-    storage.init();
+    storage.init({ includeAppointments: true });
   },
 
   getDoctors: (): Doctor[] => {


### PR DESCRIPTION
## Summary

Consolidates every reachable Supabase-active appointment reader on the tenant-scoped appointment repository. Patient history, patient-list previous/next summaries, patient overview, timeline, and SchedulePage now read the same authoritative appointment rows with shared date/status semantics and stale tenant/patient response protection. Configured Supabase bootstrap no longer creates df_appointments; explicit dev/local mode remains supported. No migration, new RPC, write redesign, cloud apply, finance mutation, or clinical mutation was introduced.

Implementation head reviewed: 35046311399ad973142a3f8427aeed56853aa81e.
Final report-only PR head: 9f4b94101887a0ee2220350406a18c0a8b068d4e.
Immutable local receipt: D:\hermes\reports\receipts\SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001_finalization.json.

Do not merge as part of this task.

## Checks

- Targeted appointment reader/UI suite: 12 files / 85 tests passed
- Full quality gate: lint, 86 test files / 922 tests, production build passed
- 0024 grants SQL and 0025 appointment hardening SQL passed
- All 11 appointment concurrency scenarios passed with 0 overlaps, invalid intervals, or deadlocks
- Authenticated tenant A/B browser smoke and stale patient/tenant response checks passed
- Chrome DevTools MCP 1.5.0 configured-mode validation passed
- Configured browser kept df_appointments absent before and after real writes
- Final local db reset --no-seed verified zero QA rows
- Implementation CI #701 / run 29183273692 passed on 35046311399ad973142a3f8427aeed56853aa81e
- Final CI #702 / run 29183883160 passed on exact PR head 9f4b94101887a0ee2220350406a18c0a8b068d4e

## Limitations

- Final report-only commit cannot contain its own future SHA/CI, so exact final values are stored in the immutable local receipt and this PR body.
- Patient-list summary uses one tenant-wide appointment fetch and may eventually need a server read model at larger scale.
- Existing role policies, cabinet free text, hard delete, and schedule filtering remain unchanged.
