### PR TITLE
feat(schedule): add appointment cancellation and no-show lifecycle

### DIFF
--- a/_ai_work/REPORTS/APPOINTMENT-CANCELLATION-NOSHOW-001_lifecycle.md
+++ b/_ai_work/REPORTS/APPOINTMENT-CANCELLATION-NOSHOW-001_lifecycle.md
@@ -1,0 +1,249 @@
+﻿# APPOINTMENT-CANCELLATION-NOSHOW-001: controlled appointment lifecycle actions
+
+## Final verdict
+
+Final verdict: **PASS**
+
+APPOINTMENT CANCELLATION AND NO-SHOW LIFECYCLE IMPLEMENTED AND VERIFIED
+
+## Summary
+
+Appointment cancellation and no-show are now dedicated controlled lifecycle operations rather than generic status values. New transitions require auditable metadata, use tenant-scoped transactional RPCs, preserve operation-key idempotency and recovery, emit exactly one audit/activity pair, and enforce role, transition, tenant, optimistic-version, and concurrency boundaries in PostgreSQL.
+
+The schedule UI separates `Cancel appointment`, `Mark no-show`, and physical `Delete appointment`. Terminal metadata remains visible after reload in SchedulePage and patient appointment history. Generic create, reschedule, and details RPCs cannot create, enter, or reactivate `cancelled` / `no_show` states.
+
+No reminder, penalty, waitlist, finance, document, clinical, stock, amoCRM, cloud migration, or automatic expiry behavior was introduced.
+
+## Branch
+
+`feature/appointment-cancellation-noshow-001`
+
+## PR URL
+
+PENDING
+
+## Baseline
+
+- repository: `NckNA/codex-test`;
+- required and verified `origin/main`: `1ec15f8df7285502d4c3726c9557d3a5ac712aac`;
+- PR #348 was merged into that exact baseline;
+- the task worktree was created from that baseline.
+
+## PR head reviewed before final report update
+
+- implementation head reviewed: PENDING;
+- workflow: `CI`;
+- run: PENDING;
+- run ID: PENDING;
+- conclusion: PENDING;
+- the PR must remain open and unmerged.
+
+## Report update commit
+
+- Report update commit: N/A because the report commit cannot reference itself.
+- The final report head and fresh CI run are recorded by the immutable finalization receipt.
+
+## Changed files
+
+- `supabase/migrations/0026_appointment_cancellation_noshow.sql`
+- `supabase/tests/0026_appointment_cancellation_noshow_test.sql`
+- `supabase/tests/0026_appointment_cancellation_noshow_concurrency.ps1`
+- `supabase/tests/0025_appointment_conflict_hardening_test.sql`
+- `src/types/index.ts`
+- `src/data/repositories/AppointmentRepository.ts`
+- `src/data/repositories/AppointmentRepository.test.ts`
+- `src/data/hooks/useScheduleAppointments.ts`
+- `src/data/hooks/useScheduleAppointments.test.tsx`
+- `src/components/schedule/appointmentLifecycle.ts`
+- `src/components/schedule/AppointmentCancellationDialog.tsx`
+- `src/components/schedule/AppointmentNoShowDialog.tsx`
+- `src/components/schedule/AppointmentLifecycleDialogs.test.tsx`
+- `src/components/schedule/AppointmentModal.tsx`
+- `src/components/schedule/AppointmentModal.test.tsx`
+- `src/components/patients/patient-card/PatientHistoryTab.tsx`
+- `src/components/patients/patient-card/PatientHistoryTab.test.tsx`
+- `src/pages/SchedulePage.tsx`
+- `_ai_work/REPORTS/APPOINTMENT-CANCELLATION-NOSHOW-001_lifecycle.md`
+
+## Original lifecycle inventory
+
+Before this task:
+
+- `cancelled` and `no_show` were generic status options;
+- create, reschedule, and details RPCs accepted terminal statuses;
+- reason, source, actor, and lifecycle timestamp were not required;
+- no dedicated audit/activity event represented either transition;
+- generic tenant-member mutation permissions admitted doctor/cashier attempts;
+- registrar UI exposed hard delete although backend RLS denied it;
+- cancellation released its slot because conflict SQL excluded `cancelled`;
+- `no_show` remained slot-blocking;
+- hard delete was already a distinct physical operation.
+
+## Lifecycle data model
+
+Migration `0026` adds to `appointments`:
+
+- `cancelled_at`, `cancelled_by`, `cancellation_source`, `cancellation_reason`;
+- `no_show_at`, `no_show_by`, `no_show_reason`;
+- `lifecycle_metadata_version`.
+
+Historical terminal rows remain unchanged with version `0`; the migration does not invent missing facts. New controlled transitions write complete version `1` metadata.
+
+## Controlled RPC contract
+
+Dedicated RPCs:
+
+- `cancel_appointment(...)`;
+- `mark_appointment_no_show(...)`;
+- existing `get_appointment_operation(...)` recovers both operation types.
+
+They require tenant membership, permit only `clinic_owner`, `clinic_admin`, and `registrar`, reject doctor/cashier/no-membership/cross-tenant calls, validate metadata, lock the appointment, enforce expected `updated_at`, enforce transitions, reuse `appointment_operations`, and write one audit/activity pair.
+
+A preliminary implementation left the lifecycle GUC active until transaction end. SQL tests reproduced a generic-create bypass in the same transaction. The final RPCs reset the one-time marker immediately after the protected update.
+
+## Generic bypass protection
+
+A lifecycle trigger rejects unauthorized terminal inserts/updates and terminal reactivation. Generic create/reschedule/details RPCs no longer accept `cancelled` or `no_show`.
+
+`update_appointment_details` is replaced in `0026` so terminal-state denial occurs before unrelated conflict checks, producing the correct lifecycle error.
+
+## Role and UI policy
+
+- owner/admin: cancel, mark no-show, hard delete;
+- registrar: cancel and mark no-show, no hard delete;
+- doctor/cashier/no-tenant: no lifecycle or delete action;
+- physical delete remains the existing owner/admin RLS operation.
+
+Terminal statuses are removed from generic status controls. Separate dialogs require metadata, warn the user, disable duplicate submission, show reconciliation/safe errors, and retain a confirmed success view.
+
+## Client, recovery, and stale context
+
+The repository adds `cancelAppointment` and `markAppointmentNoShow` using the existing operation-key and recovery pattern. The hook shares duplicate calls, preserves keys after ambiguous failures, clears them after definitive failures, and discards results after context changes.
+
+Browser QA found and fixed two integration defects, both covered by regression tests:
+
+1. SchedulePage prematurely replaced modal `initialData`, closing the nested success view. The modal now owns its confirmed lifecycle result.
+2. A delayed result for appointment A could overwrite newly selected appointment B. `AppointmentModal` verifies the captured appointment ID before applying a result.
+
+## Audit and history
+
+Each successful transition writes exactly one operation row, one audit row, and one activity row. Replay does not duplicate them.
+
+Schedule details and patient history display terminal status, timestamp, reason, cancellation source where applicable, and a neutral `Clinic employee` label instead of a raw actor UUID. No-show wording does not imply completed treatment or a clinical encounter.
+
+## Browser validation
+
+Real local Supabase browser QA covered:
+
+- owner/admin/registrar/doctor/cashier/no-tenant role matrix;
+- cancellation and no-show with metadata, reload, and patient-history verification;
+- separate cancellation and physical delete actions;
+- rapid double submit;
+- actual UI reuse of a released slot;
+- lost response after commit with visible reconciliation and recovery;
+- delayed old-appointment response after context change;
+- two pre-opened sessions racing cancel versus no-show;
+- tenant isolation and safe user-visible errors.
+
+Chrome DevTools MCP used `chrome_devtools` version `1.5.0` in isolated headless contexts. It confirmed one logical result for double-click, successful rebooking of the released `17:00` slot, generic bypass rejection, `cancel_appointment` plus `get_appointment_operation` recovery, exactly one winner in the lifecycle race, RPC-only lifecycle writes with no direct PATCH/DELETE, and no service-role material, SQLSTATE, stack trace, or secret.
+
+Existing unrelated accessibility issues were reported by Chrome. The expected HTTP 400 was the handled losing lifecycle race request.
+
+## Database validation
+
+The browser fixture snapshot proved:
+
+- five cancellations and one no-show had complete metadata version `1`;
+- duplicate, recovery, and race appointments each had one operation/audit/activity result;
+- the released slot contained one new active appointment;
+- active doctor overlaps: `0`;
+- active patient overlaps: `0`;
+- invalid intervals: `0`;
+- all seven fixture `patients.balance` values were unchanged;
+- visits, encounters, completed services, treatment plans, findings, dental charts, invoices, invoice items, payments, allocations, refunds, adjustments, and documents received zero side-effect rows.
+
+Temporary QA users, tenants, patients, doctors, appointments, MCP clients, fixtures, logs, delay shims, and Vite processes were removed. The final local database was reset with `npx supabase db reset --no-seed`.
+
+## SQL and concurrency validation
+
+Passed after a fresh migration reset:
+
+- `0024_legacy_core_table_grants_test.sql`;
+- updated `0025_appointment_conflict_hardening_test.sql`;
+- `0026_appointment_cancellation_noshow_test.sql`;
+- `0025_appointment_conflict_concurrency.ps1`;
+- `0026_appointment_cancellation_noshow_concurrency.ps1`.
+
+Conflict hardening concurrency final result:
+
+- success operations: `13`;
+- appointment rows: `15`;
+- unique appointment IDs: `13`;
+- doctor overlaps: `0`;
+- patient overlaps: `0`;
+- invalid intervals: `0`;
+- audit/activity: `13/13`;
+- deadlocks: `0`.
+
+Lifecycle concurrency final result:
+
+- success count: `13`;
+- replay count: `2`;
+- conflict count: `5`;
+- cancelled rows: `8`;
+- no-show rows: `2`;
+- audit/activity: `10/10`;
+- active overlaps: `0`;
+- deadlocks: `0`.
+
+## Lint, tests, and build
+
+Final checks:
+
+- `npm run lint`: passed;
+- `npm run test -- --run`: **87 files / 957 tests passed**;
+- `npm run build`: passed;
+- targeted lifecycle/repository/hook/modal/history suite: passed.
+
+Existing unrelated React `act(...)` warnings and the existing Vite bundle-size warning remain. They did not fail the commands and were not introduced by this task.
+
+## Security boundaries
+
+- no frontend service-role key;
+- no direct lifecycle table write;
+- no cross-tenant lifecycle mutation;
+- no raw database error displayed;
+- operation rows remain unreadable to ordinary browser roles;
+- generic terminal bypasses are rejected;
+- lifecycle authorization does not leak across statements;
+- hard delete remains separate and owner/admin-only.
+
+## Issues / limitations
+
+- Historical terminal rows cannot receive trustworthy reasons or actors retroactively and remain metadata version `0`.
+- Terminal correction/reopen is intentionally unavailable and requires a dedicated audited workflow.
+- No-show continues to block its original interval, preserving the existing slot policy.
+- Hard delete and broad non-lifecycle appointment mutation permissions were not redesigned.
+
+## What was intentionally not implemented
+
+- reminders, confirmation messages, or cancellation notifications;
+- penalties, deposits, or no-show charges;
+- waitlist or slot-offer automation;
+- terminal correction/reopen;
+- room/chair resource model;
+- finance, documents, stock, treatment, visit, encounter, or completed-service mutation;
+- amoCRM integration;
+- cloud Supabase apply;
+- package or lock-file change;
+- PR merge.
+
+## Fresh CI
+
+Implementation CI is pending after commit and push. A second fresh CI run is required after the final report-only metadata commit. The PR must remain open and unmerged.
+
+## Recommended next task
+
+**APPOINTMENT-LIFECYCLE-CORRECTION-001**
+
+Reason: any correction or reopening must be a separate privileged operation with its own reason, actor, before/after audit, idempotency, and conflict revalidation rather than a return to generic status editing.

--- a/_ai_work/REPORTS/APPOINTMENT-CANCELLATION-NOSHOW-001_lifecycle.md
+++ b/_ai_work/REPORTS/APPOINTMENT-CANCELLATION-NOSHOW-001_lifecycle.md
@@ -1,4 +1,4 @@
-﻿# APPOINTMENT-CANCELLATION-NOSHOW-001: controlled appointment lifecycle actions
+# APPOINTMENT-CANCELLATION-NOSHOW-001: controlled appointment lifecycle actions
 
 ## Final verdict
 
@@ -20,7 +20,7 @@ No reminder, penalty, waitlist, finance, document, clinical, stock, amoCRM, clou
 
 ## PR URL
 
-PENDING
+https://github.com/NckNA/codex-test/pull/349
 
 ## Baseline
 
@@ -31,11 +31,12 @@ PENDING
 
 ## PR head reviewed before final report update
 
-- implementation head reviewed: PENDING;
+- implementation head reviewed: `8844da0f0ad580f8c10a68e9368c1d8de37df7a5`;
 - workflow: `CI`;
-- run: PENDING;
-- run ID: PENDING;
-- conclusion: PENDING;
+- run: `#704`;
+- run ID: `29188737624`;
+- conclusion: `success`;
+- tested commit matched the reviewed implementation head exactly;
 - the PR must remain open and unmerged.
 
 ## Report update commit
@@ -240,7 +241,16 @@ Existing unrelated React `act(...)` warnings and the existing Vite bundle-size w
 
 ## Fresh CI
 
-Implementation CI is pending after commit and push. A second fresh CI run is required after the final report-only metadata commit. The PR must remain open and unmerged.
+Implementation CI:
+
+- workflow: `CI`;
+- run: `#704`;
+- run ID: `29188737624`;
+- conclusion: `success`;
+- tested commit: `8844da0f0ad580f8c10a68e9368c1d8de37df7a5`;
+- validate job passed ESLint, tests, and build.
+
+A second fresh CI run is required after the final report-only metadata commit. The PR must remain open and unmerged.
 
 ## Recommended next task
 

--- a/src/components/patients/patient-card/PatientHistoryTab.test.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.test.tsx
@@ -71,6 +71,51 @@ describe('PatientHistoryTab', () => {
     await act(async () => root.unmount());
   });
 
