### PR TITLE
TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001: make tenant timezone authoritative

### DIFF
--- a/_ai_work/REPORTS/TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001_foundation.md
@@ -1,384 +1,411 @@
 # TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001
 
-## Final verdict
+## 1. Final verdict
 
-PARTIAL: separate Chrome DevTools MCP execution was unavailable in this ChatGPT/Hermes environment; equivalent isolated HeadlessChrome browser automation, PostgREST network validation, local Supabase tests, concurrency tests, TypeScript tests, lint, and production build passed.
+Task verdict: **TENANT TIMEZONE SCHEDULING FOUNDATION IMPLEMENTED AND VERIFIED WITH ONE TOOLING LIMITATION**
 
-## Summary
+Machine-readable final verdict: **PARTIAL**
 
-This task makes the tenant IANA timezone authoritative for appointment scheduling. Appointment timestamps remain PostgreSQL `timestamptz` instants. Forms use tenant-local `YYYY-MM-DDTHH:mm`, repository writes accept only offset-aware instants, and schedule dates are plain tenant-local `YYYY-MM-DD` values. Browser timezone and UTC midnight no longer define the clinic calendar day.
+The implementation is functionally complete and passed local migration reset, SQL regression, concurrency regression, full TypeScript quality checks, production build, and real isolated HeadlessChrome browser scenarios against local Supabase.
 
-A minimal tenant switcher was added for multi-tenant users. No reminder queue, delivery provider, cron, worker, webhook, finance change, clinical change, public booking, cloud migration, or historical mass shift was introduced.
+The verdict is PARTIAL only because the task requested a separately invokable `chrome-devtools-mcp` execution, while this ChatGPT/Hermes environment exposed isolated HeadlessChrome browser automation but no callable Chrome DevTools MCP action or executable. Equivalent browser, console, network, gateway-log, and database validation was completed.
 
-## Branch
+The pull request remains open and unmerged.
+
+## 2. Summary
+
+This task makes each tenant's IANA timezone authoritative for appointment scheduling.
+
+Appointment timestamps remain PostgreSQL `timestamptz` instants. Appointment forms use tenant-local `YYYY-MM-DDTHH:mm` values, repository writes accept only offset-aware instants, and the selected schedule day is a plain tenant-local `YYYY-MM-DD` value. Browser timezone and UTC midnight no longer define the clinic calendar day.
+
+A minimal tenant selector was added for users with multiple clinic memberships. Tenant, role, timezone, and schedule-date state now change together without stale cross-tenant UI state.
+
+No reminder queue, delivery provider, cron, worker, webhook, finance mutation, clinical mutation, public booking, cloud migration, or historical mass timestamp shift was introduced.
+
+## 3. Branch
 
 `feature/tenant-timezone-scheduling-foundation-001`
 
-## PR URL
+## 4. PR URL
 
-Pending creation after the implementation commit.
+https://github.com/NckNA/codex-test/pull/353
 
-## Baseline
+PR #353 is ready for review, open, and intentionally unmerged.
 
-- Required PR #351 is present in `main`.
-- Branch baseline: `9a67dd54d2d1a3c14abeb7c37e4538865f8cf35c`.
-- Required earlier merge `9cb2a080f7a92702829b35505c733bad882b836f` is an ancestor.
-- Baseline also includes PR #352, which added an explicit no-merge CI guard and an active main-branch ruleset.
+## 5. Baseline
 
-## PR head reviewed before final report update
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- task branch baseline: `9a67dd54d2d1a3c14abeb7c37e4538865f8cf35c`;
+- required PR #351 is present in `main`;
+- required earlier merge `9cb2a080f7a92702829b35505c733bad882b836f` is an ancestor;
+- baseline also includes PR #352, which added the explicit no-merge CI guard and active `main` branch ruleset;
+- cloud Supabase was not used or modified.
 
-Pending implementation commit.
+## 6. Implementation head reviewed before final report update
 
-## Report update commit
+- implementation head: `c2ef7962eb061e1c84c6ce3e716b3ee23cffc845`;
+- workflow: `CI`;
+- run number: `#715`;
+- run ID: `29202579685`;
+- status: `completed`;
+- conclusion: `success`;
+- tested commit: `c2ef7962eb061e1c84c6ce3e716b3ee23cffc845`;
+- tested commit matched the implementation head exactly;
+- PR merge state was clean;
+- the pull request remained open and unmerged.
 
-N/A because a final report commit cannot reference itself.
+## 7. Report update commit
 
-## Changed files
+Report update commit: N/A because a report-only commit cannot contain its own future SHA or the CI result that tests it.
 
-Migration and SQL validation:
+The exact final report-only commit and fresh final CI run must be recorded in the immutable finalization receipt and final task response.
 
-- `supabase/migrations/0028_tenant_timezone_scheduling_foundation.sql`
-- `supabase/tests/0028_tenant_timezone_scheduling_foundation_test.sql`
+## 8. Changed files
 
-Timezone and tenant/schedule context:
+- `_ai_work/REPORTS/TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001_foundation.md`;
+- `src/App.test.tsx`;
+- `src/components/admin/AdminAuditViewer.test.tsx`;
+- `src/components/layout/Header.test.tsx`;
+- `src/components/layout/Header.tsx`;
+- `src/components/patients/patient-card/PatientHistoryTab.test.tsx`;
+- `src/components/patients/patient-card/PatientHistoryTab.tsx`;
+- `src/components/patients/patient-card/PatientOverviewTab.tsx`;
+- `src/components/schedule/AppointmentCancellationDialog.tsx`;
+- `src/components/schedule/AppointmentConfirmationPanel.test.tsx`;
+- `src/components/schedule/AppointmentConfirmationPanel.tsx`;
+- `src/components/schedule/AppointmentLifecycleDialogs.test.tsx`;
+- `src/components/schedule/AppointmentModal.test.tsx`;
+- `src/components/schedule/AppointmentModal.tsx`;
+- `src/components/schedule/AppointmentNoShowDialog.tsx`;
+- `src/context/ScheduleContext.tsx`;
+- `src/context/ScheduleProvider.test.tsx`;
+- `src/context/ScheduleProvider.tsx`;
+- `src/contexts/TenantContext.test.tsx`;
+- `src/contexts/TenantContext.tsx`;
+- `src/data/hooks/useChiefComplaint.test.tsx`;
+- `src/data/hooks/useClinicalWorkflow.test.tsx`;
+- `src/data/hooks/useDentalChart.test.tsx`;
+- `src/data/hooks/useDictionaries.test.tsx`;
+- `src/data/hooks/usePatientAppointments.test.tsx`;
+- `src/data/hooks/usePatientAppointments.ts`;
+- `src/data/hooks/usePatientFindings.test.tsx`;
+- `src/data/hooks/usePatientListVisitSummary.test.tsx`;
+- `src/data/hooks/usePatientListVisitSummary.ts`;
+- `src/data/hooks/usePatientMedicalSummary.test.tsx`;
+- `src/data/hooks/usePatientTimeline.test.tsx`;
+- `src/data/hooks/useScheduleAppointments.ts`;
+- `src/data/hooks/useTreatmentPlans.test.tsx`;
+- `src/data/repositories/AppointmentRepository.test.ts`;
+- `src/data/repositories/AppointmentRepository.ts`;
+- `src/domain/timezone.test.ts`;
+- `src/domain/timezone.ts`;
+- `src/pages/MedicalPage.test.tsx`;
+- `src/pages/PatientCardPage.test.tsx`;
+- `src/pages/PatientCardPage.tsx`;
+- `src/pages/PatientsPage.test.tsx`;
+- `src/pages/PatientsPage.tsx`;
+- `src/pages/SchedulePage.tsx`;
+- `supabase/migrations/0028_tenant_timezone_scheduling_foundation.sql`;
+- `supabase/tests/0028_tenant_timezone_scheduling_foundation_test.sql`.
 
-- `src/domain/timezone.ts`
-- `src/domain/timezone.test.ts`
-- `src/contexts/TenantContext.tsx`
-- `src/contexts/TenantContext.test.tsx`
-- `src/context/ScheduleContext.tsx`
-- `src/context/ScheduleProvider.tsx`
-- `src/context/ScheduleProvider.test.tsx`
-- `src/components/layout/Header.tsx`
-- `src/components/layout/Header.test.tsx`
+No package, lockfile, generated type, environment file, screenshot, browser fixture, or cloud migration artifact belongs in the final diff.
 
-Appointment and patient scheduling paths:
+## 9. Pre-read
 
-- `src/data/repositories/AppointmentRepository.ts`
-- `src/data/repositories/AppointmentRepository.test.ts`
-- `src/data/hooks/useScheduleAppointments.ts`
-- `src/data/hooks/usePatientAppointments.ts`
-- `src/data/hooks/usePatientListVisitSummary.ts`
-- `src/pages/SchedulePage.tsx`
-- `src/components/schedule/AppointmentModal.tsx`
-- confirmation, cancellation, and no-show components/tests
-- patient list, overview, card, and history components/tests
+The following architecture and operation reports were reviewed before implementation:
 
-Existing test fixtures were updated wherever `ActiveTenant.timezone` became required. No package or generated-type changes were made.
+- `SCHEDULE-OPERATIONS-RECON-001`;
+- `APPOINTMENT-CONFLICT-HARDENING-001`;
+- `SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001`;
+- `APPOINTMENT-CANCELLATION-NOSHOW-001`;
+- `APPOINTMENT-CONFIRMATION-WORKFLOW-001`;
+- `APPOINTMENT-REMINDER-OPERATIONS-RECON-001`;
+- roles and permissions;
+- multi-tenant architecture rules;
+- data isolation and security;
+- appointments and schedule;
+- backend/API architecture;
+- storage and migration strategy;
+- testing and QA strategy.
 
-## Pre-read
-
-Read before implementation:
-
-- SCHEDULE-OPERATIONS-RECON-001
-- APPOINTMENT-CONFLICT-HARDENING-001
-- SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001
-- APPOINTMENT-CANCELLATION-NOSHOW-001
-- APPOINTMENT-CONFIRMATION-WORKFLOW-001
-- APPOINTMENT-REMINDER-OPERATIONS-RECON-001
-- roles and permissions
-- multi-tenant architecture rules
-- data isolation and security
-- appointments and schedule
-- backend/API architecture
-- storage and migration strategy
-- testing and QA strategy
-
-## Original time-semantics inventory
+## 10. Original time-semantics inventory
 
 | Area | Original behavior | Classification | Risk |
 |---|---|---|---|
 | Schedule selected day | JavaScript `Date` plus `toISOString().split('T')[0]` | UTC-day bug | wrong clinic day near UTC midnight |
-| Slot creation | offset-free local string later marked with `Z` | unsafe Z append | local wall time persisted as UTC |
-| Repository reads | stripped `Z`/explicit offset | offset stripping | instant meaning lost |
+| Slot creation | offset-free local string later marked with `Z` | unsafe `Z` append | local wall time persisted as UTC |
+| Repository reads | stripped `Z` or explicit offset | offset stripping | instant meaning lost |
 | Appointment modal | browser-local `Date` parsing | browser dependency | different workstations save different instants |
-| Card position/time | browser `getHours()` | browser dependency | wrong schedule position |
-| Patient/lifecycle display | locale formatting without explicit zone | browser dependency | inconsistent schedule/history facts |
-| Next/previous selection | epoch comparison | safe instant conversion | retained |
+| Card position and label | browser `getHours()` | browser dependency | wrong schedule position and label |
+| Patient and lifecycle display | locale formatting without explicit timezone | browser dependency | inconsistent schedule and history facts |
+| Next or previous selection | epoch comparison | safe instant conversion | retained |
 | Existing appointment rows | PostgreSQL `timestamptz` | safe stored instant | intentionally not rewritten |
 
-## Original defects
+## 11. Original defects
 
 1. UTC midnight defined the clinic day.
 2. Offset-free wall time was blindly treated as UTC.
 3. Persisted offsets were removed during reads.
 4. Browser timezone controlled forms, cards, patient history, and lifecycle metadata.
-5. Tenant context did not expose authoritative timezone.
+5. Tenant context did not expose an authoritative timezone.
 6. Multi-tenant users had no practical tenant switch control.
-7. Initial browser reschedule exposed microsecond loss in `updated_at` when canonicalized through JavaScript `Date`; final code preserves database timestamp text and precision.
+7. The first real-browser reschedule exposed microsecond loss in `updated_at` when it was canonicalized through JavaScript `Date`; the final repository preserves exact database timestamp text and precision.
 
-## Tenant timezone model
+## 12. Tenant timezone model and migration
 
-- `public.tenants.timezone text not null`
-- legacy/default value: `Asia/Almaty`
-- exact IANA names only
-- numeric offsets are not authoritative identifiers
-- appointments remain `timestamptz`
-- active timezone is loaded with tenant membership context
+Migration `0028_tenant_timezone_scheduling_foundation.sql`:
 
-## Migration behavior
+1. adds `public.tenants.timezone text not null`;
+2. backfills null or empty legacy values to `Asia/Almaty`;
+3. sets `Asia/Almaty` as the default;
+4. validates exact IANA names against PostgreSQL `pg_timezone_names`;
+5. rejects invalid values through a trigger;
+6. blocks direct timezone changes outside the controlled RPC path;
+7. adds owner/admin-only `set_tenant_timezone(uuid,text)`;
+8. emits one audit event and one activity event for an actual change;
+9. preserves RLS and existing role boundaries;
+10. does not rewrite appointment timestamps.
 
-Migration 0028:
-
-1. Adds `tenants.timezone`.
-2. Backfills null/empty legacy values to `Asia/Almaty`.
-3. Sets default and `NOT NULL`.
-4. Validates against PostgreSQL `pg_timezone_names`.
-5. Rejects invalid values through a trigger.
-6. Blocks direct timezone changes outside the controlled RPC path.
-7. Adds owner/admin-only `set_tenant_timezone(uuid,text)`.
-8. Emits audit and activity events for actual changes.
-9. Preserves RLS and existing role boundaries.
-10. Does not rewrite appointment timestamps.
+Numeric offsets are not accepted as authoritative timezone identifiers. Existing appointments remain `timestamptz` instants.
 
 No cloud migration was applied.
 
-## Historical-data handling
+## 13. Historical-data policy
 
-Existing timestamps are treated as stored instants. No row was shifted based on guessed prior intent. Historical rows created under earlier unsafe browser conversion may require a separate evidence-based audited repair task. This task prevents future ambiguous writes without inventing history.
+Existing appointment timestamps are treated as stored instants. No row was shifted using guessed prior intent.
 
-## Time representation contract
+Historical rows created under earlier unsafe browser conversion may require a separate evidence-based and audited repair task. This task prevents future ambiguous writes without inventing historical intent.
 
-- persisted timestamp: offset-aware ISO 8601 instant
-- tenant-local form: `YYYY-MM-DDTHH:mm`
-- tenant-local date: `YYYY-MM-DD`
-- timezone: IANA name
-- repository boundary: offset-aware instants only
-- UI boundary: tenant-local wall time converted through tenant timezone
-- day interval: tenant midnight to next tenant midnight, half-open
-- comparisons: instant based
-## Timezone utility
+## 14. Time representation contract
 
-`src/domain/timezone.ts` provides IANA validation, offset-aware instant validation, instant-to-tenant date/time conversion, tenant-local wall-time-to-instant conversion, tenant day boundaries, injected tenant-aware now, tenant-day comparison, formatting, and calendar-day arithmetic. Invalid inputs fail with safe Russian messages and never silently fall back to browser timezone.
+- persisted timestamp: offset-aware ISO 8601 instant;
+- tenant-local form value: `YYYY-MM-DDTHH:mm`;
+- tenant-local calendar date: `YYYY-MM-DD`;
+- tenant timezone: exact IANA name;
+- repository write boundary: offset-aware instant only;
+- UI write boundary: tenant-local wall time converted through active tenant timezone;
+- day interval: tenant-local midnight to next tenant-local midnight, half-open;
+- comparisons: absolute instant or epoch based;
+- database timestamp reads: validated but returned without changing offset or precision.
 
-## Dependency decision
+## 15. Timezone utility and DST policy
 
-No dependency was added. Native `Intl.DateTimeFormat` is used with explicit `timeZone`. Wall-time conversion enumerates real zone offsets around the requested local time and verifies exact formatted parts, which detects missing and repeated local times without a single-offset guesser.
+`src/domain/timezone.ts` provides:
 
-## DST and ambiguity policy
+- required IANA timezone validation;
+- offset-aware instant validation;
+- instant-to-tenant date conversion;
+- instant-to-tenant `datetime-local` conversion;
+- tenant-local wall-time-to-instant conversion;
+- tenant day start and next-day exclusive boundaries;
+- tenant-aware current date with injected `now`;
+- tenant-day comparison;
+- tenant-local formatting;
+- calendar-day arithmetic without browser timezone parsing.
 
-- nonexistent spring-forward time: reject
-- repeated fall-back time: reject as ambiguous
-- never silently shift by one hour
-- Berlin and New York winter/summer offsets tested
-- historical IANA rules delegated to runtime timezone data
+No dependency was added. Native `Intl.DateTimeFormat` is used with explicit `timeZone`.
 
-## Tenant context
+DST policy:
 
-- `ActiveTenant.timezone` is required.
-- Supabase membership query loads tenant timezone.
-- Only the migration-guaranteed `Asia/Almaty` legacy fallback is permitted.
-- Invalid database timezone blocks scheduling with a safe error.
-- Tenant and timezone participate in relevant query identities.
-- Pending old tenant/user responses remain guarded.
-- Tenant switch changes tenant, role, and timezone together.
-- Schedule date state is keyed by tenant id plus timezone.
-- Header contains a minimal tenant selector, not a broad settings module.
+- nonexistent spring-forward local time is rejected;
+- repeated fall-back local time is rejected as ambiguous;
+- no silent one-hour correction is performed;
+- Berlin and New York winter and summer offsets are tested;
+- Asia/Almaty and leap-day behavior are tested.
 
-## Repository conversion fixes
+## 16. Tenant context and switching
 
-- removed blind `Z` append
-- removed timezone suffix stripping
-- create/reschedule require offset-aware instants
-- write values normalize to equivalent UTC ISO instants
-- database timestamps are validated but returned unchanged
-- explicit offsets and PostgreSQL microseconds survive reads
-- `updated_at` remains exact for optimistic concurrency
-- lifecycle and confirmation timestamps remain instants
-- raw SQLSTATE, catalog names, stack traces, and PostgREST payloads are not exposed
+- `ActiveTenant.timezone` is required;
+- Supabase membership loading includes the tenant timezone;
+- only the migration-guaranteed `Asia/Almaty` legacy fallback is permitted;
+- invalid database timezone blocks scheduling with a safe error;
+- tenant and timezone participate in relevant query identities;
+- pending old tenant or user responses remain guarded;
+- switching tenant changes tenant, role, and timezone together;
+- schedule date state is keyed by tenant ID plus timezone;
+- the header exposes a minimal tenant selector only for multi-tenant users;
+- no broad tenant settings module was introduced.
 
-## Appointment modal integration
+## 17. Repository and optimistic concurrency fixes
 
-Existing appointments convert from persisted instant to tenant-local form values. Saving converts tenant-local start/end through the tenant timezone. Conflict checks remain instant based. Save/reload preserves local wall time. Reschedule uses the same contract. DST gaps and repeated times return safe errors.
+- removed blind `Z` appending;
+- removed timezone suffix stripping;
+- create and reschedule require offset-aware instants;
+- write values normalize to equivalent UTC ISO instants;
+- database timestamps are validated but returned unchanged;
+- explicit offsets and PostgreSQL microseconds survive reads;
+- exact `updated_at` remains suitable for optimistic concurrency;
+- lifecycle and confirmation timestamps remain instants;
+- raw SQLSTATE, catalog names, stack traces, and PostgREST payloads are not exposed.
 
-## Schedule-day boundaries
+The initial browser reschedule failed safely because JavaScript normalization truncated PostgreSQL microseconds. After exact timestamp preservation, the same browser scenario passed.
 
-- selected date is plain tenant-local `YYYY-MM-DD`
-- reachable `toISOString().split('T')[0]` logic removed
-- day membership uses tenant start and next-day start
-- interval is half-open
-- card position and label use tenant wall time
-- month/year heading formats a plain tenant date without browser drift
+## 18. Schedule, modal, patient, and lifecycle integration
 
-## Today and tomorrow semantics
+- selected schedule date is a plain tenant-local `YYYY-MM-DD`;
+- reachable `toISOString().split('T')[0]` logic was removed;
+- schedule day membership uses tenant-local start and next-day start;
+- the interval is half-open;
+- card position and displayed time use tenant wall time;
+- month and year headings format plain tenant dates without browser drift;
+- existing appointment instants convert to tenant-local modal values;
+- saving converts tenant-local start and end through active tenant timezone;
+- save and reload preserve displayed local time;
+- reschedule uses the same conversion contract;
+- next and previous appointment selection remains instant based;
+- patient list, overview, card history, confirmation, cancellation, and no-show timestamps render through the active tenant timezone.
 
