### PR TITLE
APPOINTMENT-CONFIRMATION-WORKFLOW-001: add auditable appointment confirmation workflow

### DIFF
--- a/_ai_work/REPORTS/APPOINTMENT-CONFIRMATION-WORKFLOW-001_workflow.md
+++ b/_ai_work/REPORTS/APPOINTMENT-CONFIRMATION-WORKFLOW-001_workflow.md
@@ -1,0 +1,634 @@
+# APPOINTMENT-CONFIRMATION-WORKFLOW-001
+
+## 1. Final verdict
+
+Task verdict: **APPOINTMENT CONFIRMATION WORKFLOW IMPLEMENTED AND VERIFIED**
+
+Machine-readable final verdict: **PASS**
+
+The appointment confirmation workflow is implemented as an auditable operational fact that is separate from appointment attendance, clinical treatment, completed services, billing, and the legacy appointment status value `confirmed`.
+
+The implementation passed local migration reset, typed schema assertions, SQL validation, concurrency validation, the full TypeScript quality gate, and real-browser Chrome DevTools MCP scenarios. The pull request must remain open and unmerged.
+
+## 2. Summary
+
+The schedule now supports controlled confirmation work through two explicit actions:
+
+1. record a contact attempt;
+2. confirm an appointment directly.
+
+Each successful action uses a tenant-scoped transactional RPC, an operation key, optimistic version checking, immutable attempt history, and exactly one audit/activity pair. The UI shows the current confirmation state, attempt count, latest outcome, confirmed timestamp/channel, and attempt history.
+
+No SMS, WhatsApp, email, reminder, background job, finance, clinical, stock, document, or cloud workflow was introduced.
+
+## 3. Branch
+
+`feature/appointment-confirmation-workflow-001`
+
+## 4. PR URL
+
+https://github.com/NckNA/codex-test/pull/350
+
+## 5. Baseline
+
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- required and verified baseline: `17caef8336a0627ff01d0615d0847eec01255324`;
+- PR #349 was verified as merged into that exact baseline;
+- the task worktree was created from the verified baseline;
+- cloud Supabase was not used.
+
+## 6. Implementation head reviewed before final report update
+
+- implementation head: `9aedc88620e35054521efaab7f506b122f8969ae`;
+- workflow: `CI`;
+- run number: `#707`;
+- run ID: `29195697038`;
+- conclusion: `success`;
+- tested commit: `9aedc88620e35054521efaab7f506b122f8969ae`;
+- tested commit matched the implementation head exactly;
+- ESLint, tests, and build passed;
+- the pull request remains open and unmerged.
+
+## 7. Report update commit
+
+Report update commit: N/A because a report-only commit cannot contain its own future SHA or the CI result that tests it.
+
+The exact final report-only commit and fresh final CI run must be recorded in the immutable finalization receipt and final task response.
+
+## 8. Changed files
+
+Implementation and tests:
+
+- `src/components/patients/patient-card/PatientHistoryTab.test.tsx`;
+- `src/components/patients/patient-card/PatientHistoryTab.tsx`;
+- `src/components/schedule/AppointmentConfirmationPanel.test.tsx`;
+- `src/components/schedule/AppointmentConfirmationPanel.tsx`;
+- `src/components/schedule/AppointmentModal.test.tsx`;
+- `src/components/schedule/AppointmentModal.tsx`;
+- `src/components/schedule/appointmentConfirmation.ts`;
+- `src/data/hooks/useScheduleAppointments.test.tsx`;
+- `src/data/hooks/useScheduleAppointments.ts`;
+- `src/data/repositories/AppointmentRepository.test.ts`;
+- `src/data/repositories/AppointmentRepository.ts`;
+- `src/pages/SchedulePage.tsx`;
+- `src/types/index.ts`;
+- `supabase/migrations/0027_appointment_confirmation_workflow.sql`;
+- `supabase/tests/0027_appointment_confirmation_workflow_concurrency.ps1`;
+- `supabase/tests/0027_appointment_confirmation_workflow_test.sql`;
+- `_ai_work/REPORTS/APPOINTMENT-CONFIRMATION-WORKFLOW-001_workflow.md`.
+
+No package, lockfile, generated type, environment file, screenshot, local fixture, MCP helper, or cloud migration file belongs in the final diff.
+
+## 9. Original confirmation inventory
+
+Before this task:
+
+- confirmation existed only as the legacy scheduling status `appointment.status = confirmed`;
+- no separate confirmation state existed;
+- no actor, time, channel, note, attempt count, or latest outcome was stored;
+- no immutable attempt history existed;
+- no idempotent confirmation operation existed;
+- no recovery operation existed for an uncertain response;
+- the generic appointment editor could select `confirmed` as an ordinary status;
+- patient history could show the old status but not auditable confirmation facts;
+- the SMS page was a placeholder and no reminder/provider architecture existed.
+
+## 10. Confirmation domain semantics
+
+Confirmation is an administrative communication fact, not a visit fact.
+
+The implementation explicitly preserves these distinctions:
+
+```text
+confirmed appointment != patient arrived
+confirmed appointment != encounter started
+confirmed appointment != service completed
+message sent != patient confirmed
+contact attempt != successful contact
+legacy status confirmed != audited confirmation metadata
+```
+
+The workflow does not create visits, encounters, completed services, invoices, payments, documents, or stock movements.
+
+## 11. Historical compatibility
+
+Existing rows are not assigned invented actor, timestamp, channel, or note metadata.
+
+Migration `0027` gives historical appointments:
+
+- `confirmation_state = unconfirmed`;
+- `confirmation_attempt_count = 0`;
+- `confirmation_metadata_version = 0`;
+- null confirmation actor/time/channel/outcome metadata.
+
+A historical `appointment.status = confirmed` remains unchanged as a legacy scheduling status, but it is not treated as a new auditable confirmation.
+
+## 12. Appointment confirmation data model
+
+Migration `0027` adds to `appointments`:
+
+- `confirmation_state`;
+- `confirmed_at`;
+- `confirmed_by`;
+- `confirmation_channel`;
+- `confirmation_note`;
+- `last_confirmation_attempt_at`;
+- `confirmation_attempt_count`;
+- `confirmation_metadata_version`;
+- `last_confirmation_outcome`;
+- `last_confirmation_note`.
+
+Database constraints enforce coherent metadata for confirmed and non-confirmed rows.
+
+## 13. Attempt history model
+
+The new table `public.appointment_confirmation_attempts` stores:
+
+- tenant;
+- appointment;
+- patient;
+- actor;
+- channel;
+- outcome;
+- note;
+- attempted timestamp;
+- operation key;
+- fingerprint;
+- created timestamp.
+
+The table is RLS-enabled. Authenticated users receive tenant-scoped read access only. Frontend direct INSERT, UPDATE, and DELETE are not granted.
+
+## 14. Confirmation state model
+
+Supported states:
+
+- `unconfirmed`;
+- `contact_in_progress`;
+- `confirmed`;
+- `unreachable`;
+- `callback_requested`.
+
+The state is derived from the latest controlled contact outcome. The latest outcome remains separately visible so operational meaning is not lost when several outcomes map to the same attention state.
+
+## 15. Contact channels and outcomes
+
+Supported channels:
+
+- phone;
+- WhatsApp;
+- SMS;
+- email;
+- in person;
+- other.
+
+Supported outcomes:
+
+- confirmed;
+- no answer;
+- unreachable;
+- callback requested;
+- declined;
+- wrong number;
+- message sent;
+- other.
+
+`message_sent` maps to `contact_in_progress`, not `confirmed`.
+
+## 16. Controlled RPC contract
+
+Dedicated RPCs:
+
+- `record_appointment_confirmation_attempt(...)`;
+- `confirm_appointment(...)`;
+- existing `get_appointment_operation(...)` extended for confirmation recovery.
+
+The RPCs:
+
+- require authenticated tenant membership;
+- authorize only clinic owner, clinic admin, and registrar;
+- lock the appointment row;
+- enforce expected `updated_at`;
+- validate appointment status and metadata;
+- reuse `appointment_operations`;
+- write the appointment state and history atomically;
+- write exactly one audit/activity pair;
+- return a safe structured result.
+
+## 17. Transition policy
+
+Confirmation actions are allowed for operationally confirmable scheduling rows, including `new` and historical legacy `confirmed` status rows.
+
+Actions are rejected for:
+
+- arrived;
+- in progress;
+- completed;
+- cancelled;
+- no-show;
+- blocked.
+
+No unconfirm/reopen/correction operation was added. That requires a separate privileged audited workflow.
+
+## 18. Idempotency and replay
+
+Each confirmation mutation uses a tenant-scoped operation key and fingerprint.
+
+Behavior:
+
+- the same key and same payload replays one logical result;
+- replay does not duplicate attempt, operation, audit, or activity rows;
+- the same key with changed payload is rejected;
+- operation keys are independent across tenants;
+- duplicate browser submission shares one in-flight promise.
+
+## 19. Uncertain-response recovery
+
+If the write request may have committed but the client receives an uncertain transport result, the repository calls `get_appointment_operation` with the original key.
+
+The hook:
+
+- exposes reconciliation state;
+- preserves the same key after ambiguous failure;
+- clears the key after definitive failure or confirmed success;
+- ignores late results after tenant or appointment context changes.
+
+Real-browser QA intentionally lost a successful response after commit and recovered exactly one saved attempt.
+
+## 20. Optimistic concurrency model
+
+Confirmation mutations require the appointment `updated_at` version observed by the client.
+
+Two independent actions against the same stale version do not silently merge. One action wins; the other receives a controlled concurrent-change result and must reload before intentionally retrying.
+
+This model was verified for:
+
+- attempt versus attempt;
+- confirm versus cancel;
+- confirm versus no-show;
+- confirm versus reschedule;
+- stale expected version.
+
+## 21. Generic status separation
+
+The generic appointment status editor no longer exposes `confirmed` as the way to confirm an appointment.
+
+The legacy `AppointmentStatus` value remains supported for historical data compatibility, but all new operational confirmation uses the dedicated confirmation panel and RPC boundary.
+
+Generic appointment details edits preserve confirmation metadata and cannot directly reset or fabricate confirmation facts.
+
+## 22. Role matrix
+
+| Role | Read confirmation facts | Record attempt | Confirm |
+| --- | --- | --- | --- |
+| clinic_owner | yes | yes | yes |
+| clinic_admin | yes | yes | yes |
+| registrar | yes | yes | yes |
+| doctor | yes | no | no |
+| cashier | yes | no | no |
+| unknown / no tenant | no tenant data | no | no |
+
+Backend authorization remains authoritative even when UI actions are hidden.
+
+## 23. Tenant and RLS boundaries
+
+The implementation enforces:
+
+- tenant-scoped appointment lookup;
+- tenant-scoped attempt history SELECT;
+- cross-tenant mutation rejection;
+- no-tenant denial;
+- tenant-local operation keys;
+- patient/appointment tenant consistency;
+- no raw operation ledger visibility to ordinary browser roles.
+
+Real-browser tenant B isolation showed tenant B data while hiding tenant A confirmation fixtures.
+
+## 24. Audit and activity events
+
+Every successful confirmation attempt writes:
+
+- one `appointment_operations` row;
+- one `audit_events` row;
+- one `activity_events` row.
+
+Direct confirmation records an immutable attempt with outcome `confirmed` and emits the confirmation event once.
+
+Replay, duplicate click, recovery, and losing race requests do not create duplicate audit/activity facts.
+
+## 25. Repository implementation
+
+`AppointmentRepository` now supports:
+
+- `recordConfirmationAttempt`;
+- `confirmAppointment`;
+- `listConfirmationAttempts`;
+- confirmation-aware operation recovery;
+- row mapping for all confirmation metadata;
+- safe confirmation error mapping.
+
+The Supabase repository contains no direct confirmation INSERT/UPDATE and no service-role or localStorage fallback path.
+
+## 26. Hook implementation
+
+`useScheduleAppointments` adds:
+
+- confirmation attempt mutation;
+- direct confirmation mutation;
+- shared in-flight exclusion with cancellation/no-show operations;
+- operation-key retention and recovery;
+- explicit recording/confirming/reconciling states;
+- one refetch after confirmed success;
+- stale tenant/context protection.
+
+Rapid duplicate calls receive the same promise and invoke the repository once.
+
+## 27. Schedule UI
+
+`AppointmentConfirmationPanel` displays:
+
+- confirmation state;
+- attempt count;
+- latest attempt time;
+- latest outcome;
+- confirmed time;
+- confirmed channel;
+- latest note;
+- expandable attempt history.
+
+Authorized users receive separate actions:
+
+- `Зафиксировать попытку связи`;
+- `Подтвердить запись`.
+
+The panel explains that confirmation does not mean arrival or completed treatment.
+
+## 28. Attention view
+
+SchedulePage shows an operational count and filter for appointments that still require confirmation attention.
+
+The attention set includes:
+
+- unconfirmed;
+- contact in progress;
+- unreachable;
+- callback requested.
+
+It excludes confirmed, cancelled, and no-show rows. Callback and unreachable outcomes remain visible instead of disappearing from the work queue.
+
+## 29. Patient appointment history
+
+Patient history shows confirmation facts inside the appointment history row:
+
+- state;
+- attempt count;
+- last attempt;
+- latest outcome;
+- confirmed timestamp;
+- channel;
+- note.
+
+The wording does not imply that treatment was completed, a visit occurred, or a clinical encounter was created.
+
+## 30. Validation and safe errors
+
+The UI requires:
+
+- selected contact channel;
+- selected contact outcome for an attempt;
+- trimmed optional note;
+- valid appointment context.
+
+The backend revalidates all fields and authorization.
+
+Safe user-visible errors cover:
+
+- missing channel;
+- missing outcome;
+- already confirmed;
+- invalid transition;
+- permission denial;
+- concurrent change;
+- idempotency conflict;
+- unresolved recovery.
+
+Raw SQLSTATE, function names, fingerprints, and stack traces are not exposed.
+
+## 31. Browser-discovered nested-form defect
+
+The first integrated browser run discovered that the confirmation panel contained a nested `<form>` inside the main appointment editor form.
+
+HTML form nesting is invalid. Clicking confirmation submit triggered the outer appointment form and navigated to `/?` without invoking the confirmation RPC.
+
+The panel was changed to a non-form container with explicit `type="button"` submission. A regression test now requires exactly one form inside `AppointmentModal` while the confirmation attempt UI is open.
+
+Chrome DevTools MCP then verified the correct confirmation RPC and visible saved history.
+
+## 32. Component and integration tests
+
+Added or updated tests cover:
+
+- state, attempt count, latest outcome, channel, and history display;
+- required channel/outcome;
+- note trimming;
+- `message_sent` not becoming confirmed;
+- direct confirmation success;
+- reconciliation and safe errors;
+- owner/admin/registrar actions;
+- doctor/cashier/unknown read-only behavior;
+- terminal status action hiding;
+- attention policy;
+- removal of legacy generic confirmed action;
+- no nested form regression;
+- patient-history confirmation facts without clinical wording.
+
+## 33. Repository and hook tests
+
+Repository tests cover:
+
+- exact RPC signatures;
+- attempt mapping;
+- direct confirm mapping;
+- tenant-scoped history SELECT;
+- same-key recovery;
+- safe error mapping;
+- source scan for RPC-only mutation boundaries.
+
+Hook tests cover:
+
+- rapid duplicate attempt;
+- attempt versus confirm mutual exclusion;
+- ambiguous retry with the same key;
+- definitive failure with a new corrected key;
+- stale tenant success suppression;
+- one refresh after confirmed success.
+
+## 34. SQL validation
+
+Passed after a fresh local migration reset:
+
+- `0024_legacy_core_table_grants_test.sql`;
+- `0025_appointment_conflict_hardening_test.sql`;
+- `0026_appointment_cancellation_noshow_test.sql`;
+- `0027_appointment_confirmation_workflow_test.sql`.
+
+The `0027` SQL test validates historical compatibility, owner/admin/registrar permissions, doctor/cashier/no-tenant denial, tenant isolation, state mapping, replay, changed-payload conflict, recovery, terminal blocking, RLS, generic edit preservation, and zero clinical/financial side effects.
+
+## 35. Concurrency validation
+
+Passed:
+
+- `0025_appointment_conflict_concurrency.ps1`;
+- `0026_appointment_cancellation_noshow_concurrency.ps1`;
+- `0027_appointment_confirmation_workflow_concurrency.ps1`.
+
+Final confirmation concurrency result:
+
+```text
+successCount=12
+replayCount=2
+conflictCount=7
+attempts=10
+confirmations=6
+operations=10
+audit=10
+activity=10
+duplicateKeys=0
+deadlocks=0
+```
+
+No active doctor/patient overlap or invalid interval was introduced.
+
+## 36. Browser smoke: Chrome DevTools MCP A-J
+
+Chrome DevTools MCP server version `1.5.0` ran isolated real-browser contexts against local Vite and local Supabase.
+
+Verified scenarios:
+
+- role visibility for owner/admin/registrar/doctor/cashier/no-tenant;
+- tenant B isolation;
+- A: no answer;
+- B: callback requested;
+- C: direct WhatsApp confirmation and reload persistence;
+- D: message sent without confirmation;
+- E: rapid double click with one RPC;
+- F: lost committed response with visible reconciliation and recovery;
+- G: confirmation versus cancellation race with one winner;
+- J: delayed old-appointment result hidden after context switch;
+- patient-history confirmation facts without treatment wording.
+
+## 37. Network validation
+
+Observed application mutation requests used only:
+
+- `POST /rest/v1/rpc/record_appointment_confirmation_attempt`;
+- `POST /rest/v1/rpc/confirm_appointment`;
+- `POST /rest/v1/rpc/get_appointment_operation` for recovery;
+- existing controlled lifecycle RPC for the intentional losing race.
+
+No direct appointment PATCH was used for confirmation.
+
+No direct POST to `appointment_confirmation_attempts` was used.
+
+No frontend service-role material, SQLSTATE, secret, or unhandled rejection was observed.
+
+## 38. Database validation
+
+Final browser fixture snapshot:
+
+- confirmation attempts: `8`;
+- confirmed outcomes: `2`;
+- appointment operations: `8`;
+- audit events: `8`;
+- activity events: `8`;
+- duplicate operation keys: `0`;
+- duplicate attempt keys: `0`;
+- invalid tenant/patient links: `0`;
+- doctor overlaps: `0`;
+- patient overlaps: `0`;
+- invalid intervals: `0`.
+
+Double-click, recovery, and race scenarios each produced exactly one logical result.
+
+## 39. Side-effect and cleanup validation
+
+All nine fixture `patients.balance` control values remained unchanged.
+
+Zero task side-effect rows were created in:
+
+- visits;
+- encounters;
+- completed services;
+- treatment plans;
+- findings;
+- dental charts;
+- invoices;
+- invoice items;
+- payments;
+- allocations;
+- refunds;
+- financial adjustments;
+- documents.
+
+Temporary QA users, tenants, patients, doctors, appointments, attempts, MCP scripts, fixtures, logs, and task Vite processes were removed.
+
+The local database was reset with `npx supabase db reset --no-seed`; final auth, tenant, patient, appointment, attempt, operation, audit, and activity control counts were zero.
+
+## 40. Checks: lint, tests, and build
+
+Final checks after the browser-discovered fix and cleanup:
+
+- ESLint: passed;
+- full Vitest suite: **88 files / 987 tests passed**;
+- TypeScript build: passed;
+- Vite production build: passed;
+- transformed modules: `1952`;
+- `git diff --check`: required before commit.
+
+Non-blocking baseline warnings:
+
+- existing React `act(...)` warnings in older tests;
+- existing Vite large-bundle warning.
+
+No package dependency was changed.
+
+## 41. Issues / Limitations
+
+Security boundaries:
+
+- no frontend service-role key;
+- no direct confirmation table mutation;
+- no cross-tenant mutation;
+- no raw database error displayed;
+- operation-key fingerprints remain internal;
+- role and terminal-status checks are enforced server-side;
+- cloud Supabase remains untouched.
+
+Known limitations and excluded scope:
+
+- historical legacy confirmed rows remain metadata version `0`;
+- no correction/unconfirm/reopen workflow;
+- no automated reminder scheduler;
+- no SMS, WhatsApp, email, or provider integration;
+- no callback task scheduler;
+- no call-center queue beyond the narrow attention filter;
+- no public booking;
+- no finance, penalty, deposit, document, treatment, encounter, stock, or amoCRM mutation;
+- no package/lockfile/generated-type change;
+- no PR merge.
+
+## 42. Recommended next task
+
+Implementation CI: workflow `CI`, run `#707`, run ID `29195697038`, conclusion `success`, tested commit `9aedc88620e35054521efaab7f506b122f8969ae`.
+
+A second fresh CI run is mandatory after the report-only metadata commit. The final CI run must test the exact final PR HEAD.
+
+The PR must remain open and unmerged.
+
+Recommended next task: **APPOINTMENT-CONFIRMATION-CORRECTION-001**
+
+Reason: an incorrect confirmation must not be reset through generic status editing. Any correction/unconfirm operation should require privileged authorization, a correction reason, before/after audit data, idempotency, and optimistic conflict validation.
+
+This next task was not started.
+
+Final task verdict: **APPOINTMENT CONFIRMATION WORKFLOW IMPLEMENTED AND VERIFIED**