+  it('shows auditable cancellation metadata without raw actor UUID', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({
+      appointments: [row({
+        status: 'cancelled',
+        cancelledAt: '2026-08-01T12:00:00',
+        cancelledBy: 'raw-user-uuid',
+        cancellationSource: 'patient',
+        cancellationReason: 'Пациент попросил отменить',
+        lifecycleMetadataVersion: 1,
+      })],
+      isLoading: false,
+      isError: false,
+    } as any);
+    const { container, root } = await render();
+
+    const metadata = container.querySelector('[data-testid="history-cancellation-appointment-1"]');
+    expect(metadata?.textContent).toContain('Пациент попросил отменить');
+    expect(metadata?.textContent).toContain('Источник: Пациент');
+    expect(metadata?.textContent).toContain('Сотрудник клиники');
+    expect(metadata?.textContent).not.toContain('raw-user-uuid');
+    await act(async () => root.unmount());
+  });
+
+  it('shows auditable no-show metadata without creating treatment wording', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({
+      appointments: [row({
+        status: 'no_show',
+        noShowAt: '2026-08-01T12:00:00',
+        noShowBy: 'raw-user-uuid',
+        noShowReason: 'Не отвечает на звонки',
+        lifecycleMetadataVersion: 1,
+      })],
+      isLoading: false,
+      isError: false,
+    } as any);
+    const { container, root } = await render();
+
+    const metadata = container.querySelector('[data-testid="history-no-show-appointment-1"]');
+    expect(metadata?.textContent).toContain('Не отвечает на звонки');
+    expect(metadata?.textContent).toContain('Сотрудник клиники');
+    expect(metadata?.textContent).not.toContain('raw-user-uuid');
+    expect(metadata?.textContent).not.toContain('Лечение выполнено');
+    await act(async () => root.unmount());
+  });
+
   it('shows loading and empty states without demo rows', async () => {
     vi.mocked(usePatientAppointments).mockReturnValue({ appointments: [], isLoading: true, isError: false } as any);
     const loading = await render();

--- a/src/components/patients/patient-card/PatientHistoryTab.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.tsx
@@ -3,6 +3,7 @@ import { Stethoscope, ClipboardList } from 'lucide-react';
 
 import { useClinicDoctors } from '../../../data/hooks/useClinicDoctors';
 import { usePatientAppointments } from '../../../data/hooks/usePatientAppointments';
+import { cancellationSourceLabel } from '../../schedule/appointmentLifecycle';
 
 interface PatientHistoryTabProps {
   patientId: string;
@@ -95,6 +96,21 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
                   <td className="py-3 px-4">
                     <div className="text-slate-800 font-medium">{appt.service || 'Без названия'}</div>
                     {appt.comment && <div className="text-xs text-slate-500 truncate max-w-[200px] mt-0.5">{appt.comment}</div>}
+                    {appt.status === 'cancelled' && (
+                      <div className="mt-2 max-w-sm rounded bg-red-50 p-2 text-xs text-red-800" data-testid={`history-cancellation-${appt.id}`}>
+                        <div>Отменено: {appt.cancelledAt ? new Date(appt.cancelledAt).toLocaleString('ru-RU') : 'историческая запись'}</div>
+                        <div>Источник: {cancellationSourceLabel(appt.cancellationSource)}</div>
+                        <div>Причина: {appt.cancellationReason || 'Не была сохранена в прежней версии системы'}</div>
+                        <div>Сотрудник: {appt.cancelledBy ? 'Сотрудник клиники' : 'Не указан'}</div>
+                      </div>
+                    )}
+                    {appt.status === 'no_show' && (
+                      <div className="mt-2 max-w-sm rounded bg-rose-50 p-2 text-xs text-rose-800" data-testid={`history-no-show-${appt.id}`}>
+                        <div>Неявка: {appt.noShowAt ? new Date(appt.noShowAt).toLocaleString('ru-RU') : 'историческая запись'}</div>
+                        <div>Причина: {appt.noShowReason || 'Не была сохранена в прежней версии системы'}</div>
+                        <div>Сотрудник: {appt.noShowBy ? 'Сотрудник клиники' : 'Не указан'}</div>
+                      </div>
+                    )}
                   </td>
                   <td className="py-3 px-4 text-slate-600">{appt.cabinet}</td>
                   <td className="py-3 px-4">

--- a/src/components/schedule/AppointmentCancellationDialog.tsx
+++ b/src/components/schedule/AppointmentCancellationDialog.tsx
@@ -1,0 +1,126 @@
+import { useState, type FormEvent } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import type { Appointment, CancellationSource } from '../../types';
+import { CANCELLATION_SOURCE_LABELS } from './appointmentLifecycle';
+
+interface AppointmentCancellationDialogProps {
+  appointment: Appointment;
+  patientName: string;
+  doctorName: string;
+  isSaving: boolean;
+  isReconciling: boolean;
+  error: Error | null;
+  onConfirm: (source: CancellationSource, reason: string) => Promise<Appointment | null>;
+  onClose: () => void;
+}
+
+export function AppointmentCancellationDialog({
+  appointment,
+  patientName,
+  doctorName,
+  isSaving,
+  isReconciling,
+  error,
+  onConfirm,
+  onClose,
+}: AppointmentCancellationDialogProps) {
+  const [source, setSource] = useState<CancellationSource | ''>('');
+  const [reason, setReason] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [succeeded, setSucceeded] = useState(false);
+  const start = new Date(appointment.start);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const normalizedReason = reason.trim();
+    if (!source) {
+      setValidationError('Укажите, кто отменил запись.');
+      return;
+    }
+    if (!normalizedReason) {
+      setValidationError('Укажите причину.');
+      return;
+    }
+    setValidationError(null);
+    try {
+      const result = await onConfirm(source, normalizedReason);
+      if (result) setSucceeded(true);
+    } catch {
+      // The hook exposes the safe error. Keep the form open for correction/retry.
+    }
+  };
+
+  const displayedError = validationError || error?.message;
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-900/50 p-4" data-testid="appointment-cancellation-dialog">
+      <div className="w-full max-w-lg rounded-xl bg-white shadow-xl" role="dialog" aria-modal="true" aria-labelledby="appointment-cancellation-title">
+        <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+          <h2 id="appointment-cancellation-title" className="text-lg font-semibold text-slate-900">Отменить запись</h2>
+          <button type="button" onClick={onClose} disabled={isSaving} className="rounded p-1 text-slate-400 hover:bg-slate-100 disabled:opacity-50" aria-label="Закрыть">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {succeeded ? (
+          <div className="space-y-4 p-5">
+            <p className="rounded-lg bg-emerald-50 p-3 font-medium text-emerald-700" data-testid="appointment-cancellation-success">Запись отменена.</p>
+            <button type="button" data-testid="appointment-cancellation-success-close" onClick={onClose} className="w-full rounded-lg bg-slate-900 px-4 py-2 text-white">Закрыть</button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4 p-5">
+            <dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-2 rounded-lg bg-slate-50 p-3 text-sm">
+              <dt className="text-slate-500">Пациент</dt><dd className="font-medium text-slate-800">{patientName}</dd>
+              <dt className="text-slate-500">Врач</dt><dd className="font-medium text-slate-800">{doctorName}</dd>
+              <dt className="text-slate-500">Дата и время</dt><dd className="font-medium text-slate-800">{start.toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short' })}</dd>
+              <dt className="text-slate-500">Текущий статус</dt><dd className="font-medium text-slate-800">{appointment.status}</dd>
+            </dl>
+
+            <div>
+              <label htmlFor="cancellation-source" className="mb-1 block text-sm font-medium text-slate-700">Кто отменил запись</label>
+              <select
+                id="cancellation-source"
+                data-testid="appointment-cancellation-source"
+                value={source}
+                onChange={(event) => setSource(event.target.value as CancellationSource | '')}
+                disabled={isSaving}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              >
+                <option value="">Выберите источник</option>
+                {Object.entries(CANCELLATION_SOURCE_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="cancellation-reason" className="mb-1 block text-sm font-medium text-slate-700">Причина отмены</label>
+              <textarea
+                id="cancellation-reason"
+                data-testid="appointment-cancellation-reason"
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                disabled={isSaving}
+                rows={3}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              />
+            </div>
+
+            <p className="flex gap-2 rounded-lg bg-amber-50 p-3 text-sm text-amber-800">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              Запись останется в истории, а время врача станет доступно для новой записи.
+            </p>
+
+            {displayedError && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700" role="alert">{displayedError}</p>}
+            {isReconciling && <p className="text-sm font-medium text-indigo-700">Проверяем, была ли запись отменена…</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <button type="button" onClick={onClose} disabled={isSaving} className="rounded-lg border border-slate-300 px-4 py-2 text-slate-700 disabled:opacity-50">Назад</button>
+              <button type="submit" disabled={isSaving} data-testid="appointment-cancellation-submit" className="rounded-lg bg-red-600 px-4 py-2 font-medium text-white disabled:opacity-50">
+                {isSaving ? (isReconciling ? 'Проверяем…' : 'Отменяем запись…') : 'Отменить запись'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/schedule/AppointmentLifecycleDialogs.test.tsx
+++ b/src/components/schedule/AppointmentLifecycleDialogs.test.tsx
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Appointment } from '../../types';
+import { AppointmentCancellationDialog } from './AppointmentCancellationDialog';
+import { AppointmentNoShowDialog } from './AppointmentNoShowDialog';
+
+const appointment: Appointment = {
+  id: 'appointment-1',
+  patientId: 'patient-1',
+  doctorId: 'doctor-1',
+  cabinet: 'A1',
+  service: 'Осмотр',
+  status: 'confirmed',
+  start: '2026-08-01T10:00:00',
+  end: '2026-08-01T11:00:00',
+  createdAt: '2026-07-01T09:00:00',
+  updatedAt: '2026-07-01T09:30:00+00:00',
+};
+
+const setNativeValue = async (element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement, value: string) => {
+  const prototype = element instanceof HTMLSelectElement
+    ? HTMLSelectElement.prototype
+    : element instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(prototype, 'value')?.set?.call(element, value);
+    element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? 'change' : 'input', { bubbles: true }));
+  });
+};
+
+const submit = async (container: HTMLElement) => {
+  const form = container.querySelector('form') as HTMLFormElement;
+  await act(async () => form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })));
+};
+
+const cleanup = async (root: Root, container: HTMLElement) => {
+  await act(async () => root.unmount());
+  container.remove();
+};
+
+const renderCancellation = async (overrides: Record<string, unknown> = {}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onConfirm = (overrides.onConfirm as any) || vi.fn().mockResolvedValue({ ...appointment, status: 'cancelled' });
+  const onClose = vi.fn();
+  await act(async () => root.render(
+    <AppointmentCancellationDialog
+      appointment={appointment}
+      patientName="Пациент Один"
+      doctorName="Врач Один"
+      isSaving={Boolean(overrides.isSaving)}
+      isReconciling={Boolean(overrides.isReconciling)}
+      error={(overrides.error as Error | null) || null}
+      onConfirm={onConfirm}
+      onClose={onClose}
+    />,
+  ));
+  return { container, root, onConfirm, onClose };
+};
+
+const renderNoShow = async (overrides: Record<string, unknown> = {}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onConfirm = (overrides.onConfirm as any) || vi.fn().mockResolvedValue({ ...appointment, status: 'no_show' });
+  const onClose = vi.fn();
+  await act(async () => root.render(
+    <AppointmentNoShowDialog
+      appointment={appointment}
+      patientName="Пациент Один"
+      doctorName="Врач Один"
+      isSaving={Boolean(overrides.isSaving)}
+      isReconciling={Boolean(overrides.isReconciling)}
+      error={(overrides.error as Error | null) || null}
+      onConfirm={onConfirm}
+      onClose={onClose}
+    />,
+  ));
+  return { container, root, onConfirm, onClose };
+};
+
+describe('Appointment lifecycle dialogs', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows fixed appointment facts and cancellation warning', async () => {
+    const view = await renderCancellation();
+    expect(view.container.textContent).toContain('Пациент Один');
+    expect(view.container.textContent).toContain('Врач Один');
+    expect(view.container.textContent).toContain('confirmed');
+    expect(view.container.textContent).toContain('Запись останется в истории, а время врача станет доступно для новой записи.');
+    await cleanup(view.root, view.container);
+  });
+
+  it('requires cancellation source before submit', async () => {
+    const view = await renderCancellation();
+    await setNativeValue(view.container.querySelector('#cancellation-reason') as HTMLTextAreaElement, 'Причина');
+    await submit(view.container);
+    expect(view.container.textContent).toContain('Укажите, кто отменил запись.');
+    expect(view.onConfirm).not.toHaveBeenCalled();
+    await cleanup(view.root, view.container);
+  });
+
+  it('requires a non-empty cancellation reason', async () => {
+    const view = await renderCancellation();
+    await setNativeValue(view.container.querySelector('#cancellation-source') as HTMLSelectElement, 'patient');
+    await setNativeValue(view.container.querySelector('#cancellation-reason') as HTMLTextAreaElement, '   ');
+    await submit(view.container);
+    expect(view.container.textContent).toContain('Укажите причину.');
+    expect(view.onConfirm).not.toHaveBeenCalled();
+    await cleanup(view.root, view.container);
+  });
+
+  it('trims cancellation reason and shows confirmed success', async () => {
+    const view = await renderCancellation();
+    await setNativeValue(view.container.querySelector('#cancellation-source') as HTMLSelectElement, 'clinic');
+    await setNativeValue(view.container.querySelector('#cancellation-reason') as HTMLTextAreaElement, '  Клиника закрыта  ');
+    await submit(view.container);
+    expect(view.onConfirm).toHaveBeenCalledWith('clinic', 'Клиника закрыта');
+    expect(view.container.textContent).toContain('Запись отменена.');
+    await cleanup(view.root, view.container);
+  });
+
+  it('shows cancellation loading and recovery states with disabled controls', async () => {
+    const view = await renderCancellation({ isSaving: true, isReconciling: true });
+    expect(view.container.textContent).toContain('Проверяем, была ли запись отменена…');
+    expect(view.container.textContent).toContain('Проверяем…');
+    expect((view.container.querySelector('#cancellation-source') as HTMLSelectElement).disabled).toBe(true);
+    await cleanup(view.root, view.container);
+  });
+
+  it('keeps cancellation form open for a safe conflict', async () => {
+    const view = await renderCancellation({ error: new Error('Запись была изменена другим пользователем. Обновите расписание.') });
+    expect(view.container.textContent).toContain('Запись была изменена другим пользователем. Обновите расписание.');
+    expect(view.container.querySelector('form')).not.toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
+  it('renders a separate no-show workflow and explicit no-treatment warning', async () => {
+    const view = await renderNoShow();
+    expect(view.container.textContent).toContain('Отметить неявку');
+    expect(view.container.textContent).toContain('Неявка будет сохранена в истории пациента. Лечение и выполненная услуга автоматически не создаются.');
+    expect(view.container.textContent).not.toContain('Кто отменил запись');
+    await cleanup(view.root, view.container);
+  });
+
+  it('requires no-show reason', async () => {
+    const view = await renderNoShow();
+    await submit(view.container);
+    expect(view.container.textContent).toContain('Укажите причину.');
+    expect(view.onConfirm).not.toHaveBeenCalled();
+    await cleanup(view.root, view.container);
+  });
+
+  it('trims no-show reason and shows confirmed success', async () => {
+    const view = await renderNoShow();
+    await setNativeValue(view.container.querySelector('#no-show-reason') as HTMLTextAreaElement, '  Не отвечает  ');
+    await submit(view.container);
+    expect(view.onConfirm).toHaveBeenCalledWith('Не отвечает');
+    expect(view.container.textContent).toContain('Неявка отмечена.');
+    await cleanup(view.root, view.container);
+  });
+
+  it('shows no-show recovery and safe error states', async () => {
+    const view = await renderNoShow({
+      isSaving: true,
+      isReconciling: true,
+      error: new Error('Текущий статус записи не позволяет выполнить это действие.'),
+    });
+    expect(view.container.textContent).toContain('Проверяем, была ли неявка сохранена…');
+    expect(view.container.textContent).toContain('Текущий статус записи не позволяет выполнить это действие.');
+    expect((view.container.querySelector('#no-show-reason') as HTMLTextAreaElement).disabled).toBe(true);
+    await cleanup(view.root, view.container);
+  });
+});

--- a/src/components/schedule/AppointmentModal.test.tsx
+++ b/src/components/schedule/AppointmentModal.test.tsx
@@ -36,6 +36,10 @@ interface RenderOptions {
   appointments?: Appointment[];
   onSave?: any;
   onClose?: any;
+  onCancel?: any;
+  onMarkNoShow?: any;
+  onDelete?: any;
+  role?: string;
   isSaving?: boolean;
   isReconciling?: boolean;
   serverError?: string | null;
@@ -55,6 +59,10 @@ const renderModal = async (options: RenderOptions = {}) => {
           isOpen
           onClose={onClose}
           onSave={onSave}
+          onCancel={options.onCancel}
+          onMarkNoShow={options.onMarkNoShow}
+          onDelete={options.onDelete}
+          role={options.role}
           initialData={{ ...baseInitial, ...options.initialData }}
           appointments={options.appointments || []}
           doctors={doctors}
@@ -255,6 +263,172 @@ describe('AppointmentModal', () => {
     expect(container.textContent).toContain('У врача уже есть запись на это время.');
     const service = container.querySelector('input[name="service"]') as HTMLInputElement;
     expect(service.value).toBe('Осмотр');
+    await cleanup(root, container);
+  });
+
+  it('removes cancelled and no-show from generic status controls', async () => {
+    const view = await renderModal({
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      role: 'clinic_admin',
+      onCancel: vi.fn(),
+      onMarkNoShow: vi.fn(),
+    });
+    expect(view.container.querySelector('[data-testid="appointment-status-cancelled"]')).toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-status-no_show"]')).toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-cancel-action"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-no-show-action"]')).not.toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
+  it('keeps cancellation and hard delete visually separate for owner/admin', async () => {
+    const view = await renderModal({
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      role: 'clinic_owner',
+      onCancel: vi.fn(),
+      onMarkNoShow: vi.fn(),
+      onDelete: vi.fn().mockResolvedValue(true),
+    });
+    expect(view.container.textContent).toContain('Отменить запись');
+    expect(view.container.textContent).toContain('Удалить запись');
+    expect(view.container.querySelector('[data-testid="appointment-cancel-action"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-delete-action"]')).not.toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
+  it('allows registrar lifecycle actions but hides hard delete', async () => {
+    const view = await renderModal({
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      role: 'registrar',
+      onCancel: vi.fn(),
+      onMarkNoShow: vi.fn(),
+      onDelete: vi.fn(),
+    });
+    expect(view.container.querySelector('[data-testid="appointment-cancel-action"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-no-show-action"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-delete-action"]')).toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
+  it.each(['doctor', 'cashier', 'unknown'] as const)('hides lifecycle and delete actions for %s', async (role) => {
+    const view = await renderModal({
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      role,
+      onCancel: vi.fn(),
+      onMarkNoShow: vi.fn(),
+      onDelete: vi.fn(),
+    });
+    expect(view.container.querySelector('[data-testid="appointment-cancel-action"]')).toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-no-show-action"]')).toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-delete-action"]')).toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
+  it('opens separate cancellation and no-show dialogs from lifecycle actions', async () => {
+    const view = await renderModal({
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      role: 'clinic_admin',
+      onCancel: vi.fn().mockResolvedValue({ ...baseInitial, id: 'existing-id', status: 'cancelled', createdAt: '', updatedAt: '' }),
+      onMarkNoShow: vi.fn().mockResolvedValue({ ...baseInitial, id: 'existing-id', status: 'no_show', createdAt: '', updatedAt: '' }),
+    });
+    await act(async () => (view.container.querySelector('[data-testid="appointment-cancel-action"]') as HTMLButtonElement).click());
+    expect(document.body.querySelector('[data-testid="appointment-cancellation-dialog"]')).not.toBeNull();
+    await act(async () => (document.body.querySelector('[data-testid="appointment-cancellation-dialog"] button[aria-label="Закрыть"]') as HTMLButtonElement).click());
+    await act(async () => (view.container.querySelector('[data-testid="appointment-no-show-action"]') as HTMLButtonElement).click());
+    expect(document.body.querySelector('[data-testid="appointment-no-show-dialog"]')).not.toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
+  it('renders terminal lifecycle metadata and hides generic save', async () => {
+    const view = await renderModal({
+      initialData: {
+        id: 'cancelled-id',
+        status: 'cancelled',
+        cancelledAt: '2026-08-01T12:00:00',
+        cancelledBy: 'user-id',
+        cancellationSource: 'patient',
+        cancellationReason: 'Пациент попросил',
+        lifecycleMetadataVersion: 1,
+        createdAt: '2026-07-01T09:00:00',
+        updatedAt: '2026-08-01T12:00:00+00:00',
+      },
+      role: 'clinic_admin',
+      onDelete: vi.fn(),
+    });
+    expect(view.container.querySelector('[data-testid="appointment-cancellation-metadata"]')?.textContent).toContain('Пациент попросил');
+    expect(view.container.querySelector('button[form="appointment-form"]')).toBeNull();
+    expect(view.container.textContent).toContain('Сотрудник клиники');
+    await cleanup(view.root, view.container);
+  });
+
+  it('ignores a delayed lifecycle result after the appointment context changes', async () => {
+    let resolveLifecycle!: (value: Appointment | null) => void;
+    const lifecycleResult = new Promise<Appointment | null>((resolve) => {
+      resolveLifecycle = resolve;
+    });
+    const onMarkNoShow = vi.fn(() => lifecycleResult);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const renderAppointment = async (id: string, service: string) => {
+      await act(async () => {
+        root.render(
+          <MemoryRouter>
+            <AppointmentModal
+              isOpen
+              onClose={vi.fn()}
+              onSave={vi.fn().mockResolvedValue(true)}
+              onMarkNoShow={onMarkNoShow}
+              role="clinic_admin"
+              initialData={{
+                ...baseInitial,
+                id,
+                service,
+                createdAt: '2026-07-01T09:00:00',
+                updatedAt: '2026-07-01T09:30:00+00:00',
+              }}
+              appointments={[]}
+              doctors={doctors}
+              patients={patients}
+            />
+          </MemoryRouter>,
+        );
+      });
+    };
+
+    await renderAppointment('appointment-a', 'Приём A');
+    await act(async () => {
+      (container.querySelector('[data-testid="appointment-no-show-action"]') as HTMLButtonElement).click();
+    });
+
+    const reason = document.body.querySelector('[data-testid="appointment-no-show-reason"]') as HTMLTextAreaElement;
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set?.call(reason, 'Задержанный ответ');
+      reason.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      (document.body.querySelector('[data-testid="appointment-no-show-submit"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(onMarkNoShow).toHaveBeenCalledTimes(1);
+
+    await renderAppointment('appointment-b', 'Приём B');
+    await act(async () => {
+      resolveLifecycle({
+        ...baseInitial,
+        id: 'appointment-a',
+        service: 'Приём A',
+        status: 'no_show',
+        noShowReason: 'Задержанный ответ',
+        createdAt: '2026-07-01T09:00:00',
+        updatedAt: '2026-07-01T10:00:00+00:00',
+      } as Appointment);
+      await lifecycleResult;
+    });
+
+    expect((container.querySelector('input[name="service"]') as HTMLInputElement).value).toBe('Приём B');
+    expect(container.textContent).not.toContain('Задержанный ответ');
+    expect(container.querySelector('[data-testid="appointment-no-show-metadata"]')).toBeNull();
     await cleanup(root, container);
   });
 });

--- a/src/components/schedule/AppointmentModal.tsx
+++ b/src/components/schedule/AppointmentModal.tsx
@@ -1,13 +1,25 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X, AlertCircle, ExternalLink } from 'lucide-react';
-import type { Appointment, AppointmentStatus, PaymentType, Source, Doctor, Patient } from '../../types';
+import type { Appointment, AppointmentStatus, CancellationSource, PaymentType, Source, Doctor, Patient } from '../../types';
+import { AppointmentCancellationDialog } from './AppointmentCancellationDialog';
+import { AppointmentNoShowDialog } from './AppointmentNoShowDialog';
+import {
+  canHardDeleteAppointment,
+  canManageAppointmentLifecycle,
+  canTransitionAppointmentLifecycle,
+  cancellationSourceLabel,
+  isTerminalAppointmentLifecycle,
+} from './appointmentLifecycle';
 
 interface AppointmentModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (appointment: Appointment) => Promise<boolean>;
+  onCancel?: (appointment: Appointment, source: CancellationSource, reason: string) => Promise<Appointment | null>;
+  onMarkNoShow?: (appointment: Appointment, reason: string) => Promise<Appointment | null>;
   onDelete?: (id: string) => Promise<boolean>;
+  role?: string;
   initialData?: Partial<Appointment>;
   appointments: Appointment[];
   doctors: Doctor[];
@@ -35,7 +47,10 @@ export function AppointmentModal({
   isOpen,
   onClose,
   onSave,
+  onCancel,
+  onMarkNoShow,
   onDelete,
+  role,
   initialData,
   appointments,
   doctors,
@@ -47,16 +62,23 @@ export function AppointmentModal({
   const isEditing = Boolean(initialData?.id);
   const navigate = useNavigate();
   const submitLockRef = useRef(false);
+  const appointmentContextRef = useRef<string | null>(initialData?.id || null);
   const [isSubmittingLocally, setIsSubmittingLocally] = useState(false);
   const [formData, setFormData] = useState<Partial<Appointment>>({
     ...defaultForm(),
     ...initialData,
   });
   const [localError, setLocalError] = useState<string | null>(null);
+  const [lifecycleDialog, setLifecycleDialog] = useState<'cancel' | 'no_show' | null>(null);
   const isBusy = isSaving || isSubmittingLocally;
+  const storedAppointment = isEditing ? initialData as Appointment : null;
+  const isTerminal = Boolean(formData.status && isTerminalAppointmentLifecycle(formData.status));
+  const canManageLifecycle = canManageAppointmentLifecycle(role);
+  const canDelete = canHardDeleteAppointment(role);
   const visibleError = localError || serverError;
 
   useEffect(() => {
+    appointmentContextRef.current = initialData?.id || null;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setFormData({
       ...defaultForm(),
@@ -64,6 +86,7 @@ export function AppointmentModal({
     });
     setLocalError(null);
     setIsSubmittingLocally(false);
+    setLifecycleDialog(null);
     submitLockRef.current = false;
   }, [isOpen, initialData]);
 
@@ -84,8 +107,6 @@ export function AppointmentModal({
   };
 
   const checkConflicts = (): boolean => {
-    if (formData.status === 'cancelled') return false;
-
     const proposedStart = new Date(formData.start as string).getTime();
     const proposedEnd = new Date(formData.end as string).getTime();
 
@@ -187,11 +208,33 @@ export function AppointmentModal({
     }
   };
 
+  const handleCancelAppointment = async (source: CancellationSource, reason: string): Promise<Appointment | null> => {
+    if (!storedAppointment || !onCancel) return null;
+    const capturedAppointmentId = storedAppointment.id;
+    const result = await onCancel(storedAppointment, source, reason);
+    if (appointmentContextRef.current !== capturedAppointmentId) return null;
+    if (result) setFormData(result);
+    return result;
+  };
+
+  const handleMarkNoShow = async (reason: string): Promise<Appointment | null> => {
+    if (!storedAppointment || !onMarkNoShow) return null;
+    const capturedAppointmentId = storedAppointment.id;
+    const result = await onMarkNoShow(storedAppointment, reason);
+    if (appointmentContextRef.current !== capturedAppointmentId) return null;
+    if (result) setFormData(result);
+    return result;
+  };
+
+  const patientName = patients.find((patient) => patient.id === formData.patientId)?.fullName || 'Пациент не указан';
+  const doctorName = doctors.find((doctor) => doctor.id === formData.doctorId)?.fullName || 'Врач не указан';
+
   const closeSafely = () => {
     if (!isBusy) onClose();
   };
 
   return (
+    <>
     <div className="fixed inset-0 bg-slate-900/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
         <div className="flex items-center justify-between p-4 border-b border-slate-200">
@@ -239,7 +282,7 @@ export function AppointmentModal({
           )}
 
           <form id="appointment-form" onSubmit={handleSubmit} className="space-y-4">
-            <fieldset disabled={isBusy} className="space-y-4 disabled:opacity-70">
+            <fieldset disabled={isBusy || isTerminal} className="space-y-4 disabled:opacity-70">
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-700 mb-1">Пациент</label>
@@ -369,8 +412,6 @@ export function AppointmentModal({
                     { value: 'arrived', label: 'Пришел' },
                     { value: 'in_progress', label: 'В работе' },
                     { value: 'completed', label: 'Завершен' },
-                    { value: 'no_show', label: 'Не пришел' },
-                    { value: 'cancelled', label: 'Отменен' },
                   ].map((status) => (
                     <button
                       key={status.value}
@@ -388,20 +429,62 @@ export function AppointmentModal({
                   ))}
                 </div>
               </div>
+
+              {isEditing && formData.status === 'cancelled' && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800" data-testid="appointment-cancellation-metadata">
+                  <div className="font-semibold">Запись отменена</div>
+                  <div>Дата: {formData.cancelledAt ? new Date(formData.cancelledAt).toLocaleString('ru-RU') : 'Историческая запись'}</div>
+                  <div>Кто отменил: {cancellationSourceLabel(formData.cancellationSource)}</div>
+                  <div>Причина: {formData.cancellationReason || 'Причина не была сохранена в прежней версии системы'}</div>
+                  <div>Сотрудник: {formData.cancelledBy ? 'Сотрудник клиники' : 'Не указан'}</div>
+                </div>
+              )}
+
+              {isEditing && formData.status === 'no_show' && (
+                <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800" data-testid="appointment-no-show-metadata">
+                  <div className="font-semibold">Отмечена неявка</div>
+                  <div>Дата: {formData.noShowAt ? new Date(formData.noShowAt).toLocaleString('ru-RU') : 'Историческая запись'}</div>
+                  <div>Причина: {formData.noShowReason || 'Причина не была сохранена в прежней версии системы'}</div>
+                  <div>Сотрудник: {formData.noShowBy ? 'Сотрудник клиники' : 'Не указан'}</div>
+                </div>
+              )}
             </fieldset>
           </form>
         </div>
 
-        <div className="flex items-center justify-between p-4 border-t border-slate-200 bg-slate-50 rounded-b-xl">
-          <div>
-            {isEditing && onDelete && (
+        <div className="flex flex-wrap items-center justify-between gap-3 p-4 border-t border-slate-200 bg-slate-50 rounded-b-xl">
+          <div className="flex flex-wrap gap-2">
+            {isEditing && canDelete && onDelete && (
               <button
                 type="button"
                 disabled={isBusy}
                 onClick={() => void handleDelete()}
-                className="px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                data-testid="appointment-delete-action"
+                className="px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-100 rounded-lg transition-colors disabled:opacity-50"
               >
-                Удалить
+                Удалить запись
+              </button>
+            )}
+            {isEditing && storedAppointment && canManageLifecycle && canTransitionAppointmentLifecycle(storedAppointment.status) && onMarkNoShow && (
+              <button
+                type="button"
+                disabled={isBusy}
+                onClick={() => setLifecycleDialog('no_show')}
+                data-testid="appointment-no-show-action"
+                className="px-4 py-2 text-sm font-medium text-rose-700 hover:bg-rose-100 rounded-lg transition-colors disabled:opacity-50"
+              >
+                Отметить неявку
+              </button>
+            )}
+            {isEditing && storedAppointment && canManageLifecycle && canTransitionAppointmentLifecycle(storedAppointment.status) && onCancel && (
+              <button
+                type="button"
+                disabled={isBusy}
+                onClick={() => setLifecycleDialog('cancel')}
+                data-testid="appointment-cancel-action"
+                className="px-4 py-2 text-sm font-medium text-amber-800 hover:bg-amber-100 rounded-lg transition-colors disabled:opacity-50"
+              >
+                Отменить запись
               </button>
             )}
           </div>
@@ -412,19 +495,46 @@ export function AppointmentModal({
               onClick={closeSafely}
               className="px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-200 bg-slate-100 rounded-lg transition-colors disabled:opacity-50"
             >
-              Отмена
+              {isTerminal ? 'Закрыть' : 'Отмена'}
             </button>
-            <button
-              type="submit"
-              form="appointment-form"
-              disabled={isBusy}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {isBusy ? 'Сохраняем запись…' : 'Сохранить'}
-            </button>
+            {!isTerminal && (
+              <button
+                type="submit"
+                form="appointment-form"
+                disabled={isBusy}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isBusy ? 'Сохраняем запись…' : 'Сохранить'}
+              </button>
+            )}
           </div>
         </div>
       </div>
     </div>
+    {lifecycleDialog === 'cancel' && storedAppointment && (
+      <AppointmentCancellationDialog
+        appointment={storedAppointment}
+        patientName={patientName}
+        doctorName={doctorName}
+        isSaving={isBusy}
+        isReconciling={isReconciling}
+        error={visibleError ? new Error(visibleError) : null}
+        onConfirm={handleCancelAppointment}
+        onClose={() => setLifecycleDialog(null)}
+      />
+    )}
+    {lifecycleDialog === 'no_show' && storedAppointment && (
+      <AppointmentNoShowDialog
+        appointment={storedAppointment}
+        patientName={patientName}
+        doctorName={doctorName}
+        isSaving={isBusy}
+        isReconciling={isReconciling}
+        error={visibleError ? new Error(visibleError) : null}
+        onConfirm={handleMarkNoShow}
+        onClose={() => setLifecycleDialog(null)}
+      />
+    )}
+    </>
   );
 }

--- a/src/components/schedule/AppointmentNoShowDialog.tsx
+++ b/src/components/schedule/AppointmentNoShowDialog.tsx
@@ -1,0 +1,105 @@
+import { useState, type FormEvent } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import type { Appointment } from '../../types';
+
+interface AppointmentNoShowDialogProps {
+  appointment: Appointment;
+  patientName: string;
+  doctorName: string;
+  isSaving: boolean;
+  isReconciling: boolean;
+  error: Error | null;
+  onConfirm: (reason: string) => Promise<Appointment | null>;
+  onClose: () => void;
+}
+
+export function AppointmentNoShowDialog({
+  appointment,
+  patientName,
+  doctorName,
+  isSaving,
+  isReconciling,
+  error,
+  onConfirm,
+  onClose,
+}: AppointmentNoShowDialogProps) {
+  const [reason, setReason] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [succeeded, setSucceeded] = useState(false);
+  const start = new Date(appointment.start);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      setValidationError('Укажите причину.');
+      return;
+    }
+    setValidationError(null);
+    try {
+      const result = await onConfirm(normalizedReason);
+      if (result) setSucceeded(true);
+    } catch {
+      // The hook exposes only the mapped safe error; keep this form open.
+    }
+  };
+
+  const displayedError = validationError || error?.message;
+
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-slate-900/50 p-4" data-testid="appointment-no-show-dialog">
+      <div className="w-full max-w-lg rounded-xl bg-white shadow-xl" role="dialog" aria-modal="true" aria-labelledby="appointment-no-show-title">
+        <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+          <h2 id="appointment-no-show-title" className="text-lg font-semibold text-slate-900">Отметить неявку</h2>
+          <button type="button" onClick={onClose} disabled={isSaving} className="rounded p-1 text-slate-400 hover:bg-slate-100 disabled:opacity-50" aria-label="Закрыть">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {succeeded ? (
+          <div className="space-y-4 p-5">
+            <p className="rounded-lg bg-emerald-50 p-3 font-medium text-emerald-700" data-testid="appointment-no-show-success">Неявка отмечена.</p>
+            <button type="button" data-testid="appointment-no-show-success-close" onClick={onClose} className="w-full rounded-lg bg-slate-900 px-4 py-2 text-white">Закрыть</button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4 p-5">
+            <dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-2 rounded-lg bg-slate-50 p-3 text-sm">
+              <dt className="text-slate-500">Пациент</dt><dd className="font-medium text-slate-800">{patientName}</dd>
+              <dt className="text-slate-500">Врач</dt><dd className="font-medium text-slate-800">{doctorName}</dd>
+              <dt className="text-slate-500">Дата и время</dt><dd className="font-medium text-slate-800">{start.toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short' })}</dd>
+              <dt className="text-slate-500">Текущий статус</dt><dd className="font-medium text-slate-800">{appointment.status}</dd>
+            </dl>
+
+            <div>
+              <label htmlFor="no-show-reason" className="mb-1 block text-sm font-medium text-slate-700">Причина неявки</label>
+              <textarea
+                id="no-show-reason"
+                data-testid="appointment-no-show-reason"
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                disabled={isSaving}
+                rows={3}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              />
+            </div>
+
+            <p className="flex gap-2 rounded-lg bg-amber-50 p-3 text-sm text-amber-800">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              Неявка будет сохранена в истории пациента. Лечение и выполненная услуга автоматически не создаются.
+            </p>
+
+            {displayedError && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700" role="alert">{displayedError}</p>}
+            {isReconciling && <p className="text-sm font-medium text-indigo-700">Проверяем, была ли неявка сохранена…</p>}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <button type="button" onClick={onClose} disabled={isSaving} className="rounded-lg border border-slate-300 px-4 py-2 text-slate-700 disabled:opacity-50">Назад</button>
+              <button type="submit" disabled={isSaving} data-testid="appointment-no-show-submit" className="rounded-lg bg-rose-600 px-4 py-2 font-medium text-white disabled:opacity-50">
+                {isSaving ? (isReconciling ? 'Проверяем…' : 'Сохраняем неявку…') : 'Отметить неявку'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/schedule/appointmentLifecycle.ts
+++ b/src/components/schedule/appointmentLifecycle.ts
@@ -1,0 +1,31 @@
+import type { AppointmentStatus, CancellationSource } from '../../types';
+
+export type AppointmentLifecycleRole = string | null | undefined;
+
+export const CANCELLATION_SOURCE_LABELS: Record<CancellationSource, string> = {
+  patient: 'Пациент',
+  clinic: 'Клиника',
+  doctor: 'Врач',
+  technical: 'Техническая причина',
+  other: 'Другое',
+};
+
+export const cancellationSourceLabel = (source?: CancellationSource): string => (
+  source ? CANCELLATION_SOURCE_LABELS[source] : 'Не указано'
+);
+
+export const canManageAppointmentLifecycle = (role: AppointmentLifecycleRole): boolean => (
+  role === 'clinic_owner' || role === 'clinic_admin' || role === 'registrar'
+);
+
+export const canHardDeleteAppointment = (role: AppointmentLifecycleRole): boolean => (
+  role === 'clinic_owner' || role === 'clinic_admin'
+);
+
+export const canTransitionAppointmentLifecycle = (status: AppointmentStatus): boolean => (
+  status === 'new' || status === 'confirmed'
+);
+
+export const isTerminalAppointmentLifecycle = (status: AppointmentStatus): boolean => (
+  status === 'cancelled' || status === 'no_show'
+);

--- a/src/data/hooks/useScheduleAppointments.test.tsx
+++ b/src/data/hooks/useScheduleAppointments.test.tsx
@@ -5,7 +5,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Appointment } from '../../types';
+import type { Appointment, CancellationSource } from '../../types';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 import {
@@ -51,7 +51,7 @@ const appointment: Appointment = {
   updatedAt: '2026-07-01T09:00:00+00:00',
 };
 
-const writeResult = (value: Appointment = appointment, operationType: 'create' | 'reschedule' | 'details' = 'create') => ({
+const writeResult = (value: Appointment = appointment, operationType: 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' = 'create') => ({
   appointment: value,
   replayed: false,
   recovered: false,
@@ -74,6 +74,8 @@ const makeRepository = (): IAppointmentRepository => ({
   createAppointment: vi.fn().mockResolvedValue(writeResult()),
   rescheduleAppointment: vi.fn().mockResolvedValue(writeResult(appointment, 'reschedule')),
   updateAppointmentDetails: vi.fn().mockResolvedValue(writeResult(appointment, 'details')),
+  cancelAppointment: vi.fn().mockResolvedValue(writeResult({ ...appointment, status: 'cancelled' }, 'cancel')),
+  markAppointmentNoShow: vi.fn().mockResolvedValue(writeResult({ ...appointment, status: 'no_show' }, 'no_show')),
   recoverAppointmentOperation: vi.fn().mockResolvedValue({ found: false }),
   deleteAppointment: vi.fn().mockResolvedValue(undefined),
 });
@@ -300,6 +302,144 @@ describe('useScheduleAppointments', () => {
 
     expect(harness.getResult().saveError?.message).toBe('У пациента уже есть другая запись на это время.');
     expect(refetchMock).not.toHaveBeenCalled();
+    await harness.unmount();
+  });
+
+  it('blocks rapid duplicate cancellation with one repository call, key, and refetch', async () => {
+    const save = deferred<ReturnType<typeof writeResult>>();
+    const cancel = vi.fn((...args: Parameters<IAppointmentRepository['cancelAppointment']>) => {
+      void args;
+      return save.promise;
+    });
+    repository.cancelAppointment = cancel;
+    const harness = await renderHook();
+
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
+    await act(async () => {
+      first = harness.getResult().cancelAppointment(appointment, 'patient', 'Patient requested');
+      second = harness.getResult().cancelAppointment(appointment, 'patient', 'Patient requested');
+      await Promise.resolve();
+    });
+
+    expect(first).toBe(second);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel.mock.calls[0][3].operationKey).toMatch(/^[0-9a-f-]{36}$/);
+    expect(harness.getResult()).toMatchObject({ isSaving: true, isCancelling: true, isMarkingNoShow: false });
+
+    await act(async () => save.resolve(writeResult({ ...appointment, status: 'cancelled' }, 'cancel')));
+    await first;
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    expect(harness.getResult().isCancelling).toBe(false);
+    await harness.unmount();
+  });
+
+  it('blocks rapid duplicate no-show and cannot run cancel and no-show simultaneously', async () => {
+    const save = deferred<ReturnType<typeof writeResult>>();
+    const noShow = vi.fn(() => save.promise);
+    const cancel = vi.fn().mockResolvedValue(writeResult({ ...appointment, status: 'cancelled' }, 'cancel'));
+    repository.markAppointmentNoShow = noShow;
+    repository.cancelAppointment = cancel;
+    const harness = await renderHook();
+
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
+    let competing!: Promise<unknown>;
+    await act(async () => {
+      first = harness.getResult().markAppointmentNoShow(appointment, 'Unable to contact');
+      second = harness.getResult().markAppointmentNoShow(appointment, 'Unable to contact');
+      competing = harness.getResult().cancelAppointment(appointment, 'clinic', 'Competing action');
+      await Promise.resolve();
+    });
+
+    expect(first).toBe(second);
+    expect(competing).toBe(first);
+    expect(noShow).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
+    expect(harness.getResult()).toMatchObject({ isMarkingNoShow: true, isCancelling: false });
+
+    await act(async () => save.resolve(writeResult({ ...appointment, status: 'no_show' }, 'no_show')));
+    await first;
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    await harness.unmount();
+  });
+
+  it('shows lifecycle reconciliation state and keeps the operation key for an ambiguous retry', async () => {
+    const keys: string[] = [];
+    const cancel = vi.fn()
+      .mockImplementationOnce((_current: Appointment, _source: CancellationSource, _reason: string, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        options.onRecoveryStateChange?.(true);
+        options.onRecoveryStateChange?.(false);
+        return Promise.reject(new AppointmentRepositoryError(
+          'generic',
+          'Не удалось изменить статус записи. Обновите расписание и проверьте результат.',
+          true,
+        ));
+      })
+      .mockImplementationOnce((_current: Appointment, _source: CancellationSource, _reason: string, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        return Promise.resolve(writeResult({ ...appointment, status: 'cancelled' }, 'cancel'));
+      });
+    repository.cancelAppointment = cancel;
+    const harness = await renderHook();
+
+    await act(async () => {
+      await expect(harness.getResult().cancelAppointment(appointment, 'clinic', 'Reason')).rejects.toMatchObject({ ambiguous: true });
+    });
+    await act(async () => {
+      await expect(harness.getResult().cancelAppointment(appointment, 'clinic', 'Reason')).resolves.toMatchObject({ operationType: 'cancel' });
+    });
+
+    expect(keys).toHaveLength(2);
+    expect(keys[1]).toBe(keys[0]);
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    await harness.unmount();
+  });
+
+  it('clears lifecycle key after definitive failure so a corrected retry uses another key', async () => {
+    const keys: string[] = [];
+    const cancel = vi.fn()
+      .mockImplementationOnce((_current: Appointment, _source: CancellationSource, _reason: string, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        return Promise.reject(new AppointmentRepositoryError('reason_required', 'Укажите причину.'));
+      })
+      .mockImplementationOnce((_current: Appointment, _source: CancellationSource, _reason: string, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        return Promise.resolve(writeResult({ ...appointment, status: 'cancelled' }, 'cancel'));
+      });
+    repository.cancelAppointment = cancel;
+    const harness = await renderHook();
+
+    await act(async () => {
+      await expect(harness.getResult().cancelAppointment(appointment, 'clinic', 'Bad')).rejects.toThrow('Укажите причину');
+    });
+    await act(async () => {
+      await harness.getResult().cancelAppointment(appointment, 'clinic', 'Corrected');
+    });
+
+    expect(keys[1]).not.toBe(keys[0]);
+    await harness.unmount();
+  });
+
+  it('ignores stale lifecycle success after tenant changes and does not refresh new tenant', async () => {
+    const save = deferred<ReturnType<typeof writeResult>>();
+    repository.cancelAppointment = vi.fn(() => save.promise);
+    const harness = await renderHook();
+
+    let pending!: Promise<unknown>;
+    await act(async () => {
+      pending = harness.getResult().cancelAppointment(appointment, 'clinic', 'Tenant A action');
+      await Promise.resolve();
+    });
+    activeTenant = { tenantId: 'tenant-b' };
+    await harness.rerender();
+    expect(harness.getResult().isCancelling).toBe(false);
+
+    await act(async () => save.resolve(writeResult({ ...appointment, status: 'cancelled' }, 'cancel')));
+    await expect(pending).resolves.toBeNull();
+    expect(refetchMock).not.toHaveBeenCalled();
+    expect(harness.getResult().saveError).toBeNull();
     await harness.unmount();
   });
 });

--- a/src/data/hooks/useScheduleAppointments.ts
+++ b/src/data/hooks/useScheduleAppointments.ts
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
-import type { Appointment } from '../../types';
+import type { Appointment, CancellationSource } from '../../types';
 import {
   AppointmentRepositoryError,
   createAppointmentRepository,
@@ -62,9 +62,15 @@ export function useScheduleAppointments() {
     isReconciling: false,
     error: null,
   });
+  const [mutationAction, setMutationAction] = useState<{
+    contextKey: string;
+    action: 'save' | 'cancel' | 'no_show' | null;
+  }>({ contextKey, action: null });
 
   const createAttemptRef = useRef<OperationAttempt | null>(null);
   const rescheduleAttemptRef = useRef<OperationAttempt | null>(null);
+  const cancellationAttemptRef = useRef<OperationAttempt | null>(null);
+  const noShowAttemptRef = useRef<OperationAttempt | null>(null);
   const inFlightRef = useRef<{
     contextKey: string;
     signature: string;
@@ -136,11 +142,13 @@ export function useScheduleAppointments() {
     signature: string,
     write: (onRecoveryStateChange: (recovering: boolean) => void) => Promise<AppointmentWriteResult>,
     attemptRef?: MutableRefObject<OperationAttempt | null>,
+    action: 'save' | 'cancel' | 'no_show' = 'save',
   ): Promise<AppointmentWriteResult | null> => {
     const existing = inFlightRef.current;
     if (existing && existing.contextKey === contextKey) return existing.promise;
 
     const capturedContext = contextKey;
+    setMutationAction({ contextKey: capturedContext, action });
     setMutationState({
       contextKey: capturedContext,
       isSaving: true,
@@ -176,6 +184,7 @@ export function useScheduleAppointments() {
         }
 
         if (currentContextRef.current === capturedContext) {
+          setMutationAction({ contextKey: capturedContext, action: null });
           setMutationState({
             contextKey: capturedContext,
             isSaving: false,
@@ -186,6 +195,7 @@ export function useScheduleAppointments() {
         throw parsedError;
       } finally {
         if (currentContextRef.current === capturedContext) {
+          setMutationAction({ contextKey: capturedContext, action: null });
           setMutationState((current) => ({
             contextKey: capturedContext,
             isSaving: false,
@@ -238,11 +248,48 @@ export function useScheduleAppointments() {
     );
   }, [contextKey, getOperationKey, requireRepository, runMutation]);
 
+  const cancelAppointment = useCallback((
+    current: Appointment,
+    source: CancellationSource,
+    reason: string,
+  ) => {
+    const activeRepository = requireRepository();
+    const normalizedReason = reason.trim();
+    const signature = `cancel:${contextKey}:${current.id}:${current.updatedAt || ''}:${source}:${normalizedReason}`;
+    const operationKey = getOperationKey(cancellationAttemptRef, signature);
+    return runMutation(
+      signature,
+      (onRecoveryStateChange) => activeRepository.cancelAppointment(current, source, normalizedReason, {
+        operationKey,
+        onRecoveryStateChange,
+      }),
+      cancellationAttemptRef,
+      'cancel',
+    );
+  }, [contextKey, getOperationKey, requireRepository, runMutation]);
+
+  const markAppointmentNoShow = useCallback((current: Appointment, reason: string) => {
+    const activeRepository = requireRepository();
+    const normalizedReason = reason.trim();
+    const signature = `no-show:${contextKey}:${current.id}:${current.updatedAt || ''}:${normalizedReason}`;
+    const operationKey = getOperationKey(noShowAttemptRef, signature);
+    return runMutation(
+      signature,
+      (onRecoveryStateChange) => activeRepository.markAppointmentNoShow(current, normalizedReason, {
+        operationKey,
+        onRecoveryStateChange,
+      }),
+      noShowAttemptRef,
+      'no_show',
+    );
+  }, [contextKey, getOperationKey, requireRepository, runMutation]);
+
   const deleteAppointment = useCallback(async (appointmentId: string): Promise<boolean> => {
     const activeRepository = requireRepository();
     const capturedContext = contextKey;
     if (inFlightRef.current?.contextKey === capturedContext) return false;
 
+    setMutationAction({ contextKey: capturedContext, action: 'save' });
     setMutationState({ contextKey: capturedContext, isSaving: true, isReconciling: false, error: null });
     try {
       await activeRepository.deleteAppointment(appointmentId);
@@ -252,11 +299,13 @@ export function useScheduleAppointments() {
     } catch (error) {
       const parsedError = safeMutationError(error);
       if (currentContextRef.current === capturedContext) {
+        setMutationAction({ contextKey: capturedContext, action: null });
         setMutationState({ contextKey: capturedContext, isSaving: false, isReconciling: false, error: parsedError });
       }
       throw parsedError;
     } finally {
       if (currentContextRef.current === capturedContext) {
+        setMutationAction({ contextKey: capturedContext, action: null });
         setMutationState((current) => ({
           contextKey: capturedContext,
           isSaving: false,
@@ -270,6 +319,7 @@ export function useScheduleAppointments() {
   const mutationForCurrentContext = mutationState.contextKey === contextKey
     ? mutationState
     : { contextKey, isSaving: false, isReconciling: false, error: null };
+  const actionForCurrentContext = mutationAction.contextKey === contextKey ? mutationAction.action : null;
   const isError = isQueryError || mutationForCurrentContext.error !== null;
   const error = mutationForCurrentContext.error || queryError;
 
@@ -280,9 +330,15 @@ export function useScheduleAppointments() {
     error,
     isSaving: mutationForCurrentContext.isSaving,
     isReconciling: mutationForCurrentContext.isReconciling,
+    isCancelling: actionForCurrentContext === 'cancel' && mutationForCurrentContext.isSaving,
+    isMarkingNoShow: actionForCurrentContext === 'no_show' && mutationForCurrentContext.isSaving,
+    isLifecycleReconciling: (actionForCurrentContext === 'cancel' || actionForCurrentContext === 'no_show')
+      && mutationForCurrentContext.isReconciling,
     saveError: mutationForCurrentContext.error,
     createAppointment,
     updateAppointment,
+    cancelAppointment,
+    markAppointmentNoShow,
     deleteAppointment,
     refetch,
   };

--- a/src/data/repositories/AppointmentRepository.test.ts
+++ b/src/data/repositories/AppointmentRepository.test.ts
@@ -62,7 +62,7 @@ const databaseRow = (overrides: Record<string, unknown> = {}) => ({
 });
 
 const rpcResult = (
-  operationType: 'create' | 'reschedule' | 'details' = 'create',
+  operationType: 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' = 'create',
   overrides: Record<string, unknown> = {},
 ) => ({
   appointment: databaseRow(overrides),
@@ -244,6 +244,92 @@ describe('AppointmentRepository', () => {
     expect(from).not.toHaveBeenCalled();
   });
 
+  it('cancels through cancel_appointment RPC, preserves tenant/key, trims reason, and maps metadata', async () => {
+    const { client, rpc, from } = createClient();
+    rpc.mockResolvedValue({
+      data: rpcResult('cancel', {
+        status: 'cancelled',
+        cancelled_at: '2026-08-01T09:30:00+00:00',
+        cancelled_by: '55555555-5555-4555-8555-555555555555',
+        cancellation_source: 'patient',
+        cancellation_reason: 'Patient requested',
+        lifecycle_metadata_version: 1,
+      }),
+      error: null,
+    });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const result = await repository.cancelAppointment(appointment, 'patient', '  Patient requested  ', { operationKey });
+
+    expect(rpc).toHaveBeenCalledWith('cancel_appointment', {
+      p_tenant_id: tenantId,
+      p_appointment_id: appointmentId,
+      p_cancellation_source: 'patient',
+      p_cancellation_reason: 'Patient requested',
+      p_expected_updated_at: appointment.updatedAt,
+      p_operation_key: operationKey,
+    });
+    expect(from).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      operationType: 'cancel',
+      appointment: {
+        status: 'cancelled',
+        cancellationSource: 'patient',
+        cancellationReason: 'Patient requested',
+        cancelledBy: '55555555-5555-4555-8555-555555555555',
+        lifecycleMetadataVersion: 1,
+      },
+    });
+  });
+
+  it('marks no-show through mark_appointment_no_show RPC and maps metadata', async () => {
+    const { client, rpc, from } = createClient();
+    rpc.mockResolvedValue({
+      data: rpcResult('no_show', {
+        status: 'no_show',
+        no_show_at: '2026-08-01T09:30:00+00:00',
+        no_show_by: '55555555-5555-4555-8555-555555555555',
+        no_show_reason: 'Unable to contact',
+        lifecycle_metadata_version: 1,
+      }),
+      error: null,
+    });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const result = await repository.markAppointmentNoShow(appointment, '  Unable to contact  ', { operationKey });
+
+    expect(rpc).toHaveBeenCalledWith('mark_appointment_no_show', {
+      p_tenant_id: tenantId,
+      p_appointment_id: appointmentId,
+      p_no_show_reason: 'Unable to contact',
+      p_expected_updated_at: appointment.updatedAt,
+      p_operation_key: operationKey,
+    });
+    expect(from).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      operationType: 'no_show',
+      appointment: {
+        status: 'no_show',
+        noShowReason: 'Unable to contact',
+        noShowBy: '55555555-5555-4555-8555-555555555555',
+        lifecycleMetadataVersion: 1,
+      },
+    });
+  });
+
+  it('rejects generic create, details, and reschedule attempts into lifecycle statuses before RPC', async () => {
+    const { client, rpc } = createClient();
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    await expect(repository.createAppointment({ ...appointment, status: 'cancelled' }, { operationKey }))
+      .rejects.toMatchObject({ code: 'invalid_transition' });
+    await expect(repository.updateAppointmentDetails(appointment, { ...appointment, status: 'no_show' }))
+      .rejects.toMatchObject({ code: 'invalid_transition' });
+    await expect(repository.rescheduleAppointment(appointment, { ...appointment, status: 'cancelled', start: '2026-08-01T12:00:00' }, { operationKey }))
+      .rejects.toMatchObject({ code: 'invalid_transition' });
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
   it('recovers operation through scoped recovery RPC without exposing fingerprint', async () => {
     const { client, rpc } = createClient();
     rpc.mockResolvedValue({
@@ -305,13 +391,61 @@ describe('AppointmentRepository', () => {
     expect(result).toMatchObject({ recovered: true, replayed: true, appointment: { id: appointmentId } });
   });
 
+  it('recovers an uncertain cancellation with the original operation key', async () => {
+    const { client, rpc } = createClient();
+    rpc
+      .mockResolvedValueOnce({ data: null, error: { message: 'Failed to fetch' } })
+      .mockResolvedValueOnce({
+        data: {
+          found: true,
+          operationType: 'cancel',
+          appointment: databaseRow({
+            status: 'cancelled',
+            cancellation_source: 'clinic',
+            cancellation_reason: 'Recovered cancellation',
+            cancelled_at: '2026-08-01T09:30:00+00:00',
+            cancelled_by: '55555555-5555-4555-8555-555555555555',
+            lifecycle_metadata_version: 1,
+          }),
+          replayed: true,
+          recovered: true,
+        },
+        error: null,
+      });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+    const recoveryStates: boolean[] = [];
+
+    const result = await repository.cancelAppointment(appointment, 'clinic', 'Recovered cancellation', {
+      operationKey,
+      onRecoveryStateChange: (recovering) => recoveryStates.push(recovering),
+    });
+
+    expect(rpc.mock.calls[0]).toEqual(['cancel_appointment', expect.objectContaining({ p_operation_key: operationKey })]);
+    expect(rpc.mock.calls[1]).toEqual(['get_appointment_operation', {
+      p_tenant_id: tenantId,
+      p_operation_key: operationKey,
+    }]);
+    expect(recoveryStates).toEqual([true, false]);
+    expect(result).toMatchObject({
+      recovered: true,
+      replayed: true,
+      operationType: 'cancel',
+      appointment: { status: 'cancelled', cancellationReason: 'Recovered cancellation' },
+    });
+  });
+
   it.each([
     ['У врача уже есть запись на это время.', 'doctor_conflict', 'У врача уже есть запись на это время.'],
     ['У пациента уже есть другая запись на это время.', 'patient_conflict', 'У пациента уже есть другая запись на это время.'],
     ['Время окончания должно быть позже времени начала.', 'invalid_interval', 'Время окончания должно быть позже времени начала.'],
     ['Пациент недоступен в этой клинике.', 'patient_unavailable', 'Пациент недоступен в этой клинике.'],
     ['Врач недоступен в этой клинике.', 'doctor_unavailable', 'Врач недоступен в этой клинике.'],
-    ['Операция с этим идентификатором уже выполнена с другими параметрами.', 'idempotency_conflict', 'Операция с этим идентификатором уже выполнена с другими параметрами.'],
+    ['Операция с этим идентификатором уже выполнена с другими параметрами.', 'idempotency_conflict', 'Эта операция уже была выполнена с другими параметрами.'],
+    ['Запись уже отменена.', 'already_cancelled', 'Запись уже отменена.'],
+    ['Неявка уже отмечена.', 'already_no_show', 'Неявка уже отмечена.'],
+    ['Текущий статус записи не позволяет выполнить это действие.', 'invalid_transition', 'Текущий статус записи не позволяет выполнить это действие.'],
+    ['Укажите причину.', 'reason_required', 'Укажите причину.'],
+    ['Укажите, кто отменил запись.', 'source_required', 'Укажите, кто отменил запись.'],
     ['Запись была изменена другим пользователем. Обновите расписание.', 'concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.'],
     ['permission denied for function', 'permission', 'Недостаточно прав для изменения записи.'],
   ])('maps server error safely: %s', (rawMessage, code, safeMessage) => {
@@ -375,6 +509,8 @@ describe('AppointmentRepository', () => {
     expect(supabaseClass).not.toContain('storage.');
     expect(supabaseClass).toContain("rpc('create_appointment'");
     expect(supabaseClass).toContain("rpc('reschedule_appointment'");
+    expect(supabaseClass).toContain("rpc('cancel_appointment'");
+    expect(supabaseClass).toContain("rpc('mark_appointment_no_show'");
     expect(supabaseClass).toContain("rpc('get_appointment_operation'");
   });
 });

--- a/src/data/repositories/AppointmentRepository.ts
+++ b/src/data/repositories/AppointmentRepository.ts
@@ -1,10 +1,10 @@
-import type { Appointment, AppointmentStatus, PaymentType, Source } from '../../types';
+import type { Appointment, AppointmentStatus, CancellationSource, PaymentType, Source } from '../../types';
 import { compareAppointmentsByStartThenId } from '../../domain/appointmentSummary';
 import { storage } from '../../utils/storage';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-export type AppointmentOperationType = 'create' | 'reschedule' | 'details';
+export type AppointmentOperationType = 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show';
 export type AppointmentRepositoryErrorCode =
   | 'doctor_conflict'
   | 'patient_conflict'
@@ -13,6 +13,11 @@ export type AppointmentRepositoryErrorCode =
   | 'doctor_unavailable'
   | 'idempotency_conflict'
   | 'concurrent_change'
+  | 'already_cancelled'
+  | 'already_no_show'
+  | 'invalid_transition'
+  | 'reason_required'
+  | 'source_required'
   | 'permission'
   | 'tenant_required'
   | 'schedule_read_failed'
@@ -45,7 +50,7 @@ export interface AppointmentWriteResult {
 
 export interface AppointmentRecoveryResult {
   found: boolean;
-  operationType?: 'create' | 'reschedule';
+  operationType?: 'create' | 'reschedule' | 'cancel' | 'no_show';
   appointment?: Appointment;
   replayed?: boolean;
   recovered?: boolean;
@@ -57,6 +62,8 @@ export interface IAppointmentRepository {
   createAppointment(appointment: Appointment, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
   rescheduleAppointment(current: Appointment, next: Appointment, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
   updateAppointmentDetails(current: Appointment, next: Appointment): Promise<AppointmentWriteResult>;
+  cancelAppointment(current: Appointment, source: CancellationSource, reason: string, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
+  markAppointmentNoShow(current: Appointment, reason: string, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
   recoverAppointmentOperation(operationKey: string): Promise<AppointmentRecoveryResult>;
   deleteAppointment(appointmentId: string): Promise<void>;
 }
@@ -71,6 +78,12 @@ export interface CreateAppointmentRepositoryOptions {
 const genericSaveError = () => new AppointmentRepositoryError(
   'generic',
   'Не удалось сохранить запись. Обновите расписание и проверьте результат.',
+  true,
+);
+
+const genericLifecycleError = () => new AppointmentRepositoryError(
+  'generic',
+  'Не удалось изменить статус записи. Обновите расписание и проверьте результат.',
   true,
 );
 
@@ -114,11 +127,28 @@ export const toSafeAppointmentError = (error: unknown): AppointmentRepositoryErr
   if (text.includes('запись была изменена другим пользователем')) {
     return new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
   }
+  if (text.includes('запись уже отменена')) {
+    return new AppointmentRepositoryError('already_cancelled', 'Запись уже отменена.');
+  }
+  if (text.includes('неявка уже отмечена')) {
+    return new AppointmentRepositoryError('already_no_show', 'Неявка уже отмечена.');
+  }
+  if (text.includes('текущий статус записи не позволяет выполнить это действие')) {
+    return new AppointmentRepositoryError('invalid_transition', 'Текущий статус записи не позволяет выполнить это действие.');
+  }
+  if (text.includes('укажите причину')) {
+    return new AppointmentRepositoryError('reason_required', 'Укажите причину.');
+  }
+  if (text.includes('укажите, кто отменил запись')) {
+    return new AppointmentRepositoryError('source_required', 'Укажите, кто отменил запись.');
+  }
   if (text.includes('недостаточно прав для изменения записи') || text.includes('permission denied') || text.includes('42501')) {
     return new AppointmentRepositoryError('permission', 'Недостаточно прав для изменения записи.');
   }
-  if (text.includes('операция с этим идентификатором уже выполнена с другими параметрами') || text.includes('appointment_operations_tenant_key_key')) {
-    return new AppointmentRepositoryError('idempotency_conflict', 'Операция с этим идентификатором уже выполнена с другими параметрами.');
+  if (text.includes('операция с этим идентификатором уже выполнена с другими параметрами')
+      || text.includes('эта операция уже была выполнена с другими параметрами')
+      || text.includes('appointment_operations_tenant_key_key')) {
+    return new AppointmentRepositoryError('idempotency_conflict', 'Эта операция уже была выполнена с другими параметрами.');
   }
 
   return genericSaveError();
@@ -174,6 +204,42 @@ export const LocalStorageAppointmentRepository: IAppointmentRepository = {
     return localWriteResult(next, 'details');
   },
 
+  cancelAppointment: async (current: Appointment, source: CancellationSource, reason: string): Promise<AppointmentWriteResult> => {
+    const timestamp = new Date().toISOString();
+    const next: Appointment = {
+      ...current,
+      status: 'cancelled',
+      cancelledAt: timestamp,
+      cancelledBy: 'local-user',
+      cancellationSource: source,
+      cancellationReason: reason.trim(),
+      noShowAt: undefined,
+      noShowBy: undefined,
+      noShowReason: undefined,
+      lifecycleMetadataVersion: 1,
+    };
+    storage.updateAppointment(next);
+    return localWriteResult(next, 'cancel');
+  },
+
+  markAppointmentNoShow: async (current: Appointment, reason: string): Promise<AppointmentWriteResult> => {
+    const timestamp = new Date().toISOString();
+    const next: Appointment = {
+      ...current,
+      status: 'no_show',
+      noShowAt: timestamp,
+      noShowBy: 'local-user',
+      noShowReason: reason.trim(),
+      cancelledAt: undefined,
+      cancelledBy: undefined,
+      cancellationSource: undefined,
+      cancellationReason: undefined,
+      lifecycleMetadataVersion: 1,
+    };
+    storage.updateAppointment(next);
+    return localWriteResult(next, 'no_show');
+  },
+
   recoverAppointmentOperation: async (): Promise<AppointmentRecoveryResult> => ({ found: false }),
 
   deleteAppointment: async (appointmentId: string): Promise<void> => {
@@ -216,6 +282,9 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
   }
 
   async createAppointment(appointment: Appointment, options: AppointmentWriteOptions): Promise<AppointmentWriteResult> {
+    if (appointment.status === 'cancelled' || appointment.status === 'no_show') {
+      throw new AppointmentRepositoryError('invalid_transition', 'Текущий статус записи не позволяет выполнить это действие.');
+    }
     return this.executeRecoverableWrite(options, async () => {
       const { data, error } = await this.client.rpc('create_appointment', {
         p_tenant_id: this.tenantId,
@@ -246,6 +315,9 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     if (!current.updatedAt) {
       throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
     }
+    if (next.status === 'cancelled' || next.status === 'no_show') {
+      throw new AppointmentRepositoryError('invalid_transition', 'Текущий статус записи не позволяет выполнить это действие.');
+    }
 
     return this.executeRecoverableWrite(options, async () => {
       const { data, error } = await this.client.rpc('reschedule_appointment', {
@@ -272,6 +344,9 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
   }
 
   async updateAppointmentDetails(current: Appointment, next: Appointment): Promise<AppointmentWriteResult> {
+    if (next.status === 'cancelled' || next.status === 'no_show') {
+      throw new AppointmentRepositoryError('invalid_transition', 'Текущий статус записи не позволяет выполнить это действие.');
+    }
     if (!current.updatedAt) {
       throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
     }
@@ -297,6 +372,50 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     }
   }
 
+  async cancelAppointment(
+    current: Appointment,
+    source: CancellationSource,
+    reason: string,
+    options: AppointmentWriteOptions,
+  ): Promise<AppointmentWriteResult> {
+    if (!current.updatedAt) {
+      throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+    }
+    return this.executeRecoverableWrite(options, async () => {
+      const { data, error } = await this.client.rpc('cancel_appointment', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: current.id,
+        p_cancellation_source: source,
+        p_cancellation_reason: reason.trim(),
+        p_expected_updated_at: current.updatedAt,
+        p_operation_key: options.operationKey,
+      });
+      if (error) throw error;
+      return this.parseWriteResult(data, 'cancel');
+    }, genericLifecycleError);
+  }
+
+  async markAppointmentNoShow(
+    current: Appointment,
+    reason: string,
+    options: AppointmentWriteOptions,
+  ): Promise<AppointmentWriteResult> {
+    if (!current.updatedAt) {
+      throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+    }
+    return this.executeRecoverableWrite(options, async () => {
+      const { data, error } = await this.client.rpc('mark_appointment_no_show', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: current.id,
+        p_no_show_reason: reason.trim(),
+        p_expected_updated_at: current.updatedAt,
+        p_operation_key: options.operationKey,
+      });
+      if (error) throw error;
+      return this.parseWriteResult(data, 'no_show');
+    }, genericLifecycleError);
+  }
+
   async recoverAppointmentOperation(operationKey: string): Promise<AppointmentRecoveryResult> {
     try {
       const { data, error } = await this.client.rpc('get_appointment_operation', {
@@ -313,7 +432,11 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
 
       return {
         found: true,
-        operationType: payload.operationType === 'reschedule' ? 'reschedule' : 'create',
+        operationType: payload.operationType === 'reschedule'
+          || payload.operationType === 'cancel'
+          || payload.operationType === 'no_show'
+          ? payload.operationType
+          : 'create',
         appointment: this.mapToAppointment(payload.appointment as Record<string, unknown>),
         replayed: payload.replayed === true,
         recovered: payload.recovered === true,
@@ -336,11 +459,13 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
   private async executeRecoverableWrite(
     options: AppointmentWriteOptions,
     write: () => Promise<AppointmentWriteResult>,
+    fallbackError: () => AppointmentRepositoryError = genericSaveError,
   ): Promise<AppointmentWriteResult> {
     try {
       return await write();
     } catch (error) {
-      const safeError = toSafeAppointmentError(error);
+      let safeError = toSafeAppointmentError(error);
+      if (safeError.code === 'generic') safeError = fallbackError();
       if (!safeError.ambiguous) throw safeError;
 
       options.onRecoveryStateChange?.(true);
@@ -355,7 +480,8 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
           };
         }
       } catch (recoveryError) {
-        const recoverySafeError = toSafeAppointmentError(recoveryError);
+        let recoverySafeError = toSafeAppointmentError(recoveryError);
+        if (recoverySafeError.code === 'generic') recoverySafeError = fallbackError();
         if (!recoverySafeError.ambiguous) throw recoverySafeError;
       } finally {
         options.onRecoveryStateChange?.(false);
@@ -373,6 +499,8 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     const operationType = payload.operationType === 'create'
       || payload.operationType === 'reschedule'
       || payload.operationType === 'details'
+      || payload.operationType === 'cancel'
+      || payload.operationType === 'no_show'
       ? payload.operationType
       : fallbackType;
 
@@ -406,6 +534,16 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     source: (row.source as Source) || undefined,
     price: row.price !== null && row.price !== undefined ? Number(row.price) : undefined,
     comment: (row.comment as string) || undefined,
+    cancelledAt: row.cancelled_at ? this.normalizeTimeFromDb(row.cancelled_at as string) : undefined,
+    cancelledBy: (row.cancelled_by as string) || undefined,
+    cancellationSource: (row.cancellation_source as CancellationSource) || undefined,
+    cancellationReason: (row.cancellation_reason as string) || undefined,
+    noShowAt: row.no_show_at ? this.normalizeTimeFromDb(row.no_show_at as string) : undefined,
+    noShowBy: (row.no_show_by as string) || undefined,
+    noShowReason: (row.no_show_reason as string) || undefined,
+    lifecycleMetadataVersion: row.lifecycle_metadata_version !== null && row.lifecycle_metadata_version !== undefined
+      ? Number(row.lifecycle_metadata_version)
+      : undefined,
     start: this.normalizeTimeFromDb(row.start_time as string),
     end: this.normalizeTimeFromDb(row.end_time as string),
     createdAt: this.normalizeTimeFromDb(row.created_at as string),

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -6,7 +6,8 @@ import { useScheduleAppointments } from '../data/hooks/useScheduleAppointments';
 import { useClinicDoctors } from '../data/hooks/useClinicDoctors';
 import { usePatientsCollection } from '../data/hooks/usePatientsCollection';
 import { AppointmentModal } from '../components/schedule/AppointmentModal';
-import type { Appointment, Doctor, AppointmentStatus } from '../types';
+import { useTenant } from '../contexts/TenantContext';
+import type { Appointment, CancellationSource, Doctor, AppointmentStatus } from '../types';
 
 const timeSlots = Array.from({ length: 23 }, (_, i) => {
   const hour = Math.floor(i / 2) + 9;
@@ -60,6 +61,8 @@ export function SchedulePage() {
     appointments,
     createAppointment,
     updateAppointment,
+    cancelAppointment,
+    markAppointmentNoShow,
     deleteAppointment,
     isSaving,
     isReconciling,
@@ -68,6 +71,7 @@ export function SchedulePage() {
   
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Partial<Appointment> | undefined>();
+  const { activeTenant } = useTenant();
 
   const { doctors: allDoctors } = useClinicDoctors();
   const { patients } = usePatientsCollection();
@@ -126,6 +130,28 @@ export function SchedulePage() {
       return true;
     } catch {
       return false;
+    }
+  };
+
+  const handleCancelAppointment = async (
+    appointment: Appointment,
+    source: CancellationSource,
+    reason: string,
+  ): Promise<Appointment | null> => {
+    try {
+      const result = await cancelAppointment(appointment, source, reason);
+      return result?.appointment || null;
+    } catch {
+      return null;
+    }
+  };
+
+  const handleMarkNoShow = async (appointment: Appointment, reason: string): Promise<Appointment | null> => {
+    try {
+      const result = await markAppointmentNoShow(appointment, reason);
+      return result?.appointment || null;
+    } catch {
+      return null;
     }
   };
 
@@ -305,7 +331,10 @@ export function SchedulePage() {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSave={handleSaveAppointment}
+        onCancel={handleCancelAppointment}
+        onMarkNoShow={handleMarkNoShow}
         onDelete={handleDeleteAppointment}
+        role={activeTenant?.role}
         initialData={editingAppointment}
         appointments={appointments}
         doctors={allDoctors}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // src/types/index.ts
 
 export type AppointmentStatus = 'new' | 'confirmed' | 'arrived' | 'in_progress' | 'completed' | 'cancelled' | 'no_show' | 'blocked';
+export type CancellationSource = 'patient' | 'clinic' | 'doctor' | 'technical' | 'other';
 export type PaymentType = 'cash' | 'card' | 'kaspi' | 'insurance' | 'installment' | 'unpaid';
 export type Source = 'phone' | 'whatsapp' | 'instagram' | 'walk_in' | 'repeat' | 'referral';
 
@@ -65,6 +66,14 @@ export interface Appointment {
   source?: Source;
   comment?: string;
   price?: number;
+  cancelledAt?: string;
+  cancelledBy?: string;
+  cancellationSource?: CancellationSource;
+  cancellationReason?: string;
+  noShowAt?: string;
+  noShowBy?: string;
+  noShowReason?: string;
+  lifecycleMetadataVersion?: number;
   createdAt: string;
   updatedAt?: string;
 }

--- a/supabase/migrations/0026_appointment_cancellation_noshow.sql
+++ b/supabase/migrations/0026_appointment_cancellation_noshow.sql
@@ -1,0 +1,690 @@
+-- 0026_appointment_cancellation_noshow.sql
+-- APPOINTMENT-CANCELLATION-NOSHOW-001
+-- Auditable, idempotent and tenant-safe cancellation/no-show lifecycle boundary.
+
+DO $$
+DECLARE
+  v_cancelled bigint;
+  v_no_show bigint;
+BEGIN
+  SELECT count(*) INTO v_cancelled FROM public.appointments WHERE status = 'cancelled';
+  SELECT count(*) INTO v_no_show FROM public.appointments WHERE status = 'no_show';
+
+  -- Existing terminal rows are preserved as legacy version 0.  No actor, reason
+  -- or timestamp is fabricated.  New controlled lifecycle actions use version 1.
+  RAISE NOTICE 'APPOINTMENT-CANCELLATION-NOSHOW-001 legacy rows: cancelled=%, no_show=%',
+    v_cancelled, v_no_show;
+END;
+$$;
+
+ALTER TABLE public.appointments
+  ADD COLUMN cancelled_at timestamptz,
+  ADD COLUMN cancelled_by uuid,
+  ADD COLUMN cancellation_source text,
+  ADD COLUMN cancellation_reason text,
+  ADD COLUMN no_show_at timestamptz,
+  ADD COLUMN no_show_by uuid,
+  ADD COLUMN no_show_reason text,
+  ADD COLUMN lifecycle_metadata_version integer NOT NULL DEFAULT 0;
+
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_cancelled_by_fk
+    FOREIGN KEY (cancelled_by) REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD CONSTRAINT appointments_no_show_by_fk
+    FOREIGN KEY (no_show_by) REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD CONSTRAINT appointments_lifecycle_metadata_version_check
+    CHECK (lifecycle_metadata_version IN (0, 1)),
+  ADD CONSTRAINT appointments_cancellation_source_check
+    CHECK (
+      cancellation_source IS NULL
+      OR cancellation_source IN ('patient', 'clinic', 'doctor', 'technical', 'other')
+    ),
+  ADD CONSTRAINT appointments_lifecycle_metadata_check
+    CHECK (
+      (
+        status = 'cancelled'
+        AND no_show_at IS NULL
+        AND no_show_by IS NULL
+        AND no_show_reason IS NULL
+        AND (
+          (
+            lifecycle_metadata_version = 0
+            AND cancelled_at IS NULL
+            AND cancelled_by IS NULL
+            AND cancellation_source IS NULL
+            AND cancellation_reason IS NULL
+          )
+          OR
+          (
+            lifecycle_metadata_version = 1
+            AND cancelled_at IS NOT NULL
+            AND cancelled_by IS NOT NULL
+            AND cancellation_source IS NOT NULL
+            AND cancellation_reason IS NOT NULL
+            AND length(btrim(cancellation_reason)) > 0
+          )
+        )
+      )
+      OR
+      (
+        status = 'no_show'
+        AND cancelled_at IS NULL
+        AND cancelled_by IS NULL
+        AND cancellation_source IS NULL
+        AND cancellation_reason IS NULL
+        AND (
+          (
+            lifecycle_metadata_version = 0
+            AND no_show_at IS NULL
+            AND no_show_by IS NULL
+            AND no_show_reason IS NULL
+          )
+          OR
+          (
+            lifecycle_metadata_version = 1
+            AND no_show_at IS NOT NULL
+            AND no_show_by IS NOT NULL
+            AND no_show_reason IS NOT NULL
+            AND length(btrim(no_show_reason)) > 0
+          )
+        )
+      )
+      OR
+      (
+        status NOT IN ('cancelled', 'no_show')
+        AND lifecycle_metadata_version = 0
+        AND cancelled_at IS NULL
+        AND cancelled_by IS NULL
+        AND cancellation_source IS NULL
+        AND cancellation_reason IS NULL
+        AND no_show_at IS NULL
+        AND no_show_by IS NULL
+        AND no_show_reason IS NULL
+      )
+    );
+
+ALTER TABLE public.appointment_operations
+  DROP CONSTRAINT appointment_operations_operation_type_check;
+
+ALTER TABLE public.appointment_operations
+  ADD CONSTRAINT appointment_operations_operation_type_check
+  CHECK (operation_type IN ('create', 'reschedule', 'cancel', 'no_show'));
+
+CREATE OR REPLACE FUNCTION public.guard_appointment_lifecycle_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $lifecycle_guard$
+DECLARE
+  v_action text := current_setting('app.appointment_lifecycle_action', true);
+BEGIN
+  -- service_role remains available for local setup/cleanup and explicit imports.
+  -- Ordinary authenticated writes are already blocked by the authoritative-write
+  -- trigger.  This second guard also prevents SECURITY DEFINER create/reschedule/
+  -- details RPCs from manufacturing cancellation or no-show state.
+  IF current_user = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status = 'cancelled' AND v_action IS DISTINCT FROM 'cancel' THEN
+      RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+    END IF;
+    IF NEW.status = 'no_show' AND v_action IS DISTINCT FROM 'no_show' THEN
+      RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF OLD.status IN ('cancelled', 'no_show') OR NEW.status IN ('cancelled', 'no_show') THEN
+    IF v_action = 'cancel'
+       AND OLD.status IN ('new', 'confirmed')
+       AND NEW.status = 'cancelled' THEN
+      RETURN NEW;
+    END IF;
+
+    IF v_action = 'no_show'
+       AND OLD.status IN ('new', 'confirmed')
+       AND NEW.status = 'no_show' THEN
+      RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+
+  RETURN NEW;
+END;
+$lifecycle_guard$;
+
+DROP TRIGGER IF EXISTS appointments_lifecycle_write_guard ON public.appointments;
+CREATE TRIGGER appointments_lifecycle_write_guard
+BEFORE INSERT OR UPDATE ON public.appointments
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_appointment_lifecycle_write();
+
+CREATE OR REPLACE FUNCTION public.cancel_appointment(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_cancellation_source text,
+  p_cancellation_reason text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $cancel_rpc$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_key text;
+  v_source text := NULLIF(btrim(p_cancellation_source), '');
+  v_reason text := NULLIF(btrim(p_cancellation_reason), '');
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_lock_key text;
+  v_audit_id uuid;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_source IS NULL THEN
+    RAISE EXCEPTION 'Укажите, кто отменил запись.';
+  END IF;
+  IF v_source NOT IN ('patient', 'clinic', 'doctor', 'technical', 'other') THEN
+    RAISE EXCEPTION 'Укажите, кто отменил запись.';
+  END IF;
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'Укажите причину.';
+  END IF;
+  IF p_expected_updated_at IS NULL THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'cancel',
+    'tenantId', p_tenant_id,
+    'appointmentId', p_appointment_id,
+    'expectedUpdatedEpoch', extract(epoch FROM p_expected_updated_at),
+    'cancellationSource', v_source,
+    'cancellationReason', v_reason
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0)
+  );
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'cancel' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже была выполнена с другими параметрами.';
+    END IF;
+    RETURN jsonb_build_object(
+      'appointment', v_operation.result_appointment,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'cancel'
+    );
+  END IF;
+
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_before.status = 'cancelled' THEN
+    RAISE EXCEPTION 'Запись уже отменена.';
+  END IF;
+  IF v_before.status NOT IN ('new', 'confirmed') THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+  IF v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  FOR v_lock_key IN
+    SELECT resource_key
+    FROM (
+      VALUES
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || v_before.doctor_id::text),
+        (CASE WHEN v_before.patient_id IS NOT NULL
+          THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || v_before.patient_id::text END)
+    ) AS resources(resource_key)
+    WHERE resource_key IS NOT NULL
+    ORDER BY resource_key
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_lock_key, 0));
+  END LOOP;
+
+  PERFORM set_config('app.appointment_lifecycle_action', 'cancel', true);
+
+  UPDATE public.appointments
+  SET status = 'cancelled',
+      cancelled_at = transaction_timestamp(),
+      cancelled_by = v_actor,
+      cancellation_source = v_source,
+      cancellation_reason = v_reason,
+      no_show_at = NULL,
+      no_show_by = NULL,
+      no_show_reason = NULL,
+      lifecycle_metadata_version = 1
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  PERFORM set_config('app.appointment_lifecycle_action', '', true);
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => 'appointment_cancelled',
+    p_category => 'appointment',
+    p_target_type => 'appointment',
+    p_target_id => p_appointment_id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_actor_role,
+    p_patient_id => v_before.patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_before_data => jsonb_build_object(
+      'status', v_before.status,
+      'updatedAt', v_before.updated_at
+    ),
+    p_after_data => jsonb_build_object(
+      'status', v_after.status,
+      'cancelledAt', v_after.cancelled_at,
+      'cancelledBy', v_after.cancelled_by,
+      'cancellationSource', v_after.cancellation_source,
+      'cancellationReason', v_after.cancellation_reason
+    ),
+    p_request_id => v_key,
+    p_metadata => jsonb_build_object('operationKey', v_key, 'replayed', false)
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'appointment',
+    p_type => 'appointment_cancelled',
+    p_title => 'Запись отменена',
+    p_source_type => 'appointment',
+    p_source_id => p_appointment_id::text,
+    p_patient_id => v_before.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_source_status => 'cancelled',
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_appointment_id,
+      'cancellationSource', v_source,
+      'cancellationReason', v_reason,
+      'operationKey', v_key,
+      'replayed', false
+    )
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id
+  ) VALUES (
+    p_tenant_id, v_key, 'cancel', v_fingerprint, p_appointment_id,
+    v_before.patient_id, v_before.doctor_id, v_before.start_time, v_before.end_time, 'cancelled',
+    public.appointment_row_json(v_after), v_actor
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'cancel'
+  );
+END;
+$cancel_rpc$;
+
+CREATE OR REPLACE FUNCTION public.mark_appointment_no_show(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_no_show_reason text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $no_show_rpc$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_key text;
+  v_reason text := NULLIF(btrim(p_no_show_reason), '');
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_lock_key text;
+  v_audit_id uuid;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'Укажите причину.';
+  END IF;
+  IF p_expected_updated_at IS NULL THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'no_show',
+    'tenantId', p_tenant_id,
+    'appointmentId', p_appointment_id,
+    'expectedUpdatedEpoch', extract(epoch FROM p_expected_updated_at),
+    'noShowReason', v_reason
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0)
+  );
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'no_show' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже была выполнена с другими параметрами.';
+    END IF;
+    RETURN jsonb_build_object(
+      'appointment', v_operation.result_appointment,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'no_show'
+    );
+  END IF;
+
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_before.status = 'no_show' THEN
+    RAISE EXCEPTION 'Неявка уже отмечена.';
+  END IF;
+  IF v_before.status NOT IN ('new', 'confirmed') THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+  IF v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  FOR v_lock_key IN
+    SELECT resource_key
+    FROM (
+      VALUES
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || v_before.doctor_id::text),
+        (CASE WHEN v_before.patient_id IS NOT NULL
+          THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || v_before.patient_id::text END)
+    ) AS resources(resource_key)
+    WHERE resource_key IS NOT NULL
+    ORDER BY resource_key
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_lock_key, 0));
+  END LOOP;
+
+  PERFORM set_config('app.appointment_lifecycle_action', 'no_show', true);
+
+  UPDATE public.appointments
+  SET status = 'no_show',
+      no_show_at = transaction_timestamp(),
+      no_show_by = v_actor,
+      no_show_reason = v_reason,
+      cancelled_at = NULL,
+      cancelled_by = NULL,
+      cancellation_source = NULL,
+      cancellation_reason = NULL,
+      lifecycle_metadata_version = 1
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  PERFORM set_config('app.appointment_lifecycle_action', '', true);
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => 'appointment_no_show_marked',
+    p_category => 'appointment',
+    p_target_type => 'appointment',
+    p_target_id => p_appointment_id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_actor_role,
+    p_patient_id => v_before.patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_before_data => jsonb_build_object(
+      'status', v_before.status,
+      'updatedAt', v_before.updated_at
+    ),
+    p_after_data => jsonb_build_object(
+      'status', v_after.status,
+      'noShowAt', v_after.no_show_at,
+      'noShowBy', v_after.no_show_by,
+      'noShowReason', v_after.no_show_reason
+    ),
+    p_request_id => v_key,
+    p_metadata => jsonb_build_object('operationKey', v_key, 'replayed', false)
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'appointment',
+    p_type => 'appointment_no_show_marked',
+    p_title => 'Отмечена неявка',
+    p_source_type => 'appointment',
+    p_source_id => p_appointment_id::text,
+    p_patient_id => v_before.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_source_status => 'no_show',
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_appointment_id,
+      'noShowReason', v_reason,
+      'operationKey', v_key,
+      'replayed', false
+    )
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id
+  ) VALUES (
+    p_tenant_id, v_key, 'no_show', v_fingerprint, p_appointment_id,
+    v_before.patient_id, v_before.doctor_id, v_before.start_time, v_before.end_time, 'no_show',
+    public.appointment_row_json(v_after), v_actor
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'no_show'
+  );
+END;
+$no_show_rpc$;
+
+-- Replace the generic details RPC so lifecycle terminal states fail before
+-- unrelated slot-conflict checks.  This preserves the 0025 contract for all
+-- non-terminal details while making cancellation/no-show dedicated actions.
+CREATE OR REPLACE FUNCTION public.update_appointment_details(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_cabinet text,
+  p_service text,
+  p_status text,
+  p_payment_type text,
+  p_source text,
+  p_price numeric,
+  p_comment text,
+  p_expected_updated_at timestamptz
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $details_rpc$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_status text := COALESCE(NULLIF(btrim(p_status), ''), 'new');
+  v_cabinet text := COALESCE(btrim(p_cabinet), '');
+  v_service text := COALESCE(btrim(p_service), '');
+  v_comment text := NULLIF(btrim(p_comment), '');
+  v_payment_type text := NULLIF(btrim(p_payment_type), '');
+  v_source text := NULLIF(btrim(p_source), '');
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_lock_key text;
+BEGIN
+  IF v_actor IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.tenant_users tu
+    WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor
+  ) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_status NOT IN ('new', 'confirmed', 'arrived', 'in_progress', 'completed', 'blocked') THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+
+  IF v_payment_type IS NOT NULL AND v_payment_type NOT IN ('cash', 'card', 'kaspi', 'insurance', 'installment', 'unpaid') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  IF v_source IS NOT NULL AND v_source NOT IN ('phone', 'whatsapp', 'instagram', 'walk_in', 'repeat', 'referral') THEN
+    RAISE EXCEPTION 'Не удалось сохранить запись. Обновите расписание и проверьте результат.';
+  END IF;
+
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  IF v_before.status IN ('cancelled', 'no_show') THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+
+  IF p_expected_updated_at IS NULL OR v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  IF v_before.patient_id IS NULL AND v_status <> 'blocked' THEN
+    RAISE EXCEPTION 'Пациент недоступен в этой клинике.';
+  END IF;
+
+  FOR v_lock_key IN
+    SELECT resource_key
+    FROM (
+      VALUES
+        ('appointment-resource:' || p_tenant_id::text || ':doctor:' || v_before.doctor_id::text),
+        (CASE WHEN v_before.patient_id IS NOT NULL THEN 'appointment-resource:' || p_tenant_id::text || ':patient:' || v_before.patient_id::text END)
+    ) AS resources(resource_key)
+    WHERE resource_key IS NOT NULL
+    ORDER BY resource_key
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_lock_key, 0));
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM public.appointments a
+    WHERE a.tenant_id = p_tenant_id
+      AND a.id <> p_appointment_id
+      AND a.doctor_id = v_before.doctor_id
+      AND a.status <> 'cancelled'
+      AND a.start_time < v_before.end_time
+      AND a.end_time > v_before.start_time
+  ) THEN
+    RAISE EXCEPTION 'У врача уже есть запись на это время.';
+  END IF;
+
+  IF v_before.patient_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.appointments a
+    WHERE a.tenant_id = p_tenant_id
+      AND a.id <> p_appointment_id
+      AND a.patient_id = v_before.patient_id
+      AND a.status <> 'cancelled'
+      AND a.start_time < v_before.end_time
+      AND a.end_time > v_before.start_time
+  ) THEN
+    RAISE EXCEPTION 'У пациента уже есть другая запись на это время.';
+  END IF;
+
+  UPDATE public.appointments
+  SET cabinet = v_cabinet,
+      service = v_service,
+      status = v_status,
+      payment_type = v_payment_type,
+      source = v_source,
+      price = p_price,
+      comment = v_comment
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'details'
+  );
+END;
+$details_rpc$;
+
+REVOKE ALL ON FUNCTION public.guard_appointment_lifecycle_write() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.cancel_appointment(uuid,uuid,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.mark_appointment_no_show(uuid,uuid,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.cancel_appointment(uuid,uuid,text,text,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.mark_appointment_no_show(uuid,uuid,text,timestamptz,text) TO authenticated, service_role;

--- a/supabase/tests/0025_appointment_conflict_hardening_test.sql
+++ b/supabase/tests/0025_appointment_conflict_hardening_test.sql
@@ -140,12 +140,14 @@ SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a2','2026-08
 SELECT pg_temp.assert_true(:'different_resources' IS NOT NULL,'different doctor and patient may share interval');
 
 -- Cancelled releases slots; every other current status blocks.
-SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 08:00+00','2026-08-04 09:00+00','A1','Cancelled','cancelled','unpaid','phone',1,NULL,'ach-cancelled-anchor');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 08:00+00','2026-08-04 09:00+00','A1','Cancelled','new','unpaid','phone',1,NULL,'ach-cancelled-anchor-create')::text AS cancelled_anchor_created \gset
+SELECT public.cancel_appointment(:'tenant_a',(:'cancelled_anchor_created'::jsonb#>>'{appointment,id}')::uuid,'clinic','Conflict regression fixture',(:'cancelled_anchor_created'::jsonb#>>'{appointment,updated_at}')::timestamptz,'ach-cancelled-anchor');
 SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-04 08:00+00','2026-08-04 09:00+00','A1','Cancelled released','new','unpaid','phone',1,NULL,'ach-cancelled-reuse')->'appointment'->>'id' AS cancelled_reuse \gset
 SELECT pg_temp.assert_true(:'cancelled_reuse' IS NOT NULL,'cancelled appointment releases doctor slot');
 SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 10:00+00','2026-08-04 11:00+00','A1','Completed','completed','unpaid','phone',1,NULL,'ach-completed-anchor');
 SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-04 10:00+00','2026-08-04 11:00+00','A1','Completed blocks','new','unpaid','phone','1','','ach-completed-overlap'),'У врача уже есть запись');
-SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 11:00+00','2026-08-04 12:00+00','A1','No show','no_show','unpaid','phone',1,NULL,'ach-noshow-anchor');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-08-04 11:00+00','2026-08-04 12:00+00','A1','No show','new','unpaid','phone',1,NULL,'ach-noshow-anchor-create')::text AS noshow_anchor_created \gset
+SELECT public.mark_appointment_no_show(:'tenant_a',(:'noshow_anchor_created'::jsonb#>>'{appointment,id}')::uuid,'Conflict regression fixture',(:'noshow_anchor_created'::jsonb#>>'{appointment,updated_at}')::timestamptz,'ach-noshow-anchor');
 SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-08-04 11:00+00','2026-08-04 12:00+00','A1','No show blocks','new','unpaid','phone','1','','ach-noshow-overlap'),'У врача уже есть запись');
 SELECT public.create_appointment(:'tenant_a',NULL,:'doctor_a2','2026-08-04 12:00+00','2026-08-04 13:00+00','A2','Blocked','blocked',NULL,NULL,NULL,NULL,'ach-blocked-anchor');
 SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a3',:'doctor_a2','2026-08-04 12:00+00','2026-08-04 13:00+00','A2','Blocked blocks','new','unpaid','phone','1','','ach-blocked-overlap'),'У врача уже есть запись');
@@ -197,13 +199,14 @@ SELECT pg_temp.assert_true((:'res_adjacent'::jsonb#>>'{appointment,start_time}')
 SELECT (:'res_adjacent'::jsonb#>>'{appointment,updated_at}') AS res_adjacent_updated \gset
 SELECT pg_temp.expect_error(format('select public.reschedule_appointment(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz,%L)',:'tenant_b',:'res_id',:'patient_b1',:'doctor_b1','2026-08-06 14:00+00','2026-08-06 15:00+00','B1','Cross tenant res','new','unpaid','phone','1','',:'res_adjacent_updated','ach-cross-res'),'Недостаточно прав');
 
--- Details/status update cannot mutate protected fields and reactivation checks conflicts.
-SELECT public.update_appointment_details(:'tenant_a',:'res_id','A1','Details only','cancelled','unpaid','phone',30,'cancelled',:'res_adjacent_updated')::text AS details_cancel \gset
-SELECT pg_temp.assert_true((:'details_cancel'::jsonb#>>'{appointment,status}')='cancelled','details RPC updates status');
+-- Dedicated cancellation releases the slot; generic details cannot enter or leave lifecycle terminal states.
+SELECT pg_temp.expect_error(format('select public.update_appointment_details(%L::uuid,%L::uuid,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz)',:'tenant_a',:'res_id','A1','Details only','cancelled','unpaid','phone','30','cancelled',:'res_adjacent_updated'),'Текущий статус');
+SELECT public.cancel_appointment(:'tenant_a',:'res_id','clinic','Conflict regression cancellation',:'res_adjacent_updated','ach-details-cancel')::text AS details_cancel \gset
+SELECT pg_temp.assert_true((:'details_cancel'::jsonb#>>'{appointment,status}')='cancelled','dedicated cancellation updates status');
 SELECT (:'details_cancel'::jsonb#>>'{appointment,updated_at}') AS details_cancel_updated \gset
 SELECT public.create_appointment(:'tenant_a',:'patient_a3',:'doctor_a1','2026-08-06 12:00+00','2026-08-06 13:00+00','A1','Released by cancel','new','unpaid','phone',1,NULL,'ach-released-after-cancel')->'appointment'->>'id' AS released_after_cancel \gset
 SELECT pg_temp.assert_true(:'released_after_cancel' IS NOT NULL,'controlled cancellation releases slot');
-SELECT pg_temp.expect_error(format('select public.update_appointment_details(%L::uuid,%L::uuid,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz)',:'tenant_a',:'res_id','A1','Reactivate','new','unpaid','phone','30','reactivate',:'details_cancel_updated'),'У врача уже есть запись');
+SELECT pg_temp.expect_error(format('select public.update_appointment_details(%L::uuid,%L::uuid,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz)',:'tenant_a',:'res_id','A1','Reactivate','new','unpaid','phone','30','reactivate',:'details_cancel_updated'),'Текущий статус');
 
 -- Concurrent-change message from optimistic expected_updated_at.
 SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a2','2026-08-07 08:00+00','2026-08-07 09:00+00','A2','Concurrent version','new','unpaid','phone',1,NULL,'ach-version-create')::text AS version_create \gset

--- a/supabase/tests/0026_appointment_cancellation_noshow_concurrency.ps1
+++ b/supabase/tests/0026_appointment_cancellation_noshow_concurrency.ps1
@@ -1,0 +1,255 @@
+$ErrorActionPreference = 'Stop'
+
+# APPOINTMENT-CANCELLATION-NOSHOW-001 local-only concurrency validation.
+$container = (docker ps --format '{{.Names}}' | Where-Object { $_ -like 'supabase_db_*' } | Select-Object -First 1)
+if (-not $container) { throw 'Local Supabase DB container is not running.' }
+
+$tenantA = 'c2610000-0000-4000-8000-000000000001'
+$tenantB = 'c2610000-0000-4000-8000-000000000002'
+$adminA = 'c2620000-0000-4000-8000-000000000001'
+$adminB = 'c2620000-0000-4000-8000-000000000002'
+$patientA1 = 'c2630000-0000-4000-8000-000000000001'
+$patientA2 = 'c2630000-0000-4000-8000-000000000002'
+$patientB1 = 'c2630000-0000-4000-8000-000000000003'
+$doctorA1 = 'c2640000-0000-4000-8000-000000000001'
+$doctorA2 = 'c2640000-0000-4000-8000-000000000002'
+$doctorB1 = 'c2640000-0000-4000-8000-000000000003'
+
+$ids = @{
+  A = 'c2650000-0000-4000-8000-000000000001'
+  B = 'c2650000-0000-4000-8000-000000000002'
+  C = 'c2650000-0000-4000-8000-000000000003'
+  D = 'c2650000-0000-4000-8000-000000000004'
+  E = 'c2650000-0000-4000-8000-000000000005'
+  F = 'c2650000-0000-4000-8000-000000000006'
+  G = 'c2650000-0000-4000-8000-000000000007'
+  H = 'c2650000-0000-4000-8000-000000000008'
+  IA = 'c2650000-0000-4000-8000-000000000009'
+  IB = 'c2650000-0000-4000-8000-000000000010'
+}
+
+function Invoke-Sql([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "SQL failed:`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return (($output | Where-Object { $_ -ne $null -and $_.ToString().Trim() -ne '' } | Select-Object -Last 1).ToString().Trim())
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function AuthContext([string]$userId) {
+  return "BEGIN; SET LOCAL ROLE authenticated; SET LOCAL `"request.jwt.claim.sub`"='$userId'; "
+}
+
+function CancelSql([string]$userId, [string]$tenantId, [string]$appointmentId, [string]$source, [string]$reason, [string]$expected, [string]$key) {
+  return (AuthContext $userId) + "SELECT (r->>'operationType') || '|' || (r->>'replayed') || '|' || (r#>>'{appointment,id}') FROM (SELECT public.cancel_appointment('$tenantId','$appointmentId','$source','$reason','$expected','$key') r) q; COMMIT;"
+}
+
+function NoShowSql([string]$userId, [string]$tenantId, [string]$appointmentId, [string]$reason, [string]$expected, [string]$key) {
+  return (AuthContext $userId) + "SELECT (r->>'operationType') || '|' || (r->>'replayed') || '|' || (r#>>'{appointment,id}') FROM (SELECT public.mark_appointment_no_show('$tenantId','$appointmentId','$reason','$expected','$key') r) q; COMMIT;"
+}
+
+function CreateSql([string]$userId, [string]$tenantId, [string]$patientId, [string]$doctorId, [string]$start, [string]$end, [string]$key) {
+  return (AuthContext $userId) + "SELECT (r->>'operationType') || '|' || (r->>'replayed') || '|' || (r#>>'{appointment,id}') FROM (SELECT public.create_appointment('$tenantId','$patientId','$doctorId','$start','$end','QA','Concurrent booking','new','unpaid','phone',1,null,'$key') r) q; COMMIT;"
+}
+
+function RescheduleSql([string]$appointmentId, [string]$patientId, [string]$doctorId, [string]$start, [string]$end, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT (r->>'operationType') || '|' || (r->>'replayed') || '|' || (r#>>'{appointment,id}') FROM (SELECT public.reschedule_appointment('$tenantA','$appointmentId','$patientId','$doctorId','$start','$end','QA','Concurrent move','new','unpaid','phone',1,null,'$expected','$key') r) q; COMMIT;"
+}
+
+function Count-Success([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 }).Count }
+function Count-Conflict([object[]]$results) { return @($results | Where-Object { $_.Code -ne 0 }).Count }
+function Count-Replay([object[]]$results) { return @($results | Where-Object { $_.Text -match '\|true\|' }).Count }
+function Count-Deadlocks([object[]]$results) { return @($results | Where-Object { $_.Text -match 'deadlock detected' }).Count }
+
+function Assert-OneWinner([object[]]$results, [string]$name) {
+  $success = Count-Success $results
+  $conflict = Count-Conflict $results
+  if ($success -ne 1 -or $conflict -ne 1) {
+    throw "$name expected one success and one controlled conflict; success=$success conflict=$conflict outputs=$($results.Text -join ' || ')"
+  }
+}
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id IN ('$tenantA'::uuid,'$tenantB'::uuid);
+DELETE FROM auth.users WHERE id IN ('$adminA'::uuid,'$adminB'::uuid);
+"@
+
+$setupAppointments = @(
+  @($ids.A,$tenantA,$patientA1,$doctorA1,'2026-11-01 08:00+00','2026-11-01 09:00+00','new'),
+  @($ids.B,$tenantA,$patientA1,$doctorA1,'2026-11-02 08:00+00','2026-11-02 09:00+00','new'),
+  @($ids.C,$tenantA,$patientA1,$doctorA1,'2026-11-03 08:00+00','2026-11-03 09:00+00','new'),
+  @($ids.D,$tenantA,$patientA1,$doctorA1,'2026-11-04 08:00+00','2026-11-04 09:00+00','confirmed'),
+  @($ids.E,$tenantA,$patientA1,$doctorA1,'2026-11-05 08:00+00','2026-11-05 09:00+00','new'),
+  @($ids.F,$tenantA,$patientA1,$doctorA1,'2026-11-06 08:00+00','2026-11-06 09:00+00','new'),
+  @($ids.G,$tenantA,$patientA1,$doctorA1,'2026-11-07 08:00+00','2026-11-07 09:00+00','confirmed'),
+  @($ids.H,$tenantA,$patientA1,$doctorA1,'2026-11-08 08:00+00','2026-11-08 09:00+00','new'),
+  @($ids.IA,$tenantA,$patientA1,$doctorA2,'2026-11-09 08:00+00','2026-11-09 09:00+00','new'),
+  @($ids.IB,$tenantB,$patientB1,$doctorB1,'2026-11-09 08:00+00','2026-11-09 09:00+00','new')
+)
+$appointmentValues = ($setupAppointments | ForEach-Object { "('$($_[0])','$($_[1])','$($_[2])','$($_[3])','QA','Lifecycle $($_[0])','$($_[6])','unpaid','phone',1,'$($_[4])','$($_[5])')" }) -join ",`n"
+
+$setup = @"
+BEGIN;
+$cleanup
+INSERT INTO public.tenants(id,name) VALUES ('$tenantA','ACN concurrency A'),('$tenantB','ACN concurrency B');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+ ('$adminA','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-concurrency-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+ ('$adminB','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-concurrency-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$adminA'),('$adminB');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES ('$tenantA','$adminA','clinic_admin'),('$tenantB','$adminB','clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status) VALUES
+ ('$patientA1','$tenantA','ACN Concurrent A1','+77002631001','phone','active'),
+ ('$patientA2','$tenantA','ACN Concurrent A2','+77002631002','phone','active'),
+ ('$patientB1','$tenantB','ACN Concurrent B1','+77002631003','phone','active');
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+ ('$doctorA1','$tenantA','ACN Doctor A1','General','A1','#111111',true),
+ ('$doctorA2','$tenantA','ACN Doctor A2','General','A2','#222222',true),
+ ('$doctorB1','$tenantB','ACN Doctor B1','General','B1','#333333',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,payment_type,source,price,start_time,end_time) VALUES
+$appointmentValues;
+COMMIT;
+"@
+
+$allResults = @()
+$totalSuccess = 0
+$totalReplay = 0
+$totalConflict = 0
+
+try {
+  Invoke-Sql $setup | Out-Null
+  $updated = @{}
+  foreach ($name in $ids.Keys) { $updated[$name] = Invoke-Scalar "select updated_at from public.appointments where id='$($ids[$name])'" }
+
+  # A. Same cancellation key and payload: both callers return one logical action.
+  $aSql = CancelSql $adminA $tenantA $ids.A 'patient' 'Same cancellation' $updated.A 'acn-conc-a-same'
+  $a = @(Invoke-ConcurrentPair $aSql $aSql); $allResults += $a
+  if ((Count-Success $a) -ne 2 -or (Count-Replay $a) -ne 1) { throw "A replay failed: $($a.Text -join ' || ')" }
+  $totalSuccess += 2; $totalReplay += 1
+  Write-Output "A_SAME_CANCEL_KEY success=2 replay=$(Count-Replay $a)"
+
+  # B. Same cancellation key, different reason.
+  $b = @(Invoke-ConcurrentPair `
+    (CancelSql $adminA $tenantA $ids.B 'clinic' 'Reason one' $updated.B 'acn-conc-b-conflict') `
+    (CancelSql $adminA $tenantA $ids.B 'clinic' 'Reason two' $updated.B 'acn-conc-b-conflict'))
+  $allResults += $b; Assert-OneWinner $b 'B changed cancellation payload'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "B_CHANGED_CANCEL_PAYLOAD success=1 conflict=1"
+
+  # C. Different keys race to cancel the same row.
+  $c = @(Invoke-ConcurrentPair `
+    (CancelSql $adminA $tenantA $ids.C 'clinic' 'Different key one' $updated.C 'acn-conc-c-one') `
+    (CancelSql $adminA $tenantA $ids.C 'clinic' 'Different key two' $updated.C 'acn-conc-c-two'))
+  $allResults += $c; Assert-OneWinner $c 'C different cancel keys'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "C_DIFFERENT_CANCEL_KEYS success=1 conflict=1"
+
+  # D. Cancellation versus no-show: exactly one terminal fact wins.
+  $d = @(Invoke-ConcurrentPair `
+    (CancelSql $adminA $tenantA $ids.D 'patient' 'Cancelled during race' $updated.D 'acn-conc-d-cancel') `
+    (NoShowSql $adminA $tenantA $ids.D 'No-show during race' $updated.D 'acn-conc-d-noshow'))
+  $allResults += $d; Assert-OneWinner $d 'D cancel versus no-show'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "D_CANCEL_VS_NOSHOW success=1 conflict=1 finalStatus=$(Invoke-Scalar "select status from public.appointments where id='$($ids.D)'")"
+
+  # E. Cancellation versus reschedule: one consistent final state, no lost update.
+  $e = @(Invoke-ConcurrentPair `
+    (CancelSql $adminA $tenantA $ids.E 'doctor' 'Cancel while moving' $updated.E 'acn-conc-e-cancel') `
+    (RescheduleSql $ids.E $patientA1 $doctorA2 '2026-11-05 10:00+00' '2026-11-05 11:00+00' $updated.E 'acn-conc-e-reschedule'))
+  $allResults += $e; Assert-OneWinner $e 'E cancel versus reschedule'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "E_CANCEL_VS_RESCHEDULE success=1 conflict=1 finalStatus=$(Invoke-Scalar "select status from public.appointments where id='$($ids.E)'")"
+
+  # F. Cancellation versus a new booking for the same slot.
+  $f = @(Invoke-ConcurrentPair `
+    (CancelSql $adminA $tenantA $ids.F 'clinic' 'Release slot' $updated.F 'acn-conc-f-cancel') `
+    (CreateSql $adminA $tenantA $patientA2 $doctorA1 '2026-11-06 08:00+00' '2026-11-06 09:00+00' 'acn-conc-f-book'))
+  $allResults += $f
+  $fSuccess = Count-Success $f; $fConflict = Count-Conflict $f
+  if ($fSuccess -lt 1 -or $fSuccess -gt 2 -or $fConflict -gt 1) { throw "F unexpected race result: $($f.Text -join ' || ')" }
+  if ((Invoke-Scalar "select status from public.appointments where id='$($ids.F)'") -ne 'cancelled') { throw 'F cancellation did not commit' }
+  $totalSuccess += $fSuccess; $totalConflict += $fConflict
+  Write-Output "F_CANCEL_VS_BOOKING success=$fSuccess conflict=$fConflict activeSlotRows=$(Invoke-Scalar "select count(*) from public.appointments where tenant_id='$tenantA' and doctor_id='$doctorA1' and start_time='2026-11-06 08:00+00' and status<>'cancelled'")"
+
+  # G. Same no-show key and payload.
+  $gSql = NoShowSql $adminA $tenantA $ids.G 'Same no-show' $updated.G 'acn-conc-g-same'
+  $g = @(Invoke-ConcurrentPair $gSql $gSql); $allResults += $g
+  if ((Count-Success $g) -ne 2 -or (Count-Replay $g) -ne 1) { throw "G replay failed: $($g.Text -join ' || ')" }
+  $totalSuccess += 2; $totalReplay += 1
+  Write-Output "G_SAME_NOSHOW_KEY success=2 replay=$(Count-Replay $g)"
+
+  # H. Different no-show payloads, same key.
+  $h = @(Invoke-ConcurrentPair `
+    (NoShowSql $adminA $tenantA $ids.H 'No-show reason one' $updated.H 'acn-conc-h-conflict') `
+    (NoShowSql $adminA $tenantA $ids.H 'No-show reason two' $updated.H 'acn-conc-h-conflict'))
+  $allResults += $h; Assert-OneWinner $h 'H changed no-show payload'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "H_CHANGED_NOSHOW_PAYLOAD success=1 conflict=1"
+
+  # I. Same key in different tenants is independent.
+  $i = @(Invoke-ConcurrentPair `
+    (CancelSql $adminA $tenantA $ids.IA 'technical' 'Tenant A independent' $updated.IA 'acn-conc-i-same') `
+    (CancelSql $adminB $tenantB $ids.IB 'technical' 'Tenant B independent' $updated.IB 'acn-conc-i-same'))
+  $allResults += $i
+  if ((Count-Success $i) -ne 2) { throw "I tenant isolation failed: $($i.Text -join ' || ')" }
+  $totalSuccess += 2
+  Write-Output "I_TENANT_ISOLATION success=2 operationRows=$(Invoke-Scalar "select count(*) from public.appointment_operations where operation_key='acn-conc-i-same'")"
+
+  $deadlocks = Count-Deadlocks $allResults
+  $cancelledRows = [int](Invoke-Scalar "select count(*) from public.appointments where tenant_id in ('$tenantA','$tenantB') and status='cancelled'")
+  $noShowRows = [int](Invoke-Scalar "select count(*) from public.appointments where tenant_id in ('$tenantA','$tenantB') and status='no_show'")
+  $lifecycleOps = [int](Invoke-Scalar "select count(*) from public.appointment_operations where tenant_id in ('$tenantA','$tenantB') and operation_type in ('cancel','no_show') and operation_key like 'acn-conc-%'")
+  $auditCount = [int](Invoke-Scalar "select count(*) from public.audit_events where tenant_id in ('$tenantA','$tenantB') and request_id like 'acn-conc-%' and action in ('appointment_cancelled','appointment_no_show_marked')")
+  $activityCount = [int](Invoke-Scalar "select count(*) from public.activity_events where tenant_id in ('$tenantA','$tenantB') and metadata->>'operationKey' like 'acn-conc-%' and type in ('appointment_cancelled','appointment_no_show_marked')")
+  $activeOverlaps = [int](Invoke-Scalar "select count(*) from public.appointments a join public.appointments b on b.id>a.id and b.tenant_id=a.tenant_id and a.status<>'cancelled' and b.status<>'cancelled' and b.start_time<a.end_time and b.end_time>a.start_time and (b.doctor_id=a.doctor_id or (a.patient_id is not null and b.patient_id=a.patient_id)) where a.tenant_id in ('$tenantA','$tenantB')")
+
+  if ($lifecycleOps -ne ($auditCount) -or $auditCount -ne $activityCount) {
+    throw "Lifecycle event totals differ operations=$lifecycleOps audit=$auditCount activity=$activityCount"
+  }
+  if ($activeOverlaps -ne 0) { throw "Active overlap pairs remain: $activeOverlaps" }
+  if ($deadlocks -ne 0) { throw "Deadlocks detected: $deadlocks" }
+
+  Write-Output "FINAL successCount=$totalSuccess replayCount=$totalReplay conflictCount=$totalConflict cancelledRows=$cancelledRows noShowRows=$noShowRows auditCount=$auditCount activityCount=$activityCount activeOverlapPairs=$activeOverlaps deadlocks=$deadlocks"
+  Write-Output 'APPOINTMENT-CANCELLATION-NOSHOW-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remaining = Invoke-Scalar "select (select count(*) from public.tenants where id in ('$tenantA','$tenantB')) + (select count(*) from auth.users where id in ('$adminA','$adminB'))"
+  if ([int]$remaining -ne 0) { throw "Concurrency cleanup failed: remaining=$remaining" }
+}

--- a/supabase/tests/0026_appointment_cancellation_noshow_test.sql
+++ b/supabase/tests/0026_appointment_cancellation_noshow_test.sql
@@ -1,0 +1,302 @@
+\set ON_ERROR_STOP on
+\echo 'APPOINTMENT-CANCELLATION-NOSHOW-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+\set tenant_a 'a2610000-0000-4000-8000-000000000001'
+\set tenant_b 'b2610000-0000-4000-8000-000000000001'
+\set owner_a 'a2620000-0000-4000-8000-000000000001'
+\set admin_a 'a2620000-0000-4000-8000-000000000002'
+\set registrar_a 'a2620000-0000-4000-8000-000000000003'
+\set doctor_user_a 'a2620000-0000-4000-8000-000000000004'
+\set cashier_a 'a2620000-0000-4000-8000-000000000005'
+\set no_tenant 'a2620000-0000-4000-8000-000000000006'
+\set unknown_user 'a2620000-0000-4000-8000-000000000007'
+\set admin_b 'b2620000-0000-4000-8000-000000000001'
+\set patient_a1 'a2630000-0000-4000-8000-000000000001'
+\set patient_a2 'a2630000-0000-4000-8000-000000000002'
+\set patient_a3 'a2630000-0000-4000-8000-000000000003'
+\set patient_b1 'b2630000-0000-4000-8000-000000000001'
+\set doctor_a1 'a2640000-0000-4000-8000-000000000001'
+\set doctor_a2 'a2640000-0000-4000-8000-000000000002'
+\set doctor_b1 'b2640000-0000-4000-8000-000000000001'
+\set legacy_cancelled 'a2650000-0000-4000-8000-000000000001'
+\set legacy_no_show 'a2650000-0000-4000-8000-000000000002'
+
+INSERT INTO public.tenants(id,name) VALUES
+  (:'tenant_a','Appointment lifecycle A'),
+  (:'tenant_b','Appointment lifecycle B');
+
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+  (:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-owner@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-admin@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-registrar@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'doctor_user_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-doctor@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-cashier@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'no_tenant','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-notenant@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'unknown_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-unknown@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acn-admin-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id,first_name,last_name) VALUES
+  (:'owner_a','Owner','A'),(:'admin_a','Admin','A'),(:'registrar_a','Registrar','A'),
+  (:'doctor_user_a','Doctor','A'),(:'cashier_a','Cashier','A'),(:'no_tenant','No','Tenant'),
+  (:'unknown_user','Unknown','User'),(:'admin_b','Admin','B');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+  (:'tenant_a',:'owner_a','clinic_owner'),
+  (:'tenant_a',:'admin_a','clinic_admin'),
+  (:'tenant_a',:'registrar_a','registrar'),
+  (:'tenant_a',:'doctor_user_a','doctor'),
+  (:'tenant_a',:'cashier_a','cashier'),
+  (:'tenant_b',:'admin_b','clinic_admin');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+  (:'patient_a1',:'tenant_a','ACN Patient A1','+77002630001','phone','active',321),
+  (:'patient_a2',:'tenant_a','ACN Patient A2','+77002630002','phone','active',654),
+  (:'patient_a3',:'tenant_a','ACN Patient A3','+77002630003','phone','active',987),
+  (:'patient_b1',:'tenant_b','ACN Patient B1','+77002630004','phone','active',111);
+
+INSERT INTO public.doctors(id,tenant_id,user_id,full_name,specialization,cabinet,color,active) VALUES
+  (:'doctor_a1',:'tenant_a',:'doctor_user_a','ACN Doctor A1','General','A1','#111111',true),
+  (:'doctor_a2',:'tenant_a',NULL,'ACN Doctor A2','Surgery','A2','#222222',true),
+  (:'doctor_b1',:'tenant_b',NULL,'ACN Doctor B1','General','B1','#333333',true);
+
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS plans_before FROM public.treatment_plans \gset
+SELECT count(*)::text AS findings_before FROM public.findings \gset
+SELECT count(*)::text AS charts_before FROM public.dental_charts \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments \gset
+SELECT count(*)::text AS documents_before FROM public.documents \gset
+SELECT balance::text AS balance_a1_before FROM public.patients WHERE id=:'patient_a1' \gset
+SELECT balance::text AS balance_a2_before FROM public.patients WHERE id=:'patient_a2' \gset
+
+-- Historical compatibility: terminal rows existing before 0026 remain version 0
+-- without fabricated actor/reason/timestamp metadata.
+SET LOCAL ROLE service_role;
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time)
+VALUES
+  (:'legacy_cancelled',:'tenant_a',:'patient_a1',:'doctor_a1','A1','Legacy cancelled','cancelled','2026-10-01 08:00+00','2026-10-01 09:00+00'),
+  (:'legacy_no_show',:'tenant_a',:'patient_a2',:'doctor_a2','A2','Legacy no-show','no_show','2026-10-01 10:00+00','2026-10-01 11:00+00');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT lifecycle_metadata_version=0 AND cancelled_at IS NULL AND cancellation_reason IS NULL FROM public.appointments WHERE id=:'legacy_cancelled'),'legacy cancelled row preserved without invented metadata');
+SELECT pg_temp.assert_true((SELECT lifecycle_metadata_version=0 AND no_show_at IS NULL AND no_show_reason IS NULL FROM public.appointments WHERE id=:'legacy_no_show'),'legacy no-show row preserved without invented metadata');
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+
+-- Owner cancels a new appointment and complete lifecycle metadata is stored.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-02 08:00+00','2026-10-02 09:00+00','A1','Owner cancel','new','unpaid','phone',100,'before cancel','acn-owner-cancel-create')::text AS owner_create \gset
+SELECT (:'owner_create'::jsonb#>>'{appointment,id}') AS owner_cancel_id \gset
+SELECT (:'owner_create'::jsonb#>>'{appointment,updated_at}') AS owner_cancel_updated \gset
+SELECT public.cancel_appointment(:'tenant_a',:'owner_cancel_id','patient','Patient requested cancellation',:'owner_cancel_updated','acn-owner-cancel')::text AS owner_cancel \gset
+SELECT pg_temp.assert_true((:'owner_cancel'::jsonb#>>'{appointment,status}')='cancelled','owner cancels new appointment');
+SELECT pg_temp.assert_true((:'owner_cancel'::jsonb#>>'{appointment,cancellation_source}')='patient','cancellation source stored');
+SELECT pg_temp.assert_true((:'owner_cancel'::jsonb#>>'{appointment,cancellation_reason}')='Patient requested cancellation','cancellation reason stored trimmed');
+SELECT pg_temp.assert_true((:'owner_cancel'::jsonb#>>'{appointment,cancelled_by}')::uuid=:'owner_a','cancelled_by stored');
+SELECT pg_temp.assert_true((:'owner_cancel'::jsonb#>>'{appointment,cancelled_at}')::timestamptz IS NOT NULL,'cancelled_at stored');
+SELECT pg_temp.assert_true((:'owner_cancel'::jsonb#>>'{appointment,lifecycle_metadata_version}')::integer=1,'controlled cancellation version stored');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=:'owner_cancel_id')=1,'cancelled appointment row preserved');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointment_operations WHERE tenant_id=:'tenant_a' AND operation_key='acn-owner-cancel' AND operation_type='cancel')=1,'cancellation creates one operation row');
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE request_id='acn-owner-cancel' AND action='appointment_cancelled')=1,'cancellation creates one audit event');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE type='appointment_cancelled' AND metadata->>'operationKey'='acn-owner-cancel')=1,'cancellation creates one activity event');
+
+-- Same-key replay is safe and changed payloads are rejected.
+SELECT public.cancel_appointment(:'tenant_a',:'owner_cancel_id','patient','Patient requested cancellation',:'owner_cancel_updated','acn-owner-cancel')::text AS owner_cancel_replay \gset
+SELECT pg_temp.assert_true((:'owner_cancel_replay'::jsonb->>'replayed')::boolean,'same cancellation key marks replay');
+SELECT pg_temp.assert_true((:'owner_cancel_replay'::jsonb#>>'{appointment,id}')=:'owner_cancel_id','same cancellation key returns same appointment');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE request_id='acn-owner-cancel')=1,'replay creates no duplicate audit');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE metadata->>'operationKey'='acn-owner-cancel')=1,'replay creates no duplicate activity');
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_cancel_id','patient','Changed reason',:'owner_cancel_updated','acn-owner-cancel'),'другими параметрами');
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_cancel_id','clinic','Patient requested cancellation',:'owner_cancel_updated','acn-owner-cancel'),'другими параметрами');
+
+-- Cancelled row releases both doctor and patient resources.
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-10-02 08:00+00','2026-10-02 09:00+00','A1','Doctor slot reused','new','unpaid','phone',1,NULL,'acn-reuse-doctor')->'appointment'->>'id' AS reused_doctor \gset
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a2','2026-10-02 08:00+00','2026-10-02 09:00+00','A2','Patient slot reused','new','unpaid','phone',1,NULL,'acn-reuse-patient')->'appointment'->>'id' AS reused_patient \gset
+SELECT pg_temp.assert_true(:'reused_doctor' IS NOT NULL AND :'reused_patient' IS NOT NULL,'cancelled row releases doctor and patient slots');
+
+-- Admin and registrar follow intended policy.
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-03 08:00+00','2026-10-03 09:00+00','A1','Admin confirmed','confirmed','unpaid','phone',1,NULL,'acn-admin-cancel-create')::text AS admin_create \gset
+SELECT public.cancel_appointment(:'tenant_a',(:'admin_create'::jsonb#>>'{appointment,id}')::uuid,'clinic','Clinic schedule changed',(:'admin_create'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acn-admin-cancel')->>'operationType' AS admin_cancel_type \gset
+SELECT pg_temp.assert_true(:'admin_cancel_type'='cancel','admin cancels confirmed appointment');
+
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-03 10:00+00','2026-10-03 11:00+00','A1','Registrar new','new','unpaid','phone',1,NULL,'acn-registrar-cancel-create')::text AS registrar_create \gset
+SELECT public.cancel_appointment(:'tenant_a',(:'registrar_create'::jsonb#>>'{appointment,id}')::uuid,'doctor','Doctor unavailable',(:'registrar_create'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acn-registrar-cancel')->>'operationType' AS registrar_cancel_type \gset
+SELECT pg_temp.assert_true(:'registrar_cancel_type'='cancel','registrar may cancel');
+
+-- Doctor, cashier, unknown/no-tenant and cross-tenant callers are blocked.
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-04 08:00+00','2026-10-04 09:00+00','A1','Role cancel target','new','unpaid','phone',1,NULL,'acn-role-cancel-create')::text AS role_cancel_create \gset
+SELECT (:'role_cancel_create'::jsonb#>>'{appointment,id}') AS role_cancel_id \gset
+SELECT (:'role_cancel_create'::jsonb#>>'{appointment,updated_at}') AS role_cancel_updated \gset
+SELECT set_config('request.jwt.claim.sub',:'doctor_user_a',true);
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','Doctor tries',:'role_cancel_updated','acn-doctor-cancel'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','Cashier tries',:'role_cancel_updated','acn-cashier-cancel'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'no_tenant',true);
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','No tenant tries',:'role_cancel_updated','acn-no-tenant-cancel'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'unknown_user',true);
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','Unknown tries',:'role_cancel_updated','acn-unknown-cancel'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'admin_b',true);
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','Cross tenant tries',:'role_cancel_updated','acn-cross-cancel'),'Недостаточно прав');
+
+-- Required source/reason and transition protection.
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','','Reason',:'role_cancel_updated','acn-source-empty'),'Укажите, кто отменил');
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','invalid','Reason',:'role_cancel_updated','acn-source-invalid'),'Укажите, кто отменил');
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','',:'role_cancel_updated','acn-reason-empty'),'Укажите причину');
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','   ',:'role_cancel_updated','acn-reason-space'),'Укажите причину');
+
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-05 08:00+00','2026-10-05 09:00+00','A1','Completed cancel blocked','completed','unpaid','phone',1,NULL,'acn-completed-cancel-create')::text AS completed_cancel \gset
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'completed_cancel'::jsonb#>>'{appointment,id}'),'clinic','Not allowed',(:'completed_cancel'::jsonb#>>'{appointment,updated_at}'),'acn-completed-cancel'),'Текущий статус');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-05 10:00+00','2026-10-05 11:00+00','A1','Progress cancel blocked','in_progress','unpaid','phone',1,NULL,'acn-progress-cancel-create')::text AS progress_cancel \gset
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'progress_cancel'::jsonb#>>'{appointment,id}'),'clinic','Not allowed',(:'progress_cancel'::jsonb#>>'{appointment,updated_at}'),'acn-progress-cancel'),'Текущий статус');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-05 12:00+00','2026-10-05 13:00+00','A1','Arrived cancel blocked','arrived','unpaid','phone',1,NULL,'acn-arrived-cancel-create')::text AS arrived_cancel \gset
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'arrived_cancel'::jsonb#>>'{appointment,id}'),'clinic','Not allowed',(:'arrived_cancel'::jsonb#>>'{appointment,updated_at}'),'acn-arrived-cancel'),'Текущий статус');
+
+-- Generic create/reschedule/details cannot manufacture lifecycle statuses.
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-06 08:00+00','2026-10-06 09:00+00','A1','Generic cancelled','cancelled','unpaid','phone','1','','acn-generic-create-cancel'),'Текущий статус');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-06 08:00+00','2026-10-06 09:00+00','A1','Generic no-show','no_show','unpaid','phone','1','','acn-generic-create-noshow'),'Текущий статус');
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-10-06 10:00+00','2026-10-06 11:00+00','A1','Generic details target','new','unpaid','phone',1,NULL,'acn-generic-target')::text AS generic_target \gset
+SELECT pg_temp.expect_error(format('select public.update_appointment_details(%L::uuid,%L::uuid,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz)',:'tenant_a',(:'generic_target'::jsonb#>>'{appointment,id}'),'A1','Generic details','cancelled','unpaid','phone','1','',(:'generic_target'::jsonb#>>'{appointment,updated_at}')),'Текущий статус');
+SELECT pg_temp.expect_error(format('select public.update_appointment_details(%L::uuid,%L::uuid,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz)',:'tenant_a',(:'generic_target'::jsonb#>>'{appointment,id}'),'A1','Generic details','no_show','unpaid','phone','1','',(:'generic_target'::jsonb#>>'{appointment,updated_at}')),'Текущий статус');
+SELECT pg_temp.expect_error(format('select public.reschedule_appointment(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L::timestamptz,%L)',:'tenant_a',(:'generic_target'::jsonb#>>'{appointment,id}'),:'patient_a1',:'doctor_a1','2026-10-06 11:00+00','2026-10-06 12:00+00','A1','Generic reschedule','cancelled','unpaid','phone','1','',(:'generic_target'::jsonb#>>'{appointment,updated_at}'),'acn-generic-reschedule'),'Текущий статус');
+
+-- No-show controlled action from new and confirmed statuses.
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a1','2026-10-07 08:00+00','2026-10-07 09:00+00','A1','No-show new','new','unpaid','phone',1,NULL,'acn-noshow-new-create')::text AS noshow_new_create \gset
+SELECT public.mark_appointment_no_show(:'tenant_a',(:'noshow_new_create'::jsonb#>>'{appointment,id}')::uuid,'Patient did not arrive',(:'noshow_new_create'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acn-noshow-new')::text AS noshow_new \gset
+SELECT pg_temp.assert_true((:'noshow_new'::jsonb#>>'{appointment,status}')='no_show','new appointment marked no-show');
+SELECT pg_temp.assert_true((:'noshow_new'::jsonb#>>'{appointment,no_show_reason}')='Patient did not arrive','no-show reason stored');
+SELECT pg_temp.assert_true((:'noshow_new'::jsonb#>>'{appointment,no_show_by}')::uuid=:'admin_a','no_show_by stored');
+SELECT pg_temp.assert_true((:'noshow_new'::jsonb#>>'{appointment,no_show_at}')::timestamptz IS NOT NULL,'no_show_at stored');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=(:'noshow_new'::jsonb#>>'{appointment,id}')::uuid)=1,'no-show row preserved');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointment_operations WHERE operation_key='acn-noshow-new' AND operation_type='no_show')=1,'no-show creates one operation');
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE request_id='acn-noshow-new' AND action='appointment_no_show_marked')=1,'no-show creates one audit');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.activity_events WHERE metadata->>'operationKey'='acn-noshow-new' AND type='appointment_no_show_marked')=1,'no-show creates one activity');
+
+SELECT public.mark_appointment_no_show(:'tenant_a',(:'noshow_new_create'::jsonb#>>'{appointment,id}')::uuid,'Patient did not arrive',(:'noshow_new_create'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acn-noshow-new')::text AS noshow_replay \gset
+SELECT pg_temp.assert_true((:'noshow_replay'::jsonb->>'replayed')::boolean,'same no-show key replays');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE request_id='acn-noshow-new')=1,'no-show replay has one audit');
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'noshow_new_create'::jsonb#>>'{appointment,id}'),'Changed reason',(:'noshow_new_create'::jsonb#>>'{appointment,updated_at}'),'acn-noshow-new'),'другими параметрами');
+
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a2','2026-10-07 10:00+00','2026-10-07 11:00+00','A2','No-show confirmed','confirmed','unpaid','phone',1,NULL,'acn-noshow-confirmed-create')::text AS noshow_confirmed_create \gset
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.mark_appointment_no_show(:'tenant_a',(:'noshow_confirmed_create'::jsonb#>>'{appointment,id}')::uuid,'Unable to contact patient',(:'noshow_confirmed_create'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acn-noshow-confirmed')->>'operationType' AS registrar_noshow_type \gset
+SELECT pg_temp.assert_true(:'registrar_noshow_type'='no_show','registrar marks confirmed no-show');
+
+-- No-show continues to block doctor and patient slots under existing policy.
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a3',:'doctor_a1','2026-10-07 08:00+00','2026-10-07 09:00+00','A1','No-show doctor overlap','new','unpaid','phone','1','','acn-noshow-doctor-overlap'),'У врача уже есть запись');
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a2','2026-10-07 08:00+00','2026-10-07 09:00+00','A2','No-show patient overlap','new','unpaid','phone','1','','acn-noshow-patient-overlap-2'),'У пациента уже есть другая запись');
+
+-- No-show validation, role and transition matrix.
+SELECT public.create_appointment(:'tenant_a',:'patient_a3',:'doctor_a1','2026-10-08 08:00+00','2026-10-08 09:00+00','A1','Role no-show target','new','unpaid','phone',1,NULL,'acn-role-noshow-create')::text AS role_noshow \gset
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'role_noshow'::jsonb#>>'{appointment,id}'),'   ',(:'role_noshow'::jsonb#>>'{appointment,updated_at}'),'acn-noshow-empty'),'Укажите причину');
+SELECT set_config('request.jwt.claim.sub',:'doctor_user_a',true);
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'role_noshow'::jsonb#>>'{appointment,id}'),'Doctor tries',(:'role_noshow'::jsonb#>>'{appointment,updated_at}'),'acn-doctor-noshow'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'role_noshow'::jsonb#>>'{appointment,id}'),'Cashier tries',(:'role_noshow'::jsonb#>>'{appointment,updated_at}'),'acn-cashier-noshow'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'admin_b',true);
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'role_noshow'::jsonb#>>'{appointment,id}'),'Cross tenant',(:'role_noshow'::jsonb#>>'{appointment,updated_at}'),'acn-cross-noshow'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'owner_cancel'::jsonb#>>'{appointment,id}'),'Cancelled cannot no-show',(:'owner_cancel'::jsonb#>>'{appointment,updated_at}'),'acn-cancelled-to-noshow'),'Текущий статус');
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'noshow_new'::jsonb#>>'{appointment,id}'),'clinic','No-show cannot cancel',(:'noshow_new'::jsonb#>>'{appointment,updated_at}'),'acn-noshow-to-cancel'),'Текущий статус');
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'completed_cancel'::jsonb#>>'{appointment,id}'),'Completed cannot no-show',(:'completed_cancel'::jsonb#>>'{appointment,updated_at}'),'acn-completed-noshow'),'Текущий статус');
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',(:'arrived_cancel'::jsonb#>>'{appointment,id}'),'Arrived cannot no-show',(:'arrived_cancel'::jsonb#>>'{appointment,updated_at}'),'acn-arrived-noshow'),'Текущий статус');
+
+-- Recovery for both lifecycle operations and safe not-found.
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','acn-owner-cancel')->>'found')::boolean,'recovery finds cancellation');
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','acn-owner-cancel')->>'operationType')='cancel','recovery identifies cancellation');
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','acn-noshow-new')->>'found')::boolean,'recovery finds no-show');
+SELECT pg_temp.assert_true((public.get_appointment_operation(:'tenant_a','acn-noshow-new')->>'operationType')='no_show','recovery identifies no-show');
+SELECT pg_temp.assert_true(NOT (public.get_appointment_operation(:'tenant_a','acn-unknown-lifecycle')->>'found')::boolean,'unknown operation returns found=false');
+
+-- Hard delete remains separate and owner/admin-only. Cancellation never calls DELETE.
+SELECT public.create_appointment(:'tenant_a',:'patient_a3',:'doctor_a2','2026-10-09 08:00+00','2026-10-09 09:00+00','A2','Delete target','new','unpaid','phone',1,NULL,'acn-delete-create')->'appointment'->>'id' AS delete_target \gset
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+DELETE FROM public.appointments WHERE id=:'delete_target';
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=:'delete_target')=1,'registrar cannot hard delete');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+DELETE FROM public.appointments WHERE id=:'delete_target';
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=:'delete_target')=0,'admin hard delete remains separate');
+
+-- Anonymous execution is denied.
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error(format('select public.cancel_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','patient','Anon',:'role_cancel_updated','acn-anon-cancel'),'permission denied');
+SELECT pg_temp.expect_error(format('select public.mark_appointment_no_show(%L::uuid,%L::uuid,%L,%L::timestamptz,%L)',:'tenant_a',:'role_cancel_id','Anon',:'role_cancel_updated','acn-anon-noshow'),'permission denied');
+RESET ROLE;
+
+-- Catalog, RLS, grants and preserved history facts.
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointments'::regclass),'appointments RLS remains enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointment_operations'::regclass),'operations RLS remains enabled');
+SELECT pg_temp.assert_true(EXISTS(SELECT 1 FROM pg_trigger WHERE tgrelid='public.appointments'::regclass AND tgname='appointments_lifecycle_write_guard' AND NOT tgisinternal),'lifecycle guard installed');
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.cancel_appointment(uuid,uuid,text,text,timestamptz,text)','EXECUTE'),'authenticated cancel RPC granted');
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.mark_appointment_no_show(uuid,uuid,text,timestamptz,text)','EXECUTE'),'authenticated no-show RPC granted');
+SELECT pg_temp.assert_true(NOT has_function_privilege('anon','public.cancel_appointment(uuid,uuid,text,text,timestamptz,text)','EXECUTE'),'anon cancel execute denied');
+SELECT pg_temp.assert_true(NOT has_function_privilege('anon','public.mark_appointment_no_show(uuid,uuid,text,timestamptz,text)','EXECUTE'),'anon no-show execute denied');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointments','SELECT'),'existing appointment read grant preserved');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointments','DELETE'),'existing delete grant preserved for RLS');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=:'owner_cancel_id' AND status='cancelled')=1,'cancelled history row remains queryable');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE id=(:'noshow_new'::jsonb#>>'{appointment,id}')::uuid AND status='no_show')=1,'no-show history row remains queryable');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE status='cancelled' AND lifecycle_metadata_version=1 AND (cancelled_at IS NULL OR cancelled_by IS NULL OR cancellation_source IS NULL OR btrim(cancellation_reason)=''))=0,'controlled cancelled rows have complete metadata');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE status='no_show' AND lifecycle_metadata_version=1 AND (no_show_at IS NULL OR no_show_by IS NULL OR btrim(no_show_reason)=''))=0,'controlled no-show rows have complete metadata');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a JOIN public.appointments b ON b.id>a.id AND b.tenant_id=a.tenant_id AND b.doctor_id=a.doctor_id AND a.status<>'cancelled' AND b.status<>'cancelled' AND b.start_time<a.end_time AND b.end_time>a.start_time)=0,'conflict protection still has zero doctor overlaps');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a JOIN public.appointments b ON b.id>a.id AND b.tenant_id=a.tenant_id AND b.patient_id=a.patient_id AND a.patient_id IS NOT NULL AND a.status<>'cancelled' AND b.status<>'cancelled' AND b.start_time<a.end_time AND b.end_time>a.start_time)=0,'conflict protection still has zero patient overlaps');
+
+-- Appointment lifecycle actions do not create clinical or financial facts.
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.patient_visits)=:'visits_before'::integer,'no visit created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.clinical_encounters)=:'encounters_before'::integer,'no encounter created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.completed_services)=:'services_before'::integer,'no completed service created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.treatment_plans)=:'plans_before'::integer,'no treatment plan mutation');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.findings)=:'findings_before'::integer,'no finding mutation');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.dental_charts)=:'charts_before'::integer,'no dental chart mutation');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.invoices)=:'invoices_before'::integer,'no invoice created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.payments)=:'payments_before'::integer,'no payment created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.refunds)=:'refunds_before'::integer,'no refund created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.financial_adjustments)=:'adjustments_before'::integer,'no write-off created');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.documents)=:'documents_before'::integer,'no document created');
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id=:'patient_a1')=:'balance_a1_before'::numeric,'patient A1 balance unchanged');
+SELECT pg_temp.assert_true((SELECT balance FROM public.patients WHERE id=:'patient_a2')=:'balance_a2_before'::numeric,'patient A2 balance unchanged');
+
+ROLLBACK;
+\echo 'APPOINTMENT-CANCELLATION-NOSHOW-001 SQL validation passed'


### PR DESCRIPTION
## Summary
- add dedicated audited cancellation and no-show RPCs with metadata, idempotency, recovery, role and transition checks
- remove terminal statuses from generic appointment editing and separate cancel, no-show, and hard delete in UI
- show lifecycle metadata in schedule and patient history with stale-context protection

## Validation
- ESLint passed
- 87 test files / 957 tests passed
- production build passed
- SQL 0024-0026 passed on clean reset
- appointment conflict and lifecycle concurrency passed with 0 overlaps and 0 deadlocks
- local browser and Chrome DevTools MCP lifecycle smoke passed

PR must remain open and unmerged.