-Schedule initialization uses `tenantNowDate(timezone)`. Date navigation uses plain-date calendar arithmetic. Tests inject 
-ow` and prove a near-midnight UTC instant produces different correct dates in Almaty and Berlin. UTC midnight and browser midnight no longer define clinic today.
-
-## Patient summaries
-
-Next/previous selection remains instant based. Patient list, overview, card history, and schedule display through active tenant timezone. The same instant was browser-verified as `13.07.2026 00:30` in Almaty and `12.07.2026 21:30` in Berlin.
-
-## Lifecycle timestamp display
-
-Confirmation, last attempt, cancellation, no-show, and patient-history lifecycle facts render in tenant timezone. Repository values remain persisted instants.
-
-## Role matrix
+## 19. Role matrix
 
 Timezone read:
 
-- owner/admin/registrar/doctor/cashier: allowed for their tenant
-- unknown/no tenant: blocked
+- owner, admin, registrar, doctor, and cashier: allowed for their own tenant;
+- unknown or no-tenant user: blocked.
 
 Timezone mutation RPC:
 
-- owner: allowed
-- admin: allowed
-- registrar: blocked
-- doctor: blocked
-- cashier: blocked
-- unknown/no tenant: blocked
-- cross-tenant admin: blocked
+- owner: allowed;
+- admin: allowed;
+- registrar: blocked;
+- doctor: blocked;
+- cashier: blocked;
+- unknown or no-tenant user: blocked;
+- cross-tenant admin: blocked.
 
-No frontend service role was introduced.
+No frontend service-role key or service-role path was introduced.
 
-## SQL tests
+## 20. SQL and migration validation
 
-Clean local reset applied migrations 0001 through 0028. Passed:
+A clean local reset applied migrations `0001` through `0028`.
 
-- `0024_legacy_core_table_grants_test.sql`
-- `0025_appointment_conflict_hardening_test.sql`
-- `0026_appointment_cancellation_noshow_test.sql`
-- `0027_appointment_confirmation_workflow_test.sql`
-- `0028_tenant_timezone_scheduling_foundation_test.sql`
+Passed SQL suites:
 
-SQL 0028 verifies default/backfill, valid and invalid IANA names, direct-update blocking, role matrix, cross-tenant isolation, RLS, audited mutation, unchanged appointment instants, no invalid intervals, and no clinical/financial effects.
+- `0024_legacy_core_table_grants_test.sql`;
+- `0025_appointment_conflict_hardening_test.sql`;
+- `0026_appointment_cancellation_noshow_test.sql`;
+- `0027_appointment_confirmation_workflow_test.sql`;
+- `0028_tenant_timezone_scheduling_foundation_test.sql`.
 
-## Concurrency tests
+The 0028 suite verifies default and backfill behavior, valid and invalid IANA names, direct-update blocking, role boundaries, cross-tenant isolation, RLS, audited mutation, unchanged appointment instants, zero invalid intervals, and zero clinical or financial side effects.
 
-- 0025: success operations 13; doctor overlaps 0; patient overlaps 0; invalid intervals 0; audit/activity 13/13; deadlocks 0.
-- 0026: successes 13; replays 2; controlled conflicts 5; cancelled 8; no-show 2; active overlaps 0; deadlocks 0.
-- 0027: successes 12; replays 2; controlled conflicts 7; attempts 10; confirmations 6; duplicate keys 0; deadlocks 0.
+## 21. Concurrency validation
 
-## Timezone utility tests
+- 0025: success operations `13`; doctor overlap pairs `0`; patient overlap pairs `0`; invalid intervals `0`; audit/activity `13/13`; deadlocks `0`;
+- 0026: successes `13`; replays `2`; controlled conflicts `5`; cancelled rows `8`; no-show rows `2`; active overlap pairs `0`; deadlocks `0`;
+- 0027: successes `12`; replays `2`; controlled conflicts `7`; attempts `10`; confirmations `6`; duplicate operation keys `0`; deadlocks `0`.
 
-Covered Almaty conversion and round trips, UTC-midnight crossing, Berlin/New York winter and summer, DST gap rejection, DST ambiguity rejection, invalid timezone/date/instant, leap day, half-open boundaries, injected now, and browser-zone independence.
-
-## Repository tests
-
-Covered explicit offset preservation, offset-free rejection, no suffix stripping, no blind `Z` append, correct create/reschedule instants, exact database timestamp precision, lifecycle/confirmation mapping, save/reload instant stability, and safe errors.
-
-## Schedule and UI tests
-
-Covered tenant-local selected day, boundary inclusion/exclusion, tenant-switch date reset, different A/B dates for one instant, modal wall-time round trip, tenant selector behavior, and unchanged confirmation/cancellation/no-show behavior.
-## Browser smoke
+## 22. Browser smoke
 
 Real isolated HeadlessChrome 150 smoke ran against local Supabase and this task branch on `127.0.0.1:5188`.
 
 Passed scenarios:
 
-1. Create at Almaty local 09:00 and reload at 09:00.
-2. Database raw creation instant: `2026-07-12 04:00:00+00`; Almaty wall time 09:00.
-3. Reschedule to Almaty local 11:30-12:30 and reload unchanged.
-4. Database raw reschedule instants: 06:30-07:30 UTC; Almaty wall time 11:30-12:30.
-5. One UTC instant rendered as 13 July 00:30 in Almaty.
-6. The same instant rendered as 12 July 21:30 in Berlin.
-7. Host timezone is UTC+5, but Berlin still rendered Berlin time.
-8. Tenant A to B switch changed role/timezone and removed old custom date without stale A content.
-9. Confirmation succeeded and survived reload.
-10. Cancellation succeeded and rendered tenant-local metadata.
-11. No-show succeeded and rendered tenant-local metadata.
-12. Successful final scenarios had no console errors, failed requests, or visible secrets.
+1. create at Almaty local `09:00`, reload, and still display `09:00`;
+2. raw database creation instant `2026-07-12 04:00:00+00`, which is Almaty `09:00`;
+3. reschedule to Almaty local `11:30-12:30` and reload unchanged;
+4. raw reschedule instants `06:30-07:30+00`, which are Almaty `11:30-12:30`;
+5. one instant `2026-07-12T19:30:00Z` displayed as `13.07.2026 00:30` in Almaty;
+6. the same instant displayed as `12.07.2026 21:30` in Berlin;
+7. host timezone UTC+5 did not override Berlin tenant time;
+8. tenant A to tenant B switch changed role and timezone and cleared the old custom date without stale A content;
+9. confirmation succeeded and survived reload;
+10. cancellation succeeded and rendered tenant-local metadata;
+11. no-show succeeded and rendered tenant-local metadata;
+12. successful final scenarios had no console errors, failed requests, or visible secrets.
 
-The first browser reschedule before the precision fix returned the safe stale-write error. It exposed JavaScript truncation of PostgreSQL microseconds in `updated_at`. After preserving raw timestamp precision, the same smoke passed.
+Kong and PostgREST logs captured successful RPC calls:
 
-### Chrome DevTools MCP limitation
+- `create_appointment` -> 200;
+- `reschedule_appointment` -> 200 after the precision fix;
+- `confirm_appointment` -> 200;
+- `cancel_appointment` -> 200;
+- `mark_appointment_no_show` -> 200.
 
-Hermes exposed isolated browser automation and HeadlessChrome, but no separately invokable `chrome-devtools-mcp` action or executable. Codex configuration references a Chrome plugin, but Codex/Chrome MCP was not callable in this conversation. This exact named-tool gap is the reason for the PARTIAL verdict. Equivalent browser, console, request, gateway-log, and database validation was completed.
+Database checks after browser operations showed:
 
-## Network validation
+- doctor overlap pairs: `0`;
+- patient overlap pairs: `0`;
+- invalid intervals: `0`;
+- operation facts present for create, reschedule, confirm, cancel, and no-show;
+- matching audit events present;
+- lifecycle timestamps stored as UTC instants;
+- tenant isolation preserved;
+- clinical and financial side-effect counts remained zero.
 
-Kong/PostgREST logs captured successful calls:
+## 23. Cleanup
 
-- `POST /rest/v1/rpc/create_appointment` -> 200
-- `POST /rest/v1/rpc/reschedule_appointment` -> 200 after precision fix
-- `POST /rest/v1/rpc/confirm_appointment` -> 200
-- `POST /rest/v1/rpc/cancel_appointment` -> 200
-- `POST /rest/v1/rpc/mark_appointment_no_show` -> 200
-- tenant-scoped reads for A and B
-- patient-scoped history reads
+- task Vite process stopped;
+- local Supabase reset with `--no-seed` after browser and concurrency QA;
+- final counters were zero for tenants, memberships, patients, doctors, appointments, appointment operations, confirmation attempts, visits, encounters, invoices, and payments;
+- browser screenshots remain outside the repository under `D:\hermes\reports\tenant-timezone-smoke` and are not committed.
 
-No protected direct appointment insert/update and no frontend service-role credential were used.
+## 24. Checks: lint, tests, and build
 
-## Database validation
+Final clean checks:
 
-Browser-smoke database results:
+- ESLint: passed;
+- full Vitest suite: **90 files / 1007 tests passed**;
+- TypeScript build: passed;
+- Vite production build: passed;
+- SQL suites 0024 through 0028: passed;
+- concurrency suites 0025 through 0027: passed;
+- implementation CI run `#715`, run ID `29202579685`: success on exact implementation head `c2ef7962eb061e1c84c6ce3e716b3ee23cffc845`.
 
-- doctor overlap pairs: 0
-- patient overlap pairs: 0
-- invalid intervals: 0
-- create/reschedule/confirm/cancel/no-show operation facts present
-- matching audit events present
-- lifecycle timestamps stored as UTC instants
-- same absolute instant preserved across tenants
-- tenant isolation preserved
+Non-blocking baseline warnings:
 
-## Tenant-switch validation
+- existing React `act(...)` warnings in older tests;
+- existing Vite large-bundle warning.
 
-Tenant A used `Asia/Almaty`; Tenant B used `Europe/Berlin`. The multi-tenant user switched from admin context in A to doctor context in B. Timezone and role changed together, the old selected date disappeared, and Berlin history rendered Berlin time rather than host UTC+5 time.
+No package dependency was changed.
 
-## Side-effect validation
+## 25. Issues / Limitations
 
-After browser operations all counts remained zero:
+Security and scope boundaries:
 
-- patient visits
-- clinical encounters
-- completed services
-- invoices
-- payments
-- refunds
-- financial adjustments
+- no frontend service-role key;
+- no direct protected appointment insert or update path;
+- no cross-tenant mutation;
+- no raw database error displayed;
+- no cloud Supabase apply;
+- no historical mass timestamp shift;
+- no PR merge.
 
-SQL 0028 independently verifies the same no-side-effect contract.
+Known limitations:
 
-## Cleanup
+1. a separately invokable Chrome DevTools MCP action was unavailable; equivalent isolated HeadlessChrome validation passed;
+2. historical rows remain stored instants and may require a separate evidence-based audited repair task;
+3. no full tenant settings UI was added; only controlled backend mutation and minimal tenant switching were added;
+4. cloud Supabase remains behind local migrations because cloud apply was explicitly forbidden;
+5. existing unrelated Supabase advisor warnings remain separate hardening work;
+6. existing bundle-size and React warning baselines remain unrelated.
 
-- Task Vite process stopped.
-- Local Supabase reset with `--no-seed` after browser and concurrency QA.
-- Final counters: tenants 0, memberships 0, patients 0, doctors 0, appointments 0, operations 0, confirmation attempts 0, visits 0, encounters 0, invoices 0, payments 0.
-- Browser screenshots remain outside the repository under `D:\hermes\reports\tenant-timezone-smoke` and are not committed.
+Excluded scope:
 
-## Lint, test, and build
+- reminder queues or settings;
+- SMS, WhatsApp, or email;
+- provider SDKs;
+- cron, workers, or webhooks;
+- public booking;
+- consent or contact redesign;
+- week or month calendar redesign;
+- finance or clinical changes;
+- role redesign;
+- generated types;
+- HEP-V2.
 
-Final clean results:
+## 26. Recommended next task
 
-- ESLint: passed.
-- Full Vitest: 90 files, 1007 tests passed.
-- Production build: passed.
-- Existing unrelated React act warnings and Vite bundle-size warning remain non-failing baseline warnings.
+Implementation CI: workflow `CI`, run `#715`, run ID `29202579685`, conclusion `success`, tested commit `c2ef7962eb061e1c84c6ce3e716b3ee23cffc845`.
 
-## Fresh CI
+A second fresh CI run is mandatory after the report-only metadata commit. The final CI run must test the exact final PR HEAD.
 
-Pending PR creation and a fresh GitHub Actions run on the exact final PR head.
+The PR must remain open and unmerged.
 
-## Known limitations
+Recommended next task: **APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001**
 
-1. Separate Chrome DevTools MCP was unavailable; equivalent HeadlessChrome validation passed.
-2. Historical rows remain stored instants and may require separate evidence-based repair.
-3. No full tenant settings UI was added; only controlled backend mutation and minimal tenant switching.
-4. Cloud Supabase remains behind local migrations because cloud apply was explicitly forbidden.
-5. Existing unrelated Supabase advisor warnings remain separate hardening work.
-6. Existing bundle-size and React warning baselines remain unrelated.
+Reason: tenant-local boundaries and durable appointment instants are now authoritative, so reminder `due_at`, appointment versioning, and cancellation or reschedule invalidation can be designed without sending anything to external providers.
 
-## What was intentionally not implemented
+This next task was not started.
 
-- reminder queues or settings
-- SMS, WhatsApp, or email
-- provider SDKs
-- cron, workers, or webhooks
-- public booking
-- consent/contact redesign
-- week/month redesign
-- finance or clinical changes
-- role redesign
-- frontend service role
-- generated types
-- HEP-V2
-- cloud migration apply
-- historical appointment mass shift
-
-## Recommended next task
-
-`APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001`
-
-Reason: tenant-local boundaries and durable appointment instants are now authoritative, so reminder `due_at`, appointment versioning, and cancellation/reschedule invalidation can be designed without sending anything to providers.
+Final task verdict: **TENANT TIMEZONE SCHEDULING FOUNDATION IMPLEMENTED AND VERIFIED WITH ONE TOOLING LIMITATION**