--- a/src/components/patients/patient-card/PatientHistoryTab.test.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.test.tsx
@@ -116,6 +116,32 @@ describe('PatientHistoryTab', () => {
     await act(async () => root.unmount());
   });
 
+  it('shows confirmation facts without presenting contact as clinical treatment', async () => {
+    vi.mocked(usePatientAppointments).mockReturnValue({
+      appointments: [row({
+        confirmationState: 'confirmed',
+        confirmedAt: '2026-08-01T09:30:00',
+        confirmationChannel: 'whatsapp',
+        confirmationAttemptCount: 2,
+        lastConfirmationAttemptAt: '2026-08-01T09:30:00',
+        lastConfirmationOutcome: 'confirmed',
+        lastConfirmationNote: 'Пациент подтвердил',
+      })],
+      isLoading: false,
+      isError: false,
+    } as any);
+    const { container, root } = await render();
+
+    const metadata = container.querySelector('[data-testid="history-confirmation-appointment-1"]');
+    expect(metadata?.textContent).toContain('Подтверждена');
+    expect(metadata?.textContent).toContain('Попыток связи: 2');
+    expect(metadata?.textContent).toContain('Подтвердил');
+    expect(metadata?.textContent).toContain('WhatsApp');
+    expect(metadata?.textContent).toContain('Пациент подтвердил');
+    expect(metadata?.textContent).not.toContain('Лечение выполнено');
+    await act(async () => root.unmount());
+  });
+
   it('shows loading and empty states without demo rows', async () => {
     vi.mocked(usePatientAppointments).mockReturnValue({ appointments: [], isLoading: true, isError: false } as any);
     const loading = await render();

--- a/src/components/patients/patient-card/PatientHistoryTab.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.tsx
@@ -4,6 +4,12 @@ import { Stethoscope, ClipboardList } from 'lucide-react';
 import { useClinicDoctors } from '../../../data/hooks/useClinicDoctors';
 import { usePatientAppointments } from '../../../data/hooks/usePatientAppointments';
 import { cancellationSourceLabel } from '../../schedule/appointmentLifecycle';
+import {
+  confirmationStateClassName,
+  confirmationStateLabel,
+  CONTACT_CHANNEL_LABELS,
+  CONTACT_OUTCOME_LABELS,
+} from '../../schedule/appointmentConfirmation';
 
 interface PatientHistoryTabProps {
   patientId: string;
@@ -111,6 +117,20 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
                         <div>Сотрудник: {appt.noShowBy ? 'Сотрудник клиники' : 'Не указан'}</div>
                       </div>
                     )}
+                    <div className="mt-2 max-w-sm rounded border border-slate-200 bg-slate-50 p-2 text-xs text-slate-700" data-testid={`history-confirmation-${appt.id}`}>
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-semibold">Подтверждение</span>
+                        <span className={`rounded border px-1.5 py-0.5 ${confirmationStateClassName(appt.confirmationState)}`}>
+                          {confirmationStateLabel(appt.confirmationState)}
+                        </span>
+                      </div>
+                      <div>Попыток связи: {appt.confirmationAttemptCount || 0}</div>
+                      <div>Последняя попытка: {appt.lastConfirmationAttemptAt ? new Date(appt.lastConfirmationAttemptAt).toLocaleString('ru-RU') : 'Нет'}</div>
+                      <div>Результат: {appt.lastConfirmationOutcome ? CONTACT_OUTCOME_LABELS[appt.lastConfirmationOutcome] : 'Нет'}</div>
+                      <div>Подтверждена: {appt.confirmedAt ? new Date(appt.confirmedAt).toLocaleString('ru-RU') : 'Нет'}</div>
+                      <div>Канал: {appt.confirmationChannel ? CONTACT_CHANNEL_LABELS[appt.confirmationChannel] : 'Нет'}</div>
+                      {appt.lastConfirmationNote && <div>Примечание: {appt.lastConfirmationNote}</div>}
+                    </div>
                   </td>
                   <td className="py-3 px-4 text-slate-600">{appt.cabinet}</td>
                   <td className="py-3 px-4">

--- a/src/components/schedule/AppointmentConfirmationPanel.test.tsx
+++ b/src/components/schedule/AppointmentConfirmationPanel.test.tsx
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Appointment, AppointmentConfirmationAttempt } from '../../types';
+import { AppointmentConfirmationPanel } from './AppointmentConfirmationPanel';
+import { appointmentNeedsConfirmationAttention } from './appointmentConfirmation';
+
+const appointment: Appointment = {
+  id: 'appointment-1', patientId: 'patient-1', doctorId: 'doctor-1', cabinet: 'A1', service: 'Осмотр',
+  start: '2026-08-01T10:00:00', end: '2026-08-01T11:00:00', status: 'new', createdAt: '2026-07-01T09:00:00',
+  updatedAt: '2026-07-01T09:00:00+00:00', confirmationState: 'unconfirmed', confirmationAttemptCount: 0,
+};
+
+const attempt: AppointmentConfirmationAttempt = {
+  id: 'attempt-1', tenantId: 'tenant-1', appointmentId: appointment.id, patientId: 'patient-1', actorUserId: 'actor-1',
+  channel: 'phone', outcome: 'callback_requested', note: 'После обеда', attemptedAt: '2026-08-01T09:30:00', createdAt: '2026-08-01T09:30:00',
+};
+
+interface RenderOptions {
+  value?: Appointment;
+  role?: string;
+  attempts?: AppointmentConfirmationAttempt[];
+  isRecordingAttempt?: boolean;
+  isConfirming?: boolean;
+  isReconciling?: boolean;
+  error?: string | null;
+  onRecordAttempt?: any;
+  onConfirm?: any;
+}
+
+const mounted: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+const renderPanel = async (options: RenderOptions = {}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mounted.push({ root, container });
+  const props = {
+    appointment: options.value || appointment,
+    role: options.role ?? 'clinic_admin',
+    attempts: options.attempts || [],
+    isRecordingAttempt: options.isRecordingAttempt || false,
+    isConfirming: options.isConfirming || false,
+    isReconciling: options.isReconciling || false,
+    error: options.error || null,
+    onRecordAttempt: options.onRecordAttempt || vi.fn().mockResolvedValue({ ...appointment, confirmationState: 'contact_in_progress' }),
+    onConfirm: options.onConfirm || vi.fn().mockResolvedValue({ ...appointment, confirmationState: 'confirmed' }),
+  };
+  await act(async () => root.render(<AppointmentConfirmationPanel {...props} />));
+  return { container, root, props };
+};
+
+const setValue = async (element: HTMLSelectElement | HTMLTextAreaElement, value: string) => {
+  const prototype = element instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLTextAreaElement.prototype;
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(prototype, 'value')?.set?.call(element, value);
+    element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? 'change' : 'input', { bubbles: true }));
+  });
+};
+
+const click = async (element: Element | null) => {
+  if (!(element instanceof HTMLElement)) throw new Error('Missing element');
+  await act(async () => element.click());
+};
+
+afterEach(async () => {
+  while (mounted.length) {
+    const item = mounted.pop()!;
+    await act(async () => item.root.unmount());
+    item.container.remove();
+  }
+});
+
+describe('AppointmentConfirmationPanel', () => {
+  it('shows explicit confirmation state, count, latest attempt and history', async () => {
+    const { container } = await renderPanel({
+      value: { ...appointment, confirmationState: 'callback_requested', confirmationAttemptCount: 1, lastConfirmationOutcome: 'callback_requested', lastConfirmationAttemptAt: attempt.attemptedAt },
+      attempts: [attempt],
+    });
+    expect(container.textContent).toContain('Просит перезвонить');
+    expect(container.querySelector('[data-testid="appointment-confirmation-attempt-count"]')?.textContent).toBe('1');
+    expect(container.querySelector('[data-testid="appointment-confirmation-latest-attempt"]')?.textContent).toContain('После обеда');
+    expect(container.querySelector('[data-testid="appointment-confirmation-history"]')).not.toBeNull();
+  });
+
+  it('requires channel and outcome before recording an attempt', async () => {
+    const { container, props } = await renderPanel();
+    await click(container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]'));
+    await click(container.querySelector('[data-testid="appointment-confirmation-submit"]'));
+    expect(container.textContent).toContain('Выберите способ связи.');
+    await setValue(container.querySelector('[data-testid="appointment-confirmation-channel"]') as HTMLSelectElement, 'phone');
+    await click(container.querySelector('[data-testid="appointment-confirmation-submit"]'));
+    expect(container.textContent).toContain('Выберите результат связи.');
+    expect(props.onRecordAttempt).not.toHaveBeenCalled();
+  });
+
+  it('trims note and records message_sent without displaying confirmed success wording', async () => {
+    const onRecordAttempt = vi.fn().mockResolvedValue({ ...appointment, confirmationState: 'contact_in_progress' });
+    const { container } = await renderPanel({ onRecordAttempt });
+    await click(container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]'));
+    await setValue(container.querySelector('[data-testid="appointment-confirmation-channel"]') as HTMLSelectElement, 'sms');
+    await setValue(container.querySelector('[data-testid="appointment-confirmation-outcome"]') as HTMLSelectElement, 'message_sent');
+    await setValue(container.querySelector('[data-testid="appointment-confirmation-note"]') as HTMLTextAreaElement, '  Шаблон отправлен  ');
+    await click(container.querySelector('[data-testid="appointment-confirmation-submit"]'));
+    expect(onRecordAttempt).toHaveBeenCalledWith('sms', 'message_sent', 'Шаблон отправлен');
+    expect(container.textContent).toContain('Попытка связи сохранена.');
+    expect(container.textContent).not.toContain('Запись подтверждена.');
+  });
+
+  it('confirms with channel and shows success while keeping appointment status separate', async () => {
+    const onConfirm = vi.fn().mockResolvedValue({ ...appointment, confirmationState: 'confirmed', status: 'new' });
+    const { container } = await renderPanel({ onConfirm });
+    await click(container.querySelector('[data-testid="appointment-confirm-action"]'));
+    await setValue(container.querySelector('[data-testid="appointment-confirmation-channel"]') as HTMLSelectElement, 'whatsapp');
+    await setValue(container.querySelector('[data-testid="appointment-confirmation-note"]') as HTMLTextAreaElement, '  Подтвердил  ');
+    await click(container.querySelector('[data-testid="appointment-confirmation-submit"]'));
+    expect(onConfirm).toHaveBeenCalledWith('whatsapp', 'Подтвердил');
+    expect(container.textContent).toContain('Запись подтверждена.');
+  });
+
+  it('shows reconciliation and safe server error without closing the form', async () => {
+    const { container } = await renderPanel({ isRecordingAttempt: true, isReconciling: true, error: 'Запись была изменена другим пользователем. Обновите расписание.' });
+    await click(container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]'));
+    expect(container.textContent).toContain('Проверяем, была ли операция сохранена…');
+    expect(container.textContent).toContain('Запись была изменена другим пользователем. Обновите расписание.');
+  });
+
+  it.each(['clinic_owner', 'clinic_admin', 'registrar'])('allows operational role %s', async (role) => {
+    const { container } = await renderPanel({ role });
+    expect(container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="appointment-confirm-action"]')).not.toBeNull();
+  });
+
+  it.each(['doctor', 'cashier', 'unknown'])('hides mutation actions for %s but shows state', async (role) => {
+    const { container } = await renderPanel({ role });
+    expect(container.querySelector('[data-testid="appointment-confirmation-state"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]')).toBeNull();
+    expect(container.querySelector('[data-testid="appointment-confirm-action"]')).toBeNull();
+  });
+
+  it.each(['cancelled', 'no_show', 'completed', 'arrived', 'in_progress', 'blocked'] as const)('hides actions for terminal/operational status %s', async (status) => {
+    const { container } = await renderPanel({ value: { ...appointment, status } });
+    expect(container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]')).toBeNull();
+    expect(container.querySelector('[data-testid="appointment-confirm-action"]')).toBeNull();
+  });
+
+  it('attention policy includes callback/unreachable and excludes confirmed/cancelled/no-show', () => {
+    expect(appointmentNeedsConfirmationAttention({ ...appointment, confirmationState: 'callback_requested' })).toBe(true);
+    expect(appointmentNeedsConfirmationAttention({ ...appointment, confirmationState: 'unreachable' })).toBe(true);
+    expect(appointmentNeedsConfirmationAttention({ ...appointment, confirmationState: 'confirmed' })).toBe(false);
+    expect(appointmentNeedsConfirmationAttention({ ...appointment, status: 'cancelled' })).toBe(false);
+    expect(appointmentNeedsConfirmationAttention({ ...appointment, status: 'no_show' })).toBe(false);
+  });
+});

--- a/src/components/schedule/AppointmentConfirmationPanel.tsx
+++ b/src/components/schedule/AppointmentConfirmationPanel.tsx
@@ -1,0 +1,257 @@
+import { useMemo, useState } from 'react';
+import { CheckCircle2, PhoneCall } from 'lucide-react';
+import type {
+  Appointment,
+  AppointmentConfirmationAttempt,
+  AppointmentContactChannel,
+  AppointmentContactOutcome,
+} from '../../types';
+import {
+  canManageAppointmentConfirmation,
+  canUseAppointmentConfirmationActions,
+  confirmationStateClassName,
+  confirmationStateLabel,
+  CONTACT_CHANNEL_LABELS,
+  CONTACT_OUTCOME_LABELS,
+} from './appointmentConfirmation';
+
+interface AppointmentConfirmationPanelProps {
+  appointment: Appointment;
+  role?: string;
+  attempts: AppointmentConfirmationAttempt[];
+  isLoadingAttempts?: boolean;
+  attemptsError?: string | null;
+  isRecordingAttempt: boolean;
+  isConfirming: boolean;
+  isReconciling: boolean;
+  error?: string | null;
+  onRecordAttempt?: (
+    channel: AppointmentContactChannel,
+    outcome: AppointmentContactOutcome,
+    note: string,
+  ) => Promise<Appointment | null>;
+  onConfirm?: (channel: AppointmentContactChannel, note: string) => Promise<Appointment | null>;
+}
+
+type FormMode = 'attempt' | 'confirm' | null;
+
+const formatDate = (value?: string) => value
+  ? new Date(value).toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short' })
+  : 'Нет';
+
+export function AppointmentConfirmationPanel({
+  appointment,
+  role,
+  attempts,
+  isLoadingAttempts = false,
+  attemptsError = null,
+  isRecordingAttempt,
+  isConfirming,
+  isReconciling,
+  error = null,
+  onRecordAttempt,
+  onConfirm,
+}: AppointmentConfirmationPanelProps) {
+  const [mode, setMode] = useState<FormMode>(null);
+  const [channel, setChannel] = useState<AppointmentContactChannel | ''>('');
+  const [outcome, setOutcome] = useState<AppointmentContactOutcome | ''>('');
+  const [note, setNote] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const isBusy = isRecordingAttempt || isConfirming;
+  const canManage = canManageAppointmentConfirmation(role);
+  const canAct = canUseAppointmentConfirmationActions(appointment)
+    && (appointment.confirmationState || 'unconfirmed') !== 'confirmed';
+  const latestAttempt = attempts[0];
+  const displayedError = validationError || error || attemptsError;
+
+  const sortedAttempts = useMemo(() => [...attempts].sort((left, right) => {
+    const byTime = new Date(right.attemptedAt).getTime() - new Date(left.attemptedAt).getTime();
+    return byTime !== 0 ? byTime : left.id.localeCompare(right.id);
+  }), [attempts]);
+
+  const resetForm = () => {
+    if (isBusy) return;
+    setMode(null);
+    setChannel('');
+    setOutcome('');
+    setNote('');
+    setValidationError(null);
+    setSuccessMessage(null);
+  };
+
+  const openMode = (nextMode: Exclude<FormMode, null>) => {
+    setMode(nextMode);
+    setChannel('');
+    setOutcome(nextMode === 'confirm' ? 'confirmed' : '');
+    setNote('');
+    setValidationError(null);
+    setSuccessMessage(null);
+  };
+
+  const submit = async () => {
+    if (isBusy) return;
+    if (!channel) {
+      setValidationError('Выберите способ связи.');
+      return;
+    }
+    if (mode === 'attempt' && !outcome) {
+      setValidationError('Выберите результат связи.');
+      return;
+    }
+    setValidationError(null);
+    const normalizedNote = note.trim();
+    try {
+      const result = mode === 'confirm'
+        ? await onConfirm?.(channel, normalizedNote)
+        : await onRecordAttempt?.(channel, outcome as AppointmentContactOutcome, normalizedNote);
+      if (result) {
+        setSuccessMessage(mode === 'confirm' ? 'Запись подтверждена.' : 'Попытка связи сохранена.');
+      }
+    } catch {
+      // Safe error is supplied by the scheduling hook. Keep the form open.
+    }
+  };
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4" data-testid="appointment-confirmation-panel">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="font-semibold text-slate-900">Подтверждение записи</h3>
+          <p className="mt-1 text-xs text-slate-500">Подтверждение не означает приход пациента или выполненное лечение.</p>
+        </div>
+        <span
+          data-testid="appointment-confirmation-state"
+          className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${confirmationStateClassName(appointment.confirmationState)}`}
+        >
+          {confirmationStateLabel(appointment.confirmationState)}
+        </span>
+      </div>
+
+      <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <dt className="text-slate-500">Попыток связи</dt>
+        <dd className="font-medium text-slate-800" data-testid="appointment-confirmation-attempt-count">{appointment.confirmationAttemptCount || 0}</dd>
+        <dt className="text-slate-500">Последняя попытка</dt>
+        <dd className="font-medium text-slate-800">{formatDate(appointment.lastConfirmationAttemptAt)}</dd>
+        <dt className="text-slate-500">Последний результат</dt>
+        <dd className="font-medium text-slate-800">{appointment.lastConfirmationOutcome ? CONTACT_OUTCOME_LABELS[appointment.lastConfirmationOutcome] : 'Нет'}</dd>
+        <dt className="text-slate-500">Подтверждена</dt>
+        <dd className="font-medium text-slate-800">{formatDate(appointment.confirmedAt)}</dd>
+        <dt className="text-slate-500">Канал подтверждения</dt>
+        <dd className="font-medium text-slate-800">{appointment.confirmationChannel ? CONTACT_CHANNEL_LABELS[appointment.confirmationChannel] : 'Нет'}</dd>
+      </dl>
+
+      {latestAttempt && (
+        <div className="mt-3 rounded-lg bg-slate-50 p-3 text-xs text-slate-700" data-testid="appointment-confirmation-latest-attempt">
+          <div className="font-medium">Последняя попытка: {CONTACT_OUTCOME_LABELS[latestAttempt.outcome]}</div>
+          <div>{CONTACT_CHANNEL_LABELS[latestAttempt.channel]} · {formatDate(latestAttempt.attemptedAt)}</div>
+          {latestAttempt.note && <div className="mt-1 text-slate-600">{latestAttempt.note}</div>}
+        </div>
+      )}
+
+      {isLoadingAttempts && <p className="mt-3 text-sm text-slate-500">Загрузка истории связи…</p>}
+      {!isLoadingAttempts && sortedAttempts.length > 0 && (
+        <details className="mt-3 text-sm" data-testid="appointment-confirmation-history">
+          <summary className="cursor-pointer font-medium text-blue-700">История попыток связи ({sortedAttempts.length})</summary>
+          <div className="mt-2 space-y-2">
+            {sortedAttempts.map((attempt) => (
+              <div key={attempt.id} className="rounded-lg border border-slate-200 p-2">
+                <div className="font-medium text-slate-800">{CONTACT_OUTCOME_LABELS[attempt.outcome]}</div>
+                <div className="text-xs text-slate-500">{CONTACT_CHANNEL_LABELS[attempt.channel]} · {formatDate(attempt.attemptedAt)}</div>
+                {attempt.note && <div className="mt-1 text-xs text-slate-600">{attempt.note}</div>}
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {canManage && canAct && !mode && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            data-testid="appointment-record-confirmation-attempt-action"
+            onClick={() => openMode('attempt')}
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-medium text-blue-800"
+          >
+            <PhoneCall className="h-4 w-4" /> Зафиксировать попытку связи
+          </button>
+          <button
+            type="button"
+            data-testid="appointment-confirm-action"
+            onClick={() => openMode('confirm')}
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white"
+          >
+            <CheckCircle2 className="h-4 w-4" /> Подтвердить запись
+          </button>
+        </div>
+      )}
+
+      {mode && !successMessage && (
+        <div className="mt-4 space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-3" data-testid={`appointment-confirmation-${mode}-form`}>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Способ связи</label>
+            <select
+              data-testid="appointment-confirmation-channel"
+              value={channel}
+              onChange={(event) => setChannel(event.target.value as AppointmentContactChannel | '')}
+              disabled={isBusy}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+            >
+              <option value="">Выберите способ связи</option>
+              {Object.entries(CONTACT_CHANNEL_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+            </select>
+          </div>
+          {mode === 'attempt' && (
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">Результат связи</label>
+              <select
+                data-testid="appointment-confirmation-outcome"
+                value={outcome}
+                onChange={(event) => setOutcome(event.target.value as AppointmentContactOutcome | '')}
+                disabled={isBusy}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              >
+                <option value="">Выберите результат связи</option>
+                {Object.entries(CONTACT_OUTCOME_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </div>
+          )}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Примечание</label>
+            <textarea
+              data-testid="appointment-confirmation-note"
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              disabled={isBusy}
+              rows={2}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+            />
+          </div>
+          {displayedError && <p className="rounded-lg bg-red-50 p-2 text-sm text-red-700" role="alert">{displayedError}</p>}
+          {isReconciling && <p className="text-sm font-medium text-indigo-700">Проверяем, была ли операция сохранена…</p>}
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={resetForm} disabled={isBusy} className="rounded-lg border border-slate-300 px-3 py-2 text-sm">Назад</button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={isBusy}
+              data-testid="appointment-confirmation-submit"
+              className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {isBusy
+                ? (isReconciling ? 'Проверяем…' : mode === 'confirm' ? 'Подтверждаем запись…' : 'Сохраняем попытку связи…')
+                : mode === 'confirm' ? 'Подтвердить запись' : 'Сохранить попытку'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="mt-4 rounded-lg bg-emerald-50 p-3 text-sm font-medium text-emerald-700" data-testid="appointment-confirmation-success">
+          {successMessage}
+          <button type="button" onClick={resetForm} className="ml-3 underline">Закрыть</button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/schedule/AppointmentModal.test.tsx
+++ b/src/components/schedule/AppointmentModal.test.tsx
@@ -360,6 +360,20 @@ describe('AppointmentModal', () => {
     await cleanup(view.root, view.container);
   });
 
+  it('shows the confirmation block and does not expose legacy confirmed as a generic status action', async () => {
+    const view = await renderModal({
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      role: 'clinic_admin',
+    });
+    expect(view.container.querySelector('[data-testid="appointment-confirmation-panel"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="appointment-status-confirmed"]')).toBeNull();
+    expect(view.container.textContent).toContain('Подтверждение не означает приход пациента');
+    await act(async () => (view.container.querySelector('[data-testid="appointment-record-confirmation-attempt-action"]') as HTMLButtonElement).click());
+    expect(view.container.querySelectorAll('form')).toHaveLength(1);
+    expect(view.container.querySelector('[data-testid="appointment-confirmation-attempt-form"]')).not.toBeNull();
+    await cleanup(view.root, view.container);
+  });
+
   it('ignores a delayed lifecycle result after the appointment context changes', async () => {
     let resolveLifecycle!: (value: Appointment | null) => void;
     const lifecycleResult = new Promise<Appointment | null>((resolve) => {

--- a/src/components/schedule/AppointmentModal.tsx
+++ b/src/components/schedule/AppointmentModal.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X, AlertCircle, ExternalLink } from 'lucide-react';
-import type { Appointment, AppointmentStatus, CancellationSource, PaymentType, Source, Doctor, Patient } from '../../types';
+import type { Appointment, AppointmentConfirmationAttempt, AppointmentContactChannel, AppointmentContactOutcome, AppointmentStatus, CancellationSource, PaymentType, Source, Doctor, Patient } from '../../types';
 import { AppointmentCancellationDialog } from './AppointmentCancellationDialog';
 import { AppointmentNoShowDialog } from './AppointmentNoShowDialog';
+import { AppointmentConfirmationPanel } from './AppointmentConfirmationPanel';
 import {
   canHardDeleteAppointment,
   canManageAppointmentLifecycle,
@@ -18,6 +19,14 @@ interface AppointmentModalProps {
   onSave: (appointment: Appointment) => Promise<boolean>;
   onCancel?: (appointment: Appointment, source: CancellationSource, reason: string) => Promise<Appointment | null>;
   onMarkNoShow?: (appointment: Appointment, reason: string) => Promise<Appointment | null>;
+  onRecordConfirmationAttempt?: (appointment: Appointment, channel: AppointmentContactChannel, outcome: AppointmentContactOutcome, note: string) => Promise<Appointment | null>;
+  onConfirmAppointment?: (appointment: Appointment, channel: AppointmentContactChannel, note: string) => Promise<Appointment | null>;
+  confirmationAttempts?: AppointmentConfirmationAttempt[];
+  isLoadingConfirmationAttempts?: boolean;
+  confirmationAttemptsError?: string | null;
+  isRecordingConfirmationAttempt?: boolean;
+  isConfirmingAppointment?: boolean;
+  isReconcilingConfirmation?: boolean;
   onDelete?: (id: string) => Promise<boolean>;
   role?: string;
   initialData?: Partial<Appointment>;
@@ -49,6 +58,14 @@ export function AppointmentModal({
   onSave,
   onCancel,
   onMarkNoShow,
+  onRecordConfirmationAttempt,
+  onConfirmAppointment,
+  confirmationAttempts = [],
+  isLoadingConfirmationAttempts = false,
+  confirmationAttemptsError = null,
+  isRecordingConfirmationAttempt = false,
+  isConfirmingAppointment = false,
+  isReconcilingConfirmation = false,
   onDelete,
   role,
   initialData,
@@ -70,7 +87,7 @@ export function AppointmentModal({
   });
   const [localError, setLocalError] = useState<string | null>(null);
   const [lifecycleDialog, setLifecycleDialog] = useState<'cancel' | 'no_show' | null>(null);
-  const isBusy = isSaving || isSubmittingLocally;
+  const isBusy = isSaving || isSubmittingLocally || isRecordingConfirmationAttempt || isConfirmingAppointment;
   const storedAppointment = isEditing ? initialData as Appointment : null;
   const isTerminal = Boolean(formData.status && isTerminalAppointmentLifecycle(formData.status));
   const canManageLifecycle = canManageAppointmentLifecycle(role);
@@ -221,6 +238,31 @@ export function AppointmentModal({
     if (!storedAppointment || !onMarkNoShow) return null;
     const capturedAppointmentId = storedAppointment.id;
     const result = await onMarkNoShow(storedAppointment, reason);
+    if (appointmentContextRef.current !== capturedAppointmentId) return null;
+    if (result) setFormData(result);
+    return result;
+  };
+
+  const handleRecordConfirmationAttempt = async (
+    channel: AppointmentContactChannel,
+    outcome: AppointmentContactOutcome,
+    note: string,
+  ): Promise<Appointment | null> => {
+    if (!storedAppointment || !onRecordConfirmationAttempt) return null;
+    const capturedAppointmentId = storedAppointment.id;
+    const result = await onRecordConfirmationAttempt(storedAppointment, channel, outcome, note);
+    if (appointmentContextRef.current !== capturedAppointmentId) return null;
+    if (result) setFormData(result);
+    return result;
+  };
+
+  const handleConfirmAppointment = async (
+    channel: AppointmentContactChannel,
+    note: string,
+  ): Promise<Appointment | null> => {
+    if (!storedAppointment || !onConfirmAppointment) return null;
+    const capturedAppointmentId = storedAppointment.id;
+    const result = await onConfirmAppointment(storedAppointment, channel, note);
     if (appointmentContextRef.current !== capturedAppointmentId) return null;
     if (result) setFormData(result);
     return result;
@@ -408,7 +450,6 @@ export function AppointmentModal({
                 <div className="flex flex-wrap gap-2">
                   {[
                     { value: 'new', label: 'Новая' },
-                    { value: 'confirmed', label: 'Подтвержден' },
                     { value: 'arrived', label: 'Пришел' },
                     { value: 'in_progress', label: 'В работе' },
                     { value: 'completed', label: 'Завершен' },
@@ -447,6 +488,21 @@ export function AppointmentModal({
                   <div>Причина: {formData.noShowReason || 'Причина не была сохранена в прежней версии системы'}</div>
                   <div>Сотрудник: {formData.noShowBy ? 'Сотрудник клиники' : 'Не указан'}</div>
                 </div>
+              )}
+              {isEditing && storedAppointment && (
+                <AppointmentConfirmationPanel
+                  appointment={formData as Appointment}
+                  role={role}
+                  attempts={confirmationAttempts}
+                  isLoadingAttempts={isLoadingConfirmationAttempts}
+                  attemptsError={confirmationAttemptsError}
+                  isRecordingAttempt={isRecordingConfirmationAttempt}
+                  isConfirming={isConfirmingAppointment}
+                  isReconciling={isReconcilingConfirmation}
+                  error={serverError}
+                  onRecordAttempt={onRecordConfirmationAttempt ? handleRecordConfirmationAttempt : undefined}
+                  onConfirm={onConfirmAppointment ? handleConfirmAppointment : undefined}
+                />
               )}
             </fieldset>
           </form>

--- a/src/components/schedule/appointmentConfirmation.ts
+++ b/src/components/schedule/appointmentConfirmation.ts
@@ -1,0 +1,61 @@
+import type {
+  Appointment,
+  AppointmentConfirmationState,
+  AppointmentContactChannel,
+  AppointmentContactOutcome,
+} from '../../types';
+
+export const CONFIRMATION_STATE_LABELS: Record<AppointmentConfirmationState, string> = {
+  unconfirmed: 'Не подтверждена',
+  contact_in_progress: 'Связываемся',
+  confirmed: 'Подтверждена',
+  unreachable: 'Не удалось связаться',
+  callback_requested: 'Просит перезвонить',
+};
+
+export const CONTACT_CHANNEL_LABELS: Record<AppointmentContactChannel, string> = {
+  phone: 'Телефон',
+  whatsapp: 'WhatsApp',
+  sms: 'SMS',
+  email: 'Email',
+  in_person: 'Лично',
+  other: 'Другое',
+};
+
+export const CONTACT_OUTCOME_LABELS: Record<AppointmentContactOutcome, string> = {
+  confirmed: 'Подтвердил',
+  no_answer: 'Не ответил',
+  unreachable: 'Недоступен',
+  callback_requested: 'Просит перезвонить',
+  declined: 'Отказался',
+  wrong_number: 'Неверный номер',
+  message_sent: 'Сообщение отправлено',
+  other: 'Другое',
+};
+
+export const canManageAppointmentConfirmation = (role?: string | null): boolean => (
+  role === 'clinic_owner' || role === 'clinic_admin' || role === 'registrar'
+);
+
+export const canUseAppointmentConfirmationActions = (appointment: Appointment): boolean => (
+  appointment.status === 'new' || appointment.status === 'confirmed'
+);
+
+export const appointmentNeedsConfirmationAttention = (appointment: Appointment): boolean => (
+  canUseAppointmentConfirmationActions(appointment)
+  && (appointment.confirmationState || 'unconfirmed') !== 'confirmed'
+);
+
+export const confirmationStateLabel = (state?: AppointmentConfirmationState): string => (
+  CONFIRMATION_STATE_LABELS[state || 'unconfirmed']
+);
+
+export const confirmationStateClassName = (state?: AppointmentConfirmationState): string => {
+  switch (state || 'unconfirmed') {
+    case 'confirmed': return 'bg-emerald-100 text-emerald-800 border-emerald-200';
+    case 'callback_requested': return 'bg-amber-100 text-amber-800 border-amber-200';
+    case 'unreachable': return 'bg-rose-100 text-rose-800 border-rose-200';
+    case 'contact_in_progress': return 'bg-blue-100 text-blue-800 border-blue-200';
+    default: return 'bg-slate-100 text-slate-700 border-slate-200';
+  }
+};

--- a/src/data/hooks/useScheduleAppointments.test.tsx
+++ b/src/data/hooks/useScheduleAppointments.test.tsx
@@ -51,7 +51,7 @@ const appointment: Appointment = {
   updatedAt: '2026-07-01T09:00:00+00:00',
 };
 
-const writeResult = (value: Appointment = appointment, operationType: 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' = 'create') => ({
+const writeResult = (value: Appointment = appointment, operationType: 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' | 'confirmation_attempt' | 'confirm' = 'create') => ({
   appointment: value,
   replayed: false,
   recovered: false,
@@ -76,6 +76,9 @@ const makeRepository = (): IAppointmentRepository => ({
   updateAppointmentDetails: vi.fn().mockResolvedValue(writeResult(appointment, 'details')),
   cancelAppointment: vi.fn().mockResolvedValue(writeResult({ ...appointment, status: 'cancelled' }, 'cancel')),
   markAppointmentNoShow: vi.fn().mockResolvedValue(writeResult({ ...appointment, status: 'no_show' }, 'no_show')),
+  recordConfirmationAttempt: vi.fn().mockResolvedValue(writeResult({ ...appointment, confirmationState: 'contact_in_progress' }, 'confirmation_attempt')),
+  confirmAppointment: vi.fn().mockResolvedValue(writeResult({ ...appointment, confirmationState: 'confirmed' }, 'confirm')),
+  listConfirmationAttempts: vi.fn().mockResolvedValue([]),
   recoverAppointmentOperation: vi.fn().mockResolvedValue({ found: false }),
   deleteAppointment: vi.fn().mockResolvedValue(undefined),
 });
@@ -419,6 +422,99 @@ describe('useScheduleAppointments', () => {
     });
 
     expect(keys[1]).not.toBe(keys[0]);
+    await harness.unmount();
+  });
+
+  it('blocks duplicate attempt and simultaneous direct confirmation with one refresh', async () => {
+    const save = deferred<ReturnType<typeof writeResult>>();
+    const attempt = vi.fn((...args: Parameters<IAppointmentRepository['recordConfirmationAttempt']>) => {
+      void args;
+      return save.promise;
+    });
+    const confirm = vi.fn().mockResolvedValue(writeResult({ ...appointment, confirmationState: 'confirmed' }, 'confirm'));
+    repository.recordConfirmationAttempt = attempt;
+    repository.confirmAppointment = confirm;
+    const harness = await renderHook();
+
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
+    let competing!: Promise<unknown>;
+    await act(async () => {
+      first = harness.getResult().recordConfirmationAttempt(appointment, 'phone', 'no_answer', '  First call  ');
+      second = harness.getResult().recordConfirmationAttempt(appointment, 'phone', 'no_answer', '  First call  ');
+      competing = harness.getResult().confirmAppointment(appointment, 'whatsapp', 'Competing');
+      await Promise.resolve();
+    });
+
+    expect(first).toBe(second);
+    expect(competing).toBe(first);
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(attempt.mock.calls[0][3]).toBe('First call');
+    expect(confirm).not.toHaveBeenCalled();
+    expect(harness.getResult()).toMatchObject({ isRecordingConfirmationAttempt: true, isConfirmingAppointment: false });
+
+    await act(async () => save.resolve(writeResult({ ...appointment, confirmationState: 'contact_in_progress' }, 'confirmation_attempt')));
+    await first;
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    await harness.unmount();
+  });
+
+  it('retains confirmation operation key through ambiguous retry and exposes reconciliation', async () => {
+    const keys: string[] = [];
+    const confirm = vi.fn()
+      .mockImplementationOnce((_current: Appointment, _channel: string, _note: string, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        options.onRecoveryStateChange?.(true);
+        options.onRecoveryStateChange?.(false);
+        return Promise.reject(new AppointmentRepositoryError('generic', 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.', true));
+      })
+      .mockImplementationOnce((_current: Appointment, _channel: string, _note: string, options: AppointmentWriteOptions) => {
+        keys.push(options.operationKey);
+        return Promise.resolve(writeResult({ ...appointment, confirmationState: 'confirmed' }, 'confirm'));
+      });
+    repository.confirmAppointment = confirm;
+    const harness = await renderHook();
+
+    await act(async () => {
+      await expect(harness.getResult().confirmAppointment(appointment, 'phone', 'Confirmed')).rejects.toMatchObject({ ambiguous: true });
+    });
+    await act(async () => {
+      await expect(harness.getResult().confirmAppointment(appointment, 'phone', 'Confirmed')).resolves.toMatchObject({ operationType: 'confirm' });
+    });
+
+    expect(keys[1]).toBe(keys[0]);
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+    await harness.unmount();
+  });
+
+  it('clears confirmation key after definitive error and ignores stale tenant success', async () => {
+    const keys: string[] = [];
+    const save = deferred<ReturnType<typeof writeResult>>();
+    repository.recordConfirmationAttempt = vi.fn()
+      .mockImplementationOnce((_current, _channel, _outcome, _note, options) => {
+        keys.push(options.operationKey);
+        return Promise.reject(new AppointmentRepositoryError('channel_required', 'Выберите способ связи.'));
+      })
+      .mockImplementationOnce((_current, _channel, _outcome, _note, options) => {
+        keys.push(options.operationKey);
+        return save.promise;
+      });
+    const harness = await renderHook();
+
+    await act(async () => {
+      await expect(harness.getResult().recordConfirmationAttempt(appointment, 'phone', 'no_answer', 'Bad')).rejects.toThrow('Выберите способ связи');
+    });
+    let pending!: Promise<unknown>;
+    await act(async () => {
+      pending = harness.getResult().recordConfirmationAttempt(appointment, 'phone', 'no_answer', 'Corrected');
+      await Promise.resolve();
+    });
+    expect(keys[1]).not.toBe(keys[0]);
+    activeTenant = { tenantId: 'tenant-b' };
+    await harness.rerender();
+    await act(async () => save.resolve(writeResult({ ...appointment, confirmationState: 'contact_in_progress' }, 'confirmation_attempt')));
+    await expect(pending).resolves.toBeNull();
+    expect(refetchMock).not.toHaveBeenCalled();
     await harness.unmount();
   });
 

--- a/src/data/hooks/useScheduleAppointments.ts
+++ b/src/data/hooks/useScheduleAppointments.ts
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 import { useAsyncQuery } from './useAsyncQuery';
-import type { Appointment, CancellationSource } from '../../types';
+import type { Appointment, AppointmentConfirmationAttempt, AppointmentContactChannel, AppointmentContactOutcome, CancellationSource } from '../../types';
 import {
   AppointmentRepositoryError,
   createAppointmentRepository,
@@ -64,13 +64,15 @@ export function useScheduleAppointments() {
   });
   const [mutationAction, setMutationAction] = useState<{
     contextKey: string;
-    action: 'save' | 'cancel' | 'no_show' | null;
+    action: 'save' | 'cancel' | 'no_show' | 'confirmation_attempt' | 'confirm' | null;
   }>({ contextKey, action: null });
 
   const createAttemptRef = useRef<OperationAttempt | null>(null);
   const rescheduleAttemptRef = useRef<OperationAttempt | null>(null);
   const cancellationAttemptRef = useRef<OperationAttempt | null>(null);
   const noShowAttemptRef = useRef<OperationAttempt | null>(null);
+  const confirmationAttemptRef = useRef<OperationAttempt | null>(null);
+  const directConfirmationRef = useRef<OperationAttempt | null>(null);
   const inFlightRef = useRef<{
     contextKey: string;
     signature: string;
@@ -142,7 +144,7 @@ export function useScheduleAppointments() {
     signature: string,
     write: (onRecoveryStateChange: (recovering: boolean) => void) => Promise<AppointmentWriteResult>,
     attemptRef?: MutableRefObject<OperationAttempt | null>,
-    action: 'save' | 'cancel' | 'no_show' = 'save',
+    action: 'save' | 'cancel' | 'no_show' | 'confirmation_attempt' | 'confirm' = 'save',
   ): Promise<AppointmentWriteResult | null> => {
     const existing = inFlightRef.current;
     if (existing && existing.contextKey === contextKey) return existing.promise;
@@ -284,6 +286,47 @@ export function useScheduleAppointments() {
     );
   }, [contextKey, getOperationKey, requireRepository, runMutation]);
 
+  const recordConfirmationAttempt = useCallback((
+    current: Appointment,
+    channel: AppointmentContactChannel,
+    outcome: AppointmentContactOutcome,
+    note: string,
+  ) => {
+    const activeRepository = requireRepository();
+    const normalizedNote = note.trim();
+    const signature = `confirmation-attempt:${contextKey}:${current.id}:${current.updatedAt || ''}:${channel}:${outcome}:${normalizedNote}`;
+    const operationKey = getOperationKey(confirmationAttemptRef, signature);
+    return runMutation(
+      signature,
+      (onRecoveryStateChange) => activeRepository.recordConfirmationAttempt(current, channel, outcome, normalizedNote, {
+        operationKey,
+        onRecoveryStateChange,
+      }),
+      confirmationAttemptRef,
+      'confirmation_attempt',
+    );
+  }, [contextKey, getOperationKey, requireRepository, runMutation]);
+
+  const confirmAppointment = useCallback((
+    current: Appointment,
+    channel: AppointmentContactChannel,
+    note: string,
+  ) => {
+    const activeRepository = requireRepository();
+    const normalizedNote = note.trim();
+    const signature = `confirm:${contextKey}:${current.id}:${current.updatedAt || ''}:${channel}:${normalizedNote}`;
+    const operationKey = getOperationKey(directConfirmationRef, signature);
+    return runMutation(
+      signature,
+      (onRecoveryStateChange) => activeRepository.confirmAppointment(current, channel, normalizedNote, {
+        operationKey,
+        onRecoveryStateChange,
+      }),
+      directConfirmationRef,
+      'confirm',
+    );
+  }, [contextKey, getOperationKey, requireRepository, runMutation]);
+
   const deleteAppointment = useCallback(async (appointmentId: string): Promise<boolean> => {
     const activeRepository = requireRepository();
     const capturedContext = contextKey;
@@ -334,12 +377,55 @@ export function useScheduleAppointments() {
     isMarkingNoShow: actionForCurrentContext === 'no_show' && mutationForCurrentContext.isSaving,
     isLifecycleReconciling: (actionForCurrentContext === 'cancel' || actionForCurrentContext === 'no_show')
       && mutationForCurrentContext.isReconciling,
+    isRecordingConfirmationAttempt: actionForCurrentContext === 'confirmation_attempt' && mutationForCurrentContext.isSaving,
+    isConfirmingAppointment: actionForCurrentContext === 'confirm' && mutationForCurrentContext.isSaving,
+    isReconcilingConfirmation: (actionForCurrentContext === 'confirmation_attempt' || actionForCurrentContext === 'confirm')
+      && mutationForCurrentContext.isReconciling,
     saveError: mutationForCurrentContext.error,
     createAppointment,
     updateAppointment,
     cancelAppointment,
     markAppointmentNoShow,
+    recordConfirmationAttempt,
+    confirmAppointment,
     deleteAppointment,
     refetch,
+  };
+}
+
+
+export function useAppointmentConfirmationAttempts(appointmentId?: string) {
+  const { authMode, user } = useAuth();
+  const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
+  const contextKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${appointmentId || 'no-appointment'}`;
+  const repository = useMemo<IAppointmentRepository | null>(() => {
+    if (authMode === 'dev') return createAppointmentRepository({ backend: 'local' });
+    if (isSupabaseMode && user?.id && tenantId) return createAppointmentRepository({ backend: 'supabase', tenantId });
+    return null;
+  }, [authMode, isSupabaseMode, tenantId, user?.id]);
+  const enabled = Boolean(appointmentId) && (authMode === 'dev' || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId)));
+  const queryFn = useCallback(async (): Promise<AppointmentConfirmationAttempt[]> => {
+    if (!repository || !appointmentId) return [];
+    try {
+      return await repository.listConfirmationAttempts(appointmentId);
+    } catch {
+      throw new Error('Не удалось загрузить историю подтверждения.');
+    }
+  }, [appointmentId, repository]);
+  const query = useAsyncQuery<AppointmentConfirmationAttempt[]>({
+    queryFn,
+    initialData: [],
+    enabled,
+    queryKey: contextKey,
+    resetOnDisable: true,
+  });
+  return {
+    attempts: enabled ? query.data : [],
+    isLoading: enabled ? query.isLoading : false,
+    isError: enabled ? query.isError : false,
+    error: query.error,
+    refetch: query.refetch,
   };
 }