--- a/_ai_work/REPORTS/TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001_foundation.md
@@ -1,0 +1,384 @@
+# TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001
+
+## Final verdict
+
+PARTIAL: separate Chrome DevTools MCP execution was unavailable in this ChatGPT/Hermes environment; equivalent isolated HeadlessChrome browser automation, PostgREST network validation, local Supabase tests, concurrency tests, TypeScript tests, lint, and production build passed.
+
+## Summary
+
+This task makes the tenant IANA timezone authoritative for appointment scheduling. Appointment timestamps remain PostgreSQL `timestamptz` instants. Forms use tenant-local `YYYY-MM-DDTHH:mm`, repository writes accept only offset-aware instants, and schedule dates are plain tenant-local `YYYY-MM-DD` values. Browser timezone and UTC midnight no longer define the clinic calendar day.
+
+A minimal tenant switcher was added for multi-tenant users. No reminder queue, delivery provider, cron, worker, webhook, finance change, clinical change, public booking, cloud migration, or historical mass shift was introduced.
+
+## Branch
+
+`feature/tenant-timezone-scheduling-foundation-001`
+
+## PR URL
+
+Pending creation after the implementation commit.
+
+## Baseline
+
+- Required PR #351 is present in `main`.
+- Branch baseline: `9a67dd54d2d1a3c14abeb7c37e4538865f8cf35c`.
+- Required earlier merge `9cb2a080f7a92702829b35505c733bad882b836f` is an ancestor.
+- Baseline also includes PR #352, which added an explicit no-merge CI guard and an active main-branch ruleset.
+
+## PR head reviewed before final report update
+
+Pending implementation commit.
+
+## Report update commit
+
+N/A because a final report commit cannot reference itself.
+
+## Changed files
+
+Migration and SQL validation:
+
+- `supabase/migrations/0028_tenant_timezone_scheduling_foundation.sql`
+- `supabase/tests/0028_tenant_timezone_scheduling_foundation_test.sql`
+
+Timezone and tenant/schedule context:
+
+- `src/domain/timezone.ts`
+- `src/domain/timezone.test.ts`
+- `src/contexts/TenantContext.tsx`
+- `src/contexts/TenantContext.test.tsx`
+- `src/context/ScheduleContext.tsx`
+- `src/context/ScheduleProvider.tsx`
+- `src/context/ScheduleProvider.test.tsx`
+- `src/components/layout/Header.tsx`
+- `src/components/layout/Header.test.tsx`
+
+Appointment and patient scheduling paths:
+
+- `src/data/repositories/AppointmentRepository.ts`
+- `src/data/repositories/AppointmentRepository.test.ts`
+- `src/data/hooks/useScheduleAppointments.ts`
+- `src/data/hooks/usePatientAppointments.ts`
+- `src/data/hooks/usePatientListVisitSummary.ts`
+- `src/pages/SchedulePage.tsx`
+- `src/components/schedule/AppointmentModal.tsx`
+- confirmation, cancellation, and no-show components/tests
+- patient list, overview, card, and history components/tests
+
+Existing test fixtures were updated wherever `ActiveTenant.timezone` became required. No package or generated-type changes were made.
+
+## Pre-read
+
+Read before implementation:
+
+- SCHEDULE-OPERATIONS-RECON-001
+- APPOINTMENT-CONFLICT-HARDENING-001
+- SCHEDULE-SOURCE-OF-TRUTH-CONSOLIDATION-001
+- APPOINTMENT-CANCELLATION-NOSHOW-001
+- APPOINTMENT-CONFIRMATION-WORKFLOW-001
+- APPOINTMENT-REMINDER-OPERATIONS-RECON-001
+- roles and permissions
+- multi-tenant architecture rules
+- data isolation and security
+- appointments and schedule
+- backend/API architecture
+- storage and migration strategy
+- testing and QA strategy
+
+## Original time-semantics inventory
+
+| Area | Original behavior | Classification | Risk |
+|---|---|---|---|
+| Schedule selected day | JavaScript `Date` plus `toISOString().split('T')[0]` | UTC-day bug | wrong clinic day near UTC midnight |
+| Slot creation | offset-free local string later marked with `Z` | unsafe Z append | local wall time persisted as UTC |
+| Repository reads | stripped `Z`/explicit offset | offset stripping | instant meaning lost |
+| Appointment modal | browser-local `Date` parsing | browser dependency | different workstations save different instants |
+| Card position/time | browser `getHours()` | browser dependency | wrong schedule position |
+| Patient/lifecycle display | locale formatting without explicit zone | browser dependency | inconsistent schedule/history facts |
+| Next/previous selection | epoch comparison | safe instant conversion | retained |
+| Existing appointment rows | PostgreSQL `timestamptz` | safe stored instant | intentionally not rewritten |
+
+## Original defects
+
+1. UTC midnight defined the clinic day.
+2. Offset-free wall time was blindly treated as UTC.
+3. Persisted offsets were removed during reads.
+4. Browser timezone controlled forms, cards, patient history, and lifecycle metadata.
+5. Tenant context did not expose authoritative timezone.
+6. Multi-tenant users had no practical tenant switch control.
+7. Initial browser reschedule exposed microsecond loss in `updated_at` when canonicalized through JavaScript `Date`; final code preserves database timestamp text and precision.
+
+## Tenant timezone model
+
+- `public.tenants.timezone text not null`
+- legacy/default value: `Asia/Almaty`
+- exact IANA names only
+- numeric offsets are not authoritative identifiers
+- appointments remain `timestamptz`
+- active timezone is loaded with tenant membership context
+
+## Migration behavior
+
+Migration 0028:
+
+1. Adds `tenants.timezone`.
+2. Backfills null/empty legacy values to `Asia/Almaty`.
+3. Sets default and `NOT NULL`.
+4. Validates against PostgreSQL `pg_timezone_names`.
+5. Rejects invalid values through a trigger.
+6. Blocks direct timezone changes outside the controlled RPC path.
+7. Adds owner/admin-only `set_tenant_timezone(uuid,text)`.
+8. Emits audit and activity events for actual changes.
+9. Preserves RLS and existing role boundaries.
+10. Does not rewrite appointment timestamps.
+
+No cloud migration was applied.
+
+## Historical-data handling
+
+Existing timestamps are treated as stored instants. No row was shifted based on guessed prior intent. Historical rows created under earlier unsafe browser conversion may require a separate evidence-based audited repair task. This task prevents future ambiguous writes without inventing history.
+
+## Time representation contract
+
+- persisted timestamp: offset-aware ISO 8601 instant
+- tenant-local form: `YYYY-MM-DDTHH:mm`
+- tenant-local date: `YYYY-MM-DD`
+- timezone: IANA name
+- repository boundary: offset-aware instants only
+- UI boundary: tenant-local wall time converted through tenant timezone
+- day interval: tenant midnight to next tenant midnight, half-open
+- comparisons: instant based
+## Timezone utility
+
+`src/domain/timezone.ts` provides IANA validation, offset-aware instant validation, instant-to-tenant date/time conversion, tenant-local wall-time-to-instant conversion, tenant day boundaries, injected tenant-aware now, tenant-day comparison, formatting, and calendar-day arithmetic. Invalid inputs fail with safe Russian messages and never silently fall back to browser timezone.
+
+## Dependency decision
+
+No dependency was added. Native `Intl.DateTimeFormat` is used with explicit `timeZone`. Wall-time conversion enumerates real zone offsets around the requested local time and verifies exact formatted parts, which detects missing and repeated local times without a single-offset guesser.
+
+## DST and ambiguity policy
+
+- nonexistent spring-forward time: reject
+- repeated fall-back time: reject as ambiguous
+- never silently shift by one hour
+- Berlin and New York winter/summer offsets tested
+- historical IANA rules delegated to runtime timezone data
+
+## Tenant context
+
+- `ActiveTenant.timezone` is required.
+- Supabase membership query loads tenant timezone.
+- Only the migration-guaranteed `Asia/Almaty` legacy fallback is permitted.
+- Invalid database timezone blocks scheduling with a safe error.
+- Tenant and timezone participate in relevant query identities.
+- Pending old tenant/user responses remain guarded.
+- Tenant switch changes tenant, role, and timezone together.
+- Schedule date state is keyed by tenant id plus timezone.
+- Header contains a minimal tenant selector, not a broad settings module.
+
+## Repository conversion fixes
+
+- removed blind `Z` append
+- removed timezone suffix stripping
+- create/reschedule require offset-aware instants
+- write values normalize to equivalent UTC ISO instants
+- database timestamps are validated but returned unchanged
+- explicit offsets and PostgreSQL microseconds survive reads
+- `updated_at` remains exact for optimistic concurrency
+- lifecycle and confirmation timestamps remain instants
+- raw SQLSTATE, catalog names, stack traces, and PostgREST payloads are not exposed
+
+## Appointment modal integration
+
+Existing appointments convert from persisted instant to tenant-local form values. Saving converts tenant-local start/end through the tenant timezone. Conflict checks remain instant based. Save/reload preserves local wall time. Reschedule uses the same contract. DST gaps and repeated times return safe errors.
+
+## Schedule-day boundaries
+
+- selected date is plain tenant-local `YYYY-MM-DD`
+- reachable `toISOString().split('T')[0]` logic removed
+- day membership uses tenant start and next-day start
+- interval is half-open
+- card position and label use tenant wall time
+- month/year heading formats a plain tenant date without browser drift
+
+## Today and tomorrow semantics
+
+Schedule initialization uses `tenantNowDate(timezone)`. Date navigation uses plain-date calendar arithmetic. Tests inject 
+ow` and prove a near-midnight UTC instant produces different correct dates in Almaty and Berlin. UTC midnight and browser midnight no longer define clinic today.
+
+## Patient summaries
+
+Next/previous selection remains instant based. Patient list, overview, card history, and schedule display through active tenant timezone. The same instant was browser-verified as `13.07.2026 00:30` in Almaty and `12.07.2026 21:30` in Berlin.
+
+## Lifecycle timestamp display
+
+Confirmation, last attempt, cancellation, no-show, and patient-history lifecycle facts render in tenant timezone. Repository values remain persisted instants.
+
+## Role matrix
+
+Timezone read:
+
+- owner/admin/registrar/doctor/cashier: allowed for their tenant
+- unknown/no tenant: blocked
+
+Timezone mutation RPC:
+
+- owner: allowed
+- admin: allowed
+- registrar: blocked
+- doctor: blocked
+- cashier: blocked
+- unknown/no tenant: blocked
+- cross-tenant admin: blocked
+
+No frontend service role was introduced.
+
+## SQL tests
+
+Clean local reset applied migrations 0001 through 0028. Passed:
+
+- `0024_legacy_core_table_grants_test.sql`
+- `0025_appointment_conflict_hardening_test.sql`
+- `0026_appointment_cancellation_noshow_test.sql`
+- `0027_appointment_confirmation_workflow_test.sql`
+- `0028_tenant_timezone_scheduling_foundation_test.sql`
+
+SQL 0028 verifies default/backfill, valid and invalid IANA names, direct-update blocking, role matrix, cross-tenant isolation, RLS, audited mutation, unchanged appointment instants, no invalid intervals, and no clinical/financial effects.
+
+## Concurrency tests
+
+- 0025: success operations 13; doctor overlaps 0; patient overlaps 0; invalid intervals 0; audit/activity 13/13; deadlocks 0.
+- 0026: successes 13; replays 2; controlled conflicts 5; cancelled 8; no-show 2; active overlaps 0; deadlocks 0.
+- 0027: successes 12; replays 2; controlled conflicts 7; attempts 10; confirmations 6; duplicate keys 0; deadlocks 0.
+
+## Timezone utility tests
+
+Covered Almaty conversion and round trips, UTC-midnight crossing, Berlin/New York winter and summer, DST gap rejection, DST ambiguity rejection, invalid timezone/date/instant, leap day, half-open boundaries, injected now, and browser-zone independence.
+
+## Repository tests
+
+Covered explicit offset preservation, offset-free rejection, no suffix stripping, no blind `Z` append, correct create/reschedule instants, exact database timestamp precision, lifecycle/confirmation mapping, save/reload instant stability, and safe errors.
+
+## Schedule and UI tests
+
+Covered tenant-local selected day, boundary inclusion/exclusion, tenant-switch date reset, different A/B dates for one instant, modal wall-time round trip, tenant selector behavior, and unchanged confirmation/cancellation/no-show behavior.
+## Browser smoke
+
+Real isolated HeadlessChrome 150 smoke ran against local Supabase and this task branch on `127.0.0.1:5188`.
+
+Passed scenarios:
+
+1. Create at Almaty local 09:00 and reload at 09:00.
+2. Database raw creation instant: `2026-07-12 04:00:00+00`; Almaty wall time 09:00.
+3. Reschedule to Almaty local 11:30-12:30 and reload unchanged.
+4. Database raw reschedule instants: 06:30-07:30 UTC; Almaty wall time 11:30-12:30.
+5. One UTC instant rendered as 13 July 00:30 in Almaty.
+6. The same instant rendered as 12 July 21:30 in Berlin.
+7. Host timezone is UTC+5, but Berlin still rendered Berlin time.
+8. Tenant A to B switch changed role/timezone and removed old custom date without stale A content.
+9. Confirmation succeeded and survived reload.
+10. Cancellation succeeded and rendered tenant-local metadata.
+11. No-show succeeded and rendered tenant-local metadata.
+12. Successful final scenarios had no console errors, failed requests, or visible secrets.
+
+The first browser reschedule before the precision fix returned the safe stale-write error. It exposed JavaScript truncation of PostgreSQL microseconds in `updated_at`. After preserving raw timestamp precision, the same smoke passed.
+
+### Chrome DevTools MCP limitation
+
+Hermes exposed isolated browser automation and HeadlessChrome, but no separately invokable `chrome-devtools-mcp` action or executable. Codex configuration references a Chrome plugin, but Codex/Chrome MCP was not callable in this conversation. This exact named-tool gap is the reason for the PARTIAL verdict. Equivalent browser, console, request, gateway-log, and database validation was completed.
+
+## Network validation
+
+Kong/PostgREST logs captured successful calls:
+
+- `POST /rest/v1/rpc/create_appointment` -> 200
+- `POST /rest/v1/rpc/reschedule_appointment` -> 200 after precision fix
+- `POST /rest/v1/rpc/confirm_appointment` -> 200
+- `POST /rest/v1/rpc/cancel_appointment` -> 200
+- `POST /rest/v1/rpc/mark_appointment_no_show` -> 200
+- tenant-scoped reads for A and B
+- patient-scoped history reads
+
+No protected direct appointment insert/update and no frontend service-role credential were used.
+
+## Database validation
+
+Browser-smoke database results:
+
+- doctor overlap pairs: 0
+- patient overlap pairs: 0
+- invalid intervals: 0
+- create/reschedule/confirm/cancel/no-show operation facts present
+- matching audit events present
+- lifecycle timestamps stored as UTC instants
+- same absolute instant preserved across tenants
+- tenant isolation preserved
+
+## Tenant-switch validation
+
+Tenant A used `Asia/Almaty`; Tenant B used `Europe/Berlin`. The multi-tenant user switched from admin context in A to doctor context in B. Timezone and role changed together, the old selected date disappeared, and Berlin history rendered Berlin time rather than host UTC+5 time.
+
+## Side-effect validation
+
+After browser operations all counts remained zero:
+
+- patient visits
+- clinical encounters
+- completed services
+- invoices
+- payments
+- refunds
+- financial adjustments
+
+SQL 0028 independently verifies the same no-side-effect contract.
+
+## Cleanup
+
+- Task Vite process stopped.
+- Local Supabase reset with `--no-seed` after browser and concurrency QA.
+- Final counters: tenants 0, memberships 0, patients 0, doctors 0, appointments 0, operations 0, confirmation attempts 0, visits 0, encounters 0, invoices 0, payments 0.
+- Browser screenshots remain outside the repository under `D:\hermes\reports\tenant-timezone-smoke` and are not committed.
+
+## Lint, test, and build
+
+Final clean results:
+
+- ESLint: passed.
+- Full Vitest: 90 files, 1007 tests passed.
+- Production build: passed.
+- Existing unrelated React act warnings and Vite bundle-size warning remain non-failing baseline warnings.
+
+## Fresh CI
+
+Pending PR creation and a fresh GitHub Actions run on the exact final PR head.
+
+## Known limitations
+
+1. Separate Chrome DevTools MCP was unavailable; equivalent HeadlessChrome validation passed.
+2. Historical rows remain stored instants and may require separate evidence-based repair.
+3. No full tenant settings UI was added; only controlled backend mutation and minimal tenant switching.
+4. Cloud Supabase remains behind local migrations because cloud apply was explicitly forbidden.
+5. Existing unrelated Supabase advisor warnings remain separate hardening work.
+6. Existing bundle-size and React warning baselines remain unrelated.
+
+## What was intentionally not implemented
+
+- reminder queues or settings
+- SMS, WhatsApp, or email
+- provider SDKs
+- cron, workers, or webhooks
+- public booking
+- consent/contact redesign
+- week/month redesign
+- finance or clinical changes
+- role redesign
+- frontend service role
+- generated types
+- HEP-V2
+- cloud migration apply
+- historical appointment mass shift
+
+## Recommended next task
+
+`APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001`
+
+Reason: tenant-local boundaries and durable appointment instants are now authoritative, so reminder `due_at`, appointment versioning, and cancellation/reschedule invalidation can be designed without sending anything to providers.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -71,7 +71,7 @@ afterEach(() => {
 describe('App Auth & Tenant Gate', () => {
   it('1. dev mode renders app routes, not LoginPage, not no-tenant screen', async () => {
     mockUseAuth({ authMode: 'dev', isLoading: false });
-    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Dev', role: 'clinic_admin' }, availableTenants: [{ tenantId: '123', tenantName: 'Dev', role: 'clinic_admin' }], isLoading: false });
+    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Dev', timezone: 'Asia/Almaty', role: 'clinic_admin' }, availableTenants: [{ tenantId: '123', tenantName: 'Dev', timezone: 'Asia/Almaty', role: 'clinic_admin' }], isLoading: false });
 
     const { container, root } = await renderApp();
 
@@ -164,7 +164,7 @@ describe('App Auth & Tenant Gate', () => {
 
   it('7. supabase-active + user + activeTenant renders normal app routes', async () => {
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
-    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Real', role: 'clinic_admin' }, availableTenants: [{ tenantId: '123', tenantName: 'Real', role: 'clinic_admin' }], isLoading: false });
+    mockUseTenant({ activeTenant: { tenantId: '123', tenantName: 'Real', timezone: 'Asia/Almaty', role: 'clinic_admin' }, availableTenants: [{ tenantId: '123', tenantName: 'Real', timezone: 'Asia/Almaty', role: 'clinic_admin' }], isLoading: false });
 
     const { container, root } = await renderApp();
 
@@ -185,8 +185,8 @@ describe('App Auth & Tenant Gate', () => {
   ])('renders active clinic role label for %s', async (role, expectedLabel) => {
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
     mockUseTenant({
-      activeTenant: { tenantId: '123', tenantName: 'Real', role },
-      availableTenants: [{ tenantId: '123', tenantName: 'Real', role }],
+      activeTenant: { tenantId: '123', tenantName: 'Real', timezone: 'Asia/Almaty', role },
+      availableTenants: [{ tenantId: '123', tenantName: 'Real', timezone: 'Asia/Almaty', role }],
       isLoading: false,
     });
 
@@ -204,10 +204,10 @@ describe('App Auth & Tenant Gate', () => {
     mockUseAuth({ authMode: 'supabase-active', user: { id: '1', email: 'a@a.com' }, isLoading: false });
 
     tenantSpy.mockReturnValue({
-      activeTenant: { tenantId: 'clinic-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+      activeTenant: { tenantId: 'clinic-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
       availableTenants: [
-        { tenantId: 'clinic-a', tenantName: 'Clinic A', role: 'clinic_admin' },
-        { tenantId: 'clinic-b', tenantName: 'Clinic B', role: 'doctor' },
+        { tenantId: 'clinic-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
+        { tenantId: 'clinic-b', tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'doctor' },
       ],
       setActiveTenant: vi.fn(),
       isLoading: false,
@@ -224,10 +224,10 @@ describe('App Auth & Tenant Gate', () => {
     expect(currentRoleLabel(container)).toBe('Администратор клиники');
 
     tenantSpy.mockReturnValue({
-      activeTenant: { tenantId: 'clinic-b', tenantName: 'Clinic B', role: 'doctor' },
+      activeTenant: { tenantId: 'clinic-b', tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'doctor' },
       availableTenants: [
-        { tenantId: 'clinic-a', tenantName: 'Clinic A', role: 'clinic_admin' },
-        { tenantId: 'clinic-b', tenantName: 'Clinic B', role: 'doctor' },
+        { tenantId: 'clinic-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
+        { tenantId: 'clinic-b', tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'doctor' },
       ],
       setActiveTenant: vi.fn(),
       isLoading: false,

--- a/src/components/admin/AdminAuditViewer.test.tsx
+++ b/src/components/admin/AdminAuditViewer.test.tsx
@@ -109,8 +109,8 @@ const mockUseAuth = (overrides: Partial<ReturnType<typeof AuthContextModule.useA
 
 const mockUseTenant = (role: string | null, tenantId = 'tenant-1') => {
   vi.spyOn(TenantContextModule, 'useTenant').mockReturnValue({
-    activeTenant: tenantId ? { tenantId, tenantName: 'Clinic', role: role ?? undefined } : null,
-    availableTenants: tenantId ? [{ tenantId, tenantName: 'Clinic', role: role ?? undefined }] : [],
+    activeTenant: tenantId ? { tenantId, tenantName: 'Clinic', timezone: 'Asia/Almaty', role: role ?? undefined } : null,
+    availableTenants: tenantId ? [{ tenantId, tenantName: 'Clinic', timezone: 'Asia/Almaty', role: role ?? undefined }] : [],
     setActiveTenant: vi.fn(),
     isLoading: false,
     error: null,

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -23,8 +23,8 @@ const mockAuth = (overrides: Partial<ReturnType<typeof AuthContextModule.useAuth
 
 const mockTenant = (role?: string) => {
   vi.spyOn(TenantContextModule, 'useTenant').mockReturnValue({
-    activeTenant: { tenantId: 'tenant-1', tenantName: 'Demo Clinic', role },
-    availableTenants: [{ tenantId: 'tenant-1', tenantName: 'Demo Clinic', role }],
+    activeTenant: { tenantId: 'tenant-1', tenantName: 'Demo Clinic', timezone: 'Asia/Almaty', role },
+    availableTenants: [{ tenantId: 'tenant-1', tenantName: 'Demo Clinic', timezone: 'Asia/Almaty', role }],
     setActiveTenant: vi.fn(),
     isLoading: false,
     error: null,
@@ -33,7 +33,7 @@ const mockTenant = (role?: string) => {
 
 const mockSchedule = () => {
   vi.spyOn(ScheduleContextModule, 'useScheduleContext').mockReturnValue({
-    selectedDate: new Date('2026-06-15T00:00:00.000Z'),
+    selectedDate: '2026-06-15',
     setSelectedDate: vi.fn(),
     viewMode: 'day',
     setViewMode: vi.fn(),
@@ -181,10 +181,10 @@ describe('Header role label', () => {
   it('updates the visible label when active tenant role changes', async () => {
     const tenantSpy = vi.spyOn(TenantContextModule, 'useTenant');
     tenantSpy.mockReturnValue({
-      activeTenant: { tenantId: 'tenant-a', tenantName: 'Clinic A', role: 'clinic_admin' },
+      activeTenant: { tenantId: 'tenant-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
       availableTenants: [
-        { tenantId: 'tenant-a', tenantName: 'Clinic A', role: 'clinic_admin' },
-        { tenantId: 'tenant-b', tenantName: 'Clinic B', role: 'doctor' },
+        { tenantId: 'tenant-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
+        { tenantId: 'tenant-b', tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'doctor' },
       ],
       setActiveTenant: vi.fn(),
       isLoading: false,
@@ -201,10 +201,10 @@ describe('Header role label', () => {
     expect(roleLabel(container)).toBe('Администратор клиники');
 
     tenantSpy.mockReturnValue({
-      activeTenant: { tenantId: 'tenant-b', tenantName: 'Clinic B', role: 'doctor' },
+      activeTenant: { tenantId: 'tenant-b', tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'doctor' },
       availableTenants: [
-        { tenantId: 'tenant-a', tenantName: 'Clinic A', role: 'clinic_admin' },
-        { tenantId: 'tenant-b', tenantName: 'Clinic B', role: 'doctor' },
+        { tenantId: 'tenant-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
+        { tenantId: 'tenant-b', tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'doctor' },
       ],
       setActiveTenant: vi.fn(),
       isLoading: false,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTenant } from '../../contexts/TenantContext';
 import { getClinicRoleLabel } from '../../domain/roleLabels';
+import { formatTenantDate } from '../../domain/timezone';
 
 export function Header() {
   const {
@@ -25,10 +26,10 @@ export function Header() {
 
   const { doctors } = useClinicDoctors();
   const { user, authMode, signOut } = useAuth();
-  const { activeTenant } = useTenant();
+  const { activeTenant, availableTenants, setActiveTenant } = useTenant();
   const roleLabel = getClinicRoleLabel(activeTenant?.role);
 
-  const formattedDate = selectedDate.toLocaleDateString('ru-RU', {
+  const formattedDate = formatTenantDate(selectedDate, {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
@@ -92,6 +93,26 @@ export function Header() {
           <Calendar className="w-4 h-4 text-slate-400" />
           <span className="capitalize">{formattedDate}</span>
         </div>
+
+        {activeTenant && (
+          <label className="flex items-center gap-2 text-xs text-slate-500">
+            <span className="sr-only">Клиника</span>
+            <select
+              data-testid="tenant-switcher"
+              aria-label="Клиника"
+              value={activeTenant.tenantId}
+              onChange={(event) => setActiveTenant(event.target.value)}
+              disabled={availableTenants.length < 2}
+              className="max-w-44 rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-700 outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-50"
+            >
+              {availableTenants.map((tenant) => (
+                <option key={tenant.tenantId} value={tenant.tenantId}>
+                  {tenant.tenantName}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
 
         <div className="h-6 w-px bg-slate-200 mx-2"></div>
 

--- a/src/components/patients/patient-card/PatientHistoryTab.test.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.test.tsx
@@ -8,9 +8,11 @@ import { PatientHistoryTab } from './PatientHistoryTab';
 import { usePatientAppointments } from '../../../data/hooks/usePatientAppointments';
 import { useClinicDoctors } from '../../../data/hooks/useClinicDoctors';
 import type { Appointment } from '../../../types';
+import { useTenant } from '../../../contexts/TenantContext';
 
 vi.mock('../../../data/hooks/usePatientAppointments', () => ({ usePatientAppointments: vi.fn() }));
 vi.mock('../../../data/hooks/useClinicDoctors', () => ({ useClinicDoctors: vi.fn() }));
+vi.mock('../../../contexts/TenantContext', () => ({ useTenant: vi.fn(), LEGACY_TENANT_TIMEZONE: 'Asia/Almaty' }));
 
 const row = (overrides: Partial<Appointment> = {}): Appointment => ({
   id: 'appointment-1',
@@ -19,9 +21,9 @@ const row = (overrides: Partial<Appointment> = {}): Appointment => ({
   cabinet: 'A1',
   service: 'Осмотр',
   status: 'confirmed',
-  start: '2026-08-01T10:00:00',
-  end: '2026-08-01T11:00:00',
-  createdAt: '2026-07-01T10:00:00',
+  start: '2026-08-01T05:00:00.000Z',
+  end: '2026-08-01T06:00:00.000Z',
+  createdAt: '2026-07-01T05:00:00.000Z',
   updatedAt: '2026-07-01T10:00:00+00:00',
   ...overrides,
 });
@@ -29,6 +31,7 @@ const row = (overrides: Partial<Appointment> = {}): Appointment => ({
 describe('PatientHistoryTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-a', tenantName: 'Clinic', timezone: 'Asia/Almaty' } } as unknown as ReturnType<typeof useTenant>);
     vi.mocked(useClinicDoctors).mockReturnValue({
       doctors: [{ id: 'doctor-1', fullName: 'Доктор Один', specialization: '', cabinet: 'A1', color: '', active: true }],
       isLoading: false,
@@ -75,7 +78,7 @@ describe('PatientHistoryTab', () => {
     vi.mocked(usePatientAppointments).mockReturnValue({
       appointments: [row({
         status: 'cancelled',
-        cancelledAt: '2026-08-01T12:00:00',
+        cancelledAt: '2026-08-01T12:00:00Z',
         cancelledBy: 'raw-user-uuid',
         cancellationSource: 'patient',
         cancellationReason: 'Пациент попросил отменить',
@@ -98,7 +101,7 @@ describe('PatientHistoryTab', () => {
     vi.mocked(usePatientAppointments).mockReturnValue({
       appointments: [row({
         status: 'no_show',
-        noShowAt: '2026-08-01T12:00:00',
+        noShowAt: '2026-08-01T12:00:00Z',
         noShowBy: 'raw-user-uuid',
         noShowReason: 'Не отвечает на звонки',
         lifecycleMetadataVersion: 1,
@@ -120,10 +123,10 @@ describe('PatientHistoryTab', () => {
     vi.mocked(usePatientAppointments).mockReturnValue({
       appointments: [row({
         confirmationState: 'confirmed',
-        confirmedAt: '2026-08-01T09:30:00',
+        confirmedAt: '2026-08-01T09:30:00Z',
         confirmationChannel: 'whatsapp',
         confirmationAttemptCount: 2,
-        lastConfirmationAttemptAt: '2026-08-01T09:30:00',
+        lastConfirmationAttemptAt: '2026-08-01T09:30:00Z',
         lastConfirmationOutcome: 'confirmed',
         lastConfirmationNote: 'Пациент подтвердил',
       })],
@@ -181,7 +184,7 @@ describe('PatientHistoryTab', () => {
     await act(async () => root.render(<PatientHistoryTab patientId="patient-1" />));
     expect(container.textContent).toContain('10:00');
 
-    appointments = [row({ start: '2026-08-01T12:30:00', end: '2026-08-01T13:30:00', status: 'arrived' })];
+    appointments = [row({ start: '2026-08-01T07:30:00.000Z', end: '2026-08-01T08:30:00.000Z', status: 'arrived' })];
     await act(async () => root.render(<PatientHistoryTab patientId="patient-1" />));
 
     expect(container.textContent).toContain('12:30');

--- a/src/components/patients/patient-card/PatientHistoryTab.tsx
+++ b/src/components/patients/patient-card/PatientHistoryTab.tsx
@@ -4,6 +4,8 @@ import { Stethoscope, ClipboardList } from 'lucide-react';
 import { useClinicDoctors } from '../../../data/hooks/useClinicDoctors';
 import { usePatientAppointments } from '../../../data/hooks/usePatientAppointments';
 import { cancellationSourceLabel } from '../../schedule/appointmentLifecycle';
+import { LEGACY_TENANT_TIMEZONE, useTenant } from '../../../contexts/TenantContext';
+import { formatInstantInTenant } from '../../../domain/timezone';
 import {
   confirmationStateClassName,
   confirmationStateLabel,
@@ -44,6 +46,8 @@ const getStatusColor = (status: string) => {
 export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
   const { appointments, isLoading: isAppointmentsLoading, isError: isAppointmentsError } = usePatientAppointments(patientId);
   const { doctors, isLoading: isDoctorsLoading, isError: isDoctorsError } = useClinicDoctors();
+  const { activeTenant } = useTenant();
+  const timezone = activeTenant?.timezone ?? LEGACY_TENANT_TIMEZONE;
 
   const isLoading = isAppointmentsLoading || isDoctorsLoading;
   const isError = isAppointmentsError || isDoctorsError;
@@ -91,12 +95,11 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
           <tbody className="divide-y divide-slate-100">
             {appointments.map(appt => {
               const doctor = doctors.find(d => d.id === appt.doctorId);
-              const apptDate = new Date(appt.start);
               return (
                 <tr key={appt.id} className="hover:bg-slate-50 transition-colors">
                   <td className="py-3 px-4">
-                    <div className="font-medium text-slate-800">{apptDate.toLocaleDateString('ru-RU')}</div>
-                    <div className="text-xs text-slate-500">{apptDate.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' })}</div>
+                    <div className="font-medium text-slate-800">{formatInstantInTenant(appt.start, timezone, { dateStyle: 'short' })}</div>
+                    <div className="text-xs text-slate-500">{formatInstantInTenant(appt.start, timezone, { hour: '2-digit', minute: '2-digit' })}</div>
                   </td>
                   <td className="py-3 px-4 text-slate-700">{doctor ? doctor.fullName : '-'}</td>
                   <td className="py-3 px-4">
@@ -104,7 +107,7 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
                     {appt.comment && <div className="text-xs text-slate-500 truncate max-w-[200px] mt-0.5">{appt.comment}</div>}
                     {appt.status === 'cancelled' && (
                       <div className="mt-2 max-w-sm rounded bg-red-50 p-2 text-xs text-red-800" data-testid={`history-cancellation-${appt.id}`}>
-                        <div>Отменено: {appt.cancelledAt ? new Date(appt.cancelledAt).toLocaleString('ru-RU') : 'историческая запись'}</div>
+                        <div>Отменено: {appt.cancelledAt ? formatInstantInTenant(appt.cancelledAt, timezone) : 'историческая запись'}</div>
                         <div>Источник: {cancellationSourceLabel(appt.cancellationSource)}</div>
                         <div>Причина: {appt.cancellationReason || 'Не была сохранена в прежней версии системы'}</div>
                         <div>Сотрудник: {appt.cancelledBy ? 'Сотрудник клиники' : 'Не указан'}</div>
@@ -112,7 +115,7 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
                     )}
                     {appt.status === 'no_show' && (
                       <div className="mt-2 max-w-sm rounded bg-rose-50 p-2 text-xs text-rose-800" data-testid={`history-no-show-${appt.id}`}>
-                        <div>Неявка: {appt.noShowAt ? new Date(appt.noShowAt).toLocaleString('ru-RU') : 'историческая запись'}</div>
+                        <div>Неявка: {appt.noShowAt ? formatInstantInTenant(appt.noShowAt, timezone) : 'историческая запись'}</div>
                         <div>Причина: {appt.noShowReason || 'Не была сохранена в прежней версии системы'}</div>
                         <div>Сотрудник: {appt.noShowBy ? 'Сотрудник клиники' : 'Не указан'}</div>
                       </div>
@@ -125,9 +128,9 @@ export function PatientHistoryTab({ patientId }: PatientHistoryTabProps) {
                         </span>
                       </div>
                       <div>Попыток связи: {appt.confirmationAttemptCount || 0}</div>
-                      <div>Последняя попытка: {appt.lastConfirmationAttemptAt ? new Date(appt.lastConfirmationAttemptAt).toLocaleString('ru-RU') : 'Нет'}</div>
+                      <div>Последняя попытка: {appt.lastConfirmationAttemptAt ? formatInstantInTenant(appt.lastConfirmationAttemptAt, timezone) : 'Нет'}</div>
                       <div>Результат: {appt.lastConfirmationOutcome ? CONTACT_OUTCOME_LABELS[appt.lastConfirmationOutcome] : 'Нет'}</div>
-                      <div>Подтверждена: {appt.confirmedAt ? new Date(appt.confirmedAt).toLocaleString('ru-RU') : 'Нет'}</div>
+                      <div>Подтверждена: {appt.confirmedAt ? formatInstantInTenant(appt.confirmedAt, timezone) : 'Нет'}</div>
                       <div>Канал: {appt.confirmationChannel ? CONTACT_CHANNEL_LABELS[appt.confirmationChannel] : 'Нет'}</div>
                       {appt.lastConfirmationNote && <div>Примечание: {appt.lastConfirmationNote}</div>}
                     </div>

--- a/src/components/patients/patient-card/PatientOverviewTab.tsx
+++ b/src/components/patients/patient-card/PatientOverviewTab.tsx
@@ -1,5 +1,7 @@
 import { FileText, Wallet, Cloud, Stethoscope, ClipboardList } from 'lucide-react';
 import type { Patient } from '../../../types';
+import { LEGACY_TENANT_TIMEZONE } from '../../../contexts/TenantContext';
+import { formatInstantInTenant } from '../../../domain/timezone';
 
 interface PatientOverviewTabProps {
   patient: Patient;
@@ -15,6 +17,7 @@ interface PatientOverviewTabProps {
   };
   lastVisit?: Date;
   nextVisit?: Date;
+  timezone?: string;
   onNavigateToSchedule: () => void;
 }
 
@@ -63,6 +66,7 @@ export function PatientOverviewTab({
   dentalSummary,
   lastVisit,
   nextVisit,
+  timezone = LEGACY_TENANT_TIMEZONE,
   onNavigateToSchedule
 }: PatientOverviewTabProps) {
   return (
@@ -273,11 +277,11 @@ export function PatientOverviewTab({
            <div className="space-y-3">
              <div className="flex justify-between items-center text-sm">
                <span className="text-slate-500">Предыдущая</span>
-               <span className="font-medium text-slate-800">{lastVisit ? lastVisit.toLocaleDateString('ru-RU') : '-'}</span>
+               <span className="font-medium text-slate-800">{lastVisit ? formatInstantInTenant(lastVisit, timezone, { dateStyle: 'short' }) : '-'}</span>
              </div>
              <div className="flex justify-between items-center text-sm">
                <span className="text-slate-500">Следующая</span>
-               <span className="font-medium text-slate-800">{nextVisit ? nextVisit.toLocaleDateString('ru-RU') : '-'}</span>
+               <span className="font-medium text-slate-800">{nextVisit ? formatInstantInTenant(nextVisit, timezone, { dateStyle: 'short' }) : '-'}</span>
              </div>
            </div>
            <div className="pt-3 border-t border-slate-100">

--- a/src/components/schedule/AppointmentCancellationDialog.tsx
+++ b/src/components/schedule/AppointmentCancellationDialog.tsx
@@ -1,10 +1,12 @@
 import { useState, type FormEvent } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
+import { formatInstantInTenant } from '../../domain/timezone';
 import type { Appointment, CancellationSource } from '../../types';
 import { CANCELLATION_SOURCE_LABELS } from './appointmentLifecycle';
 
 interface AppointmentCancellationDialogProps {
   appointment: Appointment;
+  timezone: string;
   patientName: string;
   doctorName: string;
   isSaving: boolean;
@@ -16,6 +18,7 @@ interface AppointmentCancellationDialogProps {
 
 export function AppointmentCancellationDialog({
   appointment,
+  timezone,
   patientName,
   doctorName,
   isSaving,
@@ -28,7 +31,6 @@ export function AppointmentCancellationDialog({
   const [reason, setReason] = useState('');
   const [validationError, setValidationError] = useState<string | null>(null);
   const [succeeded, setSucceeded] = useState(false);
-  const start = new Date(appointment.start);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -72,7 +74,7 @@ export function AppointmentCancellationDialog({
             <dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-2 rounded-lg bg-slate-50 p-3 text-sm">
               <dt className="text-slate-500">Пациент</dt><dd className="font-medium text-slate-800">{patientName}</dd>
               <dt className="text-slate-500">Врач</dt><dd className="font-medium text-slate-800">{doctorName}</dd>
-              <dt className="text-slate-500">Дата и время</dt><dd className="font-medium text-slate-800">{start.toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short' })}</dd>
+              <dt className="text-slate-500">Дата и время</dt><dd className="font-medium text-slate-800">{formatInstantInTenant(appointment.start, timezone, { dateStyle: 'short', timeStyle: 'short' })}</dd>
               <dt className="text-slate-500">Текущий статус</dt><dd className="font-medium text-slate-800">{appointment.status}</dd>
             </dl>
 

--- a/src/components/schedule/AppointmentConfirmationPanel.test.tsx
+++ b/src/components/schedule/AppointmentConfirmationPanel.test.tsx
@@ -11,13 +11,13 @@ import { appointmentNeedsConfirmationAttention } from './appointmentConfirmation
 
 const appointment: Appointment = {
   id: 'appointment-1', patientId: 'patient-1', doctorId: 'doctor-1', cabinet: 'A1', service: 'Осмотр',
-  start: '2026-08-01T10:00:00', end: '2026-08-01T11:00:00', status: 'new', createdAt: '2026-07-01T09:00:00',
+  start: '2026-08-01T10:00:00Z', end: '2026-08-01T11:00:00Z', status: 'new', createdAt: '2026-07-01T09:00:00Z',
   updatedAt: '2026-07-01T09:00:00+00:00', confirmationState: 'unconfirmed', confirmationAttemptCount: 0,
 };
 
 const attempt: AppointmentConfirmationAttempt = {
   id: 'attempt-1', tenantId: 'tenant-1', appointmentId: appointment.id, patientId: 'patient-1', actorUserId: 'actor-1',
-  channel: 'phone', outcome: 'callback_requested', note: 'После обеда', attemptedAt: '2026-08-01T09:30:00', createdAt: '2026-08-01T09:30:00',
+  channel: 'phone', outcome: 'callback_requested', note: 'После обеда', attemptedAt: '2026-08-01T09:30:00Z', createdAt: '2026-08-01T09:30:00Z',
 };
 
 interface RenderOptions {
@@ -50,7 +50,8 @@ const renderPanel = async (options: RenderOptions = {}) => {
     onRecordAttempt: options.onRecordAttempt || vi.fn().mockResolvedValue({ ...appointment, confirmationState: 'contact_in_progress' }),
     onConfirm: options.onConfirm || vi.fn().mockResolvedValue({ ...appointment, confirmationState: 'confirmed' }),
   };
-  await act(async () => root.render(<AppointmentConfirmationPanel {...props} />));
+  await act(async () => root.render(<AppointmentConfirmationPanel
+      timezone="Asia/Almaty" {...props} />));
   return { container, root, props };
 };
 

--- a/src/components/schedule/AppointmentConfirmationPanel.tsx
+++ b/src/components/schedule/AppointmentConfirmationPanel.tsx
@@ -14,10 +14,12 @@ import {
   CONTACT_CHANNEL_LABELS,
   CONTACT_OUTCOME_LABELS,
 } from './appointmentConfirmation';
+import { formatInstantInTenant } from '../../domain/timezone';
 
 interface AppointmentConfirmationPanelProps {
   appointment: Appointment;
   role?: string;
+  timezone: string;
   attempts: AppointmentConfirmationAttempt[];
   isLoadingAttempts?: boolean;
   attemptsError?: string | null;
@@ -35,13 +37,14 @@ interface AppointmentConfirmationPanelProps {
 
 type FormMode = 'attempt' | 'confirm' | null;
 
-const formatDate = (value?: string) => value
-  ? new Date(value).toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short' })
+const formatDate = (value: string | undefined, timezone: string) => value
+  ? formatInstantInTenant(value, timezone, { dateStyle: 'short', timeStyle: 'short' })
   : 'Нет';
 
 export function AppointmentConfirmationPanel({
   appointment,
   role,
+  timezone,
   attempts,
   isLoadingAttempts = false,
   attemptsError = null,
@@ -132,11 +135,11 @@ export function AppointmentConfirmationPanel({
         <dt className="text-slate-500">Попыток связи</dt>
         <dd className="font-medium text-slate-800" data-testid="appointment-confirmation-attempt-count">{appointment.confirmationAttemptCount || 0}</dd>
         <dt className="text-slate-500">Последняя попытка</dt>
-        <dd className="font-medium text-slate-800">{formatDate(appointment.lastConfirmationAttemptAt)}</dd>
+        <dd className="font-medium text-slate-800">{formatDate(appointment.lastConfirmationAttemptAt, timezone)}</dd>
         <dt className="text-slate-500">Последний результат</dt>
         <dd className="font-medium text-slate-800">{appointment.lastConfirmationOutcome ? CONTACT_OUTCOME_LABELS[appointment.lastConfirmationOutcome] : 'Нет'}</dd>
         <dt className="text-slate-500">Подтверждена</dt>
-        <dd className="font-medium text-slate-800">{formatDate(appointment.confirmedAt)}</dd>
+        <dd className="font-medium text-slate-800">{formatDate(appointment.confirmedAt, timezone)}</dd>
         <dt className="text-slate-500">Канал подтверждения</dt>
         <dd className="font-medium text-slate-800">{appointment.confirmationChannel ? CONTACT_CHANNEL_LABELS[appointment.confirmationChannel] : 'Нет'}</dd>
       </dl>
@@ -144,7 +147,7 @@ export function AppointmentConfirmationPanel({
       {latestAttempt && (
         <div className="mt-3 rounded-lg bg-slate-50 p-3 text-xs text-slate-700" data-testid="appointment-confirmation-latest-attempt">
           <div className="font-medium">Последняя попытка: {CONTACT_OUTCOME_LABELS[latestAttempt.outcome]}</div>
-          <div>{CONTACT_CHANNEL_LABELS[latestAttempt.channel]} · {formatDate(latestAttempt.attemptedAt)}</div>
+          <div>{CONTACT_CHANNEL_LABELS[latestAttempt.channel]} · {formatDate(latestAttempt.attemptedAt, timezone)}</div>
           {latestAttempt.note && <div className="mt-1 text-slate-600">{latestAttempt.note}</div>}
         </div>
       )}
@@ -157,7 +160,7 @@ export function AppointmentConfirmationPanel({
             {sortedAttempts.map((attempt) => (
               <div key={attempt.id} className="rounded-lg border border-slate-200 p-2">
                 <div className="font-medium text-slate-800">{CONTACT_OUTCOME_LABELS[attempt.outcome]}</div>
-                <div className="text-xs text-slate-500">{CONTACT_CHANNEL_LABELS[attempt.channel]} · {formatDate(attempt.attemptedAt)}</div>
+                <div className="text-xs text-slate-500">{CONTACT_CHANNEL_LABELS[attempt.channel]} · {formatDate(attempt.attemptedAt, timezone)}</div>
                 {attempt.note && <div className="mt-1 text-xs text-slate-600">{attempt.note}</div>}
               </div>
             ))}

--- a/src/components/schedule/AppointmentLifecycleDialogs.test.tsx
+++ b/src/components/schedule/AppointmentLifecycleDialogs.test.tsx
@@ -16,9 +16,9 @@ const appointment: Appointment = {
   cabinet: 'A1',
   service: 'Осмотр',
   status: 'confirmed',
-  start: '2026-08-01T10:00:00',
-  end: '2026-08-01T11:00:00',
-  createdAt: '2026-07-01T09:00:00',
+  start: '2026-08-01T10:00:00Z',
+  end: '2026-08-01T11:00:00Z',
+  createdAt: '2026-07-01T09:00:00Z',
   updatedAt: '2026-07-01T09:30:00+00:00',
 };
 
@@ -52,6 +52,7 @@ const renderCancellation = async (overrides: Record<string, unknown> = {}) => {
   const onClose = vi.fn();
   await act(async () => root.render(
     <AppointmentCancellationDialog
+      timezone="Asia/Almaty"
       appointment={appointment}
       patientName="Пациент Один"
       doctorName="Врач Один"
@@ -73,6 +74,7 @@ const renderNoShow = async (overrides: Record<string, unknown> = {}) => {
   const onClose = vi.fn();
   await act(async () => root.render(
     <AppointmentNoShowDialog
+      timezone="Asia/Almaty"
       appointment={appointment}
       patientName="Пациент Один"
       doctorName="Врач Один"

--- a/src/components/schedule/AppointmentModal.test.tsx
+++ b/src/components/schedule/AppointmentModal.test.tsx
@@ -27,8 +27,8 @@ const baseInitial: Partial<Appointment> = {
   status: 'new',
   paymentType: 'unpaid',
   source: 'phone',
-  start: '2026-08-01T10:00:00',
-  end: '2026-08-01T11:00:00',
+  start: '2026-08-01T10:00:00Z',
+  end: '2026-08-01T11:00:00Z',
 };
 
 interface RenderOptions {
@@ -43,6 +43,7 @@ interface RenderOptions {
   isSaving?: boolean;
   isReconciling?: boolean;
   serverError?: string | null;
+  timezone?: string;
 }
 
 const renderModal = async (options: RenderOptions = {}) => {
@@ -63,6 +64,7 @@ const renderModal = async (options: RenderOptions = {}) => {
           onMarkNoShow={options.onMarkNoShow}
           onDelete={options.onDelete}
           role={options.role}
+          timezone={options.timezone ?? 'Asia/Almaty'}
           initialData={{ ...baseInitial, ...options.initialData }}
           appointments={options.appointments || []}
           doctors={doctors}
@@ -108,11 +110,30 @@ describe('AppointmentModal', () => {
     await cleanup(root, container);
   });
 
+  it('round trips tenant-local wall time through an authoritative instant', async () => {
+    const { container, root, onSave } = await renderModal({
+      initialData: {
+        start: '2026-08-01T04:00:00.000Z',
+        end: '2026-08-01T05:00:00.000Z',
+      },
+    });
+
+    expect((container.querySelector('input[name="start"]') as HTMLInputElement).value).toBe('2026-08-01T09:00');
+    expect((container.querySelector('input[name="end"]') as HTMLInputElement).value).toBe('2026-08-01T10:00');
+
+    await submit(container);
+
+    const saved = onSave.mock.calls[0][0] as Appointment;
+    expect(saved.start).toBe('2026-08-01T04:00:00.000Z');
+    expect(saved.end).toBe('2026-08-01T05:00:00.000Z');
+    await cleanup(root, container);
+  });
+
   it('preserves existing appointment id and updatedAt for optimistic reschedule', async () => {
     const { container, root, onSave } = await renderModal({
       initialData: {
         id: 'existing-id',
-        createdAt: '2026-07-01T09:00:00',
+        createdAt: '2026-07-01T09:00:00Z',
         updatedAt: '2026-07-01T09:30:00+00:00',
       },
     });
@@ -181,12 +202,12 @@ describe('AppointmentModal', () => {
       ...baseInitial,
       id: 'existing-doctor',
       patientId: 'p2',
-      start: '2026-08-01T10:00:00',
-      end: '2026-08-01T11:00:00',
-      createdAt: '2026-07-01T09:00:00',
+      start: '2026-08-01T10:00:00Z',
+      end: '2026-08-01T11:00:00Z',
+      createdAt: '2026-07-01T09:00:00Z',
     } as Appointment;
     const { container, root, onSave } = await renderModal({
-      initialData: { start: '2026-08-01T10:30:00', end: '2026-08-01T11:30:00' },
+      initialData: { start: '2026-08-01T10:30:00Z', end: '2026-08-01T11:30:00Z' },
       appointments: [existing],
     });
 
@@ -203,7 +224,7 @@ describe('AppointmentModal', () => {
       id: 'existing-patient',
       doctorId: 'd2',
       patientId: 'p1',
-      createdAt: '2026-07-01T09:00:00',
+      createdAt: '2026-07-01T09:00:00Z',
     } as Appointment;
     const { container, root, onSave } = await renderModal({ appointments: [existing] });
 
@@ -219,12 +240,12 @@ describe('AppointmentModal', () => {
       ...baseInitial,
       id: 'active',
       patientId: 'p2',
-      start: '2026-08-01T10:00:00',
-      end: '2026-08-01T11:00:00',
-      createdAt: '2026-07-01T09:00:00',
+      start: '2026-08-01T10:00:00Z',
+      end: '2026-08-01T11:00:00Z',
+      createdAt: '2026-07-01T09:00:00Z',
     } as Appointment;
     const adjacent = await renderModal({
-      initialData: { start: '2026-08-01T11:00:00', end: '2026-08-01T12:00:00' },
+      initialData: { start: '2026-08-01T11:00:00Z', end: '2026-08-01T12:00:00Z' },
       appointments: [active],
     });
     await submit(adjacent.container);
@@ -240,13 +261,13 @@ describe('AppointmentModal', () => {
   });
 
   it('rejects zero and negative intervals before repository call', async () => {
-    const zero = await renderModal({ initialData: { end: '2026-08-01T10:00:00' } });
+    const zero = await renderModal({ initialData: { end: '2026-08-01T10:00:00Z' } });
     await submit(zero.container);
     expect(zero.onSave).not.toHaveBeenCalled();
     expect(zero.container.textContent).toContain('Время окончания должно быть позже времени начала.');
     await cleanup(zero.root, zero.container);
 
-    const negative = await renderModal({ initialData: { end: '2026-08-01T09:00:00' } });
+    const negative = await renderModal({ initialData: { end: '2026-08-01T09:00:00Z' } });
     await submit(negative.container);
     expect(negative.onSave).not.toHaveBeenCalled();
     expect(negative.container.textContent).toContain('Время окончания должно быть позже времени начала.');
@@ -268,7 +289,7 @@ describe('AppointmentModal', () => {
 
   it('removes cancelled and no-show from generic status controls', async () => {
     const view = await renderModal({
-      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00Z', updatedAt: '2026-07-01T09:30:00+00:00' },
       role: 'clinic_admin',
       onCancel: vi.fn(),
       onMarkNoShow: vi.fn(),
@@ -282,7 +303,7 @@ describe('AppointmentModal', () => {
 
   it('keeps cancellation and hard delete visually separate for owner/admin', async () => {
     const view = await renderModal({
-      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00Z', updatedAt: '2026-07-01T09:30:00+00:00' },
       role: 'clinic_owner',
       onCancel: vi.fn(),
       onMarkNoShow: vi.fn(),
@@ -297,7 +318,7 @@ describe('AppointmentModal', () => {
 
   it('allows registrar lifecycle actions but hides hard delete', async () => {
     const view = await renderModal({
-      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00Z', updatedAt: '2026-07-01T09:30:00+00:00' },
       role: 'registrar',
       onCancel: vi.fn(),
       onMarkNoShow: vi.fn(),
@@ -311,7 +332,7 @@ describe('AppointmentModal', () => {
 
   it.each(['doctor', 'cashier', 'unknown'] as const)('hides lifecycle and delete actions for %s', async (role) => {
     const view = await renderModal({
-      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00Z', updatedAt: '2026-07-01T09:30:00+00:00' },
       role,
       onCancel: vi.fn(),
       onMarkNoShow: vi.fn(),
@@ -325,7 +346,7 @@ describe('AppointmentModal', () => {
 
   it('opens separate cancellation and no-show dialogs from lifecycle actions', async () => {
     const view = await renderModal({
-      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00Z', updatedAt: '2026-07-01T09:30:00+00:00' },
       role: 'clinic_admin',
       onCancel: vi.fn().mockResolvedValue({ ...baseInitial, id: 'existing-id', status: 'cancelled', createdAt: '', updatedAt: '' }),
       onMarkNoShow: vi.fn().mockResolvedValue({ ...baseInitial, id: 'existing-id', status: 'no_show', createdAt: '', updatedAt: '' }),
@@ -343,12 +364,12 @@ describe('AppointmentModal', () => {
       initialData: {
         id: 'cancelled-id',
         status: 'cancelled',
-        cancelledAt: '2026-08-01T12:00:00',
+        cancelledAt: '2026-08-01T12:00:00Z',
         cancelledBy: 'user-id',
         cancellationSource: 'patient',
         cancellationReason: 'Пациент попросил',
         lifecycleMetadataVersion: 1,
-        createdAt: '2026-07-01T09:00:00',
+        createdAt: '2026-07-01T09:00:00Z',
         updatedAt: '2026-08-01T12:00:00+00:00',
       },
       role: 'clinic_admin',
@@ -362,7 +383,7 @@ describe('AppointmentModal', () => {
 
   it('shows the confirmation block and does not expose legacy confirmed as a generic status action', async () => {
     const view = await renderModal({
-      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00', updatedAt: '2026-07-01T09:30:00+00:00' },
+      initialData: { id: 'existing-id', createdAt: '2026-07-01T09:00:00Z', updatedAt: '2026-07-01T09:30:00+00:00' },
       role: 'clinic_admin',
     });
     expect(view.container.querySelector('[data-testid="appointment-confirmation-panel"]')).not.toBeNull();
@@ -394,11 +415,12 @@ describe('AppointmentModal', () => {
               onSave={vi.fn().mockResolvedValue(true)}
               onMarkNoShow={onMarkNoShow}
               role="clinic_admin"
+              timezone="Asia/Almaty"
               initialData={{
                 ...baseInitial,
                 id,
                 service,
-                createdAt: '2026-07-01T09:00:00',
+                createdAt: '2026-07-01T09:00:00Z',
                 updatedAt: '2026-07-01T09:30:00+00:00',
               }}
               appointments={[]}
@@ -434,7 +456,7 @@ describe('AppointmentModal', () => {
         service: 'Приём A',
         status: 'no_show',
         noShowReason: 'Задержанный ответ',
-        createdAt: '2026-07-01T09:00:00',
+        createdAt: '2026-07-01T09:00:00Z',
         updatedAt: '2026-07-01T10:00:00+00:00',
       } as Appointment);
       await lifecycleResult;

--- a/src/components/schedule/AppointmentModal.tsx
+++ b/src/components/schedule/AppointmentModal.tsx
@@ -12,6 +12,12 @@ import {
   cancellationSourceLabel,
   isTerminalAppointmentLifecycle,
 } from './appointmentLifecycle';
+import {
+  formatInstantInTenant,
+  instantToTenantDateTimeInput,
+  tenantDateTimeToInstant,
+  TimezoneError,
+} from '../../domain/timezone';
 
 interface AppointmentModalProps {
   isOpen: boolean;
@@ -29,6 +35,7 @@ interface AppointmentModalProps {
   isReconcilingConfirmation?: boolean;
   onDelete?: (id: string) => Promise<boolean>;
   role?: string;
+  timezone: string;
   initialData?: Partial<Appointment>;
   appointments: Appointment[];
   doctors: Doctor[];
@@ -52,6 +59,13 @@ const defaultForm = (): Partial<Appointment> => ({
   comment: '',
 });
 
+const appointmentToFormData = (appointment: Partial<Appointment> | undefined, timezone: string): Partial<Appointment> => ({
+  ...defaultForm(),
+  ...appointment,
+  start: appointment?.start ? instantToTenantDateTimeInput(appointment.start, timezone) : '',
+  end: appointment?.end ? instantToTenantDateTimeInput(appointment.end, timezone) : '',
+});
+
 export function AppointmentModal({
   isOpen,
   onClose,
@@ -68,6 +82,7 @@ export function AppointmentModal({
   isReconcilingConfirmation = false,
   onDelete,
   role,
+  timezone,
   initialData,
   appointments,
   doctors,
@@ -81,10 +96,9 @@ export function AppointmentModal({
   const submitLockRef = useRef(false);
   const appointmentContextRef = useRef<string | null>(initialData?.id || null);
   const [isSubmittingLocally, setIsSubmittingLocally] = useState(false);
-  const [formData, setFormData] = useState<Partial<Appointment>>({
-    ...defaultForm(),
-    ...initialData,
-  });
+  const [formData, setFormData] = useState<Partial<Appointment>>(
+    () => appointmentToFormData(initialData, timezone),
+  );
   const [localError, setLocalError] = useState<string | null>(null);
   const [lifecycleDialog, setLifecycleDialog] = useState<'cancel' | 'no_show' | null>(null);
   const isBusy = isSaving || isSubmittingLocally || isRecordingConfirmationAttempt || isConfirmingAppointment;
@@ -97,15 +111,12 @@ export function AppointmentModal({
   useEffect(() => {
     appointmentContextRef.current = initialData?.id || null;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setFormData({
-      ...defaultForm(),
-      ...initialData,
-    });
+    setFormData(appointmentToFormData(initialData, timezone));
     setLocalError(null);
     setIsSubmittingLocally(false);
     setLifecycleDialog(null);
     submitLockRef.current = false;
-  }, [isOpen, initialData]);
+  }, [isOpen, initialData, timezone]);
 
   if (!isOpen) return null;
 
@@ -123,10 +134,7 @@ export function AppointmentModal({
     setLocalError(null);
   };
 
-  const checkConflicts = (): boolean => {
-    const proposedStart = new Date(formData.start as string).getTime();
-    const proposedEnd = new Date(formData.end as string).getTime();
-
+  const checkConflicts = (proposedStart: number, proposedEnd: number): boolean => {
     for (const appointment of appointments) {
       if (appointment.id === formData.id || appointment.status === 'cancelled') continue;
 
@@ -168,14 +176,24 @@ export function AppointmentModal({
       return;
     }
 
-    const startTime = new Date(formData.start).getTime();
-    const endTime = new Date(formData.end).getTime();
-    if (!Number.isFinite(startTime) || !Number.isFinite(endTime) || endTime <= startTime) {
-      setLocalError('Время окончания должно быть позже времени начала.');
+    let startInstant: string;
+    let endInstant: string;
+    try {
+      startInstant = tenantDateTimeToInstant(formData.start, timezone);
+      endInstant = tenantDateTimeToInstant(formData.end, timezone);
+    } catch (error) {
+      setLocalError(error instanceof TimezoneError ? error.message : '\u041d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u0442\u044c \u0432\u0440\u0435\u043c\u044f \u0437\u0430\u043f\u0438\u0441\u0438. \u041e\u0431\u043d\u043e\u0432\u0438\u0442\u0435 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443 \u0438 \u043f\u043e\u043f\u0440\u043e\u0431\u0443\u0439\u0442\u0435 \u0441\u043d\u043e\u0432\u0430.');
       return;
     }
 
-    if (checkConflicts()) return;
+    const startTime = new Date(startInstant).getTime();
+    const endTime = new Date(endInstant).getTime();
+    if (endTime <= startTime) {
+      setLocalError('\u0412\u0440\u0435\u043c\u044f \u043e\u043a\u043e\u043d\u0447\u0430\u043d\u0438\u044f \u0434\u043e\u043b\u0436\u043d\u043e \u0431\u044b\u0442\u044c \u043f\u043e\u0437\u0436\u0435 \u0432\u0440\u0435\u043c\u0435\u043d\u0438 \u043d\u0430\u0447\u0430\u043b\u0430.');
+      return;
+    }
+
+    if (checkConflicts(startTime, endTime)) return;
 
     const appointmentToSave: Appointment = {
       id: formData.id || crypto.randomUUID(),
@@ -183,8 +201,8 @@ export function AppointmentModal({
       doctorId: formData.doctorId,
       cabinet: formData.cabinet || doctors.find((doctor) => doctor.id === formData.doctorId)?.cabinet || 'Каб. 1',
       service: formData.service || '',
-      start: formData.start,
-      end: formData.end,
+      start: startInstant,
+      end: endInstant,
       status: formData.status as AppointmentStatus,
       paymentType: formData.paymentType as PaymentType,
       source: formData.source as Source,
@@ -230,7 +248,7 @@ export function AppointmentModal({
     const capturedAppointmentId = storedAppointment.id;
     const result = await onCancel(storedAppointment, source, reason);
     if (appointmentContextRef.current !== capturedAppointmentId) return null;
-    if (result) setFormData(result);
+    if (result) setFormData(appointmentToFormData(result, timezone));
     return result;
   };
 
@@ -239,7 +257,7 @@ export function AppointmentModal({
     const capturedAppointmentId = storedAppointment.id;
     const result = await onMarkNoShow(storedAppointment, reason);
     if (appointmentContextRef.current !== capturedAppointmentId) return null;
-    if (result) setFormData(result);
+    if (result) setFormData(appointmentToFormData(result, timezone));
     return result;
   };
 
@@ -252,7 +270,7 @@ export function AppointmentModal({
     const capturedAppointmentId = storedAppointment.id;
     const result = await onRecordConfirmationAttempt(storedAppointment, channel, outcome, note);
     if (appointmentContextRef.current !== capturedAppointmentId) return null;
-    if (result) setFormData(result);
+    if (result) setFormData(appointmentToFormData(result, timezone));
     return result;
   };
 
@@ -264,7 +282,7 @@ export function AppointmentModal({
     const capturedAppointmentId = storedAppointment.id;
     const result = await onConfirmAppointment(storedAppointment, channel, note);
     if (appointmentContextRef.current !== capturedAppointmentId) return null;
-    if (result) setFormData(result);
+    if (result) setFormData(appointmentToFormData(result, timezone));
     return result;
   };
 
@@ -474,7 +492,7 @@ export function AppointmentModal({
               {isEditing && formData.status === 'cancelled' && (
                 <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800" data-testid="appointment-cancellation-metadata">
                   <div className="font-semibold">Запись отменена</div>
-                  <div>Дата: {formData.cancelledAt ? new Date(formData.cancelledAt).toLocaleString('ru-RU') : 'Историческая запись'}</div>
+                  <div>Дата: {formData.cancelledAt ? formatInstantInTenant(formData.cancelledAt, timezone) : 'Историческая запись'}</div>
                   <div>Кто отменил: {cancellationSourceLabel(formData.cancellationSource)}</div>
                   <div>Причина: {formData.cancellationReason || 'Причина не была сохранена в прежней версии системы'}</div>
                   <div>Сотрудник: {formData.cancelledBy ? 'Сотрудник клиники' : 'Не указан'}</div>
@@ -484,15 +502,16 @@ export function AppointmentModal({
               {isEditing && formData.status === 'no_show' && (
                 <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800" data-testid="appointment-no-show-metadata">
                   <div className="font-semibold">Отмечена неявка</div>
-                  <div>Дата: {formData.noShowAt ? new Date(formData.noShowAt).toLocaleString('ru-RU') : 'Историческая запись'}</div>
+                  <div>Дата: {formData.noShowAt ? formatInstantInTenant(formData.noShowAt, timezone) : 'Историческая запись'}</div>
                   <div>Причина: {formData.noShowReason || 'Причина не была сохранена в прежней версии системы'}</div>
                   <div>Сотрудник: {formData.noShowBy ? 'Сотрудник клиники' : 'Не указан'}</div>
                 </div>
               )}
               {isEditing && storedAppointment && (
                 <AppointmentConfirmationPanel
-                  appointment={formData as Appointment}
+                  appointment={{ ...storedAppointment, ...formData, start: storedAppointment.start, end: storedAppointment.end } as Appointment}
                   role={role}
+                  timezone={timezone}
                   attempts={confirmationAttempts}
                   isLoadingAttempts={isLoadingConfirmationAttempts}
                   attemptsError={confirmationAttemptsError}
@@ -570,6 +589,7 @@ export function AppointmentModal({
     {lifecycleDialog === 'cancel' && storedAppointment && (
       <AppointmentCancellationDialog
         appointment={storedAppointment}
+        timezone={timezone}
         patientName={patientName}
         doctorName={doctorName}
         isSaving={isBusy}
@@ -582,6 +602,7 @@ export function AppointmentModal({
     {lifecycleDialog === 'no_show' && storedAppointment && (
       <AppointmentNoShowDialog
         appointment={storedAppointment}
+        timezone={timezone}
         patientName={patientName}
         doctorName={doctorName}
         isSaving={isBusy}

--- a/src/components/schedule/AppointmentNoShowDialog.tsx
+++ b/src/components/schedule/AppointmentNoShowDialog.tsx
@@ -1,9 +1,11 @@
 import { useState, type FormEvent } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
+import { formatInstantInTenant } from '../../domain/timezone';
 import type { Appointment } from '../../types';
 
 interface AppointmentNoShowDialogProps {
   appointment: Appointment;
+  timezone: string;
   patientName: string;
   doctorName: string;
   isSaving: boolean;
@@ -15,6 +17,7 @@ interface AppointmentNoShowDialogProps {
 
 export function AppointmentNoShowDialog({
   appointment,
+  timezone,
   patientName,
   doctorName,
   isSaving,
@@ -26,7 +29,6 @@ export function AppointmentNoShowDialog({
   const [reason, setReason] = useState('');
   const [validationError, setValidationError] = useState<string | null>(null);
   const [succeeded, setSucceeded] = useState(false);
-  const start = new Date(appointment.start);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -66,7 +68,7 @@ export function AppointmentNoShowDialog({
             <dl className="grid grid-cols-[140px_1fr] gap-x-3 gap-y-2 rounded-lg bg-slate-50 p-3 text-sm">
               <dt className="text-slate-500">Пациент</dt><dd className="font-medium text-slate-800">{patientName}</dd>
               <dt className="text-slate-500">Врач</dt><dd className="font-medium text-slate-800">{doctorName}</dd>
-              <dt className="text-slate-500">Дата и время</dt><dd className="font-medium text-slate-800">{start.toLocaleString('ru-RU', { dateStyle: 'short', timeStyle: 'short' })}</dd>
+              <dt className="text-slate-500">Дата и время</dt><dd className="font-medium text-slate-800">{formatInstantInTenant(appointment.start, timezone, { dateStyle: 'short', timeStyle: 'short' })}</dd>
               <dt className="text-slate-500">Текущий статус</dt><dd className="font-medium text-slate-800">{appointment.status}</dd>
             </dl>
 

--- a/src/context/ScheduleContext.tsx
+++ b/src/context/ScheduleContext.tsx
@@ -3,8 +3,8 @@ import { createContext } from 'react';
 export type ViewMode = 'day' | 'week' | 'month';
 
 export interface ScheduleContextType {
-  selectedDate: Date;
-  setSelectedDate: (date: Date) => void;
+  selectedDate: string;
+  setSelectedDate: (date: string) => void;
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
   doctorFilter: string | null;

--- a/src/context/ScheduleProvider.test.tsx
+++ b/src/context/ScheduleProvider.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScheduleProvider } from './ScheduleProvider';
+import { useScheduleContext } from '../hooks/useScheduleContext';
+
+const tenantState = vi.hoisted(() => ({
+  activeTenant: {
+    tenantId: 'tenant-a',
+    tenantName: 'Almaty Clinic',
+    timezone: 'Asia/Almaty',
+    role: 'clinic_admin',
+  } as {
+    tenantId: string;
+    tenantName: string;
+    timezone: string;
+    role: string;
+  } | null,
+}));
+
+vi.mock('../contexts/TenantContext', () => ({
+  LEGACY_TENANT_TIMEZONE: 'Asia/Almaty',
+  useTenant: () => tenantState,
+}));
+
+const Probe = () => {
+  const schedule = useScheduleContext();
+  return (
+    <div>
+      <div data-testid="selected-date">{schedule.selectedDate}</div>
+      <button type="button" data-testid="set-custom-date" onClick={() => schedule.setSelectedDate('2030-01-15')}>
+        Set custom date
+      </button>
+    </div>
+  );
+};
+
+const renderProvider = async () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const render = async () => {
+    await act(async () => {
+      root.render(
+        <ScheduleProvider>
+          <Probe />
+        </ScheduleProvider>,
+      );
+    });
+  };
+  await render();
+  return { container, root, render };
+};
+
+const selectedDate = (container: HTMLElement) => (
+  container.querySelector('[data-testid="selected-date"]')?.textContent
+);
+
+describe('ScheduleProvider tenant date context', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T21:30:00.000Z'));
+    tenantState.activeTenant = {
+      tenantId: 'tenant-a',
+      tenantName: 'Almaty Clinic',
+      timezone: 'Asia/Almaty',
+      role: 'clinic_admin',
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('derives today from the tenant timezone rather than browser or UTC day', async () => {
+    const view = await renderProvider();
+    expect(selectedDate(view.container)).toBe('2026-07-12');
+    await act(async () => view.root.unmount());
+  });
+
+  it('clears the old tenant date selection when tenant and timezone change', async () => {
+    const view = await renderProvider();
+    await act(async () => {
+      (view.container.querySelector('[data-testid="set-custom-date"]') as HTMLButtonElement).click();
+    });
+    expect(selectedDate(view.container)).toBe('2030-01-15');
+
+    tenantState.activeTenant = {
+      tenantId: 'tenant-b',
+      tenantName: 'Berlin Clinic',
+      timezone: 'Europe/Berlin',
+      role: 'doctor',
+    };
+    await view.render();
+
+    expect(selectedDate(view.container)).toBe('2026-07-11');
+    expect(view.container.textContent).not.toContain('2030-01-15');
+    await act(async () => view.root.unmount());
+  });
+});

--- a/src/context/ScheduleProvider.tsx
+++ b/src/context/ScheduleProvider.tsx
@@ -2,13 +2,31 @@ import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { ScheduleContext } from '../context/ScheduleContext';
 import type { ViewMode } from '../context/ScheduleContext';
+import { useTenant, LEGACY_TENANT_TIMEZONE } from '../contexts/TenantContext';
+import { tenantNowDate } from '../domain/timezone';
+
+interface DateSelection {
+  contextKey: string;
+  date: string;
+}
 
 export function ScheduleProvider({ children }: { children: ReactNode }) {
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const { activeTenant } = useTenant();
+  const timezone = activeTenant?.timezone ?? LEGACY_TENANT_TIMEZONE;
+  const contextKey = `${activeTenant?.tenantId ?? 'no-tenant'}:${timezone}`;
+  const [dateSelection, setDateSelection] = useState<DateSelection>(() => ({
+    contextKey,
+    date: tenantNowDate(timezone),
+  }));
   const [viewMode, setViewMode] = useState<ViewMode>('day');
   const [doctorFilter, setDoctorFilter] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [sourceFilter, setSourceFilter] = useState<string | null>(null);
+
+  const selectedDate = dateSelection.contextKey === contextKey
+    ? dateSelection.date
+    : tenantNowDate(timezone);
+  const setSelectedDate = (date: string) => setDateSelection({ contextKey, date });
 
   return (
     <ScheduleContext.Provider

--- a/src/contexts/TenantContext.test.tsx
+++ b/src/contexts/TenantContext.test.tsx
@@ -30,10 +30,10 @@ const baseAuth: AuthValue = {
   signOut: vi.fn(),
 };
 
-const tenantRow = (tenantId: string, name: string, role: string) => ({
+const tenantRow = (tenantId: string, name: string, role: string, timezone?: string) => ({
   tenant_id: tenantId,
   role,
-  tenants: { id: tenantId, name, status: 'active' },
+  tenants: { id: tenantId, name, status: 'active', ...(timezone ? { timezone } : {}) },
 });
 
 const renderTenantContext = async (authValue: AuthValue) => {
@@ -144,10 +144,10 @@ describe('TenantContext behavior', () => {
     });
 
     expect(mockFrom).toHaveBeenCalledWith('tenant_users');
-    expect(mockSelect).toHaveBeenCalledWith('role, tenant_id, tenants(id, name, status)');
+    expect(mockSelect).toHaveBeenCalledWith('role, tenant_id, tenants(id, name, status, timezone)');
     expect(mockEq).toHaveBeenCalledWith('user_id', 'real-user-123');
     expect(view.result.availableTenants).toEqual([
-      { tenantId: '11111111-1111-1111-1111-111111111111', tenantName: 'Demo Clinic A', role: 'clinic_admin' },
+      { tenantId: '11111111-1111-1111-1111-111111111111', tenantName: 'Demo Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' },
     ]);
     expect(view.result.activeTenant?.tenantId).toBe('11111111-1111-1111-1111-111111111111');
     expect(view.result.isLoading).toBe(false);
@@ -222,6 +222,36 @@ describe('TenantContext behavior', () => {
     await unmount(view.root);
   });
 
+  it('switches tenant and timezone together without retaining the previous zone', async () => {
+    mockEq.mockResolvedValue({
+      data: [
+        tenantRow('11111111-1111-1111-1111-111111111111', 'Almaty Clinic', 'clinic_admin', 'Asia/Almaty'),
+        tenantRow('22222222-2222-2222-2222-222222222222', 'Berlin Clinic', 'doctor', 'Europe/Berlin'),
+      ],
+      error: null,
+    });
+
+    const view = await renderTenantContext({
+      ...baseAuth,
+      user: { id: 'timezone-user', email: 'timezone@example.com' },
+      isLoading: false,
+      authMode: 'supabase-active',
+    });
+
+    expect(view.result.activeTenant).toMatchObject({
+      tenantId: '11111111-1111-1111-1111-111111111111',
+      timezone: 'Asia/Almaty',
+    });
+
+    await act(async () => view.result.setActiveTenant('22222222-2222-2222-2222-222222222222'));
+
+    expect(view.result.activeTenant).toMatchObject({
+      tenantId: '22222222-2222-2222-2222-222222222222',
+      timezone: 'Europe/Berlin',
+    });
+    expect(view.result.activeTenant?.timezone).not.toBe('Asia/Almaty');
+    await unmount(view.root);
+  });
   it('does not leak tenants across user switches', async () => {
     let pendingResolve: (value: unknown) => void;
     const pendingPromise = new Promise((resolve) => {

--- a/src/contexts/TenantContext.tsx
+++ b/src/contexts/TenantContext.tsx
@@ -1,10 +1,14 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
+import { isValidIanaTimezone } from '../domain/timezone';
 import { useAuth } from './AuthContext';
+
+export const LEGACY_TENANT_TIMEZONE = 'Asia/Almaty';
 
 export interface ActiveTenant {
   tenantId: string;
   tenantName: string;
+  timezone: string;
   role?: string;
 }
 
@@ -19,6 +23,7 @@ interface TenantContextType {
 interface TenantRelation {
   id?: string | null;
   name?: string | null;
+  timezone?: string | null;
 }
 
 interface TenantUserRow {
@@ -37,6 +42,7 @@ interface LoadedTenantState {
 const devTenant: ActiveTenant = {
   tenantId: '11111111-1111-1111-1111-111111111111',
   tenantName: 'Demo Clinic',
+  timezone: LEGACY_TENANT_TIMEZONE,
   role: 'clinic_admin',
 };
 
@@ -50,34 +56,34 @@ const emptyLoadedTenantState: LoadedTenantState = {
 const TenantContext = createContext<TenantContextType | undefined>(undefined);
 
 const normalizeTenantRelation = (relation: TenantUserRow['tenants']) => {
-  if (Array.isArray(relation)) {
-    return relation[0] ?? null;
-  }
-
+  if (Array.isArray(relation)) return relation[0] ?? null;
   return relation ?? null;
 };
 
-const mapTenantRows = (rows: TenantUserRow[]): ActiveTenant[] => {
-  return rows.flatMap((row) => {
-    const tenant = normalizeTenantRelation(row.tenants);
-    const tenantId = tenant?.id ?? row.tenant_id;
+const mapTenantRows = (rows: TenantUserRow[]): ActiveTenant[] => rows.flatMap((row) => {
+  const tenant = normalizeTenantRelation(row.tenants);
+  const tenantId = tenant?.id ?? row.tenant_id;
+  if (!tenantId || !tenant?.name) return [];
 
-    if (!tenantId || !tenant?.name) {
-      return [];
-    }
+  const timezone = tenant.timezone ?? LEGACY_TENANT_TIMEZONE;
+  if (!isValidIanaTimezone(timezone)) {
+    throw new Error('Не удалось определить часовой пояс клиники.');
+  }
 
-    return [{ tenantId, tenantName: tenant.name, role: row.role ?? undefined }];
-  });
-};
+  return [{
+    tenantId,
+    tenantName: tenant.name,
+    timezone,
+    role: row.role ?? undefined,
+  }];
+});
 
 export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { authMode, isLoading: authLoading, user } = useAuth();
   const [loadedTenantState, setLoadedTenantState] = useState<LoadedTenantState>(emptyLoadedTenantState);
 
   useEffect(() => {
-    if (authMode !== 'supabase-active' || authLoading || !user || !supabase) {
-      return;
-    }
+    if (authMode !== 'supabase-active' || authLoading || !user || !supabase) return;
 
     let mounted = true;
     const currentUserId = user.id;
@@ -86,60 +92,41 @@ export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       try {
         const { data, error } = await supabase!
           .from('tenant_users')
-          .select('role, tenant_id, tenants(id, name, status)')
+          .select('role, tenant_id, tenants(id, name, status, timezone)')
           .eq('user_id', currentUserId);
 
-        if (error) {
-          throw error;
-        }
-
+        if (error) throw error;
         const tenants = mapTenantRows((data ?? []) as TenantUserRow[]);
-
-        if (!mounted) {
-          return;
-        }
+        if (!mounted) return;
 
         setLoadedTenantState((current) => {
           const selectedTenantId = tenants.some((tenant) => tenant.tenantId === current.selectedTenantId)
             ? current.selectedTenantId
             : tenants[0]?.tenantId ?? null;
-
           return { userId: currentUserId, tenants, selectedTenantId, error: null };
         });
       } catch (err) {
-        if (!mounted) {
-          return;
-        }
-
+        if (!mounted) return;
         setLoadedTenantState({
           userId: currentUserId,
           tenants: [],
           selectedTenantId: null,
-          error: err instanceof Error ? err : new Error('Failed to load tenants'),
+          error: err instanceof Error ? err : new Error('Не удалось загрузить клиники.'),
         });
       }
     }
 
     loadTenants();
-
     return () => {
       mounted = false;
     };
   }, [authMode, authLoading, user]);
 
   const setActiveTenant = (tenantId: string) => {
-    if (authMode === 'dev') {
-      return;
-    }
-
+    if (authMode === 'dev') return;
     setLoadedTenantState((current) => {
-      const tenantExists = current.tenants.some((tenant) => tenant.tenantId === tenantId);
-
-      if (!tenantExists) {
-        return current;
-      }
-
-      return { ...current, selectedTenantId: tenantId };
+      if (!current.tenants.some((tenant) => tenant.tenantId === tenantId)) return current;
+      return { ...current, selectedTenantId: tenantId, error: null };
     });
   };
 
@@ -168,22 +155,17 @@ export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }
 
   const isLoading = loadedTenantState.userId !== user.id;
-
   if (isLoading) {
     return (
-      <TenantContext.Provider value={{
-        activeTenant: null,
-        availableTenants: [],
-        setActiveTenant,
-        isLoading: true,
-        error: null,
-      }}>
+      <TenantContext.Provider value={{ activeTenant: null, availableTenants: [], setActiveTenant, isLoading: true, error: null }}>
         {children}
       </TenantContext.Provider>
     );
   }
 
-  const activeTenant = loadedTenantState.tenants.find((tenant) => tenant.tenantId === loadedTenantState.selectedTenantId) ?? null;
+  const activeTenant = loadedTenantState.tenants.find(
+    (tenant) => tenant.tenantId === loadedTenantState.selectedTenantId,
+  ) ?? null;
 
   return (
     <TenantContext.Provider value={{
@@ -201,8 +183,6 @@ export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 // eslint-disable-next-line react-refresh/only-export-components
 export const useTenant = () => {
   const context = useContext(TenantContext);
-  if (context === undefined) {
-    throw new Error('useTenant must be used within a TenantProvider');
-  }
+  if (context === undefined) throw new Error('useTenant must be used within a TenantProvider');
   return context;
 };

--- a/src/data/hooks/useChiefComplaint.test.tsx
+++ b/src/data/hooks/useChiefComplaint.test.tsx
@@ -30,7 +30,7 @@ describe('useChiefComplaint', () => {
     const factorySpy = vi.spyOn(ChiefComplaintRepositoryModule, 'createChiefComplaintRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: '123', tenantName: 'Dev' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: '123', tenantName: 'Dev', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     let hookResult: ReturnType<typeof useChiefComplaint> | undefined;
 
@@ -69,7 +69,7 @@ describe('useChiefComplaint', () => {
     const factorySpy = vi.spyOn(ChiefComplaintRepositoryModule, 'createChiefComplaintRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useChiefComplaint('patient_1');

--- a/src/data/hooks/useClinicalWorkflow.test.tsx
+++ b/src/data/hooks/useClinicalWorkflow.test.tsx
@@ -36,7 +36,7 @@ describe('useClinicalWorkflow', () => {
     const treatmentPlansFactorySpy = vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useClinicalWorkflow();
@@ -65,7 +65,7 @@ describe('useClinicalWorkflow', () => {
     const treatmentPlansFactorySpy = vi.spyOn(TreatmentPlansRepositoryModule, 'createTreatmentPlansRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useClinicalWorkflow();
@@ -125,7 +125,7 @@ describe('useClinicalWorkflow', () => {
     (globalThis as typeof globalThis & { __IS_SUPABASE_CONFIGURED__?: boolean }).__IS_SUPABASE_CONFIGURED__ = false;
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useClinicalWorkflow();

--- a/src/data/hooks/useDentalChart.test.tsx
+++ b/src/data/hooks/useDentalChart.test.tsx
@@ -41,7 +41,7 @@ describe('useDentalChart', () => {
     const factorySpy = vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useDentalChart('patient_1');
@@ -66,7 +66,7 @@ describe('useDentalChart', () => {
     const factorySpy = vi.spyOn(DentalChartRepositoryModule, 'createDentalChartRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useDentalChart('patient_1');

--- a/src/data/hooks/useDictionaries.test.tsx
+++ b/src/data/hooks/useDictionaries.test.tsx
@@ -91,7 +91,7 @@ describe('useDictionaries', () => {
   describe('A. Local/dev mode & backend routing', () => {
     it('uses local backend when authMode is dev', async () => {
       vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
-      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
       const { unmount } = await setup();
       
@@ -101,7 +101,7 @@ describe('useDictionaries', () => {
 
     it('uses supabase backend when authMode is supabase-active, configured, and tenant exists', async () => {
       vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
       const { unmount } = await setup();
       
@@ -112,7 +112,7 @@ describe('useDictionaries', () => {
     it('uses local backend when authMode is supabase-active, activeTenant exists, but isSupabaseConfigured is false', async () => {
       mockSupabaseConfigured.value = false;
       vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
       const { unmount } = await setup();
       
@@ -146,7 +146,7 @@ describe('useDictionaries', () => {
   describe('B. Async loading and behavior', () => {
     beforeEach(() => {
       vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'C1' } } as unknown as ReturnType<typeof useTenant>);
+      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'C1', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
     });
 
     it('loads data initially and transitions loading state', async () => {
@@ -286,7 +286,7 @@ describe('useDictionaries', () => {
   describe('D. Error handling', () => {
     beforeEach(() => {
       vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'C1' } } as unknown as ReturnType<typeof useTenant>);
+      vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'C1', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
     });
 
     it('surfaces repository load errors and settles loading', async () => {

--- a/src/data/hooks/usePatientAppointments.test.tsx
+++ b/src/data/hooks/usePatientAppointments.test.tsx
@@ -51,7 +51,7 @@ describe('usePatientAppointments', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
-    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A', timezone: 'Asia/Almaty'} };
     vi.mocked(useAuth).mockImplementation(() => authState);
     vi.mocked(useTenant).mockImplementation(() => tenantState);
   });
@@ -159,7 +159,7 @@ describe('usePatientAppointments', () => {
     ));
     const { root, Harness } = await mount('patient-a');
 
-    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B', timezone: 'Asia/Almaty'} };
     await act(async () => root.render(<Harness id="patient-a" tick={1} />));
     expect(current?.appointments).toEqual([]);
 

--- a/src/data/hooks/usePatientAppointments.ts
+++ b/src/data/hooks/usePatientAppointments.ts
@@ -12,6 +12,7 @@ export function usePatientAppointments(patientId: string) {
   const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
   const tenantId = activeTenant?.tenantId;
+  const timezone = activeTenant?.timezone;
   const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
 
   const repository = useMemo(() => {
@@ -35,9 +36,9 @@ export function usePatientAppointments(patientId: string) {
 
   const enabled = Boolean(patientId) && (
     authMode === 'dev'
-    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId))
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId) && Boolean(timezone))
   );
-  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${patientId || 'no-patient'}`;
+  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${timezone || 'no-timezone'}:${patientId || 'no-patient'}`;
 
   const {
     data: appointments,

--- a/src/data/hooks/usePatientFindings.test.tsx
+++ b/src/data/hooks/usePatientFindings.test.tsx
@@ -41,7 +41,7 @@ describe('usePatientFindings', () => {
     const factorySpy = vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       usePatientFindings('patient_1');
@@ -66,7 +66,7 @@ describe('usePatientFindings', () => {
     const factorySpy = vi.spyOn(FindingsRepositoryModule, 'createFindingsRepository');
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'dev' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'real-tenant-id', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       usePatientFindings('patient_1');

--- a/src/data/hooks/usePatientListVisitSummary.test.tsx
+++ b/src/data/hooks/usePatientListVisitSummary.test.tsx
@@ -41,7 +41,7 @@ describe('usePatientListVisitSummary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
-    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A', timezone: 'Asia/Almaty'} };
     vi.mocked(useAuth).mockImplementation(() => authState);
     vi.mocked(useTenant).mockImplementation(() => tenantState);
   });
@@ -102,7 +102,7 @@ describe('usePatientListVisitSummary', () => {
     } as any));
     const { root, Harness } = await mount();
 
-    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B', timezone: 'Asia/Almaty'} };
     await act(async () => root.render(<Harness tick={1} />));
     expect(current?.visitSummaryByPatientId).toEqual({});
 

--- a/src/data/hooks/usePatientListVisitSummary.ts
+++ b/src/data/hooks/usePatientListVisitSummary.ts
@@ -13,6 +13,7 @@ export function usePatientListVisitSummary() {
   const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
   const tenantId = activeTenant?.tenantId;
+  const timezone = activeTenant?.timezone;
   const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
 
   const repository = useMemo(() => {
@@ -36,8 +37,8 @@ export function usePatientListVisitSummary() {
   }, [repository]);
 
   const enabled = authMode === 'dev'
-    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId));
-  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:patient-list-summary`;
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId) && Boolean(timezone));
+  const queryKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${timezone || 'no-timezone'}:patient-list-summary`;
 
   const { data, isLoading, isError, error, refetch } = useAsyncQuery<PatientVisitSummaryByPatientId>({
     queryFn,

--- a/src/data/hooks/usePatientMedicalSummary.test.tsx
+++ b/src/data/hooks/usePatientMedicalSummary.test.tsx
@@ -34,7 +34,7 @@ describe('usePatientMedicalSummary', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
-    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-a', tenantName: 'A', timezone: 'Asia/Almaty'} };
     vi.mocked(useAuth).mockImplementation(() => authState);
     vi.mocked(useTenant).mockImplementation(() => tenantState);
   });
@@ -75,7 +75,7 @@ describe('usePatientMedicalSummary', () => {
 
   it('uses local backend only in explicit dev mode', async () => {
     authState = { authMode: 'dev', user: { id: 'dev-user' } };
-    tenantState = { activeTenant: { tenantId: 'dev-tenant', tenantName: 'Dev' } };
+    tenantState = { activeTenant: { tenantId: 'dev-tenant', tenantName: 'Dev', timezone: 'Asia/Almaty'} };
     const spy = vi.spyOn(ClinicalSummary, 'getPatientMedicalSummary').mockResolvedValue(summary(200));
     const { root } = await mount('patient-a');
 
@@ -108,7 +108,7 @@ describe('usePatientMedicalSummary', () => {
       .mockImplementation((_patientId, config) => config.tenantId === 'tenant-a' ? a.promise : b.promise);
     const { root, Harness } = await mount('patient-a');
 
-    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B' } };
+    tenantState = { activeTenant: { tenantId: 'tenant-b', tenantName: 'B', timezone: 'Asia/Almaty'} };
     await act(async () => root.render(<Harness id="patient-a" tick={1} />));
     expect(current?.data).toEqual(ClinicalSummary.EMPTY_PATIENT_MEDICAL_SUMMARY);
 

--- a/src/data/hooks/usePatientTimeline.test.tsx
+++ b/src/data/hooks/usePatientTimeline.test.tsx
@@ -89,7 +89,7 @@ describe('usePatientTimeline', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active', user: { id: 'user-a' } } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', timezone: 'Asia/Almaty', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
     mocks.getChiefComplaint.mockResolvedValue(null);
     mocks.listFindingsByPatient.mockResolvedValue([]);
     mocks.listTreatmentPlansByPatient.mockResolvedValue([]);

--- a/src/data/hooks/useScheduleAppointments.ts
+++ b/src/data/hooks/useScheduleAppointments.ts
@@ -49,8 +49,9 @@ export function useScheduleAppointments() {
   const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
   const tenantId = activeTenant?.tenantId;
+  const timezone = activeTenant?.timezone;
   const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
-  const contextKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}`;
+  const contextKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${timezone || 'no-timezone'}`;
   const currentContextRef = useRef(contextKey);
   useLayoutEffect(() => {
     currentContextRef.current = contextKey;
@@ -91,7 +92,7 @@ export function useScheduleAppointments() {
   }, [authMode, isSupabaseMode, tenantId, user?.id]);
 
   const queryEnabled = authMode === 'dev'
-    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId));
+    || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId) && Boolean(timezone));
 
   const queryFn = useCallback(async (): Promise<Appointment[]> => {
     if (!repository) return [];
@@ -398,14 +399,15 @@ export function useAppointmentConfirmationAttempts(appointmentId?: string) {
   const { authMode, user } = useAuth();
   const { activeTenant } = useTenant();
   const tenantId = activeTenant?.tenantId;
+  const timezone = activeTenant?.timezone;
   const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
-  const contextKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${appointmentId || 'no-appointment'}`;
+  const contextKey = `${authMode}:${user?.id || 'no-user'}:${tenantId || 'no-tenant'}:${timezone || 'no-timezone'}:${appointmentId || 'no-appointment'}`;
   const repository = useMemo<IAppointmentRepository | null>(() => {
     if (authMode === 'dev') return createAppointmentRepository({ backend: 'local' });
     if (isSupabaseMode && user?.id && tenantId) return createAppointmentRepository({ backend: 'supabase', tenantId });
     return null;
   }, [authMode, isSupabaseMode, tenantId, user?.id]);