--- a/src/data/repositories/AppointmentRepository.test.ts
+++ b/src/data/repositories/AppointmentRepository.test.ts
@@ -62,7 +62,7 @@ const databaseRow = (overrides: Record<string, unknown> = {}) => ({
 });
 
 const rpcResult = (
-  operationType: 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' = 'create',
+  operationType: 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' | 'confirmation_attempt' | 'confirm' = 'create',
   overrides: Record<string, unknown> = {},
 ) => ({
   appointment: databaseRow(overrides),
@@ -496,6 +496,116 @@ describe('AppointmentRepository', () => {
     expect(finalEq).toHaveBeenCalledWith('id', appointmentId);
   });
 
+  it('records a confirmation attempt through tenant-scoped RPC and maps attempt metadata', async () => {
+    const { client, rpc } = createClient();
+    rpc.mockResolvedValue({
+      data: {
+        ...rpcResult('confirmation_attempt', {
+          confirmation_state: 'contact_in_progress',
+          confirmation_attempt_count: 1,
+          last_confirmation_outcome: 'no_answer',
+        }),
+        confirmationAttempt: {
+          id: 'attempt-1', tenant_id: tenantId, appointment_id: appointmentId, patient_id: patientId,
+          actor_user_id: 'actor-1', channel: 'phone', outcome: 'no_answer', note: 'Trimmed note',
+          attempted_at: '2026-08-01T09:30:00+00:00', operation_key: operationKey,
+          created_at: '2026-08-01T09:30:00+00:00',
+        },
+      },
+      error: null,
+    });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const result = await repository.recordConfirmationAttempt(appointment, 'phone', 'no_answer', '  Trimmed note  ', { operationKey });
+
+    expect(rpc).toHaveBeenCalledWith('record_appointment_confirmation_attempt', {
+      p_tenant_id: tenantId,
+      p_appointment_id: appointmentId,
+      p_channel: 'phone',
+      p_outcome: 'no_answer',
+      p_note: 'Trimmed note',
+      p_expected_updated_at: appointment.updatedAt,
+      p_operation_key: operationKey,
+    });
+    expect(result).toMatchObject({
+      operationType: 'confirmation_attempt',
+      appointment: { confirmationState: 'contact_in_progress', confirmationAttemptCount: 1, lastConfirmationOutcome: 'no_answer' },
+      confirmationAttempt: { id: 'attempt-1', channel: 'phone', outcome: 'no_answer', note: 'Trimmed note' },
+    });
+  });
+
+  it('confirms through confirm_appointment and preserves the operation key during recovery', async () => {
+    const { client, rpc } = createClient();
+    rpc
+      .mockResolvedValueOnce({ data: null, error: { message: 'Failed to fetch' } })
+      .mockResolvedValueOnce({
+        data: {
+          found: true,
+          operationType: 'confirm',
+          appointment: databaseRow({ confirmation_state: 'confirmed', confirmed_at: '2026-08-01T09:40:00+00:00', confirmed_by: 'actor-1', confirmation_channel: 'whatsapp', confirmation_attempt_count: 1 }),
+          confirmationAttempt: {
+            id: 'attempt-confirm', tenant_id: tenantId, appointment_id: appointmentId, patient_id: patientId,
+            actor_user_id: 'actor-1', channel: 'whatsapp', outcome: 'confirmed', note: null,
+            attempted_at: '2026-08-01T09:40:00+00:00', operation_key: operationKey,
+            created_at: '2026-08-01T09:40:00+00:00',
+          },
+          replayed: true,
+          recovered: true,
+        },
+        error: null,
+      });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+    const states: boolean[] = [];
+
+    const result = await repository.confirmAppointment(appointment, 'whatsapp', '', {
+      operationKey,
+      onRecoveryStateChange: (value) => states.push(value),
+    });
+
+    expect(rpc.mock.calls[0]).toEqual(['confirm_appointment', expect.objectContaining({ p_operation_key: operationKey })]);
+    expect(rpc.mock.calls[1]).toEqual(['get_appointment_operation', { p_tenant_id: tenantId, p_operation_key: operationKey }]);
+    expect(states).toEqual([true, false]);
+    expect(result).toMatchObject({ operationType: 'confirm', recovered: true, appointment: { confirmationState: 'confirmed' }, confirmationAttempt: { id: 'attempt-confirm' } });
+  });
+
+  it('reads confirmation attempt history with tenant and appointment scope', async () => {
+    const { client, from } = createClient();
+    const result = Promise.resolve({
+      data: [{
+        id: 'attempt-1', tenant_id: tenantId, appointment_id: appointmentId, patient_id: patientId,
+        actor_user_id: 'actor-1', channel: 'phone', outcome: 'callback_requested', note: 'After lunch',
+        attempted_at: '2026-08-01T09:30:00+00:00', operation_key: operationKey,
+        created_at: '2026-08-01T09:30:00+00:00',
+      }],
+      error: null,
+    });
+    const order = vi.fn().mockImplementation(() => Object.assign(result, { order }));
+    const secondEq = vi.fn().mockReturnValue({ order });
+    const firstEq = vi.fn().mockReturnValue({ eq: secondEq });
+    const select = vi.fn().mockReturnValue({ eq: firstEq });
+    from.mockReturnValue({ select });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const attempts = await repository.listConfirmationAttempts(appointmentId);
+
+    expect(from).toHaveBeenCalledWith('appointment_confirmation_attempts');
+    expect(firstEq).toHaveBeenCalledWith('tenant_id', tenantId);
+    expect(secondEq).toHaveBeenCalledWith('appointment_id', appointmentId);
+    expect(attempts[0]).toMatchObject({ id: 'attempt-1', channel: 'phone', outcome: 'callback_requested', note: 'After lunch' });
+  });
+
+  it.each([
+    ['Выберите способ связи.', 'channel_required', 'Выберите способ связи.'],
+    ['Выберите результат связи.', 'outcome_required', 'Выберите результат связи.'],
+    ['Запись уже подтверждена.', 'already_confirmed', 'Запись уже подтверждена.'],
+    ['Недостаточно прав для подтверждения записи.', 'permission', 'Недостаточно прав для подтверждения записи.'],
+  ])('maps confirmation error safely: %s', (rawMessage, code, safeMessage) => {
+    const mapped = toSafeAppointmentError({ message: rawMessage, details: 'SQLSTATE 42501 public.confirm_appointment' });
+    expect(mapped.code).toBe(code);
+    expect(mapped.message).toBe(safeMessage);
+    expect(mapped.message).not.toContain('SQLSTATE');
+  });
+
   it('source contains no protected direct INSERT/UPDATE, service role, or Supabase localStorage fallback', () => {
     const supabaseClass = repositorySource.slice(
       repositorySource.indexOf('export class SupabaseAppointmentRepository'),
@@ -511,6 +621,9 @@ describe('AppointmentRepository', () => {
     expect(supabaseClass).toContain("rpc('reschedule_appointment'");
     expect(supabaseClass).toContain("rpc('cancel_appointment'");
     expect(supabaseClass).toContain("rpc('mark_appointment_no_show'");
+    expect(supabaseClass).toContain("rpc('record_appointment_confirmation_attempt'");
+    expect(supabaseClass).toContain("rpc('confirm_appointment'");
+    expect(supabaseClass).toContain("from('appointment_confirmation_attempts'");
     expect(supabaseClass).toContain("rpc('get_appointment_operation'");
   });
 });

--- a/src/data/repositories/AppointmentRepository.ts
+++ b/src/data/repositories/AppointmentRepository.ts
@@ -1,10 +1,19 @@
-import type { Appointment, AppointmentStatus, CancellationSource, PaymentType, Source } from '../../types';
+import type {
+  Appointment,
+  AppointmentConfirmationAttempt,
+  AppointmentContactChannel,
+  AppointmentContactOutcome,
+  AppointmentStatus,
+  CancellationSource,
+  PaymentType,
+  Source,
+} from '../../types';
 import { compareAppointmentsByStartThenId } from '../../domain/appointmentSummary';
 import { storage } from '../../utils/storage';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-export type AppointmentOperationType = 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show';
+export type AppointmentOperationType = 'create' | 'reschedule' | 'details' | 'cancel' | 'no_show' | 'confirmation_attempt' | 'confirm';
 export type AppointmentRepositoryErrorCode =
   | 'doctor_conflict'
   | 'patient_conflict'
@@ -18,6 +27,9 @@ export type AppointmentRepositoryErrorCode =
   | 'invalid_transition'
   | 'reason_required'
   | 'source_required'
+  | 'channel_required'
+  | 'outcome_required'
+  | 'already_confirmed'
   | 'permission'
   | 'tenant_required'
   | 'schedule_read_failed'
@@ -43,6 +55,7 @@ export interface AppointmentWriteOptions {
 
 export interface AppointmentWriteResult {
   appointment: Appointment;
+  confirmationAttempt?: AppointmentConfirmationAttempt;
   replayed: boolean;
   recovered: boolean;
   operationType: AppointmentOperationType;
@@ -50,8 +63,9 @@ export interface AppointmentWriteResult {
 
 export interface AppointmentRecoveryResult {
   found: boolean;
-  operationType?: 'create' | 'reschedule' | 'cancel' | 'no_show';
+  operationType?: 'create' | 'reschedule' | 'cancel' | 'no_show' | 'confirmation_attempt' | 'confirm';
   appointment?: Appointment;
+  confirmationAttempt?: AppointmentConfirmationAttempt;
   replayed?: boolean;
   recovered?: boolean;
 }
@@ -64,6 +78,9 @@ export interface IAppointmentRepository {
   updateAppointmentDetails(current: Appointment, next: Appointment): Promise<AppointmentWriteResult>;
   cancelAppointment(current: Appointment, source: CancellationSource, reason: string, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
   markAppointmentNoShow(current: Appointment, reason: string, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
+  recordConfirmationAttempt(current: Appointment, channel: AppointmentContactChannel, outcome: AppointmentContactOutcome, note: string, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
+  confirmAppointment(current: Appointment, channel: AppointmentContactChannel, note: string, options: AppointmentWriteOptions): Promise<AppointmentWriteResult>;
+  listConfirmationAttempts(appointmentId: string): Promise<AppointmentConfirmationAttempt[]>;
   recoverAppointmentOperation(operationKey: string): Promise<AppointmentRecoveryResult>;
   deleteAppointment(appointmentId: string): Promise<void>;
 }
@@ -84,6 +101,12 @@ const genericSaveError = () => new AppointmentRepositoryError(
 const genericLifecycleError = () => new AppointmentRepositoryError(
   'generic',
   'Не удалось изменить статус записи. Обновите расписание и проверьте результат.',
+  true,
+);
+
+const genericConfirmationError = () => new AppointmentRepositoryError(
+  'generic',
+  'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.',
   true,
 );
 
@@ -141,6 +164,18 @@ export const toSafeAppointmentError = (error: unknown): AppointmentRepositoryErr
   }
   if (text.includes('укажите, кто отменил запись')) {
     return new AppointmentRepositoryError('source_required', 'Укажите, кто отменил запись.');
+  }
+  if (text.includes('выберите способ связи')) {
+    return new AppointmentRepositoryError('channel_required', 'Выберите способ связи.');
+  }
+  if (text.includes('выберите результат связи')) {
+    return new AppointmentRepositoryError('outcome_required', 'Выберите результат связи.');
+  }
+  if (text.includes('запись уже подтверждена')) {
+    return new AppointmentRepositoryError('already_confirmed', 'Запись уже подтверждена.');
+  }
+  if (text.includes('недостаточно прав для подтверждения записи')) {
+    return new AppointmentRepositoryError('permission', 'Недостаточно прав для подтверждения записи.');
   }
   if (text.includes('недостаточно прав для изменения записи') || text.includes('permission denied') || text.includes('42501')) {
     return new AppointmentRepositoryError('permission', 'Недостаточно прав для изменения записи.');
@@ -239,6 +274,35 @@ export const LocalStorageAppointmentRepository: IAppointmentRepository = {
     storage.updateAppointment(next);
     return localWriteResult(next, 'no_show');
   },
+
+  recordConfirmationAttempt: async (current, channel, outcome, note) => {
+    const timestamp = new Date().toISOString();
+    const state = outcome === 'confirmed' ? 'confirmed'
+      : outcome === 'callback_requested' ? 'callback_requested'
+      : ['unreachable', 'wrong_number', 'declined'].includes(outcome) ? 'unreachable'
+      : 'contact_in_progress';
+    const next: Appointment = {
+      ...current,
+      confirmationState: state,
+      confirmedAt: state === 'confirmed' ? timestamp : undefined,
+      confirmedBy: state === 'confirmed' ? 'local-user' : undefined,
+      confirmationChannel: state === 'confirmed' ? channel : undefined,
+      confirmationNote: state === 'confirmed' ? note.trim() || undefined : undefined,
+      lastConfirmationAttemptAt: timestamp,
+      confirmationAttemptCount: (current.confirmationAttemptCount || 0) + 1,
+      confirmationMetadataVersion: 1,
+      lastConfirmationOutcome: outcome,
+      lastConfirmationNote: note.trim() || undefined,
+    };
+    storage.updateAppointment(next);
+    return localWriteResult(next, outcome === 'confirmed' ? 'confirm' : 'confirmation_attempt');
+  },
+
+  confirmAppointment: async (current, channel, note) => LocalStorageAppointmentRepository.recordConfirmationAttempt(
+    current, channel, 'confirmed', note, { operationKey: crypto.randomUUID() },
+  ),
+
+  listConfirmationAttempts: async () => [],
 
   recoverAppointmentOperation: async (): Promise<AppointmentRecoveryResult> => ({ found: false }),
 
@@ -416,6 +480,62 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     }, genericLifecycleError);
   }
 
+  async recordConfirmationAttempt(
+    current: Appointment,
+    channel: AppointmentContactChannel,
+    outcome: AppointmentContactOutcome,
+    note: string,
+    options: AppointmentWriteOptions,
+  ): Promise<AppointmentWriteResult> {
+    if (!current.updatedAt) throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+    return this.executeRecoverableWrite(options, async () => {
+      const { data, error } = await this.client.rpc('record_appointment_confirmation_attempt', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: current.id,
+        p_channel: channel,
+        p_outcome: outcome,
+        p_note: note.trim() || null,
+        p_expected_updated_at: current.updatedAt,
+        p_operation_key: options.operationKey,
+      });
+      if (error) throw error;
+      return this.parseWriteResult(data, 'confirmation_attempt');
+    }, genericConfirmationError);
+  }
+
+  async confirmAppointment(
+    current: Appointment,
+    channel: AppointmentContactChannel,
+    note: string,
+    options: AppointmentWriteOptions,
+  ): Promise<AppointmentWriteResult> {
+    if (!current.updatedAt) throw new AppointmentRepositoryError('concurrent_change', 'Запись была изменена другим пользователем. Обновите расписание.');
+    return this.executeRecoverableWrite(options, async () => {
+      const { data, error } = await this.client.rpc('confirm_appointment', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: current.id,
+        p_channel: channel,
+        p_note: note.trim() || null,
+        p_expected_updated_at: current.updatedAt,
+        p_operation_key: options.operationKey,
+      });
+      if (error) throw error;
+      return this.parseWriteResult(data, 'confirm');
+    }, genericConfirmationError);
+  }
+
+  async listConfirmationAttempts(appointmentId: string): Promise<AppointmentConfirmationAttempt[]> {
+    const { data, error } = await this.client
+      .from('appointment_confirmation_attempts')
+      .select('*')
+      .eq('tenant_id', this.tenantId)
+      .eq('appointment_id', appointmentId)
+      .order('attempted_at', { ascending: false })
+      .order('id', { ascending: true });
+    if (error) throw toSafeAppointmentReadError('schedule');
+    return (data || []).map(this.mapToConfirmationAttempt);
+  }
+
   async recoverAppointmentOperation(operationKey: string): Promise<AppointmentRecoveryResult> {
     try {
       const { data, error } = await this.client.rpc('get_appointment_operation', {
@@ -435,8 +555,13 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
         operationType: payload.operationType === 'reschedule'
           || payload.operationType === 'cancel'
           || payload.operationType === 'no_show'
+          || payload.operationType === 'confirmation_attempt'
+          || payload.operationType === 'confirm'
           ? payload.operationType
           : 'create',
+        confirmationAttempt: payload.confirmationAttempt && typeof payload.confirmationAttempt === 'object'
+          ? this.mapToConfirmationAttempt(payload.confirmationAttempt as Record<string, unknown>)
+          : undefined,
         appointment: this.mapToAppointment(payload.appointment as Record<string, unknown>),
         replayed: payload.replayed === true,
         recovered: payload.recovered === true,
@@ -474,6 +599,7 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
         if (recovered.found && recovered.appointment && recovered.operationType) {
           return {
             appointment: recovered.appointment,
+            confirmationAttempt: recovered.confirmationAttempt,
             replayed: recovered.replayed === true,
             recovered: true,
             operationType: recovered.operationType,
@@ -501,11 +627,16 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
       || payload.operationType === 'details'
       || payload.operationType === 'cancel'
       || payload.operationType === 'no_show'
+      || payload.operationType === 'confirmation_attempt'
+      || payload.operationType === 'confirm'
       ? payload.operationType
       : fallbackType;
 
     return {
       appointment: this.mapToAppointment(payload.appointment as Record<string, unknown>),
+      confirmationAttempt: payload.confirmationAttempt && typeof payload.confirmationAttempt === 'object'
+        ? this.mapToConfirmationAttempt(payload.confirmationAttempt as Record<string, unknown>)
+        : undefined,
       replayed: payload.replayed === true,
       recovered: payload.recovered === true,
       operationType,
@@ -522,6 +653,20 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     if (!timeStr) return timeStr;
     return timeStr.replace(/(Z|[+-]\d{2}:\d{2})$/, '');
   }
+
+  private mapToConfirmationAttempt = (row: Record<string, unknown>): AppointmentConfirmationAttempt => ({
+    id: row.id as string,
+    tenantId: row.tenant_id as string,
+    appointmentId: (row.appointment_id as string) || undefined,
+    patientId: row.patient_id as string,
+    actorUserId: row.actor_user_id as string,
+    channel: row.channel as AppointmentContactChannel,
+    outcome: row.outcome as AppointmentContactOutcome,
+    note: (row.note as string) || undefined,
+    attemptedAt: this.normalizeTimeFromDb(row.attempted_at as string),
+    operationKey: (row.operation_key as string) || undefined,
+    createdAt: this.normalizeTimeFromDb(row.created_at as string),
+  });
 
   private mapToAppointment = (row: Record<string, unknown>): Appointment => ({
     id: row.id as string,
@@ -544,6 +689,16 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     lifecycleMetadataVersion: row.lifecycle_metadata_version !== null && row.lifecycle_metadata_version !== undefined
       ? Number(row.lifecycle_metadata_version)
       : undefined,
+    confirmationState: (row.confirmation_state as Appointment['confirmationState']) || 'unconfirmed',
+    confirmedAt: row.confirmed_at ? this.normalizeTimeFromDb(row.confirmed_at as string) : undefined,
+    confirmedBy: (row.confirmed_by as string) || undefined,
+    confirmationChannel: (row.confirmation_channel as AppointmentContactChannel) || undefined,
+    confirmationNote: (row.confirmation_note as string) || undefined,
+    lastConfirmationAttemptAt: row.last_confirmation_attempt_at ? this.normalizeTimeFromDb(row.last_confirmation_attempt_at as string) : undefined,
+    confirmationAttemptCount: row.confirmation_attempt_count !== null && row.confirmation_attempt_count !== undefined ? Number(row.confirmation_attempt_count) : 0,
+    confirmationMetadataVersion: row.confirmation_metadata_version !== null && row.confirmation_metadata_version !== undefined ? Number(row.confirmation_metadata_version) : 0,
+    lastConfirmationOutcome: (row.last_confirmation_outcome as AppointmentContactOutcome) || undefined,
+    lastConfirmationNote: (row.last_confirmation_note as string) || undefined,
     start: this.normalizeTimeFromDb(row.start_time as string),
     end: this.normalizeTimeFromDb(row.end_time as string),
     createdAt: this.normalizeTimeFromDb(row.created_at as string),

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -2,12 +2,13 @@ import { useState, useMemo } from 'react';
 import { ChevronLeft, ChevronRight, CheckSquare, Plus } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useScheduleContext } from '../hooks/useScheduleContext';
-import { useScheduleAppointments } from '../data/hooks/useScheduleAppointments';
+import { useAppointmentConfirmationAttempts, useScheduleAppointments } from '../data/hooks/useScheduleAppointments';
 import { useClinicDoctors } from '../data/hooks/useClinicDoctors';
 import { usePatientsCollection } from '../data/hooks/usePatientsCollection';
 import { AppointmentModal } from '../components/schedule/AppointmentModal';
 import { useTenant } from '../contexts/TenantContext';
-import type { Appointment, CancellationSource, Doctor, AppointmentStatus } from '../types';
+import type { Appointment, AppointmentContactChannel, AppointmentContactOutcome, CancellationSource, Doctor, AppointmentStatus } from '../types';
+import { appointmentNeedsConfirmationAttention, confirmationStateClassName, confirmationStateLabel } from '../components/schedule/appointmentConfirmation';
 
 const timeSlots = Array.from({ length: 23 }, (_, i) => {
   const hour = Math.floor(i / 2) + 9;
@@ -63,15 +64,28 @@ export function SchedulePage() {
     updateAppointment,
     cancelAppointment,
     markAppointmentNoShow,
+    recordConfirmationAttempt,
+    confirmAppointment,
     deleteAppointment,
     isSaving,
     isReconciling,
+    isRecordingConfirmationAttempt,
+    isConfirmingAppointment,
+    isReconcilingConfirmation,
     saveError,
   } = useScheduleAppointments();
   
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Partial<Appointment> | undefined>();
+  const [showConfirmationAttentionOnly, setShowConfirmationAttentionOnly] = useState(false);
   const { activeTenant } = useTenant();
+  const {
+    attempts: confirmationAttempts,
+    isLoading: isLoadingConfirmationAttempts,
+    isError: isConfirmationAttemptsError,
+    error: confirmationAttemptsError,
+    refetch: refetchConfirmationAttempts,
+  } = useAppointmentConfirmationAttempts(editingAppointment?.id);
 
   const { doctors: allDoctors } = useClinicDoctors();
   const { patients } = usePatientsCollection();
@@ -96,9 +110,14 @@ export function SchedulePage() {
       if (!a.start.startsWith(selectedDateStr)) return false;
       if (statusFilter && a.status !== statusFilter) return false;
       if (sourceFilter && a.source !== sourceFilter) return false;
+      if (showConfirmationAttentionOnly && !appointmentNeedsConfirmationAttention(a)) return false;
       return true;
     });
-  }, [appointments, selectedDateStr, statusFilter, sourceFilter]);
+  }, [appointments, selectedDateStr, statusFilter, sourceFilter, showConfirmationAttentionOnly]);
+
+  const confirmationAttentionCount = useMemo(() => appointments.filter((appointment) => (
+    appointment.start.startsWith(selectedDateStr) && appointmentNeedsConfirmationAttention(appointment)
+  )).length, [appointments, selectedDateStr]);
 
   const handleOpenModal = (doctor?: Doctor, timeSlot?: string) => {
     let initialData: Partial<Appointment> = {};
@@ -150,6 +169,37 @@ export function SchedulePage() {
     try {
       const result = await markAppointmentNoShow(appointment, reason);
       return result?.appointment || null;
+    } catch {
+      return null;
+    }
+  };
+
+  const handleRecordConfirmationAttempt = async (
+    appointment: Appointment,
+    channel: AppointmentContactChannel,
+    outcome: AppointmentContactOutcome,
+    note: string,
+  ): Promise<Appointment | null> => {
+    try {
+      const result = await recordConfirmationAttempt(appointment, channel, outcome, note);
+      if (!result) return null;
+      await refetchConfirmationAttempts();
+      return result.appointment;
+    } catch {
+      return null;
+    }
+  };
+
+  const handleConfirmAppointment = async (
+    appointment: Appointment,
+    channel: AppointmentContactChannel,
+    note: string,
+  ): Promise<Appointment | null> => {
+    try {
+      const result = await confirmAppointment(appointment, channel, note);
+      if (!result) return null;
+      await refetchConfirmationAttempts();
+      return result.appointment;
     } catch {
       return null;
     }
@@ -229,16 +279,20 @@ export function SchedulePage() {
             Задачи на сегодня
           </h3>
           <div className="space-y-2 overflow-y-auto pr-2">
-            {[
-              'Позвонить Петрову (перенос)',
-              'Заказать материалы',
-              'Подтвердить записи на завтра',
-            ].map((task, i) => (
-              <div key={i} className="flex items-start gap-2 text-sm text-slate-600 bg-slate-50 p-2 rounded-lg border border-slate-100">
-                <input type="checkbox" className="mt-0.5 rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
-                <span>{task}</span>
-              </div>
-            ))}
+            <button
+              type="button"
+              data-testid="schedule-confirmation-attention-filter"
+              onClick={() => setShowConfirmationAttentionOnly((current) => !current)}
+              className={clsx(
+                'w-full rounded-lg border p-3 text-left text-sm transition-colors',
+                showConfirmationAttentionOnly
+                  ? 'border-amber-400 bg-amber-50 text-amber-900'
+                  : 'border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100',
+              )}
+            >
+              <div className="font-semibold">Требуют подтверждения: {confirmationAttentionCount}</div>
+              <div className="mt-1 text-xs opacity-75">Не подтверждены, недоступны или просят перезвонить</div>
+            </button>
           </div>
         </div>
       </div>
@@ -310,6 +364,14 @@ export function SchedulePage() {
                           <span className="opacity-75 text-[10px]">{getStatusLabel(apt.status)}</span>
                         </div>
                         {apt.status !== 'blocked' && (
+                          <span
+                            data-testid={`schedule-confirmation-${apt.id}`}
+                            className={`mb-1 w-fit rounded border px-1.5 py-0.5 text-[9px] font-semibold ${confirmationStateClassName(apt.confirmationState)}`}
+                          >
+                            {confirmationStateLabel(apt.confirmationState)}
+                          </span>
+                        )}
+                        {apt.status !== 'blocked' && (
                           <>
                             <div className="truncate opacity-90">{apt.service}</div>
                             <div className="mt-auto flex justify-between items-end">
@@ -333,6 +395,14 @@ export function SchedulePage() {
         onSave={handleSaveAppointment}
         onCancel={handleCancelAppointment}
         onMarkNoShow={handleMarkNoShow}
+        onRecordConfirmationAttempt={handleRecordConfirmationAttempt}
+        onConfirmAppointment={handleConfirmAppointment}
+        confirmationAttempts={confirmationAttempts}
+        isLoadingConfirmationAttempts={isLoadingConfirmationAttempts}
+        confirmationAttemptsError={isConfirmationAttemptsError ? (confirmationAttemptsError?.message || 'Не удалось загрузить историю подтверждения.') : null}
+        isRecordingConfirmationAttempt={isRecordingConfirmationAttempt}
+        isConfirmingAppointment={isConfirmingAppointment}
+        isReconcilingConfirmation={isReconcilingConfirmation}
         onDelete={handleDeleteAppointment}
         role={activeTenant?.role}
         initialData={editingAppointment}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,9 @@
 
 export type AppointmentStatus = 'new' | 'confirmed' | 'arrived' | 'in_progress' | 'completed' | 'cancelled' | 'no_show' | 'blocked';
 export type CancellationSource = 'patient' | 'clinic' | 'doctor' | 'technical' | 'other';
+export type AppointmentConfirmationState = 'unconfirmed' | 'contact_in_progress' | 'confirmed' | 'unreachable' | 'callback_requested';
+export type AppointmentContactChannel = 'phone' | 'whatsapp' | 'sms' | 'email' | 'in_person' | 'other';
+export type AppointmentContactOutcome = 'confirmed' | 'no_answer' | 'unreachable' | 'callback_requested' | 'declined' | 'wrong_number' | 'message_sent' | 'other';
 export type PaymentType = 'cash' | 'card' | 'kaspi' | 'insurance' | 'installment' | 'unpaid';
 export type Source = 'phone' | 'whatsapp' | 'instagram' | 'walk_in' | 'repeat' | 'referral';
 
@@ -74,8 +77,32 @@ export interface Appointment {
   noShowBy?: string;
   noShowReason?: string;
   lifecycleMetadataVersion?: number;
+  confirmationState?: AppointmentConfirmationState;
+  confirmedAt?: string;
+  confirmedBy?: string;
+  confirmationChannel?: AppointmentContactChannel;
+  confirmationNote?: string;
+  lastConfirmationAttemptAt?: string;
+  confirmationAttemptCount?: number;
+  confirmationMetadataVersion?: number;
+  lastConfirmationOutcome?: AppointmentContactOutcome;
+  lastConfirmationNote?: string;
   createdAt: string;
   updatedAt?: string;
+}
+
+export interface AppointmentConfirmationAttempt {
+  id: string;
+  tenantId: string;
+  appointmentId?: string;
+  patientId: string;
+  actorUserId: string;
+  channel: AppointmentContactChannel;
+  outcome: AppointmentContactOutcome;
+  note?: string;
+  attemptedAt: string;
+  operationKey?: string;
+  createdAt: string;
 }
 
 export type ToothNumber =

--- a/supabase/migrations/0027_appointment_confirmation_workflow.sql
+++ b/supabase/migrations/0027_appointment_confirmation_workflow.sql
@@ -1,0 +1,507 @@
+-- 0027_appointment_confirmation_workflow.sql
+-- APPOINTMENT-CONFIRMATION-WORKFLOW-001
+-- Auditable, idempotent and tenant-safe appointment confirmation/contact workflow.
+
+DO $$
+DECLARE
+  v_rows bigint;
+  v_legacy_confirmed_status bigint;
+BEGIN
+  SELECT count(*) INTO v_rows FROM public.appointments;
+  SELECT count(*) INTO v_legacy_confirmed_status FROM public.appointments WHERE status = 'confirmed';
+  RAISE NOTICE 'APPOINTMENT-CONFIRMATION-WORKFLOW-001 existing rows=%, legacy status confirmed=%',
+    v_rows, v_legacy_confirmed_status;
+END;
+$$;
+
+ALTER TABLE public.appointments
+  ADD COLUMN confirmation_state text NOT NULL DEFAULT 'unconfirmed',
+  ADD COLUMN confirmed_at timestamptz,
+  ADD COLUMN confirmed_by uuid,
+  ADD COLUMN confirmation_channel text,
+  ADD COLUMN confirmation_note text,
+  ADD COLUMN last_confirmation_attempt_at timestamptz,
+  ADD COLUMN confirmation_attempt_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN confirmation_metadata_version integer NOT NULL DEFAULT 0,
+  ADD COLUMN last_confirmation_outcome text,
+  ADD COLUMN last_confirmation_note text;
+
+ALTER TABLE public.appointments
+  ADD CONSTRAINT appointments_confirmed_by_fk
+    FOREIGN KEY (confirmed_by) REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD CONSTRAINT appointments_confirmation_state_check
+    CHECK (confirmation_state IN ('unconfirmed', 'contact_in_progress', 'confirmed', 'unreachable', 'callback_requested')),
+  ADD CONSTRAINT appointments_confirmation_channel_check
+    CHECK (
+      confirmation_channel IS NULL
+      OR confirmation_channel IN ('phone', 'whatsapp', 'sms', 'email', 'in_person', 'other')
+    ),
+  ADD CONSTRAINT appointments_last_confirmation_outcome_check
+    CHECK (
+      last_confirmation_outcome IS NULL
+      OR last_confirmation_outcome IN (
+        'confirmed', 'no_answer', 'unreachable', 'callback_requested',
+        'declined', 'wrong_number', 'message_sent', 'other'
+      )
+    ),
+  ADD CONSTRAINT appointments_confirmation_attempt_count_check
+    CHECK (confirmation_attempt_count >= 0),
+  ADD CONSTRAINT appointments_confirmation_metadata_version_check
+    CHECK (confirmation_metadata_version IN (0, 1)),
+  ADD CONSTRAINT appointments_confirmation_metadata_check
+    CHECK (
+      (
+        confirmation_metadata_version = 0
+        AND confirmation_state = 'unconfirmed'
+        AND confirmation_attempt_count = 0
+        AND confirmed_at IS NULL
+        AND confirmed_by IS NULL
+        AND confirmation_channel IS NULL
+        AND confirmation_note IS NULL
+        AND last_confirmation_attempt_at IS NULL
+        AND last_confirmation_outcome IS NULL
+        AND last_confirmation_note IS NULL
+      )
+      OR
+      (
+        confirmation_metadata_version = 1
+        AND confirmation_attempt_count > 0
+        AND last_confirmation_attempt_at IS NOT NULL
+        AND last_confirmation_outcome IS NOT NULL
+        AND (
+          (
+            confirmation_state = 'confirmed'
+            AND confirmed_at IS NOT NULL
+            AND confirmed_by IS NOT NULL
+            AND confirmation_channel IS NOT NULL
+            AND last_confirmation_outcome = 'confirmed'
+          )
+          OR
+          (
+            confirmation_state <> 'confirmed'
+            AND confirmed_at IS NULL
+            AND confirmed_by IS NULL
+            AND confirmation_channel IS NULL
+            AND confirmation_note IS NULL
+          )
+        )
+      )
+    );
+
+CREATE INDEX idx_appointments_confirmation_attention
+  ON public.appointments (tenant_id, confirmation_state, start_time)
+  WHERE confirmation_state <> 'confirmed'
+    AND status IN ('new', 'confirmed');
+
+CREATE TABLE public.appointment_confirmation_attempts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL,
+  patient_id uuid NOT NULL,
+  actor_user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  channel text NOT NULL,
+  outcome text NOT NULL,
+  note text,
+  attempted_at timestamptz NOT NULL DEFAULT now(),
+  operation_key text NOT NULL,
+  fingerprint text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT appointment_confirmation_attempts_channel_check
+    CHECK (channel IN ('phone', 'whatsapp', 'sms', 'email', 'in_person', 'other')),
+  CONSTRAINT appointment_confirmation_attempts_outcome_check
+    CHECK (outcome IN (
+      'confirmed', 'no_answer', 'unreachable', 'callback_requested',
+      'declined', 'wrong_number', 'message_sent', 'other'
+    )),
+  CONSTRAINT appointment_confirmation_attempts_note_check
+    CHECK (note IS NULL OR (length(btrim(note)) > 0 AND length(note) <= 2000)),
+  CONSTRAINT appointment_confirmation_attempts_key_check
+    CHECK (
+      length(operation_key) BETWEEN 8 AND 160
+      AND operation_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+    ),
+  CONSTRAINT appointment_confirmation_attempts_fingerprint_check
+    CHECK (fingerprint ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT appointment_confirmation_attempts_tenant_key_key UNIQUE (tenant_id, operation_key),
+  CONSTRAINT appointment_confirmation_attempts_patient_fk
+    FOREIGN KEY (tenant_id, patient_id)
+    REFERENCES public.patients(tenant_id, id)
+    ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_appointment_confirmation_attempts_appointment
+  ON public.appointment_confirmation_attempts (tenant_id, appointment_id, attempted_at DESC, id ASC);
+CREATE INDEX idx_appointment_confirmation_attempts_patient
+  ON public.appointment_confirmation_attempts (tenant_id, patient_id, attempted_at DESC, id ASC);
+
+ALTER TABLE public.appointment_confirmation_attempts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Tenant members can read appointment confirmation attempts"
+  ON public.appointment_confirmation_attempts
+  FOR SELECT
+  TO authenticated
+  USING (tenant_id IN (SELECT public.get_user_tenants()));
+
+REVOKE ALL ON TABLE public.appointment_confirmation_attempts FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.appointment_confirmation_attempts TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.appointment_confirmation_attempts TO service_role;
+
+ALTER TABLE public.appointment_operations
+  DROP CONSTRAINT appointment_operations_operation_type_check;
+
+ALTER TABLE public.appointment_operations
+  ADD COLUMN confirmation_attempt_id uuid REFERENCES public.appointment_confirmation_attempts(id) ON DELETE SET NULL,
+  ADD COLUMN result_confirmation_attempt jsonb,
+  ADD CONSTRAINT appointment_operations_operation_type_check
+    CHECK (operation_type IN ('create', 'reschedule', 'cancel', 'no_show', 'confirmation_attempt', 'confirm')),
+  ADD CONSTRAINT appointment_operations_confirmation_result_check
+    CHECK (result_confirmation_attempt IS NULL OR jsonb_typeof(result_confirmation_attempt) = 'object');
+
+CREATE OR REPLACE FUNCTION public.appointment_confirmation_attempt_row_json(
+  p_attempt public.appointment_confirmation_attempts
+) RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT to_jsonb(p_attempt);
+$$;
+
+CREATE OR REPLACE FUNCTION public.apply_appointment_confirmation_action(
+  p_operation_type text,
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_channel text,
+  p_outcome text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET timezone = 'UTC'
+AS $confirmation_action$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_operation_type text := NULLIF(btrim(p_operation_type), '');
+  v_channel text := NULLIF(btrim(p_channel), '');
+  v_outcome text := NULLIF(btrim(p_outcome), '');
+  v_note text := NULLIF(btrim(p_note), '');
+  v_key text;
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_attempt public.appointment_confirmation_attempts%ROWTYPE;
+  v_next_state text;
+  v_now timestamptz := transaction_timestamp();
+  v_audit_id uuid;
+  v_action text;
+  v_title text;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для подтверждения записи.';
+  END IF;
+
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для подтверждения записи.';
+  END IF;
+
+  IF v_operation_type NOT IN ('confirmation_attempt', 'confirm') THEN
+    RAISE EXCEPTION 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.';
+  END IF;
+  IF v_channel IS NULL THEN
+    RAISE EXCEPTION 'Выберите способ связи.';
+  END IF;
+  IF v_channel NOT IN ('phone', 'whatsapp', 'sms', 'email', 'in_person', 'other') THEN
+    RAISE EXCEPTION 'Выберите способ связи.';
+  END IF;
+  IF v_outcome IS NULL THEN
+    RAISE EXCEPTION 'Выберите результат связи.';
+  END IF;
+  IF v_outcome NOT IN (
+    'confirmed', 'no_answer', 'unreachable', 'callback_requested',
+    'declined', 'wrong_number', 'message_sent', 'other'
+  ) THEN
+    RAISE EXCEPTION 'Выберите результат связи.';
+  END IF;
+  IF v_operation_type = 'confirm' AND v_outcome <> 'confirmed' THEN
+    RAISE EXCEPTION 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.';
+  END IF;
+  IF v_note IS NOT NULL AND length(v_note) > 2000 THEN
+    RAISE EXCEPTION 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.';
+  END IF;
+  IF p_expected_updated_at IS NULL THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', v_operation_type,
+    'tenantId', p_tenant_id,
+    'appointmentId', p_appointment_id,
+    'expectedUpdatedEpoch', extract(epoch FROM p_expected_updated_at),
+    'channel', v_channel,
+    'outcome', v_outcome,
+    'note', v_note
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0)
+  );
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF FOUND THEN
+    IF v_operation.operation_type <> v_operation_type OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже была выполнена с другими параметрами.';
+    END IF;
+    RETURN jsonb_build_object(
+      'appointment', v_operation.result_appointment,
+      'confirmationAttempt', v_operation.result_confirmation_attempt,
+      'replayed', true,
+      'recovered', false,
+      'operationType', v_operation_type
+    );
+  END IF;
+
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для подтверждения записи.';
+  END IF;
+  IF v_before.status NOT IN ('new', 'confirmed') THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+  IF v_before.confirmation_state = 'confirmed' THEN
+    RAISE EXCEPTION 'Запись уже подтверждена.';
+  END IF;
+  IF v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.';
+  END IF;
+  IF v_before.patient_id IS NULL THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.';
+  END IF;
+
+  v_next_state := CASE v_outcome
+    WHEN 'confirmed' THEN 'confirmed'
+    WHEN 'callback_requested' THEN 'callback_requested'
+    WHEN 'unreachable' THEN 'unreachable'
+    WHEN 'wrong_number' THEN 'unreachable'
+    WHEN 'declined' THEN 'unreachable'
+    ELSE 'contact_in_progress'
+  END;
+
+  INSERT INTO public.appointment_confirmation_attempts (
+    tenant_id, appointment_id, patient_id, actor_user_id,
+    channel, outcome, note, attempted_at, operation_key, fingerprint
+  ) VALUES (
+    p_tenant_id, p_appointment_id, v_before.patient_id, v_actor,
+    v_channel, v_outcome, v_note, v_now, v_key, v_fingerprint
+  )
+  RETURNING * INTO v_attempt;
+
+  UPDATE public.appointments
+  SET confirmation_state = v_next_state,
+      confirmed_at = CASE WHEN v_next_state = 'confirmed' THEN v_now ELSE NULL END,
+      confirmed_by = CASE WHEN v_next_state = 'confirmed' THEN v_actor ELSE NULL END,
+      confirmation_channel = CASE WHEN v_next_state = 'confirmed' THEN v_channel ELSE NULL END,
+      confirmation_note = CASE WHEN v_next_state = 'confirmed' THEN v_note ELSE NULL END,
+      last_confirmation_attempt_at = v_now,
+      confirmation_attempt_count = confirmation_attempt_count + 1,
+      confirmation_metadata_version = 1,
+      last_confirmation_outcome = v_outcome,
+      last_confirmation_note = v_note
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  v_action := CASE WHEN v_outcome = 'confirmed'
+    THEN 'appointment_confirmed'
+    ELSE 'appointment_confirmation_attempted'
+  END;
+  v_title := CASE WHEN v_outcome = 'confirmed'
+    THEN 'Запись подтверждена'
+    ELSE 'Зафиксирована попытка связи'
+  END;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => v_action,
+    p_category => 'appointment',
+    p_target_type => 'appointment',
+    p_target_id => p_appointment_id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_actor_role,
+    p_patient_id => v_before.patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_before_data => jsonb_build_object(
+      'confirmationState', v_before.confirmation_state,
+      'confirmationAttemptCount', v_before.confirmation_attempt_count,
+      'updatedAt', v_before.updated_at
+    ),
+    p_after_data => jsonb_build_object(
+      'confirmationState', v_after.confirmation_state,
+      'confirmationAttemptCount', v_after.confirmation_attempt_count,
+      'lastConfirmationAttemptAt', v_after.last_confirmation_attempt_at,
+      'confirmedAt', v_after.confirmed_at,
+      'confirmedBy', v_after.confirmed_by,
+      'confirmationChannel', v_after.confirmation_channel
+    ),
+    p_request_id => v_key,
+    p_metadata => jsonb_build_object(
+      'operationKey', v_key,
+      'confirmationAttemptId', v_attempt.id,
+      'channel', v_channel,
+      'outcome', v_outcome,
+      'previousConfirmationState', v_before.confirmation_state,
+      'newConfirmationState', v_after.confirmation_state,
+      'replayed', false
+    )
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'appointment',
+    p_type => v_action,
+    p_title => v_title,
+    p_source_type => 'appointment',
+    p_source_id => p_appointment_id::text,
+    p_patient_id => v_before.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_source_status => v_after.status,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_appointment_id,
+      'confirmationAttemptId', v_attempt.id,
+      'channel', v_channel,
+      'outcome', v_outcome,
+      'previousConfirmationState', v_before.confirmation_state,
+      'newConfirmationState', v_after.confirmation_state,
+      'operationKey', v_key,
+      'replayed', false
+    )
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id, confirmation_attempt_id, result_confirmation_attempt
+  ) VALUES (
+    p_tenant_id, v_key, v_operation_type, v_fingerprint, p_appointment_id,
+    v_before.patient_id, v_before.doctor_id, v_before.start_time, v_before.end_time, v_after.status,
+    public.appointment_row_json(v_after), v_actor, v_attempt.id,
+    public.appointment_confirmation_attempt_row_json(v_attempt)
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'confirmationAttempt', public.appointment_confirmation_attempt_row_json(v_attempt),
+    'replayed', false,
+    'recovered', false,
+    'operationType', v_operation_type
+  );
+END;
+$confirmation_action$;
+
+CREATE OR REPLACE FUNCTION public.record_appointment_confirmation_attempt(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_channel text,
+  p_outcome text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT public.apply_appointment_confirmation_action(
+    'confirmation_attempt', p_tenant_id, p_appointment_id,
+    p_channel, p_outcome, p_note, p_expected_updated_at, p_operation_key
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.confirm_appointment(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_channel text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT public.apply_appointment_confirmation_action(
+    'confirm', p_tenant_id, p_appointment_id,
+    p_channel, 'confirmed', p_note, p_expected_updated_at, p_operation_key
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_appointment_operation(
+  p_tenant_id uuid,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_key text;
+  v_operation public.appointment_operations%ROWTYPE;
+BEGIN
+  IF v_actor IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.tenant_users tu
+    WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor
+  ) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('found', false);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'found', true,
+    'operationType', v_operation.operation_type,
+    'appointment', v_operation.result_appointment,
+    'confirmationAttempt', v_operation.result_confirmation_attempt,
+    'replayed', true,
+    'recovered', true
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.appointment_confirmation_attempt_row_json(public.appointment_confirmation_attempts) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_appointment_confirmation_action(text,uuid,uuid,text,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.record_appointment_confirmation_attempt(uuid,uuid,text,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.confirm_appointment(uuid,uuid,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.record_appointment_confirmation_attempt(uuid,uuid,text,text,text,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.confirm_appointment(uuid,uuid,text,text,timestamptz,text) TO authenticated, service_role;

--- a/supabase/tests/0027_appointment_confirmation_workflow_concurrency.ps1
+++ b/supabase/tests/0027_appointment_confirmation_workflow_concurrency.ps1
@@ -1,0 +1,259 @@
+$ErrorActionPreference = 'Stop'
+
+# APPOINTMENT-CONFIRMATION-WORKFLOW-001 local-only concurrency validation.
+$container = (docker ps --format '{{.Names}}' | Where-Object { $_ -like 'supabase_db_*' } | Select-Object -First 1)
+if (-not $container) { throw 'Local Supabase DB container is not running.' }
+
+$tenantA = 'c2710000-0000-4000-8000-000000000001'
+$tenantB = 'c2710000-0000-4000-8000-000000000002'
+$adminA = 'c2720000-0000-4000-8000-000000000001'
+$adminB = 'c2720000-0000-4000-8000-000000000002'
+$patientA1 = 'c2730000-0000-4000-8000-000000000001'
+$patientA2 = 'c2730000-0000-4000-8000-000000000002'
+$patientB1 = 'c2730000-0000-4000-8000-000000000003'
+$doctorA1 = 'c2740000-0000-4000-8000-000000000001'
+$doctorA2 = 'c2740000-0000-4000-8000-000000000002'
+$doctorB1 = 'c2740000-0000-4000-8000-000000000003'
+
+$ids = @{
+  A = 'c2750000-0000-4000-8000-000000000001'
+  B = 'c2750000-0000-4000-8000-000000000002'
+  C = 'c2750000-0000-4000-8000-000000000003'
+  D = 'c2750000-0000-4000-8000-000000000004'
+  E = 'c2750000-0000-4000-8000-000000000005'
+  F = 'c2750000-0000-4000-8000-000000000006'
+  G = 'c2750000-0000-4000-8000-000000000007'
+  HA = 'c2750000-0000-4000-8000-000000000008'
+  HB = 'c2750000-0000-4000-8000-000000000009'
+  I = 'c2750000-0000-4000-8000-000000000010'
+}
+
+function Invoke-Sql([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "SQL failed:`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return (($output | Where-Object { $_ -ne $null -and $_.ToString().Trim() -ne '' } | Select-Object -Last 1).ToString().Trim())
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function AuthContext([string]$userId) {
+  return "BEGIN; SET LOCAL ROLE authenticated; SET LOCAL `"request.jwt.claim.sub`"='$userId'; "
+}
+
+function AttemptSql([string]$userId, [string]$tenantId, [string]$appointmentId, [string]$channel, [string]$outcome, [string]$note, [string]$expected, [string]$key) {
+  return (AuthContext $userId) + "SELECT (r->>'operationType') || '|' || (r->>'replayed') || '|' || (r#>>'{confirmationAttempt,id}') FROM (SELECT public.record_appointment_confirmation_attempt('$tenantId','$appointmentId','$channel','$outcome','$note','$expected','$key') r) q; COMMIT;"
+}
+
+function ConfirmSql([string]$userId, [string]$tenantId, [string]$appointmentId, [string]$channel, [string]$note, [string]$expected, [string]$key) {
+  return (AuthContext $userId) + "SELECT (r->>'operationType') || '|' || (r->>'replayed') || '|' || (r#>>'{confirmationAttempt,id}') FROM (SELECT public.confirm_appointment('$tenantId','$appointmentId','$channel','$note','$expected','$key') r) q; COMMIT;"
+}
+
+function CancelSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.cancel_appointment('$tenantA','$appointmentId','patient','Concurrent cancellation','$expected','$key') r) q; COMMIT;"
+}
+
+function NoShowSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.mark_appointment_no_show('$tenantA','$appointmentId','Concurrent no-show','$expected','$key') r) q; COMMIT;"
+}
+
+function RescheduleSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.reschedule_appointment('$tenantA','$appointmentId','$patientA1','$doctorA2','2027-01-06 10:00+00','2027-01-06 11:00+00','QA','Concurrent move','new','unpaid','phone',1,null,'$expected','$key') r) q; COMMIT;"
+}
+
+function Count-Success([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 }).Count }
+function Count-Conflict([object[]]$results) { return @($results | Where-Object { $_.Code -ne 0 }).Count }
+function Count-Replay([object[]]$results) { return @($results | Where-Object { $_.Text -match '\|true\|' }).Count }
+function Count-Deadlocks([object[]]$results) { return @($results | Where-Object { $_.Text -match 'deadlock detected' }).Count }
+
+function Assert-OneWinner([object[]]$results, [string]$name) {
+  $success = Count-Success $results
+  $conflict = Count-Conflict $results
+  if ($success -ne 1 -or $conflict -ne 1) {
+    throw "$name expected one success and one controlled conflict; success=$success conflict=$conflict outputs=$($results.Text -join ' || ')"
+  }
+}
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id IN ('$tenantA'::uuid,'$tenantB'::uuid);
+DELETE FROM auth.users WHERE id IN ('$adminA'::uuid,'$adminB'::uuid);
+"@
+
+$setupAppointments = @(
+  @($ids.A,$tenantA,$patientA1,$doctorA1,'2027-01-01 08:00+00','2027-01-01 09:00+00'),
+  @($ids.B,$tenantA,$patientA1,$doctorA1,'2027-01-02 08:00+00','2027-01-02 09:00+00'),
+  @($ids.C,$tenantA,$patientA1,$doctorA1,'2027-01-03 08:00+00','2027-01-03 09:00+00'),
+  @($ids.D,$tenantA,$patientA1,$doctorA1,'2027-01-04 08:00+00','2027-01-04 09:00+00'),
+  @($ids.E,$tenantA,$patientA1,$doctorA1,'2027-01-05 08:00+00','2027-01-05 09:00+00'),
+  @($ids.F,$tenantA,$patientA1,$doctorA1,'2027-01-06 08:00+00','2027-01-06 09:00+00'),
+  @($ids.G,$tenantA,$patientA1,$doctorA1,'2027-01-07 08:00+00','2027-01-07 09:00+00'),
+  @($ids.HA,$tenantA,$patientA1,$doctorA2,'2027-01-08 08:00+00','2027-01-08 09:00+00'),
+  @($ids.HB,$tenantB,$patientB1,$doctorB1,'2027-01-08 08:00+00','2027-01-08 09:00+00'),
+  @($ids.I,$tenantA,$patientA2,$doctorA2,'2027-01-09 08:00+00','2027-01-09 09:00+00')
+)
+$appointmentValues = ($setupAppointments | ForEach-Object { "('$($_[0])','$($_[1])','$($_[2])','$($_[3])','QA','Confirmation $($_[0])','new','unpaid','phone',1,'$($_[4])','$($_[5])')" }) -join ",`n"
+
+$setup = @"
+BEGIN;
+$cleanup
+INSERT INTO public.tenants(id,name) VALUES ('$tenantA','ACW concurrency A'),('$tenantB','ACW concurrency B');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+ ('$adminA','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-concurrency-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+ ('$adminB','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-concurrency-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$adminA'),('$adminB');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES ('$tenantA','$adminA','clinic_admin'),('$tenantB','$adminB','clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status) VALUES
+ ('$patientA1','$tenantA','ACW Concurrent A1','+77002711001','phone','active'),
+ ('$patientA2','$tenantA','ACW Concurrent A2','+77002711002','phone','active'),
+ ('$patientB1','$tenantB','ACW Concurrent B1','+77002711003','phone','active');
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+ ('$doctorA1','$tenantA','ACW Doctor A1','General','A1','#111111',true),
+ ('$doctorA2','$tenantA','ACW Doctor A2','General','A2','#222222',true),
+ ('$doctorB1','$tenantB','ACW Doctor B1','General','B1','#333333',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,payment_type,source,price,start_time,end_time) VALUES
+$appointmentValues;
+COMMIT;
+"@
+
+$allResults = @()
+$totalSuccess = 0
+$totalReplay = 0
+$totalConflict = 0
+
+try {
+  Invoke-Sql $setup | Out-Null
+  $updated = @{}
+  foreach ($name in $ids.Keys) { $updated[$name] = Invoke-Scalar "select updated_at from public.appointments where id='$($ids[$name])'" }
+
+  # A. Same attempt key and payload: one logical attempt, both callers receive it.
+  $aSql = AttemptSql $adminA $tenantA $ids.A 'phone' 'no_answer' 'Same attempt' $updated.A 'acw-conc-a-same'
+  $a = @(Invoke-ConcurrentPair $aSql $aSql); $allResults += $a
+  if ((Count-Success $a) -ne 2 -or (Count-Replay $a) -ne 1) { throw "A replay failed: $($a.Text -join ' || ')" }
+  $totalSuccess += 2; $totalReplay += 1
+  Write-Output "A_SAME_ATTEMPT_KEY success=2 replay=$(Count-Replay $a)"
+
+  # B. Same key with different outcomes: one success, one idempotency conflict.
+  $b = @(Invoke-ConcurrentPair `
+    (AttemptSql $adminA $tenantA $ids.B 'phone' 'no_answer' 'Outcome one' $updated.B 'acw-conc-b-conflict') `
+    (AttemptSql $adminA $tenantA $ids.B 'phone' 'callback_requested' 'Outcome two' $updated.B 'acw-conc-b-conflict'))
+  $allResults += $b; Assert-OneWinner $b 'B changed attempt outcome'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output 'B_CHANGED_OUTCOME success=1 conflict=1'
+
+  # C. Different keys with one expected version: optimistic locking intentionally allows one.
+  $c = @(Invoke-ConcurrentPair `
+    (AttemptSql $adminA $tenantA $ids.C 'phone' 'no_answer' 'First operator' $updated.C 'acw-conc-c-one') `
+    (AttemptSql $adminA $tenantA $ids.C 'whatsapp' 'message_sent' 'Second operator' $updated.C 'acw-conc-c-two'))
+  $allResults += $c; Assert-OneWinner $c 'C different attempt keys'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output 'C_DIFFERENT_ATTEMPTS success=1 conflict=1'
+
+  # D. Confirmation versus cancellation: exactly one lifecycle action wins.
+  $d = @(Invoke-ConcurrentPair `
+    (ConfirmSql $adminA $tenantA $ids.D 'phone' 'Confirm race' $updated.D 'acw-conc-d-confirm') `
+    (CancelSql $ids.D $updated.D 'acw-conc-d-cancel'))
+  $allResults += $d; Assert-OneWinner $d 'D confirm versus cancel'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "D_CONFIRM_VS_CANCEL success=1 conflict=1 final=$(Invoke-Scalar "select status||'|'||confirmation_state from public.appointments where id='$($ids.D)'")"
+
+  # E. Confirmation versus no-show: exactly one wins.
+  $e = @(Invoke-ConcurrentPair `
+    (ConfirmSql $adminA $tenantA $ids.E 'whatsapp' 'Confirm race' $updated.E 'acw-conc-e-confirm') `
+    (NoShowSql $ids.E $updated.E 'acw-conc-e-noshow'))
+  $allResults += $e; Assert-OneWinner $e 'E confirm versus no-show'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "E_CONFIRM_VS_NOSHOW success=1 conflict=1 final=$(Invoke-Scalar "select status||'|'||confirmation_state from public.appointments where id='$($ids.E)'")"
+
+  # F. Confirmation versus reschedule: no lost update.
+  $f = @(Invoke-ConcurrentPair `
+    (ConfirmSql $adminA $tenantA $ids.F 'phone' 'Confirm while moving' $updated.F 'acw-conc-f-confirm') `
+    (RescheduleSql $ids.F $updated.F 'acw-conc-f-reschedule'))
+  $allResults += $f; Assert-OneWinner $f 'F confirm versus reschedule'
+  $totalSuccess += 1; $totalConflict += 1
+  Write-Output "F_CONFIRM_VS_RESCHEDULE success=1 conflict=1 final=$(Invoke-Scalar "select start_time||'|'||confirmation_state from public.appointments where id='$($ids.F)'")"
+
+  # G. Duplicate direct confirm with same key: one logical confirmation.
+  $gSql = ConfirmSql $adminA $tenantA $ids.G 'whatsapp' 'Same confirmation' $updated.G 'acw-conc-g-same'
+  $g = @(Invoke-ConcurrentPair $gSql $gSql); $allResults += $g
+  if ((Count-Success $g) -ne 2 -or (Count-Replay $g) -ne 1) { throw "G replay failed: $($g.Text -join ' || ')" }
+  $totalSuccess += 2; $totalReplay += 1
+  Write-Output "G_DUPLICATE_CONFIRM success=2 replay=$(Count-Replay $g)"
+
+  # H. Same key in different tenants is independent.
+  $h = @(Invoke-ConcurrentPair `
+    (ConfirmSql $adminA $tenantA $ids.HA 'phone' 'Tenant A' $updated.HA 'acw-conc-h-same') `
+    (ConfirmSql $adminB $tenantB $ids.HB 'phone' 'Tenant B' $updated.HB 'acw-conc-h-same'))
+  $allResults += $h
+  if ((Count-Success $h) -ne 2) { throw "H tenant isolation failed: $($h.Text -join ' || ')" }
+  $totalSuccess += 2
+  Write-Output "H_TENANT_ISOLATION success=2 operationRows=$(Invoke-Scalar "select count(*) from public.appointment_operations where operation_key='acw-conc-h-same'")"
+
+  # I. A stale expected version is rejected after one successful attempt.
+  $iFirst = AttemptSql $adminA $tenantA $ids.I 'phone' 'no_answer' 'Fresh version' $updated.I 'acw-conc-i-first'
+  $iResult = @(Invoke-ConcurrentPair $iFirst ((AuthContext $adminA) + 'SELECT 1; COMMIT;'))
+  $allResults += $iResult
+  if ((Count-Success $iResult) -ne 2) { throw 'I setup attempt failed' }
+  $staleSql = ConfirmSql $adminA $tenantA $ids.I 'phone' 'Stale version' $updated.I 'acw-conc-i-stale'
+  $stale = @(Invoke-ConcurrentPair $staleSql $staleSql); $allResults += $stale
+  if ((Count-Success $stale) -ne 0 -or (Count-Conflict $stale) -ne 2) { throw "I stale version should fail twice: $($stale.Text -join ' || ')" }
+  $totalSuccess += 1; $totalConflict += 2
+  Write-Output 'I_STALE_VERSION success=0 conflict=2'
+
+  $deadlocks = Count-Deadlocks $allResults
+  $attemptRows = [int](Invoke-Scalar "select count(*) from public.appointment_confirmation_attempts where tenant_id in ('$tenantA','$tenantB') and operation_key like 'acw-conc-%'")
+  $confirmationRows = [int](Invoke-Scalar "select count(*) from public.appointment_confirmation_attempts where tenant_id in ('$tenantA','$tenantB') and operation_key like 'acw-conc-%' and outcome='confirmed'")
+  $operationRows = [int](Invoke-Scalar "select count(*) from public.appointment_operations where tenant_id in ('$tenantA','$tenantB') and operation_type in ('confirmation_attempt','confirm') and operation_key like 'acw-conc-%'")
+  $auditCount = [int](Invoke-Scalar "select count(*) from public.audit_events where tenant_id in ('$tenantA','$tenantB') and request_id like 'acw-conc-%' and action in ('appointment_confirmation_attempted','appointment_confirmed')")
+  $activityCount = [int](Invoke-Scalar "select count(*) from public.activity_events where tenant_id in ('$tenantA','$tenantB') and metadata->>'operationKey' like 'acw-conc-%' and type in ('appointment_confirmation_attempted','appointment_confirmed')")
+  $duplicateKeys = [int](Invoke-Scalar "select count(*) from (select tenant_id,operation_key,count(*) c from public.appointment_operations where operation_key like 'acw-conc-%' group by tenant_id,operation_key having count(*)>1) q")
+
+  if ($attemptRows -ne $operationRows -or $operationRows -ne $auditCount -or $auditCount -ne $activityCount) {
+    throw "Confirmation totals differ attempts=$attemptRows operations=$operationRows audit=$auditCount activity=$activityCount"
+  }
+  if ($duplicateKeys -ne 0) { throw "Duplicate tenant operation keys remain: $duplicateKeys" }
+  if ($deadlocks -ne 0) { throw "Deadlocks detected: $deadlocks" }
+
+  Write-Output "FINAL successCount=$totalSuccess replayCount=$totalReplay conflictCount=$totalConflict attempts=$attemptRows confirmations=$confirmationRows operations=$operationRows audit=$auditCount activity=$activityCount duplicateKeys=$duplicateKeys deadlocks=$deadlocks"
+  Write-Output 'APPOINTMENT-CONFIRMATION-WORKFLOW-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remaining = Invoke-Scalar "select (select count(*) from public.tenants where id in ('$tenantA','$tenantB')) + (select count(*) from auth.users where id in ('$adminA','$adminB'))"
+  if ([int]$remaining -ne 0) { throw "Concurrency cleanup failed: remaining=$remaining" }
+}

--- a/supabase/tests/0027_appointment_confirmation_workflow_test.sql
+++ b/supabase/tests/0027_appointment_confirmation_workflow_test.sql
@@ -1,0 +1,274 @@
+\set ON_ERROR_STOP on
+\echo 'APPOINTMENT-CONFIRMATION-WORKFLOW-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+\set tenant_a 'a2710000-0000-4000-8000-000000000001'
+\set tenant_b 'b2710000-0000-4000-8000-000000000001'
+\set owner_a 'a2720000-0000-4000-8000-000000000001'
+\set admin_a 'a2720000-0000-4000-8000-000000000002'
+\set registrar_a 'a2720000-0000-4000-8000-000000000003'
+\set doctor_user_a 'a2720000-0000-4000-8000-000000000004'
+\set cashier_a 'a2720000-0000-4000-8000-000000000005'
+\set no_tenant 'a2720000-0000-4000-8000-000000000006'
+\set unknown_user 'a2720000-0000-4000-8000-000000000007'
+\set admin_b 'b2720000-0000-4000-8000-000000000001'
+\set patient_a1 'a2730000-0000-4000-8000-000000000001'
+\set patient_a2 'a2730000-0000-4000-8000-000000000002'
+\set patient_a3 'a2730000-0000-4000-8000-000000000003'
+\set patient_b1 'b2730000-0000-4000-8000-000000000001'
+\set doctor_a1 'a2740000-0000-4000-8000-000000000001'
+\set doctor_a2 'a2740000-0000-4000-8000-000000000002'
+\set doctor_b1 'b2740000-0000-4000-8000-000000000001'
+\set legacy_confirmed 'a2750000-0000-4000-8000-000000000001'
+
+INSERT INTO public.tenants(id,name) VALUES
+  (:'tenant_a','Appointment confirmation A'),
+  (:'tenant_b','Appointment confirmation B');
+
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+  (:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-owner@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-admin@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-registrar@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'doctor_user_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-doctor@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-cashier@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'no_tenant','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-notenant@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'unknown_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-unknown@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','acw-admin-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id,first_name,last_name) VALUES
+  (:'owner_a','Owner','A'),(:'admin_a','Admin','A'),(:'registrar_a','Registrar','A'),
+  (:'doctor_user_a','Doctor','A'),(:'cashier_a','Cashier','A'),(:'no_tenant','No','Tenant'),
+  (:'unknown_user','Unknown','User'),(:'admin_b','Admin','B');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+  (:'tenant_a',:'owner_a','clinic_owner'),
+  (:'tenant_a',:'admin_a','clinic_admin'),
+  (:'tenant_a',:'registrar_a','registrar'),
+  (:'tenant_a',:'doctor_user_a','doctor'),
+  (:'tenant_a',:'cashier_a','cashier'),
+  (:'tenant_b',:'admin_b','clinic_admin');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+  (:'patient_a1',:'tenant_a','ACW Patient A1','+77002710001','phone','active',321),
+  (:'patient_a2',:'tenant_a','ACW Patient A2','+77002710002','phone','active',654),
+  (:'patient_a3',:'tenant_a','ACW Patient A3','+77002710003','phone','active',987),
+  (:'patient_b1',:'tenant_b','ACW Patient B1','+77002710004','phone','active',111);
+
+INSERT INTO public.doctors(id,tenant_id,user_id,full_name,specialization,cabinet,color,active) VALUES
+  (:'doctor_a1',:'tenant_a',:'doctor_user_a','ACW Doctor A1','General','A1','#111111',true),
+  (:'doctor_a2',:'tenant_a',NULL,'ACW Doctor A2','Surgery','A2','#222222',true),
+  (:'doctor_b1',:'tenant_b',NULL,'ACW Doctor B1','General','B1','#333333',true);
+
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS plans_before FROM public.treatment_plans \gset
+SELECT count(*)::text AS findings_before FROM public.findings \gset
+SELECT count(*)::text AS charts_before FROM public.dental_charts \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments \gset
+SELECT count(*)::text AS documents_before FROM public.documents \gset
+SELECT balance::text AS balance_a1_before FROM public.patients WHERE id=:'patient_a1' \gset
+SELECT balance::text AS balance_a2_before FROM public.patients WHERE id=:'patient_a2' \gset
+
+-- Historical compatibility: status=confirmed is not treated as audited confirmation.
+SET LOCAL ROLE service_role;
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time)
+VALUES (:'legacy_confirmed',:'tenant_a',:'patient_a1',:'doctor_a1','A1','Legacy confirmed status','confirmed','2026-12-01 08:00+00','2026-12-01 09:00+00');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT status='confirmed' AND confirmation_state='unconfirmed' AND confirmation_metadata_version=0 AND confirmation_attempt_count=0 AND confirmed_at IS NULL AND confirmed_by IS NULL FROM public.appointments WHERE id=:'legacy_confirmed'),'legacy confirmed status remains unverified without fabricated metadata');
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+
+-- Owner records a trimmed phone/no-answer attempt.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a1','2026-12-02 08:00+00','2026-12-02 09:00+00','A1','Owner attempt','new','unpaid','phone',100,NULL,'acw-owner-create')::text AS owner_created \gset
+SELECT (:'owner_created'::jsonb#>>'{appointment,id}') AS owner_id \gset
+SELECT (:'owner_created'::jsonb#>>'{appointment,updated_at}') AS owner_updated \gset
+SELECT public.record_appointment_confirmation_attempt(:'tenant_a',:'owner_id','phone','no_answer','  No answer, first call  ',:'owner_updated','acw-owner-attempt-0001')::text AS owner_attempt \gset
+SELECT (:'owner_attempt'::jsonb#>>'{appointment,updated_at}') AS owner_attempt_updated \gset
+SELECT (:'owner_attempt'::jsonb#>>'{confirmationAttempt,id}') AS owner_attempt_id \gset
+SELECT pg_temp.assert_true((:'owner_attempt'::jsonb#>>'{operationType}')='confirmation_attempt','owner attempt operation type');
+SELECT pg_temp.assert_true((:'owner_attempt'::jsonb#>>'{appointment,confirmation_state}')='contact_in_progress','no_answer maps to contact_in_progress');
+SELECT pg_temp.assert_true((:'owner_attempt'::jsonb#>>'{appointment,confirmation_attempt_count}')::int=1,'attempt count incremented');
+SELECT pg_temp.assert_true((:'owner_attempt'::jsonb#>>'{appointment,last_confirmation_attempt_at}') IS NOT NULL,'last attempt timestamp set');
+SELECT pg_temp.assert_true((:'owner_attempt'::jsonb#>>'{appointment,confirmed_at}') IS NULL,'no_answer does not confirm');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT note='No answer, first call' AND channel='phone' AND outcome='no_answer' FROM public.appointment_confirmation_attempts WHERE id=:'owner_attempt_id'),'attempt row stores normalized data');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.audit_events WHERE appointment_id=:'owner_id' AND action='appointment_confirmation_attempted'),'one attempt audit event');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.activity_events WHERE source_id=:'owner_id' AND type='appointment_confirmation_attempted'),'one attempt activity event');
+
+-- Safe replay and changed-payload rejection.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.record_appointment_confirmation_attempt(:'tenant_a',:'owner_id','phone','no_answer','  No answer, first call  ',:'owner_updated','acw-owner-attempt-0001')::text AS owner_replay \gset
+SELECT pg_temp.assert_true((:'owner_replay'::jsonb->>'replayed')::boolean,'same-key attempt replays');
+SELECT pg_temp.assert_true((:'owner_replay'::jsonb#>>'{confirmationAttempt,id}')=:'owner_attempt_id','replay returns same attempt');
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','callback_requested','changed',:'owner_updated','acw-owner-attempt-0001'),'другими параметрами');
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','whatsapp','no_answer','No answer, first call',:'owner_updated','acw-owner-attempt-0001'),'другими параметрами');
+SELECT public.get_appointment_operation(:'tenant_a','acw-owner-attempt-0001')::text AS owner_recovery \gset
+SELECT pg_temp.assert_true((:'owner_recovery'::jsonb->>'found')::boolean AND (:'owner_recovery'::jsonb#>>'{confirmationAttempt,id}')=:'owner_attempt_id','recovery returns same attempt');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_confirmation_attempts WHERE appointment_id=:'owner_id'),'replay does not duplicate attempt');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.audit_events WHERE appointment_id=:'owner_id' AND action='appointment_confirmation_attempted'),'replay does not duplicate audit');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.activity_events WHERE source_id=:'owner_id' AND type='appointment_confirmation_attempted'),'replay does not duplicate activity');
+
+-- Admin callback requested and registrar message sent.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a2','2026-12-03 08:00+00','2026-12-03 09:00+00','A2','Admin callback','new','unpaid','whatsapp',100,NULL,'acw-admin-create')::text AS admin_created \gset
+SELECT (:'admin_created'::jsonb#>>'{appointment,id}') AS admin_id \gset
+SELECT (:'admin_created'::jsonb#>>'{appointment,updated_at}') AS admin_updated \gset
+SELECT public.record_appointment_confirmation_attempt(:'tenant_a',:'admin_id','whatsapp','callback_requested','Call after lunch',:'admin_updated','acw-admin-callback-0001')::text AS admin_callback \gset
+SELECT pg_temp.assert_true((:'admin_callback'::jsonb#>>'{appointment,confirmation_state}')='callback_requested','callback state set');
+SELECT (:'admin_callback'::jsonb#>>'{appointment,updated_at}') AS admin_callback_updated \gset
+
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.record_appointment_confirmation_attempt(:'tenant_a',:'admin_id','sms','message_sent','  SMS template sent  ',:'admin_callback_updated','acw-registrar-message-0001')::text AS registrar_message \gset
+SELECT pg_temp.assert_true((:'registrar_message'::jsonb#>>'{appointment,confirmation_state}')='contact_in_progress','message_sent does not confirm');
+SELECT pg_temp.assert_true((:'registrar_message'::jsonb#>>'{appointment,confirmed_at}') IS NULL,'message_sent has no confirmed timestamp');
+SELECT (:'registrar_message'::jsonb#>>'{appointment,updated_at}') AS registrar_message_updated \gset
+
+-- Unreachable state.
+SELECT public.record_appointment_confirmation_attempt(:'tenant_a',:'admin_id','phone','unreachable','Number unavailable',:'registrar_message_updated','acw-registrar-unreachable-0001')::text AS registrar_unreachable \gset
+SELECT pg_temp.assert_true((:'registrar_unreachable'::jsonb#>>'{appointment,confirmation_state}')='unreachable','unreachable state set');
+
+-- Doctor, cashier, no-tenant, unknown, anonymous and cross-tenant are blocked.
+SELECT set_config('request.jwt.claim.sub',:'doctor_user_a',true);
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','no_answer','doctor',:'owner_attempt_updated','acw-doctor-attempt-0001'),'Недостаточно прав для подтверждения записи');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.expect_error(format('select public.confirm_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','cashier',:'owner_attempt_updated','acw-cashier-confirm-0001'),'Недостаточно прав для подтверждения записи');
+SELECT set_config('request.jwt.claim.sub',:'no_tenant',true);
+SELECT pg_temp.expect_error(format('select public.confirm_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','no tenant',:'owner_attempt_updated','acw-notenant-confirm-0001'),'Недостаточно прав для подтверждения записи');
+SELECT set_config('request.jwt.claim.sub',:'unknown_user',true);
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','no_answer','unknown',:'owner_attempt_updated','acw-unknown-attempt-0001'),'Недостаточно прав для подтверждения записи');
+SELECT set_config('request.jwt.claim.sub',:'admin_b',true);
+SELECT pg_temp.expect_error(format('select public.confirm_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','cross tenant',:'owner_attempt_updated','acw-cross-confirm-0001'),'Недостаточно прав для подтверждения записи');
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error(format('select public.get_appointment_operation(%L::uuid,%L)',:'tenant_a','acw-owner-attempt-0001'),'permission denied');
+RESET ROLE;
+
+-- Validation errors are safe.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,NULL,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','no_answer','note',:'owner_attempt_updated','acw-missing-channel'),'Выберите способ связи');
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,NULL,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','note',:'owner_attempt_updated','acw-missing-outcome'),'Выберите результат связи');
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','telegram','no_answer','note',:'owner_attempt_updated','acw-invalid-channel'),'Выберите способ связи');
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'owner_id','phone','busy_forever','note',:'owner_attempt_updated','acw-invalid-outcome'),'Выберите результат связи');
+
+-- Direct confirmation produces one attempt and complete metadata.
+SELECT public.create_appointment(:'tenant_a',:'patient_a3',:'doctor_a1','2026-12-04 08:00+00','2026-12-04 09:00+00','A1','Direct confirm','new','unpaid','phone',100,NULL,'acw-confirm-create')::text AS confirm_created \gset
+SELECT (:'confirm_created'::jsonb#>>'{appointment,id}') AS confirm_id \gset
+SELECT (:'confirm_created'::jsonb#>>'{appointment,updated_at}') AS confirm_updated \gset
+SELECT public.confirm_appointment(:'tenant_a',:'confirm_id','whatsapp','  Confirmed in WhatsApp  ',:'confirm_updated','acw-direct-confirm-0001')::text AS direct_confirm \gset
+SELECT (:'direct_confirm'::jsonb#>>'{confirmationAttempt,id}') AS direct_confirm_attempt_id \gset
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,confirmation_state}')='confirmed','direct confirm state');
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,confirmed_at}') IS NOT NULL,'confirmed_at set');
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,confirmed_by}')=:'owner_a','confirmed_by set');
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,confirmation_channel}')='whatsapp','confirmation channel set');
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,confirmation_note}')='Confirmed in WhatsApp','confirmation note trimmed');
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,confirmation_attempt_count}')::int=1,'direct confirm increments attempt count');
+SELECT pg_temp.assert_true((:'direct_confirm'::jsonb#>>'{appointment,status}')='new','confirmation does not change appointment status');
+SELECT pg_temp.expect_error(format('select public.confirm_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',:'confirm_id','phone','again',(:'direct_confirm'::jsonb#>>'{appointment,updated_at}'),'acw-direct-confirm-0002'),'Запись уже подтверждена');
+SELECT public.get_appointment_operation(:'tenant_a','acw-direct-confirm-0001')::text AS confirm_recovery \gset
+SELECT pg_temp.assert_true((:'confirm_recovery'::jsonb#>>'{confirmationAttempt,id}')=:'direct_confirm_attempt_id','direct confirmation recovery');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_confirmation_attempts WHERE appointment_id=:'confirm_id' AND outcome='confirmed'),'direct confirm has one attempt row');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.audit_events WHERE appointment_id=:'confirm_id' AND action='appointment_confirmed'),'direct confirm one audit');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.activity_events WHERE source_id=:'confirm_id' AND type='appointment_confirmed'),'direct confirm one activity');
+
+-- Generic details preserves confirmation facts and direct update is blocked.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.update_appointment_details(:'tenant_a'::uuid,:'confirm_id'::uuid,'A1','Edited after confirmation','new','unpaid','phone',100::numeric,'generic edit',(:'direct_confirm'::jsonb#>>'{appointment,updated_at}')::timestamptz)::text AS generic_edit \gset
+SELECT pg_temp.assert_true((:'generic_edit'::jsonb#>>'{appointment,confirmation_state}')='confirmed' AND (:'generic_edit'::jsonb#>>'{appointment,confirmation_attempt_count}')::int=1,'generic details preserves confirmation metadata');
+SELECT pg_temp.expect_error(format('update public.appointments set confirmation_state=%L where id=%L::uuid','unconfirmed',:'confirm_id'),'Недостаточно прав для изменения записи');
+
+-- Terminal/operational appointment statuses block confirmation actions.
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a2','2026-12-05 08:00+00','2026-12-05 09:00+00','A2','Cancelled target','new','unpaid','phone',100,NULL,'acw-cancelled-create')::text AS cancelled_created \gset
+SELECT public.cancel_appointment(:'tenant_a',(:'cancelled_created'::jsonb#>>'{appointment,id}')::uuid,'patient','Cancelled before confirmation',(:'cancelled_created'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acw-cancelled-action')::text AS cancelled_action \gset
+SELECT pg_temp.expect_error(format('select public.confirm_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'cancelled_created'::jsonb#>>'{appointment,id}'),'phone','blocked',(:'cancelled_action'::jsonb#>>'{appointment,updated_at}'),'acw-confirm-cancelled'),'Текущий статус записи');
+
+SELECT public.create_appointment(:'tenant_a',:'patient_a2',:'doctor_a2','2026-12-06 08:00+00','2026-12-06 09:00+00','A2','No-show target','new','unpaid','phone',100,NULL,'acw-noshow-create')::text AS noshow_created \gset
+SELECT public.mark_appointment_no_show(:'tenant_a',(:'noshow_created'::jsonb#>>'{appointment,id}')::uuid,'Did not attend',(:'noshow_created'::jsonb#>>'{appointment,updated_at}')::timestamptz,'acw-noshow-action')::text AS noshow_action \gset
+SELECT pg_temp.expect_error(format('select public.confirm_appointment(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'noshow_created'::jsonb#>>'{appointment,id}'),'phone','blocked',(:'noshow_action'::jsonb#>>'{appointment,updated_at}'),'acw-confirm-noshow'),'Текущий статус записи');
+
+SELECT public.create_appointment(:'tenant_a',:'patient_a1',:'doctor_a2','2026-12-07 08:00+00','2026-12-07 09:00+00','A2','Completed target','completed','unpaid','phone',100,NULL,'acw-completed-create')::text AS completed_created \gset
+SELECT pg_temp.expect_error(format('select public.record_appointment_confirmation_attempt(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L)',:'tenant_a',(:'completed_created'::jsonb#>>'{appointment,id}'),'phone','no_answer','blocked',(:'completed_created'::jsonb#>>'{appointment,updated_at}'),'acw-completed-attempt'),'Текущий статус записи');
+
+-- Unknown operation is safe not-found.
+SELECT public.get_appointment_operation(:'tenant_a','acw-not-found-0001')::text AS not_found \gset
+SELECT pg_temp.assert_true((:'not_found'::jsonb->>'found')='false','unknown operation returns not-found');
+RESET ROLE;
+
+-- Tenant-scoped history visibility and deterministic ordering.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)>=1 FROM public.appointment_confirmation_attempts WHERE tenant_id=:'tenant_a' AND appointment_id=:'owner_id'),'tenant A reads own attempt history');
+SELECT pg_temp.assert_true((
+  SELECT array_agg(id ORDER BY attempted_at DESC,id ASC) = array_agg(id ORDER BY attempted_at DESC,id ASC)
+  FROM public.appointment_confirmation_attempts WHERE appointment_id=:'admin_id'
+),'attempt history ordering is deterministic');
+SELECT set_config('request.jwt.claim.sub',:'admin_b',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_confirmation_attempts WHERE tenant_id=:'tenant_a'),'tenant B cannot read tenant A attempt history');
+RESET ROLE;
+
+-- Conflict protection is unchanged after confirmation workflow.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.expect_error(format('select public.create_appointment(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L::timestamptz,%L,%L,%L,%L,%L,%L::numeric,%L,%L)',:'tenant_a',:'patient_a2',:'doctor_a1','2026-12-04 08:30+00','2026-12-04 09:30+00','A1','Overlap','new','unpaid','phone','1','','acw-overlap'),'У врача уже есть запись');
+RESET ROLE;
+
+-- RLS and grants remain explicit.
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointment_confirmation_attempts'::regclass),'attempt RLS enabled');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointment_confirmation_attempts','SELECT'),'authenticated can read attempts');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_confirmation_attempts','INSERT'),'authenticated cannot insert attempts directly');
+SELECT pg_temp.assert_true(NOT has_table_privilege('anon','public.appointment_confirmation_attempts','SELECT'),'anon cannot read attempts');
+
+-- Side effects and balances remain unchanged.
+SELECT pg_temp.assert_true((SELECT count(*)=:visits_before::bigint FROM public.patient_visits),'no visits created');
+SELECT pg_temp.assert_true((SELECT count(*)=:encounters_before::bigint FROM public.clinical_encounters),'no encounters created');
+SELECT pg_temp.assert_true((SELECT count(*)=:services_before::bigint FROM public.completed_services),'no completed services created');
+SELECT pg_temp.assert_true((SELECT count(*)=:plans_before::bigint FROM public.treatment_plans),'no treatment plans created');
+SELECT pg_temp.assert_true((SELECT count(*)=:findings_before::bigint FROM public.findings),'no findings created');
+SELECT pg_temp.assert_true((SELECT count(*)=:charts_before::bigint FROM public.dental_charts),'no dental charts created');
+SELECT pg_temp.assert_true((SELECT count(*)=:invoices_before::bigint FROM public.invoices),'no invoices created');
+SELECT pg_temp.assert_true((SELECT count(*)=:payments_before::bigint FROM public.payments),'no payments created');
+SELECT pg_temp.assert_true((SELECT count(*)=:refunds_before::bigint FROM public.refunds),'no refunds created');
+SELECT pg_temp.assert_true((SELECT count(*)=:adjustments_before::bigint FROM public.financial_adjustments),'no adjustments created');
+SELECT pg_temp.assert_true((SELECT count(*)=:documents_before::bigint FROM public.documents),'no documents created');
+SELECT pg_temp.assert_true((SELECT balance::text=:'balance_a1_before' FROM public.patients WHERE id=:'patient_a1'),'patient A1 balance unchanged');
+SELECT pg_temp.assert_true((SELECT balance::text=:'balance_a2_before' FROM public.patients WHERE id=:'patient_a2'),'patient A2 balance unchanged');
+
+ROLLBACK;
+\echo 'APPOINTMENT-CONFIRMATION-WORKFLOW-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Adds a dedicated auditable appointment-confirmation workflow separate from appointment attendance and clinical status. Migration 0027 introduces confirmation metadata, immutable contact-attempt history, controlled tenant-scoped RPCs, operation-key idempotency/recovery, optimistic concurrency, role/RLS enforcement, audit/activity emission, schedule attention UI, confirmation history, and patient-history facts. Implementation commit: 9aedc88620e35054521efaab7f506b122f8969ae. Final report-only PR head: cb1a03dfa286e73ba4893a7e938f5f82137c8f66. The PR remains open and unmerged.

## Checks

- Implementation CI #707, run ID 29195697038, succeeded on 9aedc88620e35054521efaab7f506b122f8969ae
- Final CI #708, run ID 29195903834, succeeded on exact PR head cb1a03dfa286e73ba4893a7e938f5f82137c8f66
- ESLint, full tests, and production build passed in both CI runs
- Local Supabase migrations 0001-0027, SQL 0024-0027, and concurrency 0025-0027 passed
- Chrome DevTools MCP A-J role, tenant, attempt, confirm, double-click, recovery, race, and stale-context smoke passed
- Final diff contains 17 files including one report-only Markdown file
- Local worktree and QA cleanup are clean

## Limitations

- Historical legacy confirmed rows remain confirmation metadata version 0
- No correction/unconfirm workflow
- No SMS, WhatsApp, email, reminder scheduler, callback scheduler, public booking, or provider integration
- Cloud Supabase was not touched and the PR must remain open and unmerged