-  const enabled = Boolean(appointmentId) && (authMode === 'dev' || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId)));
+  const enabled = Boolean(appointmentId) && (authMode === 'dev' || (isSupabaseMode && Boolean(user?.id) && Boolean(tenantId) && Boolean(timezone)));
   const queryFn = useCallback(async (): Promise<AppointmentConfirmationAttempt[]> => {
     if (!repository || !appointmentId) return [];
     try {

--- a/src/data/hooks/useTreatmentPlans.test.tsx
+++ b/src/data/hooks/useTreatmentPlans.test.tsx
@@ -71,7 +71,7 @@ describe('useTreatmentPlans hook', () => {
     Object.defineProperty(SupabaseClientModule, 'isSupabaseConfigured', { value: false, configurable: true });
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useTreatmentPlans('patient_1');
@@ -125,7 +125,7 @@ describe('useTreatmentPlans hook', () => {
     Object.defineProperty(SupabaseClientModule, 'isSupabaseConfigured', { value: true, configurable: true });
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', timezone: 'Asia/Almaty'} } as unknown as ReturnType<typeof useTenant>);
 
     const TestComponent = () => {
       useTreatmentPlans('patient_1');

--- a/src/data/repositories/AppointmentRepository.test.ts
+++ b/src/data/repositories/AppointmentRepository.test.ts
@@ -36,10 +36,10 @@ const appointment: Appointment = {
   source: 'phone',
   price: 1500,
   comment: 'Комментарий',
-  start: '2026-08-01T10:00:00',
-  end: '2026-08-01T11:00:00',
-  createdAt: '2026-07-01T09:00:00',
-  updatedAt: '2026-07-01T09:00:00+00:00',
+  start: '2026-08-01T10:00:00.000Z',
+  end: '2026-08-01T11:00:00.000Z',
+  createdAt: '2026-07-01T09:00:00Z',
+  updatedAt: '2026-07-01T09:00:00.000Z',
 };
 
 const databaseRow = (overrides: Record<string, unknown> = {}) => ({
@@ -56,8 +56,8 @@ const databaseRow = (overrides: Record<string, unknown> = {}) => ({
   comment: 'Комментарий',
   start_time: '2026-08-01T10:00:00+00:00',
   end_time: '2026-08-01T11:00:00+00:00',
-  created_at: '2026-07-01T09:00:00+00:00',
-  updated_at: '2026-07-01T09:00:00+00:00',
+  created_at: '2026-07-01T09:00:00.000Z',
+  updated_at: '2026-07-01T09:00:00.000Z',
   ...overrides,
 });
 
@@ -127,9 +127,9 @@ describe('AppointmentRepository', () => {
       patientId,
       doctorId,
       status: 'new',
-      start: '2026-08-01T10:00:00',
-      end: '2026-08-01T11:00:00',
-      updatedAt: '2026-07-01T09:00:00+00:00',
+      start: '2026-08-01T10:00:00+00:00',
+      end: '2026-08-01T11:00:00+00:00',
+      updatedAt: '2026-07-01T09:00:00.000Z',
       price: 1500,
     });
     expect(byPatient).toHaveLength(1);
@@ -187,12 +187,50 @@ describe('AppointmentRepository', () => {
       p_tenant_id: tenantId,
       p_patient_id: patientId,
       p_doctor_id: doctorId,
-      p_start_time: '2026-08-01T10:00:00Z',
-      p_end_time: '2026-08-01T11:00:00Z',
+      p_start_time: '2026-08-01T10:00:00.000Z',
+      p_end_time: '2026-08-01T11:00:00.000Z',
       p_operation_key: operationKey,
     }));
     expect(from).not.toHaveBeenCalled();
     expect(result).toMatchObject({ operationType: 'create', replayed: false, recovered: false });
+  });
+
+  it('preserves explicit offsets as instants instead of stripping suffixes', async () => {
+    const { client, rpc } = createClient();
+    rpc.mockResolvedValue({
+      data: rpcResult('create', {
+        start_time: '2026-08-01T15:00:00+05:00',
+        end_time: '2026-08-01T16:00:00+05:00',
+      }),
+      error: null,
+    });
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    const result = await repository.createAppointment({
+      ...appointment,
+      start: '2026-08-01T15:00:00+05:00',
+      end: '2026-08-01T16:00:00+05:00',
+    }, { operationKey });
+
+    expect(rpc).toHaveBeenCalledWith('create_appointment', expect.objectContaining({
+      p_start_time: '2026-08-01T10:00:00.000Z',
+      p_end_time: '2026-08-01T11:00:00.000Z',
+    }));
+    expect(result.appointment.start).toBe('2026-08-01T15:00:00+05:00');
+    expect(result.appointment.end).toBe('2026-08-01T16:00:00+05:00');
+  });
+
+  it('rejects ambiguous offset-free timestamps instead of blindly appending Z', async () => {
+    const { client, rpc } = createClient();
+    const repository = new SupabaseAppointmentRepository(tenantId, client);
+
+    await expect(repository.createAppointment({
+      ...appointment,
+      start: '2026-08-01T10:00:00',
+    }, { operationKey })).rejects.toMatchObject({
+      code: 'generic',
+    });
+    expect(rpc).not.toHaveBeenCalledWith('create_appointment', expect.anything());
   });
 
   it('reschedules through reschedule_appointment RPC with optimistic version and unchanged key', async () => {
@@ -209,8 +247,8 @@ describe('AppointmentRepository', () => {
     const next: Appointment = {
       ...appointment,
       doctorId: '55555555-5555-4555-8555-555555555555',
-      start: '2026-08-01T12:00:00',
-      end: '2026-08-01T13:00:00',
+      start: '2026-08-01T12:00:00Z',
+      end: '2026-08-01T13:00:00Z',
     };
 
     const result = await repository.rescheduleAppointment(appointment, next, { operationKey });
@@ -224,7 +262,7 @@ describe('AppointmentRepository', () => {
       p_operation_key: operationKey,
     }));
     expect(from).not.toHaveBeenCalled();
-    expect(result.appointment.start).toBe('2026-08-01T12:00:00');
+    expect(result.appointment.start).toBe('2026-08-01T12:00:00+00:00');
   });
 
   it('updates non-protected details only through update_appointment_details RPC', async () => {
@@ -325,7 +363,7 @@ describe('AppointmentRepository', () => {
       .rejects.toMatchObject({ code: 'invalid_transition' });
     await expect(repository.updateAppointmentDetails(appointment, { ...appointment, status: 'no_show' }))
       .rejects.toMatchObject({ code: 'invalid_transition' });
-    await expect(repository.rescheduleAppointment(appointment, { ...appointment, status: 'cancelled', start: '2026-08-01T12:00:00' }, { operationKey }))
+    await expect(repository.rescheduleAppointment(appointment, { ...appointment, status: 'cancelled', start: '2026-08-01T12:00:00Z' }, { operationKey }))
       .rejects.toMatchObject({ code: 'invalid_transition' });
     expect(rpc).not.toHaveBeenCalled();
   });
@@ -475,7 +513,7 @@ describe('AppointmentRepository', () => {
 
   it('marks protected scheduling changes and ignores details-only edits', () => {
     expect(isProtectedAppointmentChange(appointment, { ...appointment, comment: 'Другое' })).toBe(false);
-    expect(isProtectedAppointmentChange(appointment, { ...appointment, start: '2026-08-01T10:30:00' })).toBe(true);
+    expect(isProtectedAppointmentChange(appointment, { ...appointment, start: '2026-08-01T10:30:00Z' })).toBe(true);
     expect(isProtectedAppointmentChange(appointment, { ...appointment, patientId: 'other' })).toBe(true);
     expect(isProtectedAppointmentChange(appointment, { ...appointment, doctorId: 'other' })).toBe(true);
   });

--- a/src/data/repositories/AppointmentRepository.ts
+++ b/src/data/repositories/AppointmentRepository.ts
@@ -9,6 +9,7 @@ import type {
   Source,
 } from '../../types';
 import { compareAppointmentsByStartThenId } from '../../domain/appointmentSummary';
+import { isOffsetAwareInstant } from '../../domain/timezone';
 import { storage } from '../../utils/storage';
 import { supabase } from '../../lib/supabaseClient';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -354,8 +355,8 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
         p_tenant_id: this.tenantId,
         p_patient_id: appointment.patientId || null,
         p_doctor_id: appointment.doctorId,
-        p_start_time: this.normalizeTimeForDb(appointment.start),
-        p_end_time: this.normalizeTimeForDb(appointment.end),
+        p_start_time: this.normalizeInstantForDb(appointment.start),
+        p_end_time: this.normalizeInstantForDb(appointment.end),
         p_cabinet: appointment.cabinet || '',
         p_service: appointment.service || '',
         p_status: appointment.status,
@@ -389,8 +390,8 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
         p_appointment_id: current.id,
         p_patient_id: next.patientId || null,
         p_doctor_id: next.doctorId,
-        p_start_time: this.normalizeTimeForDb(next.start),
-        p_end_time: this.normalizeTimeForDb(next.end),
+        p_start_time: this.normalizeInstantForDb(next.start),
+        p_end_time: this.normalizeInstantForDb(next.end),
         p_cabinet: next.cabinet || '',
         p_service: next.service || '',
         p_status: next.status,
@@ -643,15 +644,24 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     };
   }
 
-  private normalizeTimeForDb(timeStr: string): string {
-    if (!timeStr) return timeStr;
-    if (timeStr.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(timeStr)) return timeStr;
-    return timeStr.length === 16 ? `${timeStr}:00Z` : `${timeStr}Z`;
+  private normalizeInstantForDb(value: string): string {
+    if (!isOffsetAwareInstant(value)) {
+      throw new AppointmentRepositoryError(
+        'generic',
+        'Не удалось обработать время записи. Обновите страницу и попробуйте снова.',
+      );
+    }
+    return new Date(value).toISOString();
   }
 
-  private normalizeTimeFromDb(timeStr: string): string {
-    if (!timeStr) return timeStr;
-    return timeStr.replace(/(Z|[+-]\d{2}:\d{2})$/, '');
+  private normalizeTimeFromDb(value: string): string {
+    if (!isOffsetAwareInstant(value)) {
+      throw new AppointmentRepositoryError(
+        'generic',
+        'Не удалось обработать время записи. Обновите страницу и попробуйте снова.',
+      );
+    }
+    return value;
   }
 
   private mapToConfirmationAttempt = (row: Record<string, unknown>): AppointmentConfirmationAttempt => ({
@@ -702,7 +712,7 @@ export class SupabaseAppointmentRepository implements IAppointmentRepository {
     start: this.normalizeTimeFromDb(row.start_time as string),
     end: this.normalizeTimeFromDb(row.end_time as string),
     createdAt: this.normalizeTimeFromDb(row.created_at as string),
-    updatedAt: row.updated_at as string,
+    updatedAt: this.normalizeTimeFromDb(row.updated_at as string),
   });
 }
 

--- a/src/domain/timezone.test.ts
+++ b/src/domain/timezone.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TimezoneError,
+  addTenantCalendarDays,
+  compareInstantToTenantDay,
+  instantToTenantDate,
+  instantToTenantDateTimeInput,
+  isOffsetAwareInstant,
+  isValidIanaTimezone,
+  tenantDateEndExclusiveInstant,
+  tenantDateStartInstant,
+  tenantDateTimeToInstant,
+  tenantNowDate,
+} from './timezone';
+
+const expectTimezoneError = (run: () => unknown, code: TimezoneError['code']) => {
+  try {
+    run();
+    throw new Error('Expected timezone error');
+  } catch (error) {
+    expect(error).toBeInstanceOf(TimezoneError);
+    expect((error as TimezoneError).code).toBe(code);
+  }
+};
+
+describe('tenant timezone utility', () => {
+  it('validates IANA zones and rejects numeric offsets', () => {
+    expect(isValidIanaTimezone('Asia/Almaty')).toBe(true);
+    expect(isValidIanaTimezone('Europe/Berlin')).toBe(true);
+    expect(isValidIanaTimezone('America/New_York')).toBe(true);
+    expect(isValidIanaTimezone('+05:00')).toBe(false);
+    expect(isValidIanaTimezone('UTC+5')).toBe(false);
+    expect(isValidIanaTimezone('Not/AZone')).toBe(false);
+  });
+
+  it('maps a UTC instant to Asia/Almaty local date and time', () => {
+    expect(instantToTenantDateTimeInput('2026-07-12T04:00:00.000Z', 'Asia/Almaty')).toBe('2026-07-12T09:00');
+    expect(instantToTenantDate('2026-07-11T21:30:00.000Z', 'Asia/Almaty')).toBe('2026-07-12');
+  });
+
+  it('converts Asia/Almaty wall time to the correct instant and round trips', () => {
+    const instant = tenantDateTimeToInstant('2026-07-12T09:00', 'Asia/Almaty');
+    expect(instant).toBe('2026-07-12T04:00:00.000Z');
+    expect(instantToTenantDateTimeInput(instant, 'Asia/Almaty')).toBe('2026-07-12T09:00');
+  });
+
+  it('preserves an instant through local conversion', () => {
+    const original = '2026-01-15T12:34:00.000Z';
+    const local = instantToTenantDateTimeInput(original, 'Europe/Berlin');
+    expect(tenantDateTimeToInstant(local, 'Europe/Berlin')).toBe(original);
+  });
+
+  it('uses Berlin winter and summer offsets', () => {
+    expect(tenantDateTimeToInstant('2026-01-15T09:00', 'Europe/Berlin')).toBe('2026-01-15T08:00:00.000Z');
+    expect(tenantDateTimeToInstant('2026-07-15T09:00', 'Europe/Berlin')).toBe('2026-07-15T07:00:00.000Z');
+  });
+
+  it('uses New York winter and summer offsets', () => {
+    expect(tenantDateTimeToInstant('2026-01-15T09:00', 'America/New_York')).toBe('2026-01-15T14:00:00.000Z');
+    expect(tenantDateTimeToInstant('2026-07-15T09:00', 'America/New_York')).toBe('2026-07-15T13:00:00.000Z');
+  });
+
+  it('rejects nonexistent DST wall time', () => {
+    expectTimezoneError(
+      () => tenantDateTimeToInstant('2026-03-29T02:30', 'Europe/Berlin'),
+      'nonexistent_local_time',
+    );
+  });
+
+  it('rejects ambiguous DST wall time deterministically', () => {
+    expectTimezoneError(
+      () => tenantDateTimeToInstant('2026-10-25T02:30', 'Europe/Berlin'),
+      'ambiguous_local_time',
+    );
+  });
+
+  it('rejects invalid timezone, local date and offset-free instant', () => {
+    expectTimezoneError(() => tenantDateTimeToInstant('2026-07-12T09:00', 'UTC+5'), 'invalid_timezone');
+    expectTimezoneError(() => tenantDateTimeToInstant('2026-02-30T09:00', 'Asia/Almaty'), 'invalid_local_datetime');
+    expectTimezoneError(() => instantToTenantDate('2026-07-12T09:00', 'Asia/Almaty'), 'invalid_instant');
+  });
+
+  it('supports leap day and calendar arithmetic', () => {
+    expect(tenantDateTimeToInstant('2028-02-29T09:00', 'Asia/Almaty')).toBe('2028-02-29T04:00:00.000Z');
+    expect(addTenantCalendarDays('2028-02-28', 1)).toBe('2028-02-29');
+    expect(addTenantCalendarDays('2028-02-29', 1)).toBe('2028-03-01');
+  });
+
+  it('uses half-open tenant day boundaries', () => {
+    expect(tenantDateStartInstant('2026-07-12', 'Asia/Almaty')).toBe('2026-07-11T19:00:00.000Z');
+    expect(tenantDateEndExclusiveInstant('2026-07-12', 'Asia/Almaty')).toBe('2026-07-12T19:00:00.000Z');
+    expect(compareInstantToTenantDay('2026-07-11T19:00:00.000Z', '2026-07-12', 'Asia/Almaty')).toBe(0);
+    expect(compareInstantToTenantDay('2026-07-12T18:59:59.999Z', '2026-07-12', 'Asia/Almaty')).toBe(0);
+    expect(compareInstantToTenantDay('2026-07-12T19:00:00.000Z', '2026-07-12', 'Asia/Almaty')).toBe(1);
+  });
+
+  it('injects now deterministically', () => {
+    expect(tenantNowDate('Asia/Almaty', '2026-07-11T21:30:00.000Z')).toBe('2026-07-12');
+    expect(tenantNowDate('Europe/Berlin', '2026-07-11T21:30:00.000Z')).toBe('2026-07-11');
+  });
+
+  it('does not depend on the browser timezone for conversion results', () => {
+    const instant = tenantDateTimeToInstant('2026-07-12T09:00', 'Asia/Almaty');
+    expect(instant).toBe('2026-07-12T04:00:00.000Z');
+    expect(instantToTenantDateTimeInput(instant, 'Europe/Berlin')).toBe('2026-07-12T06:00');
+  });
+
+  it('recognizes only offset-aware instants', () => {
+    expect(isOffsetAwareInstant('2026-07-12T04:00:00Z')).toBe(true);
+    expect(isOffsetAwareInstant('2026-07-12T09:00:00+05:00')).toBe(true);
+    expect(isOffsetAwareInstant('2026-07-12T09:00:00')).toBe(false);
+  });
+});

--- a/src/domain/timezone.ts
+++ b/src/domain/timezone.ts
@@ -1,0 +1,243 @@
+export type TimezoneErrorCode =
+  | 'invalid_timezone'
+  | 'invalid_local_datetime'
+  | 'invalid_instant'
+  | 'nonexistent_local_time'
+  | 'ambiguous_local_time'
+  | 'missing_timezone';
+
+export class TimezoneError extends Error {
+  readonly code: TimezoneErrorCode;
+
+  constructor(code: TimezoneErrorCode, message: string) {
+    super(message);
+    this.name = 'TimezoneError';
+    this.code = code;
+  }
+}
+
+export const TIMEZONE_ERROR_MESSAGES: Record<TimezoneErrorCode, string> = {
+  invalid_timezone: 'Укажите корректный часовой пояс клиники.',
+  invalid_local_datetime: 'Укажите корректные дату и время.',
+  invalid_instant: 'Не удалось обработать время записи. Обновите страницу и попробуйте снова.',
+  nonexistent_local_time: 'Выбранное местное время не существует из-за перехода часового пояса.',
+  ambiguous_local_time: 'Выбранное местное время неоднозначно из-за перехода часового пояса.',
+  missing_timezone: 'Не удалось определить часовой пояс клиники.',
+};
+
+interface DateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const LOCAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const LOCAL_DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/;
+const OFFSET_AWARE_PATTERN = /(Z|[+-]\d{2}:\d{2})$/;
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+export function isValidIanaTimezone(timezone: string | null | undefined): timezone is string {
+  if (!timezone || timezone.trim() !== timezone || /^[+-]?\d{1,2}(?::?\d{2})?$/.test(timezone)) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(0);
+    return timezone.includes('/') || timezone === 'UTC';
+  } catch {
+    return false;
+  }
+}
+
+export function requireIanaTimezone(timezone: string | null | undefined): string {
+  if (!timezone) throw new TimezoneError('missing_timezone', TIMEZONE_ERROR_MESSAGES.missing_timezone);
+  if (!isValidIanaTimezone(timezone)) {
+    throw new TimezoneError('invalid_timezone', TIMEZONE_ERROR_MESSAGES.invalid_timezone);
+  }
+  return timezone;
+}
+
+function parseLocalDate(value: string): Pick<DateTimeParts, 'year' | 'month' | 'day'> {
+  const match = LOCAL_DATE_PATTERN.exec(value);
+  if (!match) throw new TimezoneError('invalid_local_datetime', TIMEZONE_ERROR_MESSAGES.invalid_local_datetime);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const test = new Date(Date.UTC(year, month - 1, day));
+  if (test.getUTCFullYear() !== year || test.getUTCMonth() !== month - 1 || test.getUTCDate() !== day) {
+    throw new TimezoneError('invalid_local_datetime', TIMEZONE_ERROR_MESSAGES.invalid_local_datetime);
+  }
+  return { year, month, day };
+}
+
+function parseLocalDateTime(value: string): DateTimeParts {
+  const match = LOCAL_DATE_TIME_PATTERN.exec(value);
+  if (!match) throw new TimezoneError('invalid_local_datetime', TIMEZONE_ERROR_MESSAGES.invalid_local_datetime);
+  const parts: DateTimeParts = {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hour: Number(match[4]),
+    minute: Number(match[5]),
+    second: Number(match[6] ?? '0'),
+  };
+  if (parts.hour > 23 || parts.minute > 59 || parts.second > 59) {
+    throw new TimezoneError('invalid_local_datetime', TIMEZONE_ERROR_MESSAGES.invalid_local_datetime);
+  }
+  const test = new Date(Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second));
+  if (
+    test.getUTCFullYear() !== parts.year
+    || test.getUTCMonth() !== parts.month - 1
+    || test.getUTCDate() !== parts.day
+    || test.getUTCHours() !== parts.hour
+    || test.getUTCMinutes() !== parts.minute
+    || test.getUTCSeconds() !== parts.second
+  ) {
+    throw new TimezoneError('invalid_local_datetime', TIMEZONE_ERROR_MESSAGES.invalid_local_datetime);
+  }
+  return parts;
+}
+
+function toInstantDate(instant: string | Date): Date {
+  if (instant instanceof Date) {
+    if (Number.isNaN(instant.getTime())) throw new TimezoneError('invalid_instant', TIMEZONE_ERROR_MESSAGES.invalid_instant);
+    return new Date(instant.getTime());
+  }
+  if (!OFFSET_AWARE_PATTERN.test(instant)) {
+    throw new TimezoneError('invalid_instant', TIMEZONE_ERROR_MESSAGES.invalid_instant);
+  }
+  const date = new Date(instant);
+  if (Number.isNaN(date.getTime())) throw new TimezoneError('invalid_instant', TIMEZONE_ERROR_MESSAGES.invalid_instant);
+  return date;
+}
+
+function zonedParts(instant: Date, timezone: string): DateTimeParts {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  });
+  const values = Object.fromEntries(
+    formatter.formatToParts(instant)
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, Number(part.value)]),
+  ) as Record<string, number>;
+  return {
+    year: values.year,
+    month: values.month,
+    day: values.day,
+    hour: values.hour,
+    minute: values.minute,
+    second: values.second,
+  };
+}
+
+const sameParts = (left: DateTimeParts, right: DateTimeParts) => (
+  left.year === right.year
+  && left.month === right.month
+  && left.day === right.day
+  && left.hour === right.hour
+  && left.minute === right.minute
+  && left.second === right.second
+);
+
+export function instantToTenantDate(instant: string | Date, timezone: string): string {
+  const zone = requireIanaTimezone(timezone);
+  const parts = zonedParts(toInstantDate(instant), zone);
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`;
+}
+
+export function instantToTenantDateTimeInput(instant: string | Date, timezone: string): string {
+  const zone = requireIanaTimezone(timezone);
+  const parts = zonedParts(toInstantDate(instant), zone);
+  return `${parts.year}-${pad(parts.month)}-${pad(parts.day)}T${pad(parts.hour)}:${pad(parts.minute)}`;
+}
+
+export function tenantDateTimeToInstant(localDateTime: string, timezone: string): string {
+  const zone = requireIanaTimezone(timezone);
+  const wanted = parseLocalDateTime(localDateTime);
+  const localAsUtc = Date.UTC(wanted.year, wanted.month - 1, wanted.day, wanted.hour, wanted.minute, wanted.second);
+  const offsets = new Set<number>();
+  const sampleWindow = 36 * 60 * 60 * 1000;
+  const sampleStep = 30 * 60 * 1000;
+
+  for (let sample = localAsUtc - sampleWindow; sample <= localAsUtc + sampleWindow; sample += sampleStep) {
+    const sampleDate = new Date(sample);
+    const parts = zonedParts(sampleDate, zone);
+    const representedAsUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+    offsets.add(representedAsUtc - sampleDate.getTime());
+  }
+
+  const candidates = [...offsets]
+    .map((offset) => new Date(localAsUtc - offset))
+    .filter((candidate) => sameParts(zonedParts(candidate, zone), wanted))
+    .map((candidate) => candidate.getTime());
+  const uniqueCandidates = [...new Set(candidates)].sort((a, b) => a - b);
+
+  if (uniqueCandidates.length === 0) {
+    throw new TimezoneError('nonexistent_local_time', TIMEZONE_ERROR_MESSAGES.nonexistent_local_time);
+  }
+  if (uniqueCandidates.length > 1) {
+    throw new TimezoneError('ambiguous_local_time', TIMEZONE_ERROR_MESSAGES.ambiguous_local_time);
+  }
+  return new Date(uniqueCandidates[0]).toISOString();
+}
+
+export function addTenantCalendarDays(date: string, days: number): string {
+  const parts = parseLocalDate(date);
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days));
+  return `${shifted.getUTCFullYear()}-${pad(shifted.getUTCMonth() + 1)}-${pad(shifted.getUTCDate())}`;
+}
+
+export function tenantDateStartInstant(date: string, timezone: string): string {
+  parseLocalDate(date);
+  return tenantDateTimeToInstant(`${date}T00:00`, timezone);
+}
+
+export function tenantDateEndExclusiveInstant(date: string, timezone: string): string {
+  return tenantDateStartInstant(addTenantCalendarDays(date, 1), timezone);
+}
+
+export function tenantNowDate(timezone: string, now: string | Date = new Date()): string {
+  return instantToTenantDate(now, timezone);
+}
+
+export function compareInstantToTenantDay(instant: string | Date, date: string, timezone: string): -1 | 0 | 1 {
+  const instantMs = toInstantDate(instant).getTime();
+  const startMs = new Date(tenantDateStartInstant(date, timezone)).getTime();
+  const endMs = new Date(tenantDateEndExclusiveInstant(date, timezone)).getTime();
+  if (instantMs < startMs) return -1;
+  if (instantMs >= endMs) return 1;
+  return 0;
+}
+
+export function formatInstantInTenant(
+  instant: string | Date,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions = { dateStyle: 'short', timeStyle: 'short' },
+  locale = 'ru-RU',
+): string {
+  const zone = requireIanaTimezone(timezone);
+  return new Intl.DateTimeFormat(locale, { ...options, timeZone: zone }).format(toInstantDate(instant));
+}
+
+export function formatTenantDate(
+  date: string,
+  options: Intl.DateTimeFormatOptions,
+  locale = 'ru-RU',
+): string {
+  const parts = parseLocalDate(date);
+  return new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' })
+    .format(new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12)));
+}
+
+export function isOffsetAwareInstant(value: string): boolean {
+  if (!OFFSET_AWARE_PATTERN.test(value)) return false;
+  return !Number.isNaN(new Date(value).getTime());
+}

--- a/src/pages/MedicalPage.test.tsx
+++ b/src/pages/MedicalPage.test.tsx
@@ -42,7 +42,7 @@ describe('MedicalPage dictionary bootstrap and restored editor behavior', () => 
     bootstrapDefaultsMock = vi.fn().mockResolvedValue({ insertedCount: 43, skippedExistingCount: 0, templateKey: 'default_dental_v1' });
 
     vi.mocked(useAuth).mockReturnValue({ authMode: 'supabase-active' } as unknown as ReturnType<typeof useAuth>);
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'Clinic A', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
     vi.mocked(useDictionaries).mockReturnValue({
       diagnoses: mockDiagnoses,
       works: mockWorks,
@@ -145,7 +145,7 @@ describe('MedicalPage dictionary bootstrap and restored editor behavior', () => 
   });
 
   it('shows explicit import button for admin/owner empty dictionaries only', async () => {
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'Clinic A', role: 'clinic_owner' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'clinic_owner' } } as unknown as ReturnType<typeof useTenant>);
     vi.mocked(useDictionaries).mockReturnValue({
       diagnoses: [],
       works: [],
@@ -168,7 +168,7 @@ describe('MedicalPage dictionary bootstrap and restored editor behavior', () => 
   });
 
   it('does not show import/edit actions for doctor or no-tenant state', async () => {
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'Clinic A', role: 'doctor' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 't1', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'doctor' } } as unknown as ReturnType<typeof useTenant>);
     vi.mocked(useDictionaries).mockReturnValue({
       diagnoses: [],
       works: [],

--- a/src/pages/PatientCardPage.test.tsx
+++ b/src/pages/PatientCardPage.test.tsx
@@ -45,7 +45,7 @@ function renderPage() {
 describe('PatientCardPage timeline tab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-1', tenantName: 'Clinic', timezone: 'Asia/Almaty', role: 'clinic_admin' } } as unknown as ReturnType<typeof useTenant>);
     vi.mocked(usePatientProfile).mockReturnValue({
       patient: {
         id: 'patient-1',

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -215,6 +215,7 @@ export function PatientCardPage() {
             dentalSummary={dentalSummary}
             lastVisit={lastVisit}
             nextVisit={nextVisit}
+            timezone={activeTenant?.timezone ?? 'Asia/Almaty'}
             onNavigateToSchedule={() => navigate('/')}
           />
         )}

--- a/src/pages/PatientsPage.test.tsx
+++ b/src/pages/PatientsPage.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PatientsPage } from './PatientsPage';
 import { usePatientsCollection } from '../data/hooks/usePatientsCollection';
 import { usePatientListVisitSummary } from '../data/hooks/usePatientListVisitSummary';
+import { useTenant } from '../contexts/TenantContext';
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
@@ -14,6 +15,7 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('../data/hooks/usePatientsCollection', () => ({ usePatientsCollection: vi.fn() }));
 vi.mock('../data/hooks/usePatientListVisitSummary', () => ({ usePatientListVisitSummary: vi.fn() }));
+vi.mock('../contexts/TenantContext', () => ({ useTenant: vi.fn(), LEGACY_TENANT_TIMEZONE: 'Asia/Almaty' }));
 vi.mock('../components/patients/PatientModal', () => ({ PatientModal: () => null }));
 
 const patient = {
@@ -36,6 +38,7 @@ function renderPage() {
 describe('PatientsPage appointment summary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useTenant).mockReturnValue({ activeTenant: { tenantId: 'tenant-a', tenantName: 'Clinic', timezone: 'Asia/Almaty' } } as unknown as ReturnType<typeof useTenant>);
     vi.mocked(usePatientsCollection).mockReturnValue({
       patients: [patient],
       isLoading: false,

--- a/src/pages/PatientsPage.tsx
+++ b/src/pages/PatientsPage.tsx
@@ -5,6 +5,8 @@ import { PatientModal } from '../components/patients/PatientModal';
 import { useNavigate } from 'react-router-dom';
 import { usePatientsCollection } from '../data/hooks/usePatientsCollection';
 import { usePatientListVisitSummary } from '../data/hooks/usePatientListVisitSummary';
+import { LEGACY_TENANT_TIMEZONE, useTenant } from '../contexts/TenantContext';
+import { formatInstantInTenant } from '../domain/timezone';
 
 const getSourceLabel = (source?: string) => {
   switch (source) {
@@ -85,6 +87,8 @@ const getLeadStatusLabel = (status?: PatientLeadStatus) => {
 
 export function PatientsPage() {
   const navigate = useNavigate();
+  const { activeTenant } = useTenant();
+  const timezone = activeTenant?.timezone ?? LEGACY_TENANT_TIMEZONE;
   const {
     patients,
     isLoading: isPatientsLoading,
@@ -139,7 +143,7 @@ export function PatientsPage() {
 
   const formatDate = (date?: Date) => {
     if (!date) return '-';
-    return date.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+    return formatInstantInTenant(date, timezone, { day: '2-digit', month: '2-digit', year: 'numeric' });
   };
 
   if (isPatientsError && patients.length === 0 && !isModalOpen) {

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -6,9 +6,16 @@ import { useAppointmentConfirmationAttempts, useScheduleAppointments } from '../
 import { useClinicDoctors } from '../data/hooks/useClinicDoctors';
 import { usePatientsCollection } from '../data/hooks/usePatientsCollection';
 import { AppointmentModal } from '../components/schedule/AppointmentModal';
-import { useTenant } from '../contexts/TenantContext';
+import { LEGACY_TENANT_TIMEZONE, useTenant } from '../contexts/TenantContext';
 import type { Appointment, AppointmentContactChannel, AppointmentContactOutcome, CancellationSource, Doctor, AppointmentStatus } from '../types';
 import { appointmentNeedsConfirmationAttention, confirmationStateClassName, confirmationStateLabel } from '../components/schedule/appointmentConfirmation';
+import {
+  addTenantCalendarDays,
+  compareInstantToTenantDay,
+  formatTenantDate,
+  instantToTenantDateTimeInput,
+  tenantDateTimeToInstant,
+} from '../domain/timezone';
 
 const timeSlots = Array.from({ length: 23 }, (_, i) => {
   const hour = Math.floor(i / 2) + 9;
@@ -79,6 +86,7 @@ export function SchedulePage() {
   const [editingAppointment, setEditingAppointment] = useState<Partial<Appointment> | undefined>();
   const [showConfirmationAttentionOnly, setShowConfirmationAttentionOnly] = useState(false);
   const { activeTenant } = useTenant();
+  const timezone = activeTenant?.timezone ?? LEGACY_TENANT_TIMEZONE;
   const {
     attempts: confirmationAttempts,
     isLoading: isLoadingConfirmationAttempts,
@@ -98,35 +106,35 @@ export function SchedulePage() {
   }, [allDoctors, doctorFilter]);
 
   const changeDate = (days: number) => {
-    const newDate = new Date(selectedDate);
-    newDate.setDate(newDate.getDate() + days);
-    setSelectedDate(newDate);
+    setSelectedDate(addTenantCalendarDays(selectedDate, days));
   };
 
-  const selectedDateStr = selectedDate.toISOString().split('T')[0];
+  const selectedDateStr = selectedDate;
 
   const dailyAppointments = useMemo(() => {
     return appointments.filter(a => {
-      if (!a.start.startsWith(selectedDateStr)) return false;
+      if (compareInstantToTenantDay(a.start, selectedDateStr, timezone) !== 0) return false;
       if (statusFilter && a.status !== statusFilter) return false;
       if (sourceFilter && a.source !== sourceFilter) return false;
       if (showConfirmationAttentionOnly && !appointmentNeedsConfirmationAttention(a)) return false;
       return true;
     });
-  }, [appointments, selectedDateStr, statusFilter, sourceFilter, showConfirmationAttentionOnly]);
+  }, [appointments, selectedDateStr, statusFilter, sourceFilter, showConfirmationAttentionOnly, timezone]);
 
   const confirmationAttentionCount = useMemo(() => appointments.filter((appointment) => (
-    appointment.start.startsWith(selectedDateStr) && appointmentNeedsConfirmationAttention(appointment)
-  )).length, [appointments, selectedDateStr]);
+    compareInstantToTenantDay(appointment.start, selectedDateStr, timezone) === 0 && appointmentNeedsConfirmationAttention(appointment)
+  )).length, [appointments, selectedDateStr, timezone]);
 
   const handleOpenModal = (doctor?: Doctor, timeSlot?: string) => {
     let initialData: Partial<Appointment> = {};
     if (doctor && timeSlot) {
+      const start = tenantDateTimeToInstant(`${selectedDateStr}T${timeSlot}`, timezone);
+      const end = new Date(new Date(start).getTime() + 60 * 60 * 1000).toISOString();
       initialData = {
         doctorId: doctor.id,
         cabinet: doctor.cabinet,
-        start: `${selectedDateStr}T${timeSlot}:00`,
-        end: `${selectedDateStr}T${String(parseInt(timeSlot.split(':')[0]) + 1).padStart(2, '0')}:${timeSlot.split(':')[1]}:00`,
+        start,
+        end,
       };
     }
     setEditingAppointment(initialData);
@@ -233,11 +241,11 @@ export function SchedulePage() {
   const hourHeight = slotHeight * 2; // 96px per hour
 
   const getCardStyle = (startStr: string, endStr: string) => {
-    const startDate = new Date(startStr);
-    const endDate = new Date(endStr);
-
-    const startMins = (startDate.getHours() - startHour) * 60 + startDate.getMinutes();
-    const durationMins = (endDate.getTime() - startDate.getTime()) / 60000;
+    const tenantStart = instantToTenantDateTimeInput(startStr, timezone);
+    const [, time] = tenantStart.split('T');
+    const [hour, minute] = time.split(':').map(Number);
+    const startMins = (hour - startHour) * 60 + minute;
+    const durationMins = (new Date(endStr).getTime() - new Date(startStr).getTime()) / 60000;
 
     const top = (startMins / 60) * hourHeight;
     const height = (durationMins / 60) * hourHeight;
@@ -252,7 +260,7 @@ export function SchedulePage() {
         <div className="p-4 border-b border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="font-medium text-slate-800 capitalize">
-              {selectedDate.toLocaleDateString('ru-RU', { month: 'long', year: 'numeric' })}
+              {formatTenantDate(selectedDate, { month: 'long', year: 'numeric' })}
             </h3>
             <div className="flex gap-1">
               <button onClick={() => changeDate(-1)} className="p-1 hover:bg-slate-100 rounded text-slate-500">
@@ -267,7 +275,7 @@ export function SchedulePage() {
             <input
               type="date"
               value={selectedDateStr}
-              onChange={(e) => setSelectedDate(new Date(e.target.value))}
+              onChange={(e) => setSelectedDate(e.target.value)}
               className="text-sm p-1 border border-slate-200 rounded text-slate-700"
             />
           </div>
@@ -360,7 +368,7 @@ export function SchedulePage() {
                         style={style}
                       >
                         <div className="font-medium truncate mb-0.5 flex justify-between">
-                          <span>{apt.start.split('T')[1].slice(0,5)} {patient?.fullName || apt.service}</span>
+                          <span>{instantToTenantDateTimeInput(apt.start, timezone).slice(11, 16)} {patient?.fullName || apt.service}</span>
                           <span className="opacity-75 text-[10px]">{getStatusLabel(apt.status)}</span>
                         </div>
                         {apt.status !== 'blocked' && (
@@ -405,6 +413,7 @@ export function SchedulePage() {
         isReconcilingConfirmation={isReconcilingConfirmation}
         onDelete={handleDeleteAppointment}
         role={activeTenant?.role}
+        timezone={timezone}
         initialData={editingAppointment}
         appointments={appointments}
         doctors={allDoctors}

--- a/supabase/migrations/0028_tenant_timezone_scheduling_foundation.sql
+++ b/supabase/migrations/0028_tenant_timezone_scheduling_foundation.sql
@@ -1,0 +1,156 @@
+-- 0028_tenant_timezone_scheduling_foundation.sql
+-- Authoritative tenant timezone foundation. Appointment timestamptz values are not rewritten.
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS timezone text;
+
+UPDATE public.tenants
+SET timezone = 'Asia/Almaty'
+WHERE timezone IS NULL OR btrim(timezone) = '';
+
+ALTER TABLE public.tenants
+  ALTER COLUMN timezone SET DEFAULT 'Asia/Almaty',
+  ALTER COLUMN timezone SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.is_valid_iana_timezone(p_timezone text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+  SELECT p_timezone IS NOT NULL
+    AND btrim(p_timezone) = p_timezone
+    AND p_timezone <> ''
+    AND p_timezone !~ '^[+-]?[0-9]{1,2}(:?[0-9]{2})?$'
+    AND EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_timezone_names
+      WHERE name = p_timezone
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.validate_tenant_timezone_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+BEGIN
+  IF NOT public.is_valid_iana_timezone(NEW.timezone) THEN
+    RAISE EXCEPTION 'Укажите корректный часовой пояс клиники.' USING ERRCODE = '22023';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND NEW.timezone IS DISTINCT FROM OLD.timezone
+     AND COALESCE(current_setting('app.tenant_timezone_rpc', true), '') <> 'on' THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения часового пояса клиники.' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tenants_validate_timezone ON public.tenants;
+CREATE TRIGGER tenants_validate_timezone
+BEFORE INSERT OR UPDATE OF timezone ON public.tenants
+FOR EACH ROW
+EXECUTE FUNCTION public.validate_tenant_timezone_row();
+
+CREATE OR REPLACE FUNCTION public.set_tenant_timezone(
+  p_tenant_id uuid,
+  p_timezone text
+) RETURNS public.tenants
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_role public.app_role;
+  v_before text;
+  v_after public.tenants;
+  v_audit_id uuid;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения часового пояса клиники.' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT tu.role
+  INTO v_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения часового пояса клиники.' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT public.is_valid_iana_timezone(p_timezone) THEN
+    RAISE EXCEPTION 'Укажите корректный часовой пояс клиники.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT timezone
+  INTO v_before
+  FROM public.tenants
+  WHERE id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Клиника не найдена.' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_before = p_timezone THEN
+    SELECT * INTO v_after FROM public.tenants WHERE id = p_tenant_id;
+    RETURN v_after;
+  END IF;
+
+  PERFORM set_config('app.tenant_timezone_rpc', 'on', true);
+
+  UPDATE public.tenants
+  SET timezone = p_timezone,
+      updated_at = now()
+  WHERE id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  PERFORM set_config('app.tenant_timezone_rpc', 'off', true);
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => 'tenant_timezone_changed',
+    p_category => 'tenant',
+    p_target_type => 'tenant',
+    p_target_id => p_tenant_id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_role::text,
+    p_before_data => jsonb_build_object('timezone', v_before),
+    p_after_data => jsonb_build_object('timezone', p_timezone),
+    p_diff_data => jsonb_build_object('timezone', jsonb_build_object('from', v_before, 'to', p_timezone)),
+    p_redaction_level => 'none',
+    p_metadata => jsonb_build_object('source', 'set_tenant_timezone')
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'system',
+    p_type => 'tenant_timezone_changed',
+    p_title => 'Изменён часовой пояс клиники',
+    p_source_type => 'tenant',
+    p_source_id => p_tenant_id::text,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object('timezone', p_timezone)
+  );
+
+  RETURN v_after;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.is_valid_iana_timezone(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_valid_iana_timezone(text) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.set_tenant_timezone(uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.set_tenant_timezone(uuid, text) TO authenticated, service_role;
+
+COMMENT ON COLUMN public.tenants.timezone IS 'Authoritative IANA timezone for tenant-local scheduling. Legacy default: Asia/Almaty.';
+COMMENT ON FUNCTION public.set_tenant_timezone(uuid, text) IS 'Owner/admin-only audited timezone mutation. Browser numeric offsets are not accepted.';
+COMMENT ON FUNCTION public.is_valid_iana_timezone(text) IS 'Validates exact IANA timezone names against PostgreSQL timezone catalog.';

--- a/supabase/tests/0028_tenant_timezone_scheduling_foundation_test.sql
+++ b/supabase/tests/0028_tenant_timezone_scheduling_foundation_test.sql
@@ -1,0 +1,153 @@
+\set ON_ERROR_STOP on
+\echo 'TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+\set tenant_a 'a2810000-0000-4000-8000-000000000001'
+\set tenant_b 'b2810000-0000-4000-8000-000000000001'
+\set owner_a 'a2820000-0000-4000-8000-000000000001'
+\set admin_a 'a2820000-0000-4000-8000-000000000002'
+\set registrar_a 'a2820000-0000-4000-8000-000000000003'
+\set doctor_a_user 'a2820000-0000-4000-8000-000000000004'
+\set cashier_a 'a2820000-0000-4000-8000-000000000005'
+\set no_tenant 'a2820000-0000-4000-8000-000000000006'
+\set unknown_user 'a2820000-0000-4000-8000-000000000007'
+\set admin_b 'b2820000-0000-4000-8000-000000000001'
+\set patient_a 'a2830000-0000-4000-8000-000000000001'
+\set doctor_a 'a2840000-0000-4000-8000-000000000001'
+\set appointment_a 'a2850000-0000-4000-8000-000000000001'
+
+SELECT pg_temp.assert_true(
+  (SELECT column_default LIKE '%Asia/Almaty%'
+   FROM information_schema.columns
+   WHERE table_schema='public' AND table_name='tenants' AND column_name='timezone'),
+  'tenant timezone has documented legacy default'
+);
+SELECT pg_temp.assert_true(
+  (SELECT is_nullable='NO'
+   FROM information_schema.columns
+   WHERE table_schema='public' AND table_name='tenants' AND column_name='timezone'),
+  'tenant timezone is not nullable'
+);
+SELECT pg_temp.assert_true(
+  (SELECT relrowsecurity FROM pg_class WHERE oid='public.tenants'::regclass),
+  'tenant RLS remains enabled'
+);
+SELECT pg_temp.assert_true(public.is_valid_iana_timezone('Asia/Almaty'), 'Asia/Almaty accepted');
+SELECT pg_temp.assert_true(public.is_valid_iana_timezone('Europe/Berlin'), 'Europe/Berlin accepted');
+SELECT pg_temp.assert_true(public.is_valid_iana_timezone('America/New_York'), 'America/New_York accepted');
+SELECT pg_temp.assert_true(NOT public.is_valid_iana_timezone('UTC+5'), 'numeric-like zone rejected');
+SELECT pg_temp.assert_true(NOT public.is_valid_iana_timezone(''), 'empty zone rejected');
+
+INSERT INTO public.tenants(id,name) VALUES
+  (:'tenant_a','Timezone Clinic A'),
+  (:'tenant_b','Timezone Clinic B');
+SELECT pg_temp.assert_true((SELECT timezone='Asia/Almaty' FROM public.tenants WHERE id=:'tenant_a'), 'legacy/default tenant receives Asia/Almaty');
+
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+  (:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-owner@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-admin@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-registrar@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'doctor_a_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-doctor@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-cashier@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'no_tenant','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-no-tenant@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'unknown_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-unknown@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','tz-admin-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id,first_name,last_name) VALUES
+  (:'owner_a','Owner','A'),(:'admin_a','Admin','A'),(:'registrar_a','Registrar','A'),
+  (:'doctor_a_user','Doctor','A'),(:'cashier_a','Cashier','A'),(:'no_tenant','No','Tenant'),
+  (:'unknown_user','Unknown','User'),(:'admin_b','Admin','B');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+  (:'tenant_a',:'owner_a','clinic_owner'),
+  (:'tenant_a',:'admin_a','clinic_admin'),
+  (:'tenant_a',:'registrar_a','registrar'),
+  (:'tenant_a',:'doctor_a_user','doctor'),
+  (:'tenant_a',:'cashier_a','cashier'),
+  (:'tenant_b',:'admin_b','clinic_admin');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance)
+VALUES (:'patient_a',:'tenant_a','Timezone Patient','+77002810001','phone','active',0);
+INSERT INTO public.doctors(id,tenant_id,user_id,full_name,specialization,cabinet,color,active)
+VALUES (:'doctor_a',:'tenant_a',:'doctor_a_user','Timezone Doctor','General','A1','#111111',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time)
+VALUES (:'appointment_a',:'tenant_a',:'patient_a',:'doctor_a','A1','Timezone baseline','new','2026-07-11 19:30+00','2026-07-11 20:30+00');
+
+SELECT start_time::text AS start_before, end_time::text AS end_before FROM public.appointments WHERE id=:'appointment_a' \gset
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments \gset
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.set_tenant_timezone(:'tenant_a','Europe/Berlin');
+SELECT pg_temp.assert_true((SELECT timezone='Europe/Berlin' FROM public.tenants WHERE id=:'tenant_a'), 'owner changes timezone');
+SELECT pg_temp.expect_error(format('update public.tenants set timezone=%L where id=%L::uuid','Asia/Almaty',:'tenant_a'),'permission denied');
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','UTC+5'),'корректный часовой пояс');
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a',''),'корректный часовой пояс');
+
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.set_tenant_timezone(:'tenant_a','America/New_York');
+SELECT pg_temp.assert_true((SELECT timezone='America/New_York' FROM public.tenants WHERE id=:'tenant_a'), 'admin changes timezone');
+
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.assert_true((SELECT timezone='America/New_York' FROM public.tenants WHERE id=:'tenant_a'), 'registrar may read timezone');
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','Asia/Almaty'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'doctor_a_user',true);
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','Asia/Almaty'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','Asia/Almaty'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'no_tenant',true);
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','Asia/Almaty'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'unknown_user',true);
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','Asia/Almaty'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'admin_b',true);
+SELECT pg_temp.expect_error(format('select public.set_tenant_timezone(%L::uuid,%L)',:'tenant_a','Asia/Almaty'),'Недостаточно прав');
+
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.audit_events WHERE tenant_id=:'tenant_a' AND action='tenant_timezone_changed'), 'timezone changes are audited once each');
+SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.activity_events WHERE tenant_id=:'tenant_a' AND type='tenant_timezone_changed'), 'timezone changes create activity facts');
+SELECT pg_temp.assert_true((SELECT start_time::text=:'start_before' AND end_time::text=:'end_before' FROM public.appointments WHERE id=:'appointment_a'), 'appointment instants unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE tenant_id=:'tenant_a')=1, 'no duplicate appointment rows');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE end_time<=start_time)=0, 'invalid intervals remain zero');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.patient_visits)=:'visits_before', 'no visit side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.clinical_encounters)=:'encounters_before', 'no encounter side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.completed_services)=:'services_before', 'no completed service side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.invoices)=:'invoices_before', 'no invoice side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.payments)=:'payments_before', 'no payment side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.refunds)=:'refunds_before', 'no refund side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.financial_adjustments)=:'adjustments_before', 'no adjustment side effects');
+
+ROLLBACK;
+\echo 'TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Adds authoritative IANA tenant timezone semantics for appointment creation, editing, rescheduling, schedule-day boundaries, patient summaries, lifecycle metadata, and tenant switching. Migration 0028 defaults legacy tenants to Asia/Almaty, validates IANA zones, and adds an audited owner/admin mutation RPC. Existing appointment instants are not rewritten.

## Validation

- clean local Supabase reset through migration 0028
- SQL tests 0024-0028 passed
- appointment concurrency suites 0025-0027 passed with zero doctor overlaps, zero patient overlaps, zero invalid intervals, and zero deadlocks
- isolated HeadlessChrome create/reload/reschedule/boundary/tenant-switch/confirmation/cancellation/no-show smoke passed
- ESLint passed
- 90 test files / 1007 tests passed
- production build passed
- final local QA row counters are zero

## Scope boundaries

No cloud migration apply, reminder queues, providers, cron, workers, webhooks, finance changes, clinical changes, or historical timestamp mass shifts. This is a protected draft; merging is outside this task.

## Limitation

A separately invokable Chrome DevTools MCP action was unavailable in this environment. Equivalent HeadlessChrome, gateway-log, SQL, and database validation passed.