### PR TITLE
APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001: add durable reminder job planning

### DIFF
--- a/_ai_work/REPORTS/APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001_foundation.md
@@ -22,7 +22,7 @@ No external message or provider request exists.
 
 ## 4. PR URL
 
-Pending creation after the implementation commit.
+https://github.com/NckNA/codex-test/pull/354
 
 ## 5. Baseline
 
@@ -36,7 +36,15 @@ Pending creation after the implementation commit.
 
 ## 6. PR head reviewed before final report update
 
-Pending implementation commit and first fresh CI run.
+- implementation head: `fd039d793cbc3af4d6bcda25ff46132956d48639`;
+- workflow: `CI`;
+- run number: `#719`;
+- run ID: `29205053951`;
+- conclusion: `success`;
+- tested commit: `fd039d793cbc3af4d6bcda25ff46132956d48639`;
+- tested commit matched the implementation head exactly;
+- ESLint, tests, build, and merge guard passed;
+- PR #354 remains open and unmerged.
 
 ## 7. Report update commit
 
@@ -400,7 +408,7 @@ Repository suite: **9/9 passed**.
 
 Full suite: **91 files / 1016 tests passed**.
 
-## 32. Browser/local smoke
+## 32. Browser smoke / local Supabase
 
 Equivalent isolated HeadlessChrome 150 was used because a separately invokable Chrome DevTools MCP action was unavailable in this environment, which the task explicitly permits when documented.
 
@@ -528,11 +536,21 @@ Non-blocking baseline warnings remain:
 
 ## 39. Fresh CI
 
-Pending PR creation and fresh GitHub Actions CI on the exact implementation head.
+Implementation CI passed on the exact implementation head:
 
-A second fresh CI run is required after the report-only metadata commit. The final CI run must test the exact final PR HEAD and include ESLint, tests, build, and merge guard.
+- workflow: `CI`;
+- run number: `#719`;
+- run ID: `29205053951`;
+- conclusion: `success`;
+- tested commit: `fd039d793cbc3af4d6bcda25ff46132956d48639`;
+- ESLint: passed;
+- tests: passed;
+- build: passed;
+- merge guard: passed.
 
-The PR must remain open and unmerged.
+A second fresh CI run is required after the report-only metadata commit. The final CI run must test the exact final PR HEAD. Its immutable metadata belongs in the finalization receipt because this report cannot reference its own future commit.
+
+PR #354 must remain open and unmerged.
 
 ## 40. Issues / Limitations
 

--- a/_ai_work/REPORTS/APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001_foundation.md
@@ -1,0 +1,585 @@
+# APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001
+
+## 1. Final verdict
+
+Final verdict: **PASS**
+
+Task verdict: **APPOINTMENT REMINDER QUEUE FOUNDATION IMPLEMENTED AND VERIFIED**
+
+The durable tenant-scoped reminder planning foundation is implemented and verified locally. It creates manual work plans only. It does not send a message, contact a provider, run a worker, register cron, expose a webhook, or add delivery state.
+
+## 2. Summary
+
+This task adds a disabled-by-default tenant reminder policy, durable version-bound appointment reminder jobs, an idempotent appointment planner, bounded tenant reconciliation, lifecycle invalidation, tenant-scoped repository reads, RLS, audit/activity facts, SQL validation, concurrency validation, TypeScript tests, and real local browser/database smoke.
+
+Each job is bound to the exact appointment `updated_at` and policy version. Repeated planning reuses the same deterministic plan. Reschedule, relevant detail/status changes, confirmation changes, policy changes, cancellation, no-show, patient arrival, visit start/completion, and hard delete cannot leave sendable stale work.
+
+No external message or provider request exists.
+
+## 3. Branch
+
+`feature/appointment-reminder-queue-foundation-001`
+
+## 4. PR URL
+
+Pending creation after the implementation commit.
+
+## 5. Baseline
+
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- exact verified baseline: `80e90b4f7a0db6559ecbacc91f673b910516afa4`;
+- `origin/main` exactly matched the expected baseline before the branch was created;
+- the baseline contains PR #353 and `TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001`;
+- the task worktree was created cleanly from current `origin/main`;
+- cloud Supabase was not used.
+
+## 6. PR head reviewed before final report update
+
+Pending implementation commit and first fresh CI run.
+
+## 7. Report update commit
+
+Report update commit: N/A because a report-only commit cannot contain its own future SHA or the CI result that tests it.
+
+The exact final report-only commit and final fresh CI run must be recorded in an immutable local finalization receipt and in the final task response.
+
+## 8. Changed files
+
+- `_ai_work/REPORTS/APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001_foundation.md`;
+- `src/data/repositories/AppointmentReminderRepository.test.ts`;
+- `src/data/repositories/AppointmentReminderRepository.ts`;
+- `src/types/index.ts`;
+- `supabase/migrations/0029_appointment_reminder_queue_foundation.sql`;
+- `supabase/tests/0029_appointment_reminder_queue_concurrency.ps1`;
+- `supabase/tests/0029_appointment_reminder_queue_foundation_test.sql`.
+
+No package, lockfile, generated type, environment file, screenshot, temporary smoke script, provider SDK, worker, cron, Edge Function, or cloud migration file belongs in the final diff.
+
+## 9. Pre-read
+
+Reports read and reconciled before/finally during implementation:
+
+- `_ai_work/REPORTS/APPOINTMENT-CONFLICT-HARDENING-001_hardening.md`;
+- `_ai_work/REPORTS/APPOINTMENT-CANCELLATION-NOSHOW-001_lifecycle.md`;
+- `_ai_work/REPORTS/APPOINTMENT-CONFIRMATION-WORKFLOW-001_workflow.md`;
+- `_ai_work/REPORTS/APPOINTMENT-REMINDER-OPERATIONS-RECON-001_recon.md`;
+- `_ai_work/REPORTS/TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001_foundation.md`.
+
+Architecture sources read and used:
+
+- `_ai_work/SOURCES/02_ROLES_AND_PERMISSIONS.md`;
+- `_ai_work/SOURCES/03_MULTI_TENANT_ARCHITECTURE_RULES.md`;
+- `_ai_work/SOURCES/04_DATA_ISOLATION_AND_SECURITY.md`;
+- `_ai_work/SOURCES/08_APPOINTMENTS_AND_SCHEDULE.md`;
+- `_ai_work/SOURCES/11_BACKEND_AND_API_ARCHITECTURE.md`;
+- `_ai_work/SOURCES/13_STORAGE_AND_MIGRATION_STRATEGY.md`;
+- `_ai_work/SOURCES/18_TESTING_AND_QUALITY_ASSURANCE_STRATEGY.md`.
+
+Code/schema inspected included migrations `0001`, `0013`, `0015`, and `0025` through `0028`; appointment create/reschedule/details, cancellation/no-show, confirmation, visit lifecycle, audit/activity helpers, tenant/timezone context, timezone utilities, repositories, schedule pages, placeholders, and existing SQL/concurrency suites.
+
+## 10. Lifecycle event map
+
+| Operation | Authoritative mutation | Transaction/version facts | Reminder result |
+|---|---|---|---|
+| appointment create | `create_appointment` inserts `appointments` | appointment insert and AFTER trigger are one transaction; tenant timezone and policy are available | if policy disabled, no jobs; if enabled and eligible, desired jobs are created |
+| appointment reschedule | `reschedule_appointment` updates start/end and `updated_at` under appointment/resource locks | old jobs and new appointment version are visible in the same transaction | old active jobs are superseded; new version-bound jobs are created atomically |
+| appointment details/status update | `update_appointment_details` updates details/status; existing updated-at trigger changes version | row is locked and optimistic `updated_at` is checked | any new appointment version supersedes old active plans; terminal/ineligible status cancels or skips work |
+| confirmation attempt | confirmation RPC updates confirmation state, attempt facts, and appointment version | immutable attempt and appointment mutation are one transaction | trigger recomputes desired set; repeated request depends on policy; callback is deferred without explicit time |
+| direct confirmation | `confirm_appointment` changes confirmation state/version | appointment lock and optimistic version check | confirmation-request/control-call jobs are superseded; ordinary day-before reminder remains only when policy permits |
+| cancellation | `cancel_appointment` sets terminal status/metadata | cancellation RPC and appointment trigger share one transaction | all pending jobs become `cancelled`; completed history is preserved |
+| no-show | `mark_appointment_no_show` sets terminal status/metadata | no-show RPC and appointment trigger share one transaction | all pending jobs become `cancelled`; completed history is preserved |
+| arrival/check-in | `check_in_patient_visit` inserts a checked-in visit linked to appointment | appointment status itself is not rewritten; visit trigger runs in the same RPC transaction | all pending jobs become `skipped` with `appointment_arrived` |
+| visit in progress | `start_patient_visit` changes visit status | visit row is locked; visit trigger shares transaction | any remaining pending jobs become `skipped` with `appointment_in_progress` |
+| visit completion | `complete_patient_visit` changes visit status | visit row is locked; visit trigger shares transaction | any remaining pending jobs become `skipped` with `appointment_completed` |
+| hard delete | existing owner/admin appointment DELETE plus composite FK cascade | database cascade is atomic | reminder jobs are deleted with appointment; no orphan row remains |
+
+The appointment trigger is intentionally attached to `updated_at` as well as scheduling/confirmation fields because plan identity is bound to the exact appointment version, not merely the start timestamp.
+
+## 11. Tenant policy model
+
+`public.tenant_reminder_policies` is the authoritative minimal planning policy.
+
+- one row per tenant;
+- existing and newly created tenants are disabled by default;
+- timezone is read from `tenants.timezone`, not duplicated;
+- policy version starts at `1` and increments only after an actual policy change;
+- owner/admin mutate policy through `set_tenant_reminder_policy`;
+- policy mutation immediately supersedes every active old-policy job;
+- new current-policy jobs appear only through appointment planning/lifecycle reconciliation or bounded tenant reconciliation;
+- no broad settings UI was added.
+
+Policy fields cover confirmation request, repeated confirmation request, day-before local time, reminder-after-confirmation, callback-task permission, control-call permission, and control-call offset.
+
+## 12. Reminder job model
+
+`public.appointment_reminder_jobs` stores durable work-plan facts:
+
+- UUID primary key;
+- tenant, appointment, and patient references;
+- composite tenant/appointment and tenant/patient foreign keys;
+- reminder type;
+- manual execution mode;
+- `due_at timestamptz`;
+- non-provider job state;
+- exact appointment `updated_at`;
+- policy version;
+- deterministic plan key and payload fingerprint;
+- priority;
+- actor/timestamps;
+- terminal timestamps/reason;
+- safe JSON metadata.
+
+No provider ID, delivery attempt, send result, retry counter, credential, template, consent, or normalized phone field was added.
+
+## 13. Reminder types
+
+Supported stable types:
+
+- `confirmation_request`;
+- `day_before_reminder`;
+- `control_call_task`;
+- `callback_task`.
+
+`callback_task` is schema-valid for the future manual queue, but this task creates none because the current confirmation model has no explicit callback due time.
+
+## 14. Job states
+
+Stored states:
+
+- `scheduled`;
+- `ready`;
+- `completed`;
+- `cancelled`;
+- `superseded`;
+- `skipped`.
+
+Provider states such as processing, sent, delivered, uncertain, retryable failure, or terminal provider failure do not exist.
+
+Terminal-state constraints require the matching timestamp and a non-empty terminal reason. Active states cannot carry terminal timestamps/reasons.
+
+## 15. Execution mode
+
+The only accepted execution mode is `manual`.
+
+`automated_reserved` was intentionally not added. A future delivery architecture must earn that state through a separate migration instead of receiving speculative fields now.
+
+## 16. Eligibility matrix
+
+| Appointment/confirmation state | Confirmation request | Day-before reminder | Control call | Callback task |
+|---|---:|---:|---:|---:|
+| new + unconfirmed | policy | policy | policy | no |
+| new + contact_in_progress | only when repeat policy enabled | policy | policy | no |
+| new + confirmed or legacy status confirmed | no | only when `reminder_after_confirmation` | no | no |
+| new + unreachable | no | no by initial policy | manual control call when enabled | no |
+| new + callback_requested | no | no | no | deferred until explicit callback time exists |
+| arrived/in_progress/completed/blocked | no | no | no | no |
+| cancelled/no_show | no | no | no | no |
+| appointment already started or past | no | no | no | no |
+| missing patient/block slot | no | no | no | no |
+
+`message_sent` is treated only as a contact outcome. It is not delivery proof.
+
+## 17. Due-time calculations
+
+All due times are computed server-side.
+
+- confirmation request: tenant-local day before appointment at configured local time;
+- day-before reminder: the same tenant-local day-before policy time;
+- control call: appointment instant minus configured minutes;
+- callback task: not generated without an explicit callback timestamp.
+
+`tenants.timezone` is validated as an IANA zone. `due_at` is stored as `timestamptz`. Browser timezone is irrelevant.
+
+Validation proves:
+
+- Asia/Almaty local noon maps to the expected UTC instant;
+- Europe/Berlin summer local noon maps correctly;
+- America/New_York summer local noon maps correctly;
+- a nonexistent spring-forward local time fails by timezone round-trip validation.
+
+For an ambiguous fall-back wall time, PostgreSQL `AT TIME ZONE` deterministically chooses the standard-time occurrence. This deterministic database policy is documented rather than silently delegating to browser behavior.
+
+## 18. Callback limitation
+
+The current `callback_requested` fact stores no callback date/time. This task does not invent one and does not use folklore such as `now() + interval '1 hour'`.
+
+The planner returns `callbackDeferred=true`, supersedes incompatible active generic plans, and creates no callback job. A dedicated future callback scheduling contract must first add an explicit human-selected due time.
+
+## 19. Plan identity
+
+`plan_key` is SHA-256 over:
+
+- tenant ID;
+- appointment ID;
+- reminder type;
+- `due_at`;
+- exact appointment `updated_at`;
+- policy version.
+
+The tenant-scoped unique constraint is `(tenant_id, plan_key)`.
+
+`payload_fingerprint` additionally includes patient, execution mode, confirmation state, and appointment status. Same logical plan reuses the existing row and emits no duplicate audit/activity event. Changed appointment or policy version produces a different plan and makes old active rows historical through `superseded`.
+
+## 20. Planner RPC
+
+Public RPC:
+
+`plan_appointment_reminder_jobs(p_tenant_id, p_appointment_id, p_reference_time)`
+
+Behavior:
+
+- authenticates caller;
+- permits owner/admin/registrar;
+- verifies tenant membership;
+- locks appointment;
+- locks policy row in shared mode;
+- validates tenant timezone;
+- evaluates eligibility;
+- computes desired jobs;
+- reuses matching plans;
+- supersedes stale plans;
+- cancels terminal appointment plans;
+- skips started/ineligible appointment plans;
+- creates missing manual jobs;
+- records audit/activity exactly once per actual transition;
+- returns created/reused/superseded/cancelled/skipped/desired rows plus appointment and policy version;
+- performs no external side effect.
+
+## 21. Tenant reconciliation
+
+Bounded RPC:
+
+`reconcile_tenant_appointment_reminders(p_tenant_id, p_from, p_to, p_limit, p_reference_time)`
+
+- owner/admin only;
+- maximum window 90 days;
+- limit 1 through 500;
+- deterministic order by appointment start and ID;
+- tenant-scoped;
+- manually invoked only;
+- returns compact counters;
+- no scheduler, cron, worker, or unbounded scan exists.
+
+## 22. Lifecycle invalidation
+
+Four database mechanisms close consistency windows:
+
+1. appointment AFTER trigger plans/reconciles on insert or relevant version/status/time/confirmation update;
+2. patient-visit AFTER trigger skips jobs on checked-in/in-progress/completed;
+3. policy RPC supersedes active old-policy jobs before returning;
+4. appointment FK cascade removes jobs on hard delete.
+
+Completed jobs are historical and are never changed by cancellation, no-show, reschedule, confirmation, policy mutation, or visit lifecycle.
+
+## 23. Transaction strategy
+
+Reminder reconciliation runs inside the same PostgreSQL transaction as authoritative appointment and visit mutations.
+
+- reschedule cannot commit new appointment time while leaving old jobs active;
+- cancellation/no-show cannot commit with sendable pending jobs;
+- confirmation cannot commit while retaining an active confirmation-request plan;
+- arrival cannot commit its visit while retaining pending reminder work;
+- policy version cannot commit while old-policy work remains active.
+
+The bounded tenant reconciliation exists for initial rollout, explicit repair, and future scheduler input, but no background scheduler is introduced.
+
+## 24. Role matrix
+
+| Role | View policy/jobs | Appointment planner | Tenant reconciliation | Policy mutation |
+|---|---:|---:|---:|---:|
+| owner | yes | yes | yes | yes |
+| admin | yes | yes | yes | yes |
+| registrar | yes | yes | no | no |
+| doctor | no | no | no | no |
+| cashier | no | no | no | no |
+| unknown/no tenant | no | no | no | no |
+| anonymous | no | no | no | no |
+
+Backend/database rules are authoritative.
+
+## 25. RLS and grants
+
+RLS is enabled on both new tables.
+
+Authenticated users receive SELECT only, and RLS narrows it to owner/admin/registrar in their tenant. Authenticated INSERT/UPDATE/DELETE grants are absent. Write-guard triggers provide defense in depth. Public mutation occurs only through controlled RPCs/internal functions. No service-role credential appears in frontend code.
+
+Composite foreign keys prevent tenant/patient and tenant/appointment mismatches.
+
+## 26. Audit/activity
+
+Emitted only for actual state changes:
+
+- `appointment_reminder_planned`;
+- `appointment_reminder_superseded`;
+- `appointment_reminder_cancelled`;
+- `appointment_reminder_skipped`.
+
+Events include tenant, appointment, patient, job ID, reminder type, due time, previous/new state, appointment version, policy version, actor/source, plan key, and execution mode.
+
+Replay creates no duplicate event. No sent/delivered/failed/retried event exists.
+
+## 27. Repository integration
+
+`AppointmentReminderRepository` provides:
+
+- `listReminderJobs`;
+- `listReminderJobsByAppointment`;
+- `planAppointmentReminderJobs`;
+- `reconcileTenantReminderJobs`.
+
+Reads always apply tenant scope and deterministic ordering. Supabase mode has no localStorage fallback and no direct write. Explicit local-development mode returns an empty disabled plan rather than pretending delivery or persistence exists. Database timestamp strings retain offset and PostgreSQL precision.
+
+No diagnostic UI/hook was added because repository coverage plus local SQL/browser validation satisfied this foundation without expanding product UI.
+
+## 28. Ready-state decision
+
+`ready` is derived operationally when a stored `scheduled` job has `due_at <= referenceTime/now`.
+
+This foundation does not mutate rows merely because time passed and therefore has no scheduler dependency. The repository exposes `operationalState=ready` and sorts derived-ready jobs before future scheduled jobs. The stored `ready` value remains schema-valid for a future explicit manual operation, but this task never background-transitions it.
+
+## 29. SQL tests
+
+Clean local reset applied migrations `0001` through `0029`.
+
+Passed regression suites:
+
+- `0024_legacy_core_table_grants_test.sql`;
+- `0025_appointment_conflict_hardening_test.sql`;
+- `0026_appointment_cancellation_noshow_test.sql`;
+- `0027_appointment_confirmation_workflow_test.sql`;
+- `0028_tenant_timezone_scheduling_foundation_test.sql`;
+- `0029_appointment_reminder_queue_foundation_test.sql`.
+
+The 0029 suite verifies schema, default-disabled policy, roles, RLS, cross-tenant boundaries, direct-write blocking, timezone calculations, eligibility/confirmation rules, callback deferral, idempotency, deterministic identity, reschedule, cancellation, no-show, visit lifecycle, hard-delete cascade, policy versioning, completed-history preservation, audit/activity exactly once, duplicate/stale invariants, and no clinical/financial side effects.
+
+Typed PostgreSQL catalog assertions passed: **42/42**.
+
+## 30. Concurrency tests
+
+Passed:
+
+- `0025_appointment_conflict_concurrency.ps1`;
+- `0026_appointment_cancellation_noshow_concurrency.ps1`;
+- `0027_appointment_confirmation_workflow_concurrency.ps1`;
+- `0029_appointment_reminder_queue_concurrency.ps1`.
+
+0029 scenarios covered same-appointment planners, overlapping tenant reconciliation, planner versus reschedule/cancellation/no-show/confirmation/policy change, cross-tenant independence, duplicate event prevention, and deadlock detection.
+
+Final 0029 counters:
+
+- created/total job records: `34`;
+- superseded: `19`;
+- cancelled: `6`;
+- duplicate plan keys: `0`;
+- duplicate logical jobs: `0`;
+- active stale jobs: `0`;
+- audit events: `59`;
+- activity events: `59`;
+- deadlocks: `0`.
+
+## 31. TypeScript tests
+
+Repository tests cover:
+
+- tenant filter;
+- appointment filter;
+- deterministic ordering;
+- derived ready state;
+- exact due/appointment-version timestamp preservation;
+- policy version/metadata mapping;
+- planner RPC arguments;
+- bounded reconciliation RPC arguments;
+- safe error mapping;
+- offset-free input rejection;
+- explicit empty local-development behavior;
+- no direct insert/update/delete;
+- no provider/delivery/source-role implementation.
+
+Repository suite: **9/9 passed**.
+
+Full suite: **91 files / 1016 tests passed**.
+
+## 32. Browser/local smoke
+
+Equivalent isolated HeadlessChrome 150 was used because a separately invokable Chrome DevTools MCP action was unavailable in this environment, which the task explicitly permits when documented.
+
+Local Supabase smoke proved:
+
+1. disabled policy creates zero jobs;
+2. enabled policy creates the expected three manual jobs;
+3. repeated planner returns/reuses the same plan with no duplicate events;
+4. Almaty day-before local noon produces the expected UTC due time;
+5. confirmation suppresses active confirmation-request/control-call work while preserving permitted ordinary reminder;
+6. reschedule supersedes old jobs and creates a new version-bound set;
+7. cancellation leaves no active job;
+8. no-show leaves no active job;
+9. tenant B cannot view tenant A jobs;
+10. a real QA administrator can log in and view the local smoke patient;
+11. browser console errors: `0`;
+12. failed browser requests: `0`;
+13. visible secrets: `0`.
+
+The smoke fixtures, temporary script, screenshots, and Vite process were removed.
+
+## 33. Network validation
+
+HeadlessChrome write traffic contained only successful local Supabase authentication:
+
+- `POST /auth/v1/token?grant_type=password`.
+
+Gateway search found no SMS, WhatsApp provider, email provider, Twilio, SendGrid, provider-message, or send endpoint. Frontend source contains no reminder-job insert/update/delete. Migration source contains no provider delivery state or provider message ID.
+
+## 34. Database validation
+
+Browser/database smoke counters before cleanup:
+
+- jobs: `16`;
+- scheduled: `4`;
+- superseded: `6`;
+- cancelled: `6`;
+- confirmation-request jobs: `5`;
+- control-call jobs: `5`;
+- day-before jobs: `6`;
+- duplicate plan keys: `0`;
+- duplicate logical jobs: `0`;
+- active stale jobs: `0`;
+- invalid appointment intervals: `0`;
+- reminder audit/activity counts matched exactly: planned `16/16`, superseded `6/6`, cancelled `6/6`.
+
+Legacy concurrency remained green with doctor overlaps `0`, patient overlaps `0`, invalid intervals `0`, and deadlocks `0`.
+
+## 35. Side-effect validation
+
+Unchanged by planning and smoke:
+
+- confirmation-attempt facts except when the explicit existing confirmation RPC was intentionally invoked;
+- cancellation/no-show metadata except through their explicit authoritative RPCs;
+- patient visits outside the explicit visit-lifecycle SQL scenario, which was removed before final side-effect counts;
+- clinical encounters;
+- completed services;
+- treatment plans;
+- findings;
+- dental charts;
+- invoices;
+- payments;
+- refunds;
+- financial adjustments/write-offs;
+- patient balances;
+- documents;
+- stock;
+- amoCRM;
+- provider credentials;
+- message delivery.
+
+Final smoke side-effect counters for visits, encounters, completed services, invoices, payments, refunds, and adjustments were all `0`.
+
+## 36. Legacy/deployment behavior
+
+- existing tenants receive a disabled policy row;
+- migration performs no appointment scan;
+- migration creates no reminder job;
+- existing appointment timestamps are not rewritten;
+- first jobs appear only through explicit planner, bounded reconciliation, or a later authoritative lifecycle mutation after policy enablement;
+- no provider configuration is required.
+
+Safe rollout:
+
+1. apply migration;
+2. verify tenant IANA timezone;
+3. configure policy explicitly;
+4. run bounded tenant reconciliation;
+5. inspect durable jobs;
+6. only later add manual operations UI in a separate task.
+
+No cloud migration was applied in this task.
+
+## 37. Cleanup
+
+- task Vite process stopped;
+- temporary SQL smoke script removed;
+- temporary screenshots removed;
+- concurrency fixtures removed by their script;
+- final local `supabase db reset --no-seed` completed;
+- smoke patient marker rows: `0`;
+- smoke doctor marker rows: `0`;
+- smoke appointment marker rows: `0`;
+- reminder job rows: `0`;
+- QA auth users: `0`.
+
+The baseline migrations themselves retain their existing non-task demo tenant/patient/doctor rows after `--no-seed`; those rows were not created by this task and were not misreported as QA residue.
+
+## 38. Checks: lint, tests, and build
+
+Final local checks:
+
+- ESLint: passed;
+- full Vitest: **91 files / 1016 tests passed**;
+- TypeScript build: passed;
+- Vite production build: passed;
+- transformed modules: `1953`;
+- `git diff --check`: passed before report publication;
+- no package or lockfile change.
+
+Non-blocking baseline warnings remain:
+
+- existing React `act(...)` warnings in older tests;
+- existing Vite large-bundle warning.
+
+## 39. Fresh CI
+
+Pending PR creation and fresh GitHub Actions CI on the exact implementation head.
+
+A second fresh CI run is required after the report-only metadata commit. The final CI run must test the exact final PR HEAD and include ESLint, tests, build, and merge guard.
+
+The PR must remain open and unmerged.
+
+## 40. Issues / Limitations
+
+- callback work is deferred because the current model has no explicit callback due time;
+- no full manual operations UI exists yet;
+- ready state is derived, not background-mutated;
+- ambiguous DST fall-back local time follows PostgreSQL standard-time occurrence;
+- separately invokable Chrome DevTools MCP was unavailable, so equivalent HeadlessChrome was used;
+- cloud Supabase remains untouched;
+- existing unrelated React and bundle-size warnings remain baseline items.
+
+These limitations do not compromise durable queue identity, invalidation, tenant isolation, or the no-delivery boundary.
+
+## 41. What was intentionally not implemented
+
+- SMS;
+- WhatsApp delivery;
+- email delivery;
+- provider SDK or credentials;
+- delivery attempts;
+- delivery/provider states;
+- provider message IDs;
+- worker;
+- cron;
+- Edge Function;
+- webhook;
+- retry engine;
+- templates;
+- consent/contact redesign;
+- phone normalization;
+- public booking;
+- broad settings UI;
+- manual operations UI;
+- appointment lifecycle redesign;
+- finance or clinical workflow redesign;
+- generated types;
+- package changes;
+- cloud migration apply;
+- HEP-V2;
+- PR merge.
+
+## 42. Recommended next task
+
+Recommended next task: **APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001**
+
+Reason: durable reminder jobs can now be created, invalidated, reconciled, audited, and read safely. Registrars next need a tenant-scoped operational queue where they can see due manual work, record completion, and reuse the existing confirmation-attempt workflow without provider automation.
+
+This next task was not started.
+
+Final task verdict: **APPOINTMENT REMINDER QUEUE FOUNDATION IMPLEMENTED AND VERIFIED**

--- a/src/data/repositories/AppointmentReminderRepository.test.ts
+++ b/src/data/repositories/AppointmentReminderRepository.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import repositorySource from './AppointmentReminderRepository.ts?raw';
+import {
+  AppointmentReminderRepositoryError,
+  LocalAppointmentReminderRepository,
+  SupabaseAppointmentReminderRepository,
+  compareReminderJobs,
+  createAppointmentReminderRepository,
+  mapAppointmentReminderJob,
+  toSafeAppointmentReminderError,
+} from './AppointmentReminderRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: { from: vi.fn(), rpc: vi.fn() },
+}));
+
+const tenantId = '11111111-1111-4111-8111-111111111111';
+const appointmentId = '22222222-2222-4222-8222-222222222222';
+const patientId = '33333333-3333-4333-8333-333333333333';
+const now = '2026-07-12T10:00:00.000Z';
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+  id: '44444444-4444-4444-8444-444444444444',
+  tenant_id: tenantId,
+  appointment_id: appointmentId,
+  patient_id: patientId,
+  reminder_type: 'day_before_reminder',
+  execution_mode: 'manual',
+  due_at: '2026-07-12T09:00:00+00:00',
+  state: 'scheduled',
+  appointment_updated_at: '2026-07-11T08:00:00.123456+00:00',
+  policy_version: 2,
+  plan_key: 'a'.repeat(64),
+  payload_fingerprint: 'b'.repeat(64),
+  priority: 80,
+  created_by: null,
+  created_at: '2026-07-11T08:00:00+00:00',
+  updated_at: '2026-07-11T08:00:00+00:00',
+  metadata: { tenantTimezone: 'Asia/Almaty' },
+  ...overrides,
+});
+
+const createListClient = (rows: Record<string, unknown>[]) => {
+  const result = Promise.resolve({ data: rows, error: null });
+  const order = vi.fn().mockImplementation(() => Object.assign(result, { order }));
+  const inState = vi.fn().mockReturnValue({ order });
+  const secondEq = vi.fn().mockReturnValue({ in: inState, order });
+  const firstEq = vi.fn().mockReturnValue({ eq: secondEq, in: inState, order });
+  const select = vi.fn().mockReturnValue({ eq: firstEq });
+  const from = vi.fn().mockReturnValue({ select });
+  return { client: { from, rpc: vi.fn() } as unknown as SupabaseClient, from, firstEq, secondEq, inState, order };
+};
+
+describe('AppointmentReminderRepository', () => {
+  it('uses explicit local mode and never silently falls back from Supabase mode', () => {
+    expect(createAppointmentReminderRepository({ backend: 'local' })).toBe(LocalAppointmentReminderRepository);
+    expect(() => createAppointmentReminderRepository({ backend: 'supabase', tenantId: null }))
+      .toThrow('Клиника не выбрана.');
+  });
+
+  it('maps database timestamps without stripping offset or PostgreSQL precision', () => {
+    const mapped = mapAppointmentReminderJob(row(), now);
+    expect(mapped.dueAt).toBe('2026-07-12T09:00:00+00:00');
+    expect(mapped.appointmentUpdatedAt).toBe('2026-07-11T08:00:00.123456+00:00');
+    expect(mapped.operationalState).toBe('ready');
+    expect(mapped.policyVersion).toBe(2);
+    expect(mapped.metadata).toEqual({ tenantTimezone: 'Asia/Almaty' });
+  });
+
+  it('orders derived ready work before scheduled work and then deterministically', () => {
+    const ready = mapAppointmentReminderJob(row({ id: 'b', due_at: '2026-07-12T09:00:00Z', priority: 100 }), now);
+    const scheduled = mapAppointmentReminderJob(row({ id: 'a', due_at: '2026-07-12T11:00:00Z', priority: 1 }), now);
+    expect([scheduled, ready].sort(compareReminderJobs).map((item) => item.id)).toEqual(['b', 'a']);
+  });
+
+  it('applies tenant and appointment filters and deterministic ordering', async () => {
+    const { client, from, firstEq, secondEq, inState, order } = createListClient([row()]);
+    const repository = new SupabaseAppointmentReminderRepository(tenantId, client);
+    const jobs = await repository.listReminderJobsByAppointment(appointmentId, false);
+
+    expect(from).toHaveBeenCalledWith('appointment_reminder_jobs');
+    expect(firstEq).toHaveBeenCalledWith('tenant_id', tenantId);
+    expect(secondEq).toHaveBeenCalledWith('appointment_id', appointmentId);
+    expect(inState).toHaveBeenCalledWith('state', ['scheduled', 'ready']);
+    expect(order).toHaveBeenCalledWith('due_at', { ascending: true });
+    expect(order).toHaveBeenCalledWith('priority', { ascending: true });
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: true });
+    expect(order).toHaveBeenCalledWith('id', { ascending: true });
+    expect(jobs).toHaveLength(1);
+  });
+
+  it('calls only planner and bounded reconciliation RPCs with tenant scope', async () => {
+    const rpc = vi.fn()
+      .mockResolvedValueOnce({
+        data: {
+          created: [row()], reused: [], superseded: [], cancelled: [], skipped: [], desired: [],
+          appointmentVersion: '2026-07-11T08:00:00.123456+00:00', policyVersion: 2,
+          policyEnabled: true, callbackDeferred: false,
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { processed: 1, created: 1, reused: 0, superseded: 0, cancelled: 0, skipped: 0 },
+        error: null,
+      });
+    const client = { rpc, from: vi.fn() } as unknown as SupabaseClient;
+    const repository = new SupabaseAppointmentReminderRepository(tenantId, client);
+
+    const plan = await repository.planAppointmentReminderJobs(appointmentId, now);
+    const reconcile = await repository.reconcileTenantReminderJobs(
+      '2026-07-12T00:00:00Z', '2026-07-20T00:00:00Z', 100, now,
+    );
+
+    expect(rpc).toHaveBeenNthCalledWith(1, 'plan_appointment_reminder_jobs', {
+      p_tenant_id: tenantId,
+      p_appointment_id: appointmentId,
+      p_reference_time: now,
+    });
+    expect(rpc).toHaveBeenNthCalledWith(2, 'reconcile_tenant_appointment_reminders', {
+      p_tenant_id: tenantId,
+      p_from: '2026-07-12T00:00:00Z',
+      p_to: '2026-07-20T00:00:00Z',
+      p_limit: 100,
+      p_reference_time: now,
+    });
+    expect(plan.created[0].operationalState).toBe('ready');
+    expect(reconcile).toMatchObject({ processed: 1, created: 1 });
+  });
+
+  it('returns an empty disabled plan in explicit local development mode', async () => {
+    await expect(LocalAppointmentReminderRepository.planAppointmentReminderJobs(appointmentId, now))
+      .resolves.toMatchObject({ policyEnabled: false, created: [], reused: [] });
+    await expect(LocalAppointmentReminderRepository.listReminderJobs()).resolves.toEqual([]);
+  });
+
+  it('maps permission, time and generic failures to safe messages', () => {
+    expect(toSafeAppointmentReminderError({ message: 'permission denied 42501' }, 'plan'))
+      .toMatchObject({ code: 'permission' });
+    expect(toSafeAppointmentReminderError({ message: 'Укажите корректный часовой пояс клиники' }, 'plan'))
+      .toMatchObject({ code: 'invalid_time' });
+    expect(toSafeAppointmentReminderError({ message: 'relation secret_table failed' }, 'read'))
+      .toEqual(new AppointmentReminderRepositoryError('read_failed', 'Не удалось загрузить очередь напоминаний.'));
+  });
+
+  it('rejects offset-free planner times before any RPC call', async () => {
+    const rpc = vi.fn();
+    const repository = new SupabaseAppointmentReminderRepository(
+      tenantId,
+      { rpc, from: vi.fn() } as unknown as SupabaseClient,
+    );
+    await expect(repository.planAppointmentReminderJobs(appointmentId, '2026-07-12T10:00:00'))
+      .rejects.toMatchObject({ code: 'invalid_time' });
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('contains no direct insert or update path for reminder jobs', () => {
+    expect(repositorySource).not.toMatch(/\.insert\s*\(/);
+    expect(repositorySource).not.toMatch(/\.update\s*\(/);
+    expect(repositorySource).not.toMatch(/service[_-]?role/i);
+    expect(repositorySource).not.toMatch(/sms|whatsapp|email|provider_message_id|delivered/i);
+  });
+});

--- a/src/data/repositories/AppointmentReminderRepository.ts
+++ b/src/data/repositories/AppointmentReminderRepository.ts
@@ -1,0 +1,313 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  AppointmentReminderJob,
+  AppointmentReminderJobState,
+  AppointmentReminderPlanResult,
+  TenantReminderReconcileResult,
+} from '../../types';
+import { isOffsetAwareInstant } from '../../domain/timezone';
+import { supabase } from '../../lib/supabaseClient';
+
+export type AppointmentReminderRepositoryBackend = 'local' | 'supabase';
+
+export interface AppointmentReminderListOptions {
+  appointmentId?: string;
+  includeTerminal?: boolean;
+  referenceTime?: string;
+}
+
+export interface IAppointmentReminderRepository {
+  listReminderJobs(options?: AppointmentReminderListOptions): Promise<AppointmentReminderJob[]>;
+  listReminderJobsByAppointment(appointmentId: string, includeTerminal?: boolean): Promise<AppointmentReminderJob[]>;
+  planAppointmentReminderJobs(appointmentId: string, referenceTime?: string): Promise<AppointmentReminderPlanResult>;
+  reconcileTenantReminderJobs(from: string, to: string, limit: number, referenceTime?: string): Promise<TenantReminderReconcileResult>;
+}
+
+export interface CreateAppointmentReminderRepositoryOptions {
+  tenantId?: string | null;
+  backend: AppointmentReminderRepositoryBackend;
+}
+
+export type AppointmentReminderRepositoryErrorCode =
+  | 'tenant_required'
+  | 'permission'
+  | 'invalid_time'
+  | 'read_failed'
+  | 'plan_failed'
+  | 'reconcile_failed';
+
+export class AppointmentReminderRepositoryError extends Error {
+  readonly code: AppointmentReminderRepositoryErrorCode;
+
+  constructor(code: AppointmentReminderRepositoryErrorCode, message: string) {
+    super(message);
+    this.name = 'AppointmentReminderRepositoryError';
+    this.code = code;
+  }
+}
+
+const TERMINAL_STATES = new Set<AppointmentReminderJobState>(['completed', 'cancelled', 'superseded', 'skipped']);
+
+const errorText = (error: unknown): string => {
+  if (!error) return '';
+  if (error instanceof Error) return error.message.toLowerCase();
+  if (typeof error !== 'object') return String(error).toLowerCase();
+  const candidate = error as { message?: unknown; details?: unknown; hint?: unknown; code?: unknown };
+  return [candidate.message, candidate.details, candidate.hint, candidate.code]
+    .filter((part): part is string => typeof part === 'string')
+    .join(' ')
+    .toLowerCase();
+};
+
+export const toSafeAppointmentReminderError = (
+  error: unknown,
+  fallback: 'read' | 'plan' | 'reconcile',
+): AppointmentReminderRepositoryError => {
+  if (error instanceof AppointmentReminderRepositoryError) return error;
+  const text = errorText(error);
+  if (text.includes('недостаточно прав') || text.includes('permission denied') || text.includes('42501')) {
+    return new AppointmentReminderRepositoryError('permission', 'Недостаточно прав для работы с очередью напоминаний.');
+  }
+  if (text.includes('контрольное время') || text.includes('ограниченный период') || text.includes('часовой пояс')) {
+    return new AppointmentReminderRepositoryError('invalid_time', 'Не удалось обработать период или время напоминания.');
+  }
+  if (fallback === 'read') {
+    return new AppointmentReminderRepositoryError('read_failed', 'Не удалось загрузить очередь напоминаний.');
+  }
+  if (fallback === 'reconcile') {
+    return new AppointmentReminderRepositoryError('reconcile_failed', 'Не удалось выполнить сверку очереди напоминаний.');
+  }
+  return new AppointmentReminderRepositoryError('plan_failed', 'Не удалось спланировать напоминания для записи.');
+};
+
+const requireInstant = (value: string, label: string): string => {
+  if (!isOffsetAwareInstant(value)) {
+    throw new AppointmentReminderRepositoryError('invalid_time', `Некорректное время: ${label}.`);
+  }
+  return value;
+};
+
+const asObject = (value: unknown): Record<string, unknown> => (
+  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+);
+
+const asNumber = (value: unknown): number => Number(value ?? 0);
+
+export const mapAppointmentReminderJob = (
+  row: Record<string, unknown>,
+  referenceTime = new Date().toISOString(),
+): AppointmentReminderJob => {
+  const dueAt = requireInstant(String(row.due_at ?? row.dueAt ?? ''), 'due_at');
+  const appointmentUpdatedAt = requireInstant(
+    String(row.appointment_updated_at ?? row.appointmentUpdatedAt ?? ''),
+    'appointment_updated_at',
+  );
+  const createdAt = requireInstant(String(row.created_at ?? row.createdAt ?? ''), 'created_at');
+  const updatedAt = requireInstant(String(row.updated_at ?? row.updatedAt ?? ''), 'updated_at');
+  const state = String(row.state ?? 'scheduled') as AppointmentReminderJobState;
+  const explicitOperational = row.operationalState ?? row.operational_state;
+  const operationalState = explicitOperational
+    ? String(explicitOperational) as AppointmentReminderJobState
+    : state === 'scheduled' && new Date(dueAt).getTime() <= new Date(referenceTime).getTime()
+      ? 'ready'
+      : state;
+
+  return {
+    id: String(row.id),
+    tenantId: String(row.tenant_id ?? row.tenantId),
+    appointmentId: String(row.appointment_id ?? row.appointmentId),
+    patientId: String(row.patient_id ?? row.patientId),
+    reminderType: String(row.reminder_type ?? row.reminderType) as AppointmentReminderJob['reminderType'],
+    executionMode: String(row.execution_mode ?? row.executionMode ?? 'manual') as AppointmentReminderJob['executionMode'],
+    dueAt,
+    state,
+    operationalState,
+    appointmentUpdatedAt,
+    policyVersion: asNumber(row.policy_version ?? row.policyVersion),
+    planKey: String(row.plan_key ?? row.planKey),
+    payloadFingerprint: String(row.payload_fingerprint ?? row.payloadFingerprint),
+    priority: asNumber(row.priority),
+    createdBy: (row.created_by ?? row.createdBy) ? String(row.created_by ?? row.createdBy) : undefined,
+    createdAt,
+    updatedAt,
+    supersededAt: row.superseded_at || row.supersededAt
+      ? requireInstant(String(row.superseded_at ?? row.supersededAt), 'superseded_at')
+      : undefined,
+    cancelledAt: row.cancelled_at || row.cancelledAt
+      ? requireInstant(String(row.cancelled_at ?? row.cancelledAt), 'cancelled_at')
+      : undefined,
+    skippedAt: row.skipped_at || row.skippedAt
+      ? requireInstant(String(row.skipped_at ?? row.skippedAt), 'skipped_at')
+      : undefined,
+    completedAt: row.completed_at || row.completedAt
+      ? requireInstant(String(row.completed_at ?? row.completedAt), 'completed_at')
+      : undefined,
+    terminalReason: (row.terminal_reason ?? row.terminalReason)
+      ? String(row.terminal_reason ?? row.terminalReason)
+      : undefined,
+    metadata: asObject(row.metadata),
+  };
+};
+
+export const compareReminderJobs = (left: AppointmentReminderJob, right: AppointmentReminderJob): number => {
+  const leftReady = left.operationalState === 'ready' ? 0 : 1;
+  const rightReady = right.operationalState === 'ready' ? 0 : 1;
+  if (leftReady !== rightReady) return leftReady - rightReady;
+  const byDue = new Date(left.dueAt).getTime() - new Date(right.dueAt).getTime();
+  if (byDue !== 0) return byDue;
+  if (left.priority !== right.priority) return left.priority - right.priority;
+  const byCreated = new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+  return byCreated !== 0 ? byCreated : left.id.localeCompare(right.id);
+};
+
+const emptyPlan = (): AppointmentReminderPlanResult => ({
+  created: [],
+  reused: [],
+  superseded: [],
+  cancelled: [],
+  skipped: [],
+  desired: [],
+  appointmentVersion: new Date(0).toISOString(),
+  policyVersion: 0,
+  policyEnabled: false,
+  callbackDeferred: false,
+});
+
+export const LocalAppointmentReminderRepository: IAppointmentReminderRepository = {
+  listReminderJobs: async () => [],
+  listReminderJobsByAppointment: async () => [],
+  planAppointmentReminderJobs: async () => emptyPlan(),
+  reconcileTenantReminderJobs: async () => ({
+    processed: 0,
+    created: 0,
+    reused: 0,
+    superseded: 0,
+    cancelled: 0,
+    skipped: 0,
+  }),
+};
+
+export class SupabaseAppointmentReminderRepository implements IAppointmentReminderRepository {
+  private readonly tenantId: string;
+  private readonly client: SupabaseClient;
+
+  constructor(tenantId: string, client: SupabaseClient) {
+    this.tenantId = tenantId;
+    this.client = client;
+  }
+
+  async listReminderJobs(options: AppointmentReminderListOptions = {}): Promise<AppointmentReminderJob[]> {
+    const referenceTime = options.referenceTime ?? new Date().toISOString();
+    requireInstant(referenceTime, 'reference_time');
+
+    let query = this.client
+      .from('appointment_reminder_jobs')
+      .select('*')
+      .eq('tenant_id', this.tenantId);
+
+    if (options.appointmentId) query = query.eq('appointment_id', options.appointmentId);
+    if (!options.includeTerminal) {
+      query = query.in('state', ['scheduled', 'ready']);
+    }
+
+    const { data, error } = await query
+      .order('due_at', { ascending: true })
+      .order('priority', { ascending: true })
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true });
+
+    if (error) throw toSafeAppointmentReminderError(error, 'read');
+    return (data || [])
+      .map((row) => mapAppointmentReminderJob(row as Record<string, unknown>, referenceTime))
+      .filter((job) => options.includeTerminal || !TERMINAL_STATES.has(job.state))
+      .sort(compareReminderJobs);
+  }
+
+  listReminderJobsByAppointment(appointmentId: string, includeTerminal = true): Promise<AppointmentReminderJob[]> {
+    return this.listReminderJobs({ appointmentId, includeTerminal });
+  }
+
+  async planAppointmentReminderJobs(
+    appointmentId: string,
+    referenceTime = new Date().toISOString(),
+  ): Promise<AppointmentReminderPlanResult> {
+    requireInstant(referenceTime, 'reference_time');
+    try {
+      const { data, error } = await this.client.rpc('plan_appointment_reminder_jobs', {
+        p_tenant_id: this.tenantId,
+        p_appointment_id: appointmentId,
+        p_reference_time: referenceTime,
+      });
+      if (error) throw error;
+      return this.mapPlanResult(data, referenceTime);
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, 'plan');
+    }
+  }
+
+  async reconcileTenantReminderJobs(
+    from: string,
+    to: string,
+    limit: number,
+    referenceTime = new Date().toISOString(),
+  ): Promise<TenantReminderReconcileResult> {
+    requireInstant(from, 'from');
+    requireInstant(to, 'to');
+    requireInstant(referenceTime, 'reference_time');
+    try {
+      const { data, error } = await this.client.rpc('reconcile_tenant_appointment_reminders', {
+        p_tenant_id: this.tenantId,
+        p_from: from,
+        p_to: to,
+        p_limit: limit,
+        p_reference_time: referenceTime,
+      });
+      if (error) throw error;
+      const payload = asObject(data);
+      return {
+        processed: asNumber(payload.processed),
+        created: asNumber(payload.created),
+        reused: asNumber(payload.reused),
+        superseded: asNumber(payload.superseded),
+        cancelled: asNumber(payload.cancelled),
+        skipped: asNumber(payload.skipped),
+      };
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, 'reconcile');
+    }
+  }
+
+  private mapPlanResult(data: unknown, referenceTime: string): AppointmentReminderPlanResult {
+    const payload = asObject(data);
+    const mapRows = (value: unknown): AppointmentReminderJob[] => (
+      Array.isArray(value)
+        ? value.map((row) => mapAppointmentReminderJob(asObject(row), referenceTime))
+        : []
+    );
+    const appointmentVersion = String(payload.appointmentVersion ?? payload.appointment_version ?? '');
+    if (appointmentVersion) requireInstant(appointmentVersion, 'appointment_version');
+
+    return {
+      created: mapRows(payload.created),
+      reused: mapRows(payload.reused),
+      superseded: mapRows(payload.superseded),
+      cancelled: mapRows(payload.cancelled),
+      skipped: mapRows(payload.skipped),
+      desired: Array.isArray(payload.desired) ? payload.desired.map(asObject) : [],
+      appointmentVersion,
+      policyVersion: asNumber(payload.policyVersion ?? payload.policy_version),
+      policyEnabled: payload.policyEnabled === true || payload.policy_enabled === true,
+      callbackDeferred: payload.callbackDeferred === true || payload.callback_deferred === true,
+    };
+  }
+}
+
+export function createAppointmentReminderRepository(
+  options: CreateAppointmentReminderRepositoryOptions,
+): IAppointmentReminderRepository {
+  if (options.backend === 'local') return LocalAppointmentReminderRepository;
+  if (!options.tenantId || !supabase) {
+    throw new AppointmentReminderRepositoryError('tenant_required', 'Клиника не выбрана.');
+  }
+  return new SupabaseAppointmentReminderRepository(options.tenantId, supabase as SupabaseClient);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,64 @@ export interface AppointmentConfirmationAttempt {
   createdAt: string;
 }
 
+export type AppointmentReminderType =
+  | 'confirmation_request'
+  | 'day_before_reminder'
+  | 'control_call_task'
+  | 'callback_task';
+
+export type AppointmentReminderExecutionMode = 'manual';
+export type AppointmentReminderJobState = 'scheduled' | 'ready' | 'completed' | 'cancelled' | 'superseded' | 'skipped';
+export type AppointmentReminderOperationalState = AppointmentReminderJobState;
+
+export interface AppointmentReminderJob {
+  id: string;
+  tenantId: string;
+  appointmentId: string;
+  patientId: string;
+  reminderType: AppointmentReminderType;
+  executionMode: AppointmentReminderExecutionMode;
+  dueAt: string;
+  state: AppointmentReminderJobState;
+  operationalState: AppointmentReminderOperationalState;
+  appointmentUpdatedAt: string;
+  policyVersion: number;
+  planKey: string;
+  payloadFingerprint: string;
+  priority: number;
+  createdBy?: string;
+  createdAt: string;
+  updatedAt: string;
+  supersededAt?: string;
+  cancelledAt?: string;
+  skippedAt?: string;
+  completedAt?: string;
+  terminalReason?: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface AppointmentReminderPlanResult {
+  created: AppointmentReminderJob[];
+  reused: AppointmentReminderJob[];
+  superseded: AppointmentReminderJob[];
+  cancelled: AppointmentReminderJob[];
+  skipped: AppointmentReminderJob[];
+  desired: Array<Record<string, unknown>>;
+  appointmentVersion: string;
+  policyVersion: number;
+  policyEnabled: boolean;
+  callbackDeferred: boolean;
+}
+
+export interface TenantReminderReconcileResult {
+  processed: number;
+  created: number;
+  reused: number;
+  superseded: number;
+  cancelled: number;
+  skipped: number;
+}
+
 export type ToothNumber =
   | 18 | 17 | 16 | 15 | 14 | 13 | 12 | 11
   | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28

--- a/supabase/migrations/0029_appointment_reminder_queue_foundation.sql
+++ b/supabase/migrations/0029_appointment_reminder_queue_foundation.sql
@@ -1,0 +1,974 @@
+-- 0029_appointment_reminder_queue_foundation.sql
+-- Durable tenant-scoped appointment reminder planning. This migration sends no messages.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.appointments'::regclass
+      AND conname = 'appointments_tenant_id_id_unique'
+  ) THEN
+    ALTER TABLE public.appointments
+      ADD CONSTRAINT appointments_tenant_id_id_unique UNIQUE (tenant_id, id);
+  END IF;
+END;
+$$;
+
+CREATE TABLE public.tenant_reminder_policies (
+  tenant_id uuid PRIMARY KEY REFERENCES public.tenants(id) ON DELETE CASCADE,
+  enabled boolean NOT NULL DEFAULT false,
+  confirmation_request_enabled boolean NOT NULL DEFAULT true,
+  repeat_confirmation_request boolean NOT NULL DEFAULT false,
+  day_before_enabled boolean NOT NULL DEFAULT true,
+  day_before_local_time time NOT NULL DEFAULT '12:00',
+  reminder_after_confirmation boolean NOT NULL DEFAULT true,
+  callback_task_enabled boolean NOT NULL DEFAULT true,
+  control_call_enabled boolean NOT NULL DEFAULT true,
+  control_call_offset_minutes integer NOT NULL DEFAULT 180,
+  policy_version integer NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  CONSTRAINT tenant_reminder_policies_offset_check
+    CHECK (control_call_offset_minutes BETWEEN 15 AND 10080),
+  CONSTRAINT tenant_reminder_policies_version_check
+    CHECK (policy_version >= 1)
+);
+
+CREATE TABLE public.appointment_reminder_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  appointment_id uuid NOT NULL,
+  patient_id uuid NOT NULL,
+  reminder_type text NOT NULL,
+  execution_mode text NOT NULL DEFAULT 'manual',
+  channel text,
+  due_at timestamptz NOT NULL,
+  state text NOT NULL DEFAULT 'scheduled',
+  appointment_updated_at timestamptz NOT NULL,
+  policy_version integer NOT NULL,
+  plan_key text NOT NULL,
+  payload_fingerprint text NOT NULL,
+  priority integer NOT NULL DEFAULT 100,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  superseded_at timestamptz,
+  cancelled_at timestamptz,
+  skipped_at timestamptz,
+  completed_at timestamptz,
+  terminal_reason text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT appointment_reminder_jobs_appointment_fk
+    FOREIGN KEY (tenant_id, appointment_id)
+    REFERENCES public.appointments(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT appointment_reminder_jobs_patient_fk
+    FOREIGN KEY (tenant_id, patient_id)
+    REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CONSTRAINT appointment_reminder_jobs_type_check
+    CHECK (reminder_type IN (
+      'confirmation_request',
+      'day_before_reminder',
+      'control_call_task',
+      'callback_task'
+    )),
+  CONSTRAINT appointment_reminder_jobs_execution_mode_check
+    CHECK (execution_mode = 'manual'),
+  CONSTRAINT appointment_reminder_jobs_channel_check
+    CHECK (channel IS NULL),
+  CONSTRAINT appointment_reminder_jobs_state_check
+    CHECK (state IN ('scheduled', 'ready', 'completed', 'cancelled', 'superseded', 'skipped')),
+  CONSTRAINT appointment_reminder_jobs_policy_version_check
+    CHECK (policy_version >= 1),
+  CONSTRAINT appointment_reminder_jobs_plan_key_check
+    CHECK (length(plan_key) = 64),
+  CONSTRAINT appointment_reminder_jobs_fingerprint_check
+    CHECK (length(payload_fingerprint) = 64),
+  CONSTRAINT appointment_reminder_jobs_priority_check
+    CHECK (priority BETWEEN 1 AND 1000),
+  CONSTRAINT appointment_reminder_jobs_metadata_check
+    CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT appointment_reminder_jobs_terminal_fields_check
+    CHECK (
+      (state = 'superseded' AND superseded_at IS NOT NULL AND cancelled_at IS NULL AND skipped_at IS NULL AND completed_at IS NULL)
+      OR (state = 'cancelled' AND cancelled_at IS NOT NULL AND superseded_at IS NULL AND skipped_at IS NULL AND completed_at IS NULL)
+      OR (state = 'skipped' AND skipped_at IS NOT NULL AND superseded_at IS NULL AND cancelled_at IS NULL AND completed_at IS NULL)
+      OR (state = 'completed' AND completed_at IS NOT NULL AND superseded_at IS NULL AND cancelled_at IS NULL AND skipped_at IS NULL)
+      OR (state IN ('scheduled', 'ready') AND superseded_at IS NULL AND cancelled_at IS NULL AND skipped_at IS NULL AND completed_at IS NULL)
+    ),
+  CONSTRAINT appointment_reminder_jobs_terminal_reason_check
+    CHECK (
+      (state IN ('scheduled', 'ready') AND terminal_reason IS NULL)
+      OR (state IN ('completed', 'cancelled', 'superseded', 'skipped') AND terminal_reason IS NOT NULL AND length(btrim(terminal_reason)) > 0)
+    ),
+  CONSTRAINT appointment_reminder_jobs_tenant_plan_key_key UNIQUE (tenant_id, plan_key)
+);
+
+CREATE INDEX idx_appointment_reminder_jobs_operational
+  ON public.appointment_reminder_jobs (tenant_id, state, due_at, priority, created_at, id);
+CREATE INDEX idx_appointment_reminder_jobs_appointment
+  ON public.appointment_reminder_jobs (tenant_id, appointment_id, created_at, id);
+CREATE INDEX idx_appointment_reminder_jobs_patient
+  ON public.appointment_reminder_jobs (tenant_id, patient_id, due_at, id);
+CREATE INDEX idx_appointment_reminder_jobs_active
+  ON public.appointment_reminder_jobs (tenant_id, due_at, priority, id)
+  WHERE state IN ('scheduled', 'ready');
+
+ALTER TABLE public.tenant_reminder_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.appointment_reminder_jobs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Schedule operators can read reminder policy"
+  ON public.tenant_reminder_policies
+  FOR SELECT TO authenticated
+  USING (public.has_tenant_role(
+    tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role]
+  ));
+
+CREATE POLICY "Schedule operators can read reminder jobs"
+  ON public.appointment_reminder_jobs
+  FOR SELECT TO authenticated
+  USING (public.has_tenant_role(
+    tenant_id,
+    ARRAY['clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role]
+  ));
+
+REVOKE ALL ON TABLE public.tenant_reminder_policies FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.tenant_reminder_policies TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.tenant_reminder_policies TO service_role;
+
+REVOKE ALL ON TABLE public.appointment_reminder_jobs FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.appointment_reminder_jobs TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.appointment_reminder_jobs TO service_role;
+
+CREATE OR REPLACE FUNCTION public.ensure_tenant_reminder_policy_internal(p_tenant_id uuid)
+RETURNS public.tenant_reminder_policies
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_policy public.tenant_reminder_policies%ROWTYPE;
+BEGIN
+  PERFORM set_config('app.reminder_policy_internal', 'on', true);
+  INSERT INTO public.tenant_reminder_policies (tenant_id)
+  VALUES (p_tenant_id)
+  ON CONFLICT (tenant_id) DO NOTHING;
+  PERFORM set_config('app.reminder_policy_internal', 'off', true);
+
+  SELECT * INTO v_policy
+  FROM public.tenant_reminder_policies
+  WHERE tenant_id = p_tenant_id;
+
+  RETURN v_policy;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.guard_tenant_reminder_policy_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND pg_trigger_depth() > 1 THEN
+    RETURN OLD;
+  END IF;
+  IF current_user IN ('postgres', 'service_role') THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+  IF COALESCE(current_setting('app.reminder_policy_internal', true), '') <> 'on' THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения политики напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tenant_reminder_policies_write_guard
+BEFORE INSERT OR UPDATE OR DELETE ON public.tenant_reminder_policies
+FOR EACH ROW EXECUTE FUNCTION public.guard_tenant_reminder_policy_write();
+
+CREATE OR REPLACE FUNCTION public.guard_appointment_reminder_job_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND pg_trigger_depth() > 1 THEN
+    RETURN OLD;
+  END IF;
+  IF current_user IN ('postgres', 'service_role') THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    NEW.updated_at := now();
+    RETURN NEW;
+  END IF;
+  IF COALESCE(current_setting('app.reminder_job_internal', true), '') <> 'on' THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения очереди напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER appointment_reminder_jobs_write_guard
+BEFORE INSERT OR UPDATE OR DELETE ON public.appointment_reminder_jobs
+FOR EACH ROW EXECUTE FUNCTION public.guard_appointment_reminder_job_write();
+
+CREATE OR REPLACE FUNCTION public.create_default_tenant_reminder_policy()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+BEGIN
+  PERFORM public.ensure_tenant_reminder_policy_internal(NEW.id);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tenants_create_default_reminder_policy
+AFTER INSERT ON public.tenants
+FOR EACH ROW EXECUTE FUNCTION public.create_default_tenant_reminder_policy();
+
+SELECT set_config('app.reminder_policy_internal', 'on', true);
+INSERT INTO public.tenant_reminder_policies (tenant_id)
+SELECT id FROM public.tenants
+ON CONFLICT (tenant_id) DO NOTHING;
+SELECT set_config('app.reminder_policy_internal', 'off', true);
+
+CREATE OR REPLACE FUNCTION public.appointment_reminder_job_row_json(p_job public.appointment_reminder_jobs)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+  SELECT jsonb_build_object(
+    'id', p_job.id,
+    'tenantId', p_job.tenant_id,
+    'appointmentId', p_job.appointment_id,
+    'patientId', p_job.patient_id,
+    'reminderType', p_job.reminder_type,
+    'executionMode', p_job.execution_mode,
+    'channel', p_job.channel,
+    'dueAt', p_job.due_at,
+    'state', p_job.state,
+    'appointmentUpdatedAt', p_job.appointment_updated_at,
+    'policyVersion', p_job.policy_version,
+    'planKey', p_job.plan_key,
+    'payloadFingerprint', p_job.payload_fingerprint,
+    'priority', p_job.priority,
+    'createdBy', p_job.created_by,
+    'createdAt', p_job.created_at,
+    'updatedAt', p_job.updated_at,
+    'supersededAt', p_job.superseded_at,
+    'cancelledAt', p_job.cancelled_at,
+    'skippedAt', p_job.skipped_at,
+    'completedAt', p_job.completed_at,
+    'terminalReason', p_job.terminal_reason,
+    'metadata', p_job.metadata,
+    'operationalState', CASE
+      WHEN p_job.state = 'scheduled' AND p_job.due_at <= now() THEN 'ready'
+      ELSE p_job.state
+    END
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_appointment_reminder_transition_internal(
+  p_job public.appointment_reminder_jobs,
+  p_action text,
+  p_previous_state text,
+  p_new_state text,
+  p_actor uuid,
+  p_source text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_role text;
+  v_audit_id uuid;
+BEGIN
+  SELECT tu.role::text INTO v_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_job.tenant_id AND tu.user_id = p_actor;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_job.tenant_id,
+    p_action => p_action,
+    p_category => 'appointment',
+    p_target_type => 'appointment_reminder_job',
+    p_target_id => p_job.id::text,
+    p_actor_user_id => p_actor,
+    p_actor_tenant_role => v_role,
+    p_patient_id => p_job.patient_id,
+    p_appointment_id => p_job.appointment_id::text,
+    p_before_data => jsonb_build_object('state', p_previous_state),
+    p_after_data => jsonb_build_object(
+      'state', p_new_state,
+      'reminderType', p_job.reminder_type,
+      'dueAt', p_job.due_at,
+      'appointmentUpdatedAt', p_job.appointment_updated_at,
+      'policyVersion', p_job.policy_version
+    ),
+    p_diff_data => jsonb_build_object('state', jsonb_build_object('from', p_previous_state, 'to', p_new_state)),
+    p_redaction_level => 'standard',
+    p_metadata => jsonb_build_object(
+      'jobId', p_job.id,
+      'planKey', p_job.plan_key,
+      'source', p_source,
+      'executionMode', p_job.execution_mode
+    )
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_job.tenant_id,
+    p_category => 'appointment',
+    p_type => p_action,
+    p_title => CASE p_action
+      WHEN 'appointment_reminder_planned' THEN 'Запланирована задача напоминания'
+      WHEN 'appointment_reminder_superseded' THEN 'Устаревшая задача напоминания заменена'
+      WHEN 'appointment_reminder_cancelled' THEN 'Задача напоминания отменена'
+      WHEN 'appointment_reminder_skipped' THEN 'Задача напоминания пропущена'
+      ELSE 'Изменена задача напоминания'
+    END,
+    p_source_type => 'appointment_reminder_job',
+    p_source_id => p_job.id::text,
+    p_patient_id => p_job.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => p_actor,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_job.appointment_id,
+      'reminderType', p_job.reminder_type,
+      'dueAt', p_job.due_at,
+      'state', p_new_state,
+      'source', p_source
+    )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.transition_active_appointment_reminder_jobs_internal(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_target_state text,
+  p_reason text,
+  p_actor uuid,
+  p_source text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_job public.appointment_reminder_jobs%ROWTYPE;
+  v_count integer := 0;
+  v_action text;
+  v_rows jsonb := '[]'::jsonb;
+BEGIN
+  IF p_target_state NOT IN ('cancelled', 'superseded', 'skipped') THEN
+    RAISE EXCEPTION 'Unsupported reminder transition state';
+  END IF;
+
+  v_action := CASE p_target_state
+    WHEN 'cancelled' THEN 'appointment_reminder_cancelled'
+    WHEN 'superseded' THEN 'appointment_reminder_superseded'
+    ELSE 'appointment_reminder_skipped'
+  END;
+
+  FOR v_job IN
+    SELECT *
+    FROM public.appointment_reminder_jobs
+    WHERE tenant_id = p_tenant_id
+      AND appointment_id = p_appointment_id
+      AND state IN ('scheduled', 'ready')
+    ORDER BY due_at, priority, created_at, id
+    FOR UPDATE
+  LOOP
+    PERFORM set_config('app.reminder_job_internal', 'on', true);
+    UPDATE public.appointment_reminder_jobs
+    SET state = p_target_state,
+        superseded_at = CASE WHEN p_target_state = 'superseded' THEN now() ELSE NULL END,
+        cancelled_at = CASE WHEN p_target_state = 'cancelled' THEN now() ELSE NULL END,
+        skipped_at = CASE WHEN p_target_state = 'skipped' THEN now() ELSE NULL END,
+        completed_at = NULL,
+        terminal_reason = p_reason
+    WHERE id = v_job.id
+    RETURNING * INTO v_job;
+    PERFORM set_config('app.reminder_job_internal', 'off', true);
+
+    PERFORM public.record_appointment_reminder_transition_internal(
+      v_job, v_action, 'scheduled', p_target_state, p_actor, p_source
+    );
+    v_count := v_count + 1;
+    v_rows := v_rows || jsonb_build_array(public.appointment_reminder_job_row_json(v_job));
+  END LOOP;
+
+  RETURN jsonb_build_object('count', v_count, 'jobs', v_rows);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reconcile_appointment_reminders_after_visit_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $visit$
+DECLARE
+  v_reason text;
+BEGIN
+  IF NEW.appointment_id IS NULL OR NEW.status NOT IN ('checked_in', 'in_progress', 'completed') THEN
+    RETURN NEW;
+  END IF;
+
+  v_reason := CASE NEW.status
+    WHEN 'checked_in' THEN 'appointment_arrived'
+    WHEN 'in_progress' THEN 'appointment_in_progress'
+    ELSE 'appointment_completed'
+  END;
+
+  PERFORM public.transition_active_appointment_reminder_jobs_internal(
+    NEW.tenant_id,
+    NEW.appointment_id,
+    'skipped',
+    v_reason,
+    auth.uid(),
+    'patient_visit_lifecycle_trigger'
+  );
+
+  RETURN NEW;
+END;
+$visit$;
+
+CREATE TRIGGER patient_visits_reconcile_reminders_after_status
+AFTER INSERT OR UPDATE OF status ON public.patient_visits
+FOR EACH ROW EXECUTE FUNCTION public.reconcile_appointment_reminders_after_visit_change();
+
+CREATE OR REPLACE FUNCTION public.plan_appointment_reminder_jobs_internal(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_reference_time timestamptz DEFAULT now(),
+  p_actor uuid DEFAULT auth.uid(),
+  p_source text DEFAULT 'internal'
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_appointment public.appointments%ROWTYPE;
+  v_policy public.tenant_reminder_policies%ROWTYPE;
+  v_timezone text;
+  v_confirmation_state text;
+  v_effective_confirmed boolean;
+  v_due_local timestamp;
+  v_due_at timestamptz;
+  v_control_due timestamptz;
+  v_plan_key text;
+  v_fingerprint text;
+  v_desired jsonb := '[]'::jsonb;
+  v_desired_item jsonb;
+  v_desired_keys text[] := ARRAY[]::text[];
+  v_job public.appointment_reminder_jobs%ROWTYPE;
+  v_created jsonb := '[]'::jsonb;
+  v_reused jsonb := '[]'::jsonb;
+  v_superseded jsonb := '[]'::jsonb;
+  v_cancelled jsonb := '[]'::jsonb;
+  v_skipped jsonb := '[]'::jsonb;
+  v_transition jsonb;
+  v_reason text;
+  v_target_state text;
+  v_type text;
+  v_priority integer;
+  v_metadata jsonb;
+BEGIN
+  IF p_reference_time IS NULL THEN
+    RAISE EXCEPTION 'Укажите контрольное время планирования.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_appointment
+  FROM public.appointments
+  WHERE tenant_id = p_tenant_id AND id = p_appointment_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Запись не найдена.' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT t.timezone INTO v_timezone
+  FROM public.tenants t
+  WHERE t.id = p_tenant_id;
+
+  IF NOT public.is_valid_iana_timezone(v_timezone) THEN
+    RAISE EXCEPTION 'Укажите корректный часовой пояс клиники.' USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM public.ensure_tenant_reminder_policy_internal(p_tenant_id);
+  SELECT * INTO v_policy
+  FROM public.tenant_reminder_policies
+  WHERE tenant_id = p_tenant_id
+  FOR SHARE;
+
+  v_confirmation_state := COALESCE(v_appointment.confirmation_state, 'unconfirmed');
+  v_effective_confirmed := v_appointment.status = 'confirmed' OR v_confirmation_state = 'confirmed';
+
+  IF NOT v_policy.enabled THEN
+    v_transition := public.transition_active_appointment_reminder_jobs_internal(
+      p_tenant_id, p_appointment_id, 'cancelled', 'policy_disabled', p_actor, p_source
+    );
+    RETURN jsonb_build_object(
+      'created', '[]'::jsonb,
+      'reused', '[]'::jsonb,
+      'superseded', '[]'::jsonb,
+      'cancelled', v_transition->'jobs',
+      'skipped', '[]'::jsonb,
+      'desired', '[]'::jsonb,
+      'appointmentVersion', v_appointment.updated_at,
+      'policyVersion', v_policy.policy_version,
+      'policyEnabled', false,
+      'callbackDeferred', v_confirmation_state = 'callback_requested'
+    );
+  END IF;
+
+  IF v_appointment.status IN ('cancelled', 'no_show') THEN
+    v_reason := CASE v_appointment.status WHEN 'cancelled' THEN 'appointment_cancelled' ELSE 'appointment_no_show' END;
+    v_transition := public.transition_active_appointment_reminder_jobs_internal(
+      p_tenant_id, p_appointment_id, 'cancelled', v_reason, p_actor, p_source
+    );
+    RETURN jsonb_build_object(
+      'created', '[]'::jsonb, 'reused', '[]'::jsonb, 'superseded', '[]'::jsonb,
+      'cancelled', v_transition->'jobs', 'skipped', '[]'::jsonb, 'desired', '[]'::jsonb,
+      'appointmentVersion', v_appointment.updated_at, 'policyVersion', v_policy.policy_version,
+      'policyEnabled', true, 'callbackDeferred', false
+    );
+  END IF;
+
+  IF v_appointment.patient_id IS NULL
+     OR v_appointment.status IN ('arrived', 'in_progress', 'completed', 'blocked')
+     OR v_appointment.start_time <= p_reference_time THEN
+    v_reason := CASE
+      WHEN v_appointment.patient_id IS NULL THEN 'patient_missing'
+      WHEN v_appointment.status = 'arrived' THEN 'appointment_arrived'
+      WHEN v_appointment.status = 'in_progress' THEN 'appointment_in_progress'
+      WHEN v_appointment.status = 'completed' THEN 'appointment_completed'
+      WHEN v_appointment.status = 'blocked' THEN 'appointment_blocked'
+      ELSE 'appointment_started_or_past'
+    END;
+    v_transition := public.transition_active_appointment_reminder_jobs_internal(
+      p_tenant_id, p_appointment_id, 'skipped', v_reason, p_actor, p_source
+    );
+    RETURN jsonb_build_object(
+      'created', '[]'::jsonb, 'reused', '[]'::jsonb, 'superseded', '[]'::jsonb,
+      'cancelled', '[]'::jsonb, 'skipped', v_transition->'jobs', 'desired', '[]'::jsonb,
+      'appointmentVersion', v_appointment.updated_at, 'policyVersion', v_policy.policy_version,
+      'policyEnabled', true, 'callbackDeferred', false
+    );
+  END IF;
+
+  -- Callback requests need an explicit callback timestamp. The current model has none, so no timestamp is invented.
+  IF v_confirmation_state = 'callback_requested' THEN
+    v_transition := public.transition_active_appointment_reminder_jobs_internal(
+      p_tenant_id, p_appointment_id, 'superseded', 'callback_time_required', p_actor, p_source
+    );
+    RETURN jsonb_build_object(
+      'created', '[]'::jsonb, 'reused', '[]'::jsonb, 'superseded', v_transition->'jobs',
+      'cancelled', '[]'::jsonb, 'skipped', '[]'::jsonb, 'desired', '[]'::jsonb,
+      'appointmentVersion', v_appointment.updated_at, 'policyVersion', v_policy.policy_version,
+      'policyEnabled', true, 'callbackDeferred', v_policy.callback_task_enabled
+    );
+  END IF;
+
+  -- Day-before local timestamp. PostgreSQL selects the standard-time occurrence for an ambiguous fall-back wall time.
+  v_due_local := (((v_appointment.start_time AT TIME ZONE v_timezone)::date - 1) + v_policy.day_before_local_time)::timestamp;
+  v_due_at := v_due_local AT TIME ZONE v_timezone;
+  IF (v_due_at AT TIME ZONE v_timezone) IS DISTINCT FROM v_due_local THEN
+    RAISE EXCEPTION 'Настроенное локальное время напоминания не существует в часовом поясе клиники.' USING ERRCODE = '22023';
+  END IF;
+  v_control_due := v_appointment.start_time - make_interval(mins => v_policy.control_call_offset_minutes);
+
+  IF v_policy.confirmation_request_enabled
+     AND NOT v_effective_confirmed
+     AND (
+       v_confirmation_state = 'unconfirmed'
+       OR (v_confirmation_state = 'contact_in_progress' AND v_policy.repeat_confirmation_request)
+     ) THEN
+    v_type := 'confirmation_request';
+    v_priority := 60;
+    v_plan_key := encode(extensions.digest(concat_ws('|', p_tenant_id, p_appointment_id, v_type, v_due_at, v_appointment.updated_at, v_policy.policy_version), 'sha256'), 'hex');
+    v_fingerprint := encode(extensions.digest(concat_ws('|', p_tenant_id, p_appointment_id, v_appointment.patient_id, v_type, 'manual', v_due_at, v_appointment.updated_at, v_policy.policy_version, v_confirmation_state, v_appointment.status), 'sha256'), 'hex');
+    v_metadata := jsonb_build_object('tenantTimezone', v_timezone, 'policyKind', 'day_before_local_time');
+    v_desired := v_desired || jsonb_build_array(jsonb_build_object('reminderType', v_type, 'dueAt', v_due_at, 'priority', v_priority, 'planKey', v_plan_key, 'payloadFingerprint', v_fingerprint, 'metadata', v_metadata));
+    v_desired_keys := array_append(v_desired_keys, v_plan_key);
+  END IF;
+
+  IF v_policy.day_before_enabled
+     AND (NOT v_effective_confirmed OR v_policy.reminder_after_confirmation)
+     AND v_confirmation_state <> 'unreachable' THEN
+    v_type := 'day_before_reminder';
+    v_priority := 80;
+    v_plan_key := encode(extensions.digest(concat_ws('|', p_tenant_id, p_appointment_id, v_type, v_due_at, v_appointment.updated_at, v_policy.policy_version), 'sha256'), 'hex');
+    v_fingerprint := encode(extensions.digest(concat_ws('|', p_tenant_id, p_appointment_id, v_appointment.patient_id, v_type, 'manual', v_due_at, v_appointment.updated_at, v_policy.policy_version, v_confirmation_state, v_appointment.status), 'sha256'), 'hex');
+    v_metadata := jsonb_build_object('tenantTimezone', v_timezone, 'policyKind', 'day_before_local_time');
+    v_desired := v_desired || jsonb_build_array(jsonb_build_object('reminderType', v_type, 'dueAt', v_due_at, 'priority', v_priority, 'planKey', v_plan_key, 'payloadFingerprint', v_fingerprint, 'metadata', v_metadata));
+    v_desired_keys := array_append(v_desired_keys, v_plan_key);
+  END IF;
+
+  IF v_policy.control_call_enabled
+     AND NOT v_effective_confirmed
+     AND v_confirmation_state IN ('unconfirmed', 'contact_in_progress', 'unreachable') THEN
+    v_type := 'control_call_task';
+    v_priority := 40;
+    v_plan_key := encode(extensions.digest(concat_ws('|', p_tenant_id, p_appointment_id, v_type, v_control_due, v_appointment.updated_at, v_policy.policy_version), 'sha256'), 'hex');
+    v_fingerprint := encode(extensions.digest(concat_ws('|', p_tenant_id, p_appointment_id, v_appointment.patient_id, v_type, 'manual', v_control_due, v_appointment.updated_at, v_policy.policy_version, v_confirmation_state, v_appointment.status), 'sha256'), 'hex');
+    v_metadata := jsonb_build_object('tenantTimezone', v_timezone, 'policyKind', 'appointment_offset', 'offsetMinutes', v_policy.control_call_offset_minutes);
+    v_desired := v_desired || jsonb_build_array(jsonb_build_object('reminderType', v_type, 'dueAt', v_control_due, 'priority', v_priority, 'planKey', v_plan_key, 'payloadFingerprint', v_fingerprint, 'metadata', v_metadata));
+    v_desired_keys := array_append(v_desired_keys, v_plan_key);
+  END IF;
+
+  FOR v_job IN
+    SELECT * FROM public.appointment_reminder_jobs
+    WHERE tenant_id = p_tenant_id
+      AND appointment_id = p_appointment_id
+      AND state IN ('scheduled', 'ready')
+      AND NOT (plan_key = ANY(v_desired_keys))
+    ORDER BY due_at, priority, created_at, id
+    FOR UPDATE
+  LOOP
+    PERFORM set_config('app.reminder_job_internal', 'on', true);
+    UPDATE public.appointment_reminder_jobs
+    SET state = 'superseded', superseded_at = now(), terminal_reason = 'plan_changed'
+    WHERE id = v_job.id
+    RETURNING * INTO v_job;
+    PERFORM set_config('app.reminder_job_internal', 'off', true);
+    PERFORM public.record_appointment_reminder_transition_internal(v_job, 'appointment_reminder_superseded', 'scheduled', 'superseded', p_actor, p_source);
+    v_superseded := v_superseded || jsonb_build_array(public.appointment_reminder_job_row_json(v_job));
+  END LOOP;
+
+  FOR v_desired_item IN SELECT value FROM jsonb_array_elements(v_desired)
+  LOOP
+    SELECT * INTO v_job
+    FROM public.appointment_reminder_jobs
+    WHERE tenant_id = p_tenant_id AND plan_key = v_desired_item->>'planKey';
+
+    IF FOUND THEN
+      v_reused := v_reused || jsonb_build_array(public.appointment_reminder_job_row_json(v_job));
+    ELSE
+      PERFORM set_config('app.reminder_job_internal', 'on', true);
+      INSERT INTO public.appointment_reminder_jobs (
+        tenant_id, appointment_id, patient_id, reminder_type, execution_mode, channel,
+        due_at, state, appointment_updated_at, policy_version, plan_key,
+        payload_fingerprint, priority, created_by, metadata
+      ) VALUES (
+        p_tenant_id,
+        p_appointment_id,
+        v_appointment.patient_id,
+        v_desired_item->>'reminderType',
+        'manual',
+        NULL,
+        (v_desired_item->>'dueAt')::timestamptz,
+        'scheduled',
+        v_appointment.updated_at,
+        v_policy.policy_version,
+        v_desired_item->>'planKey',
+        v_desired_item->>'payloadFingerprint',
+        (v_desired_item->>'priority')::integer,
+        p_actor,
+        COALESCE(v_desired_item->'metadata', '{}'::jsonb)
+      ) RETURNING * INTO v_job;
+      PERFORM set_config('app.reminder_job_internal', 'off', true);
+      PERFORM public.record_appointment_reminder_transition_internal(v_job, 'appointment_reminder_planned', NULL, 'scheduled', p_actor, p_source);
+      v_created := v_created || jsonb_build_array(public.appointment_reminder_job_row_json(v_job));
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'created', v_created,
+    'reused', v_reused,
+    'superseded', v_superseded,
+    'cancelled', v_cancelled,
+    'skipped', v_skipped,
+    'desired', v_desired,
+    'appointmentVersion', v_appointment.updated_at,
+    'policyVersion', v_policy.policy_version,
+    'policyEnabled', true,
+    'callbackDeferred', false
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.plan_appointment_reminder_jobs(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_reference_time timestamptz DEFAULT now()
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_role public.app_role;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для планирования напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT tu.role INTO v_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor;
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role, 'registrar'::public.app_role) THEN
+    RAISE EXCEPTION 'Недостаточно прав для планирования напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  RETURN public.plan_appointment_reminder_jobs_internal(p_tenant_id, p_appointment_id, p_reference_time, v_actor, 'appointment_planner_rpc');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reconcile_tenant_appointment_reminders(
+  p_tenant_id uuid,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_limit integer DEFAULT 100,
+  p_reference_time timestamptz DEFAULT now()
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_role public.app_role;
+  v_row record;
+  v_result jsonb;
+  v_processed integer := 0;
+  v_created integer := 0;
+  v_reused integer := 0;
+  v_superseded integer := 0;
+  v_cancelled integer := 0;
+  v_skipped integer := 0;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для сверки напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT tu.role INTO v_role FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor;
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Недостаточно прав для сверки напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF p_from IS NULL OR p_to IS NULL OR p_to <= p_from OR p_to - p_from > interval '90 days' THEN
+    RAISE EXCEPTION 'Укажите корректный ограниченный период сверки.' USING ERRCODE = '22023';
+  END IF;
+  IF p_limit IS NULL OR p_limit < 1 OR p_limit > 500 THEN
+    RAISE EXCEPTION 'Лимит сверки должен быть от 1 до 500.' USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_row IN
+    SELECT a.id
+    FROM public.appointments a
+    WHERE a.tenant_id = p_tenant_id
+      AND a.start_time >= p_from
+      AND a.start_time < p_to
+    ORDER BY a.start_time, a.id
+    LIMIT p_limit
+  LOOP
+    v_result := public.plan_appointment_reminder_jobs_internal(p_tenant_id, v_row.id, p_reference_time, v_actor, 'tenant_reconciliation_rpc');
+    v_processed := v_processed + 1;
+    v_created := v_created + jsonb_array_length(v_result->'created');
+    v_reused := v_reused + jsonb_array_length(v_result->'reused');
+    v_superseded := v_superseded + jsonb_array_length(v_result->'superseded');
+    v_cancelled := v_cancelled + jsonb_array_length(v_result->'cancelled');
+    v_skipped := v_skipped + jsonb_array_length(v_result->'skipped');
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'processed', v_processed,
+    'created', v_created,
+    'reused', v_reused,
+    'superseded', v_superseded,
+    'cancelled', v_cancelled,
+    'skipped', v_skipped
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_tenant_reminder_policy(
+  p_tenant_id uuid,
+  p_enabled boolean,
+  p_confirmation_request_enabled boolean DEFAULT true,
+  p_repeat_confirmation_request boolean DEFAULT false,
+  p_day_before_enabled boolean DEFAULT true,
+  p_day_before_local_time time DEFAULT '12:00',
+  p_reminder_after_confirmation boolean DEFAULT true,
+  p_callback_task_enabled boolean DEFAULT true,
+  p_control_call_enabled boolean DEFAULT true,
+  p_control_call_offset_minutes integer DEFAULT 180
+) RETURNS public.tenant_reminder_policies
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_role public.app_role;
+  v_before public.tenant_reminder_policies%ROWTYPE;
+  v_after public.tenant_reminder_policies%ROWTYPE;
+  v_changed boolean;
+  v_audit_id uuid;
+  v_appointment_id uuid;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения политики напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT tu.role INTO v_role FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor;
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner'::public.app_role, 'clinic_admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения политики напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF p_control_call_offset_minutes NOT BETWEEN 15 AND 10080 THEN
+    RAISE EXCEPTION 'Смещение контрольного звонка должно быть от 15 до 10080 минут.' USING ERRCODE = '22023';
+  END IF;
+  IF p_day_before_local_time IS NULL THEN
+    RAISE EXCEPTION 'Укажите локальное время напоминания.' USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM public.ensure_tenant_reminder_policy_internal(p_tenant_id);
+  SELECT * INTO v_before FROM public.tenant_reminder_policies WHERE tenant_id = p_tenant_id FOR UPDATE;
+
+  v_changed := ROW(
+    v_before.enabled,
+    v_before.confirmation_request_enabled,
+    v_before.repeat_confirmation_request,
+    v_before.day_before_enabled,
+    v_before.day_before_local_time,
+    v_before.reminder_after_confirmation,
+    v_before.callback_task_enabled,
+    v_before.control_call_enabled,
+    v_before.control_call_offset_minutes
+  ) IS DISTINCT FROM ROW(
+    p_enabled,
+    p_confirmation_request_enabled,
+    p_repeat_confirmation_request,
+    p_day_before_enabled,
+    p_day_before_local_time,
+    p_reminder_after_confirmation,
+    p_callback_task_enabled,
+    p_control_call_enabled,
+    p_control_call_offset_minutes
+  );
+
+  IF NOT v_changed THEN RETURN v_before; END IF;
+
+  PERFORM set_config('app.reminder_policy_internal', 'on', true);
+  UPDATE public.tenant_reminder_policies
+  SET enabled = p_enabled,
+      confirmation_request_enabled = p_confirmation_request_enabled,
+      repeat_confirmation_request = p_repeat_confirmation_request,
+      day_before_enabled = p_day_before_enabled,
+      day_before_local_time = p_day_before_local_time,
+      reminder_after_confirmation = p_reminder_after_confirmation,
+      callback_task_enabled = p_callback_task_enabled,
+      control_call_enabled = p_control_call_enabled,
+      control_call_offset_minutes = p_control_call_offset_minutes,
+      policy_version = policy_version + 1,
+      updated_at = now(),
+      updated_by = v_actor
+  WHERE tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+  PERFORM set_config('app.reminder_policy_internal', 'off', true);
+
+  FOR v_appointment_id IN
+    SELECT DISTINCT j.appointment_id
+    FROM public.appointment_reminder_jobs j
+    WHERE j.tenant_id = p_tenant_id
+      AND j.state IN ('scheduled', 'ready')
+    ORDER BY j.appointment_id
+  LOOP
+    PERFORM public.transition_active_appointment_reminder_jobs_internal(
+      p_tenant_id,
+      v_appointment_id,
+      'superseded',
+      'policy_changed',
+      v_actor,
+      'set_tenant_reminder_policy'
+    );
+  END LOOP;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => 'tenant_reminder_policy_changed',
+    p_category => 'tenant',
+    p_target_type => 'tenant_reminder_policy',
+    p_target_id => p_tenant_id::text,
+    p_actor_user_id => v_actor,
+    p_actor_tenant_role => v_role::text,
+    p_before_data => to_jsonb(v_before) - 'created_at' - 'updated_at' - 'updated_by',
+    p_after_data => to_jsonb(v_after) - 'created_at' - 'updated_at' - 'updated_by',
+    p_redaction_level => 'none',
+    p_metadata => jsonb_build_object('source', 'set_tenant_reminder_policy')
+  );
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'system',
+    p_type => 'tenant_reminder_policy_changed',
+    p_title => 'Изменена политика напоминаний',
+    p_source_type => 'tenant_reminder_policy',
+    p_source_id => p_tenant_id::text,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => v_actor,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object('policyVersion', v_after.policy_version, 'enabled', v_after.enabled)
+  );
+
+  RETURN v_after;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reconcile_appointment_reminders_after_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  PERFORM public.plan_appointment_reminder_jobs_internal(
+    NEW.tenant_id,
+    NEW.id,
+    now(),
+    auth.uid(),
+    'appointment_lifecycle_trigger'
+  );
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER appointments_reconcile_reminders_after_change
+AFTER INSERT OR UPDATE OF patient_id, start_time, end_time, status, updated_at, confirmation_state ON public.appointments
+FOR EACH ROW EXECUTE FUNCTION public.reconcile_appointment_reminders_after_change();
+
+REVOKE ALL ON FUNCTION public.ensure_tenant_reminder_policy_internal(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.guard_tenant_reminder_policy_write() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.guard_appointment_reminder_job_write() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.create_default_tenant_reminder_policy() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.appointment_reminder_job_row_json(public.appointment_reminder_jobs) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.record_appointment_reminder_transition_internal(public.appointment_reminder_jobs, text, text, text, uuid, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.transition_active_appointment_reminder_jobs_internal(uuid, uuid, text, text, uuid, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reconcile_appointment_reminders_after_visit_change() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.plan_appointment_reminder_jobs_internal(uuid, uuid, timestamptz, uuid, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reconcile_appointment_reminders_after_change() FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.plan_appointment_reminder_jobs(uuid, uuid, timestamptz) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.plan_appointment_reminder_jobs(uuid, uuid, timestamptz) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.reconcile_tenant_appointment_reminders(uuid, timestamptz, timestamptz, integer, timestamptz) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reconcile_tenant_appointment_reminders(uuid, timestamptz, timestamptz, integer, timestamptz) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.set_tenant_reminder_policy(uuid, boolean, boolean, boolean, boolean, time, boolean, boolean, boolean, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.set_tenant_reminder_policy(uuid, boolean, boolean, boolean, boolean, time, boolean, boolean, boolean, integer) TO authenticated, service_role;
+
+COMMENT ON TABLE public.tenant_reminder_policies IS 'Tenant-local reminder planning policy. Existing tenants are disabled by default.';
+COMMENT ON TABLE public.appointment_reminder_jobs IS 'Durable reminder work plans only. No provider delivery or message state exists.';
+COMMENT ON FUNCTION public.plan_appointment_reminder_jobs(uuid, uuid, timestamptz) IS 'Tenant-scoped idempotent appointment reminder planner. Produces manual jobs only and no external side effect.';
+COMMENT ON FUNCTION public.reconcile_tenant_appointment_reminders(uuid, timestamptz, timestamptz, integer, timestamptz) IS 'Bounded manual tenant reconciliation; no scheduler or worker is created.';

--- a/supabase/tests/0029_appointment_reminder_queue_concurrency.ps1
+++ b/supabase/tests/0029_appointment_reminder_queue_concurrency.ps1
@@ -1,0 +1,248 @@
+$ErrorActionPreference = 'Stop'
+
+# APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001 local-only concurrency validation.
+$container = (docker ps --format '{{.Names}}' | Where-Object { $_ -like 'supabase_db_*' } | Select-Object -First 1)
+if (-not $container) { throw 'Local Supabase DB container is not running.' }
+
+$tenantA = 'd2910000-0000-4000-8000-000000000001'
+$tenantB = 'e2910000-0000-4000-8000-000000000001'
+$adminA = 'd2920000-0000-4000-8000-000000000001'
+$adminB = 'e2920000-0000-4000-8000-000000000001'
+$patientA = 'd2930000-0000-4000-8000-000000000001'
+$patientB = 'e2930000-0000-4000-8000-000000000001'
+$doctorA = 'd2940000-0000-4000-8000-000000000001'
+$doctorB = 'e2940000-0000-4000-8000-000000000001'
+
+$ids = @{
+  A = 'd2950000-0000-4000-8000-000000000001'
+  B = 'd2950000-0000-4000-8000-000000000002'
+  C = 'd2950000-0000-4000-8000-000000000003'
+  D = 'd2950000-0000-4000-8000-000000000004'
+  E = 'd2950000-0000-4000-8000-000000000005'
+  F = 'd2950000-0000-4000-8000-000000000006'
+  G = 'd2950000-0000-4000-8000-000000000007'
+  HA = 'd2950000-0000-4000-8000-000000000008'
+  HB = 'e2950000-0000-4000-8000-000000000001'
+}
+
+function Invoke-Sql([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "SQL failed:`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return (($output | Where-Object { $_ -ne $null -and $_.ToString().Trim() -ne '' } | Select-Object -Last 1).ToString().Trim())
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function AuthContext([string]$userId) {
+  return "BEGIN; SET LOCAL ROLE authenticated; SET LOCAL `"request.jwt.claim.sub`"='$userId'; "
+}
+
+function PlanSql([string]$userId, [string]$tenantId, [string]$appointmentId) {
+  return (AuthContext $userId) + "SELECT jsonb_array_length(r->'created')||'|'||jsonb_array_length(r->'reused')||'|'||jsonb_array_length(r->'superseded')||'|'||jsonb_array_length(r->'cancelled') FROM (SELECT public.plan_appointment_reminder_jobs('$tenantId','$appointmentId','2026-12-01 00:00+00') r) q; COMMIT;"
+}
+
+function ReconcileSql([string]$userId, [string]$tenantId, [string]$from, [string]$to) {
+  return (AuthContext $userId) + "SELECT (r->>'created')||'|'||(r->>'reused') FROM (SELECT public.reconcile_tenant_appointment_reminders('$tenantId','$from','$to',100,'2026-12-01 00:00+00') r) q; COMMIT;"
+}
+
+function RescheduleSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.reschedule_appointment('$tenantA','$appointmentId','$patientA','$doctorA','2027-02-20 10:00+00','2027-02-20 11:00+00','A1','Moved','new','unpaid','phone',1,null,'$expected','$key') r) q; COMMIT;"
+}
+
+function CancelSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.cancel_appointment('$tenantA','$appointmentId','clinic','Concurrent reminder cancellation','$expected','$key') r) q; COMMIT;"
+}
+
+function NoShowSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.mark_appointment_no_show('$tenantA','$appointmentId','Concurrent reminder no-show','$expected','$key') r) q; COMMIT;"
+}
+
+function ConfirmSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.confirm_appointment('$tenantA','$appointmentId','phone','Concurrent reminder confirmation','$expected','$key') r) q; COMMIT;"
+}
+
+function PolicySql() {
+  return (AuthContext $adminA) + "SELECT policy_version FROM public.set_tenant_reminder_policy('$tenantA',true,true,false,true,'11:30',true,true,true,120); COMMIT;"
+}
+
+function Count-Success([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 }).Count }
+function Count-Deadlocks([object[]]$results) { return @($results | Where-Object { $_.Text -match 'deadlock detected' }).Count }
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id IN ('$tenantA'::uuid,'$tenantB'::uuid);
+DELETE FROM auth.users WHERE id IN ('$adminA'::uuid,'$adminB'::uuid);
+"@
+
+$appointmentValues = @(
+  @($ids.A,$tenantA,$patientA,$doctorA,'2027-02-01 08:00+00','2027-02-01 09:00+00'),
+  @($ids.B,$tenantA,$patientA,$doctorA,'2027-02-02 08:00+00','2027-02-02 09:00+00'),
+  @($ids.C,$tenantA,$patientA,$doctorA,'2027-02-03 08:00+00','2027-02-03 09:00+00'),
+  @($ids.D,$tenantA,$patientA,$doctorA,'2027-02-04 08:00+00','2027-02-04 09:00+00'),
+  @($ids.E,$tenantA,$patientA,$doctorA,'2027-02-05 08:00+00','2027-02-05 09:00+00'),
+  @($ids.F,$tenantA,$patientA,$doctorA,'2027-02-06 08:00+00','2027-02-06 09:00+00'),
+  @($ids.G,$tenantA,$patientA,$doctorA,'2027-02-07 08:00+00','2027-02-07 09:00+00'),
+  @($ids.HA,$tenantA,$patientA,$doctorA,'2027-02-08 08:00+00','2027-02-08 09:00+00'),
+  @($ids.HB,$tenantB,$patientB,$doctorB,'2027-02-08 08:00+00','2027-02-08 09:00+00')
+)
+$values = ($appointmentValues | ForEach-Object { "('$($_[0])','$($_[1])','$($_[2])','$($_[3])','A1','Reminder concurrency','new','unpaid','phone',1,'$($_[4])','$($_[5])')" }) -join ",`n"
+
+$setup = @"
+BEGIN;
+$cleanup
+INSERT INTO public.tenants(id,name,timezone) VALUES ('$tenantA','Reminder concurrency A','Asia/Almaty'),('$tenantB','Reminder concurrency B','Asia/Almaty');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+ ('$adminA','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-conc-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+ ('$adminB','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-conc-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$adminA'),('$adminB');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES ('$tenantA','$adminA','clinic_admin'),('$tenantB','$adminB','clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status) VALUES
+ ('$patientA','$tenantA','Reminder Concurrent A','+77002920001','phone','active'),
+ ('$patientB','$tenantB','Reminder Concurrent B','+77002920002','phone','active');
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+ ('$doctorA','$tenantA','Reminder Doctor A','General','A1','#111111',true),
+ ('$doctorB','$tenantB','Reminder Doctor B','General','B1','#222222',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,payment_type,source,price,start_time,end_time) VALUES
+$values;
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claim.sub"='$adminA';
+SELECT public.set_tenant_reminder_policy('$tenantA',true,true,false,true,'12:00',true,true,true,180);
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claim.sub"='$adminB';
+SELECT public.set_tenant_reminder_policy('$tenantB',true,true,false,true,'12:00',true,true,true,180);
+COMMIT;
+"@
+
+$allResults = @()
+try {
+  Invoke-Sql $setup | Out-Null
+
+  # A. Two appointment planners produce one logical job set.
+  $a = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.A) (PlanSql $adminA $tenantA $ids.A)); $allResults += $a
+  if ((Count-Success $a) -ne 2) { throw "A planners failed: $($a.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.A)'") -ne 3) { throw 'A duplicate job set detected' }
+  Write-Output 'A_SAME_APPOINTMENT_PLANNERS success=2 logicalJobs=3'
+
+  # B. Overlapping tenant reconciliations remain idempotent.
+  $bSqlA = ReconcileSql $adminA $tenantA '2027-02-02 00:00+00' '2027-02-03 00:00+00'
+  $bSqlB = ReconcileSql $adminA $tenantA '2027-02-02 00:00+00' '2027-02-03 00:00+00'
+  $b = @(Invoke-ConcurrentPair $bSqlA $bSqlB); $allResults += $b
+  if ((Count-Success $b) -ne 2) { throw "B reconciliation failed: $($b.Text -join ' || ')" }
+  $bJobCount = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.B)'")
+  if ($bJobCount -ne 3) { throw "B reconciliation expected 3 logical jobs, found $bJobCount; outputs=$($b.Text -join ' || ')" }
+  Write-Output "B_TENANT_RECONCILIATION_OVERLAP success=2 logicalJobs=$bJobCount"
+
+  # C. Existing plan versus reschedule: old version is historical, new version is active.
+  Invoke-Sql (PlanSql $adminA $tenantA $ids.C) | Out-Null
+  $updatedC = Invoke-Scalar "select updated_at from public.appointments where id='$($ids.C)'"
+  $c = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.C) (RescheduleSql $ids.C $updatedC 'rem-conc-c-reschedule')); $allResults += $c
+  if ((Count-Success $c) -ne 2) { throw "C planner/reschedule failed: $($c.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.C)' and state='superseded'") -ne 3) { throw 'C stale jobs were not superseded' }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.C)' and state in ('scheduled','ready')") -ne 3) { throw 'C new plan missing' }
+  Write-Output 'C_PLANNER_VS_RESCHEDULE success=2 superseded=3 active=3'
+
+  # D. Planner versus cancellation leaves no sendable job.
+  Invoke-Sql (PlanSql $adminA $tenantA $ids.D) | Out-Null
+  $updatedD = Invoke-Scalar "select updated_at from public.appointments where id='$($ids.D)'"
+  $d = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.D) (CancelSql $ids.D $updatedD 'rem-conc-d-cancel')); $allResults += $d
+  if ((Count-Success $d) -ne 2) { throw "D planner/cancel failed: $($d.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.D)' and state in ('scheduled','ready')") -ne 0) { throw 'D active job remains after cancellation' }
+  Write-Output 'D_PLANNER_VS_CANCELLATION success=2 active=0'
+
+  # E. Planner versus no-show leaves no sendable job.
+  Invoke-Sql (PlanSql $adminA $tenantA $ids.E) | Out-Null
+  $updatedE = Invoke-Scalar "select updated_at from public.appointments where id='$($ids.E)'"
+  $e = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.E) (NoShowSql $ids.E $updatedE 'rem-conc-e-noshow')); $allResults += $e
+  if ((Count-Success $e) -ne 2) { throw "E planner/no-show failed: $($e.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.E)' and state in ('scheduled','ready')") -ne 0) { throw 'E active job remains after no-show' }
+  Write-Output 'E_PLANNER_VS_NOSHOW success=2 active=0'
+
+  # F. Planner versus confirmation converges to the confirmed eligibility set.
+  Invoke-Sql (PlanSql $adminA $tenantA $ids.F) | Out-Null
+  $updatedF = Invoke-Scalar "select updated_at from public.appointments where id='$($ids.F)'"
+  $f = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.F) (ConfirmSql $ids.F $updatedF 'rem-conc-f-confirm')); $allResults += $f
+  if ((Count-Success $f) -ne 2) { throw "F planner/confirmation failed: $($f.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.F)' and state in ('scheduled','ready') and reminder_type='confirmation_request'") -ne 0) { throw 'F confirmation request remains active' }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.F)' and state in ('scheduled','ready') and reminder_type='day_before_reminder'") -ne 1) { throw 'F ordinary confirmed reminder missing' }
+  Write-Output 'F_PLANNER_VS_CONFIRMATION success=2 confirmationRequests=0 ordinaryReminders=1'
+
+  # G. Policy change versus planner, followed by explicit reconciliation, leaves only current policy jobs active.
+  Invoke-Sql (PlanSql $adminA $tenantA $ids.G) | Out-Null
+  $g = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.G) (PolicySql)); $allResults += $g
+  if ((Count-Success $g) -ne 2) { throw "G planner/policy failed: $($g.Text -join ' || ')" }
+  Invoke-Sql (PlanSql $adminA $tenantA $ids.G) | Out-Null
+  $currentPolicy = Invoke-Scalar "select policy_version from public.tenant_reminder_policies where tenant_id='$tenantA'"
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.G)' and state in ('scheduled','ready') and policy_version<>$currentPolicy") -ne 0) { throw 'G stale policy jobs remain active' }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where appointment_id='$($ids.G)' and state='superseded'") -lt 3) { throw 'G old policy jobs were not superseded' }
+  Write-Output "G_POLICY_VS_PLANNER success=2 currentPolicy=$currentPolicy activeStale=0"
+
+  # H. Identical plan material in different tenants remains independent.
+  $h = @(Invoke-ConcurrentPair (PlanSql $adminA $tenantA $ids.HA) (PlanSql $adminB $tenantB $ids.HB)); $allResults += $h
+  if ((Count-Success $h) -ne 2) { throw "H tenant isolation failed: $($h.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(distinct tenant_id) from public.appointment_reminder_jobs where appointment_id in ('$($ids.HA)','$($ids.HB)')") -ne 2) { throw 'H cross-tenant plan isolation failed' }
+  Write-Output 'H_CROSS_TENANT_INDEPENDENCE success=2 tenants=2'
+
+  # I/J. Aggregate duplicate, audit and deadlock checks.
+  $duplicatePlanKeys = [int](Invoke-Scalar "select count(*) from (select tenant_id,plan_key,count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') group by 1,2 having count(*)>1) q")
+  $duplicateLogical = [int](Invoke-Scalar "select count(*) from (select tenant_id,appointment_id,reminder_type,due_at,appointment_updated_at,policy_version,count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') group by 1,2,3,4,5,6 having count(*)>1) q")
+  $activeStale = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs j join public.appointments a on a.tenant_id=j.tenant_id and a.id=j.appointment_id join public.tenant_reminder_policies p on p.tenant_id=j.tenant_id where j.tenant_id in ('$tenantA','$tenantB') and j.state in ('scheduled','ready') and (j.appointment_updated_at<>a.updated_at or j.policy_version<>p.policy_version)")
+  $audit = [int](Invoke-Scalar "select count(*) from public.audit_events where tenant_id in ('$tenantA','$tenantB') and action in ('appointment_reminder_planned','appointment_reminder_superseded','appointment_reminder_cancelled','appointment_reminder_skipped')")
+  $activity = [int](Invoke-Scalar "select count(*) from public.activity_events where tenant_id in ('$tenantA','$tenantB') and type in ('appointment_reminder_planned','appointment_reminder_superseded','appointment_reminder_cancelled','appointment_reminder_skipped')")
+  $jobs = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB')")
+  $created = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB')")
+  $superseded = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') and state='superseded'")
+  $cancelled = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') and state='cancelled'")
+  $deadlocks = Count-Deadlocks $allResults
+
+  if ($duplicatePlanKeys -ne 0 -or $duplicateLogical -ne 0 -or $activeStale -ne 0) {
+    throw "Queue invariants failed duplicatePlanKeys=$duplicatePlanKeys duplicateLogical=$duplicateLogical activeStale=$activeStale"
+  }
+  if ($audit -ne $activity) { throw "Audit/activity mismatch audit=$audit activity=$activity" }
+  if ($deadlocks -ne 0) { throw "Deadlocks detected: $deadlocks" }
+
+  Write-Output "I_DUPLICATE_AUDIT_PREVENTION audit=$audit activity=$activity duplicatePlanKeys=$duplicatePlanKeys duplicateLogical=$duplicateLogical"
+  Write-Output "FINAL createdJobs=$created totalJobs=$jobs supersededJobs=$superseded cancelledJobs=$cancelled activeStaleJobs=$activeStale auditEvents=$audit activityEvents=$activity deadlocks=$deadlocks"
+  Write-Output 'APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remaining = Invoke-Scalar "select (select count(*) from public.tenants where id in ('$tenantA','$tenantB')) + (select count(*) from auth.users where id in ('$adminA','$adminB'))"
+  if ([int]$remaining -ne 0) { throw "Concurrency cleanup failed: remaining=$remaining" }
+}

--- a/supabase/tests/0029_appointment_reminder_queue_foundation_test.sql
+++ b/supabase/tests/0029_appointment_reminder_queue_foundation_test.sql
@@ -1,0 +1,318 @@
+\set ON_ERROR_STOP on
+\echo 'APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+\set tenant_a 'a2910000-0000-4000-8000-000000000001'
+\set tenant_b 'b2910000-0000-4000-8000-000000000001'
+\set tenant_c 'c2910000-0000-4000-8000-000000000001'
+\set owner_a 'a2920000-0000-4000-8000-000000000001'
+\set admin_a 'a2920000-0000-4000-8000-000000000002'
+\set registrar_a 'a2920000-0000-4000-8000-000000000003'
+\set doctor_user_a 'a2920000-0000-4000-8000-000000000004'
+\set cashier_a 'a2920000-0000-4000-8000-000000000005'
+\set no_tenant 'a2920000-0000-4000-8000-000000000006'
+\set owner_b 'b2920000-0000-4000-8000-000000000001'
+\set owner_c 'c2920000-0000-4000-8000-000000000001'
+\set patient_a 'a2930000-0000-4000-8000-000000000001'
+\set patient_b 'b2930000-0000-4000-8000-000000000001'
+\set patient_c 'c2930000-0000-4000-8000-000000000001'
+\set doctor_a 'a2940000-0000-4000-8000-000000000001'
+\set doctor_b 'b2940000-0000-4000-8000-000000000001'
+\set doctor_c 'c2940000-0000-4000-8000-000000000001'
+\set appt_a 'a2950000-0000-4000-8000-000000000001'
+\set appt_contact 'a2950000-0000-4000-8000-000000000002'
+\set appt_confirmed 'a2950000-0000-4000-8000-000000000003'
+\set appt_unreachable 'a2950000-0000-4000-8000-000000000004'
+\set appt_callback 'a2950000-0000-4000-8000-000000000005'
+\set appt_cancel 'a2950000-0000-4000-8000-000000000006'
+\set appt_noshow 'a2950000-0000-4000-8000-000000000007'
+\set appt_completed 'a2950000-0000-4000-8000-000000000008'
+\set appt_arrived 'a2950000-0000-4000-8000-000000000009'
+\set appt_progress 'a2950000-0000-4000-8000-000000000010'
+\set appt_blocked 'a2950000-0000-4000-8000-000000000011'
+\set appt_past 'a2950000-0000-4000-8000-000000000012'
+\set appt_visit 'a2950000-0000-4000-8000-000000000013'
+\set appt_delete 'a2950000-0000-4000-8000-000000000014'
+\set appt_b 'b2950000-0000-4000-8000-000000000001'
+\set appt_c 'c2950000-0000-4000-8000-000000000001'
+
+SELECT pg_temp.assert_true(to_regclass('public.tenant_reminder_policies') IS NOT NULL, 'policy table exists');
+SELECT pg_temp.assert_true(to_regclass('public.appointment_reminder_jobs') IS NOT NULL, 'job table exists');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.tenant_reminder_policies'::regclass), 'policy RLS enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointment_reminder_jobs'::regclass), 'job RLS enabled');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_reminder_jobs','INSERT'), 'authenticated cannot insert jobs');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_reminder_jobs','UPDATE'), 'authenticated cannot update jobs');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_reminder_jobs','DELETE'), 'authenticated cannot delete jobs');
+SELECT pg_temp.assert_true(has_table_privilege('authenticated','public.appointment_reminder_jobs','SELECT'), 'authenticated can select through RLS');
+
+INSERT INTO public.tenants(id,name,timezone) VALUES
+  (:'tenant_a','Reminder Clinic A','Asia/Almaty'),
+  (:'tenant_b','Reminder Clinic B','Europe/Berlin'),
+  (:'tenant_c','Reminder Clinic C','America/New_York');
+
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.tenant_reminder_policies WHERE tenant_id IN (:'tenant_a',:'tenant_b',:'tenant_c')), 'new tenants receive policies');
+SELECT pg_temp.assert_true((SELECT bool_and(NOT enabled) FROM public.tenant_reminder_policies WHERE tenant_id IN (:'tenant_a',:'tenant_b',:'tenant_c')), 'existing/new tenants disabled by default');
+
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+  (:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-owner-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-admin-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-reg-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'doctor_user_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-doc-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-cash-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'no_tenant','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-none@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'owner_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-owner-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'owner_c','00000000-0000-0000-0000-000000000000','authenticated','authenticated','rem-owner-c@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id,first_name,last_name) VALUES
+  (:'owner_a','Owner','A'),(:'admin_a','Admin','A'),(:'registrar_a','Registrar','A'),
+  (:'doctor_user_a','Doctor','A'),(:'cashier_a','Cashier','A'),(:'no_tenant','No','Tenant'),
+  (:'owner_b','Owner','B'),(:'owner_c','Owner','C');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+  (:'tenant_a',:'owner_a','clinic_owner'),(:'tenant_a',:'admin_a','clinic_admin'),
+  (:'tenant_a',:'registrar_a','registrar'),(:'tenant_a',:'doctor_user_a','doctor'),
+  (:'tenant_a',:'cashier_a','cashier'),(:'tenant_b',:'owner_b','clinic_owner'),
+  (:'tenant_c',:'owner_c','clinic_owner');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+  (:'patient_a',:'tenant_a','Reminder Patient A','+77002910001','phone','active',0),
+  (:'patient_b',:'tenant_b','Reminder Patient B','+49002910001','phone','active',0),
+  (:'patient_c',:'tenant_c','Reminder Patient C','+12022910001','phone','active',0);
+INSERT INTO public.doctors(id,tenant_id,user_id,full_name,specialization,cabinet,color,active) VALUES
+  (:'doctor_a',:'tenant_a',:'doctor_user_a','Reminder Doctor A','General','A1','#111111',true),
+  (:'doctor_b',:'tenant_b',NULL,'Reminder Doctor B','General','B1','#222222',true),
+  (:'doctor_c',:'tenant_c',NULL,'Reminder Doctor C','General','C1','#333333',true);
+
+-- All fixtures are inserted while policies are disabled; migration/insert must not create jobs.
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time) VALUES
+  (:'appt_a',:'tenant_a',:'patient_a',:'doctor_a','A1','Base','new','2026-08-10 05:00+00','2026-08-10 06:00+00'),
+  (:'appt_cancel',:'tenant_a',:'patient_a',:'doctor_a','A1','Cancel','new','2026-08-15 05:00+00','2026-08-15 06:00+00'),
+  (:'appt_noshow',:'tenant_a',:'patient_a',:'doctor_a','A1','No show','new','2026-08-16 05:00+00','2026-08-16 06:00+00'),
+  (:'appt_completed',:'tenant_a',:'patient_a',:'doctor_a','A1','Completed','completed','2026-08-17 05:00+00','2026-08-17 06:00+00'),
+  (:'appt_arrived',:'tenant_a',:'patient_a',:'doctor_a','A1','Arrived','arrived','2026-08-18 05:00+00','2026-08-18 06:00+00'),
+  (:'appt_progress',:'tenant_a',:'patient_a',:'doctor_a','A1','Progress','in_progress','2026-08-19 05:00+00','2026-08-19 06:00+00'),
+  (:'appt_blocked',:'tenant_a',NULL,:'doctor_a','A1','Blocked','blocked','2026-08-20 05:00+00','2026-08-20 06:00+00'),
+  (:'appt_past',:'tenant_a',:'patient_a',:'doctor_a','A1','Past','new','2026-06-01 05:00+00','2026-06-01 06:00+00'),
+  (:'appt_visit',:'tenant_a',:'patient_a',:'doctor_a','A1','Visit lifecycle','new','2026-08-21 05:00+00','2026-08-21 06:00+00'),
+  (:'appt_delete',:'tenant_a',:'patient_a',:'doctor_a','A1','Hard delete','new','2026-08-22 05:00+00','2026-08-22 06:00+00'),
+  (:'appt_b',:'tenant_b',:'patient_b',:'doctor_b','B1','Berlin','new','2026-08-10 08:00+00','2026-08-10 09:00+00'),
+  (:'appt_c',:'tenant_c',:'patient_c',:'doctor_c','C1','New York','new','2026-08-10 14:00+00','2026-08-10 15:00+00');
+
+INSERT INTO public.appointments(
+  id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time,
+  confirmation_state,last_confirmation_attempt_at,confirmation_attempt_count,
+  confirmation_metadata_version,last_confirmation_outcome
+) VALUES
+  (:'appt_contact',:'tenant_a',:'patient_a',:'doctor_a','A1','Contact','new','2026-08-11 05:00+00','2026-08-11 06:00+00','contact_in_progress','2026-07-01 00:00+00',1,1,'message_sent'),
+  (:'appt_unreachable',:'tenant_a',:'patient_a',:'doctor_a','A1','Unreachable','new','2026-08-13 05:00+00','2026-08-13 06:00+00','unreachable','2026-07-01 00:00+00',1,1,'unreachable'),
+  (:'appt_callback',:'tenant_a',:'patient_a',:'doctor_a','A1','Callback','new','2026-08-14 05:00+00','2026-08-14 06:00+00','callback_requested','2026-07-01 00:00+00',1,1,'callback_requested');
+
+INSERT INTO public.appointments(
+  id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time,
+  confirmation_state,confirmed_at,confirmed_by,confirmation_channel,
+  last_confirmation_attempt_at,confirmation_attempt_count,confirmation_metadata_version,
+  last_confirmation_outcome
+) VALUES
+  (:'appt_confirmed',:'tenant_a',:'patient_a',:'doctor_a','A1','Confirmed','new','2026-08-12 05:00+00','2026-08-12 06:00+00','confirmed','2026-07-01 00:00+00',:'owner_a','phone','2026-07-01 00:00+00',1,1,'confirmed');
+
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs), 'disabled policy and migration create no jobs');
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments \gset
+SELECT balance::text AS balance_before FROM public.patients WHERE id=:'patient_a' \gset
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.set_tenant_reminder_policy(:'tenant_a',true,true,false,true,'12:00',true,true,true,180);
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT public.set_tenant_reminder_policy(:'tenant_b',true,true,false,true,'12:00',true,true,true,180);
+SELECT set_config('request.jwt.claim.sub',:'owner_c',true);
+SELECT public.set_tenant_reminder_policy(:'tenant_c',true,true,false,true,'12:00',true,true,true,180);
+
+-- Owner/admin/registrar can read policy/jobs; doctor/cashier/no-tenant cannot see queue rows.
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_a','2026-07-01 00:00+00') AS first_plan \gset
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_a','2026-07-01 00:00+00') AS second_plan \gset
+SELECT pg_temp.assert_true(jsonb_array_length(:'first_plan'::jsonb->'created')=3, 'unconfirmed creates three jobs');
+SELECT pg_temp.assert_true(jsonb_array_length(:'second_plan'::jsonb->'created')=0 AND jsonb_array_length(:'second_plan'::jsonb->'reused')=3, 'repeat planning reuses exact jobs');
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a' AND appointment_id=:'appt_a'), 'repeat planner creates no duplicates');
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.audit_events WHERE tenant_id=:'tenant_a' AND action='appointment_reminder_planned' AND appointment_id=:'appt_a'::text), 'replay creates no duplicate audit');
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.activity_events WHERE tenant_id=:'tenant_a' AND type='appointment_reminder_planned' AND source_id IN (SELECT id::text FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_a')), 'activity emitted once per created job');
+
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a' AND appointment_id=:'appt_a'), 'admin reads own tenant jobs');
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a' AND appointment_id=:'appt_a'), 'registrar reads operational jobs');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_contact','2026-07-01 00:00+00') AS contact_plan \gset
+SELECT pg_temp.assert_true(jsonb_array_length(:'contact_plan'::jsonb->'created')=2, 'contact in progress suppresses repeated confirmation request by default');
+SELECT set_config('request.jwt.claim.sub',:'doctor_user_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'doctor has no reminder queue access');
+SELECT pg_temp.expect_error(format('select public.plan_appointment_reminder_jobs(%L::uuid,%L::uuid,%L::timestamptz)',:'tenant_a',:'appt_a','2026-07-01 00:00+00'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'cashier has no reminder queue access');
+SELECT set_config('request.jwt.claim.sub',:'no_tenant',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs), 'no-tenant user sees no jobs');
+SELECT pg_temp.expect_error(format('select public.plan_appointment_reminder_jobs(%L::uuid,%L::uuid,%L::timestamptz)',:'tenant_a',:'appt_a','2026-07-01 00:00+00'),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT pg_temp.expect_error(format('select public.plan_appointment_reminder_jobs(%L::uuid,%L::uuid,%L::timestamptz)',:'tenant_a',:'appt_a','2026-07-01 00:00+00'),'Недостаточно прав');
+
+-- Timezone calculations are server-side and exact.
+SELECT public.plan_appointment_reminder_jobs(:'tenant_b',:'appt_b','2026-07-01 00:00+00');
+SELECT set_config('request.jwt.claim.sub',:'owner_c',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_c',:'appt_c','2026-07-01 00:00+00');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT due_at='2026-08-09 07:00+00' FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_a' AND reminder_type='day_before_reminder'), 'Asia/Almaty local noon maps to 07:00 UTC');
+SELECT pg_temp.assert_true((SELECT due_at='2026-08-09 10:00+00' FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_b' AND reminder_type='day_before_reminder'), 'Europe/Berlin local noon maps to 10:00 UTC');
+SELECT pg_temp.assert_true((SELECT due_at='2026-08-09 16:00+00' FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_c' AND reminder_type='day_before_reminder'), 'America/New_York local noon maps to 16:00 UTC');
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_confirmed','2026-07-01 00:00+00') AS confirmed_plan \gset
+SELECT pg_temp.assert_true(jsonb_array_length(:'confirmed_plan'::jsonb->'created')=1, 'confirmed creates ordinary reminder only');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_unreachable','2026-07-01 00:00+00') AS unreachable_plan \gset
+SELECT pg_temp.assert_true(jsonb_array_length(:'unreachable_plan'::jsonb->'created')=1, 'unreachable creates control call only');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_callback','2026-07-01 00:00+00') AS callback_plan \gset
+SELECT pg_temp.assert_true((:'callback_plan'::jsonb->>'callbackDeferred')::boolean, 'callback is explicitly deferred without a callback time');
+SELECT pg_temp.assert_true(jsonb_array_length(:'callback_plan'::jsonb->'created')=0, 'callback timestamp is not invented');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_completed','2026-07-01 00:00+00');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_arrived','2026-07-01 00:00+00');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_progress','2026-07-01 00:00+00');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_blocked','2026-07-01 00:00+00');
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_past','2026-07-01 00:00+00');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs WHERE appointment_id IN (:'appt_completed',:'appt_arrived',:'appt_progress',:'appt_blocked',:'appt_past')), 'ineligible and past appointments create no jobs');
+
+-- Visit lifecycle invalidates pending reminder work without rewriting appointment status.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_visit','2026-07-01 00:00+00');
+SELECT (public.check_in_patient_visit(:'tenant_a',:'patient_a',:'appt_visit','regular','2026-08-21 04:55+00','Reminder visit lifecycle','{"smokeTest":"reminder-queue"}'::jsonb)).id AS visit_id \gset
+SELECT public.start_patient_visit(:'tenant_a',:'visit_id','{"smokeTest":"reminder-queue"}'::jsonb);
+SELECT public.complete_patient_visit(:'tenant_a',:'visit_id','{"smokeTest":"reminder-queue"}'::jsonb);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_visit' AND state='skipped' AND terminal_reason='appointment_arrived'), 'arrival skips all pending jobs');
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.audit_events WHERE action='appointment_reminder_skipped' AND appointment_id=:'appt_visit'::text), 'visit invalidation audits each actual transition once');
+DELETE FROM public.patient_visits WHERE id=:'visit_id';
+
+-- Hard delete cascades reminder jobs and leaves no orphan rows.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_delete','2026-07-01 00:00+00');
+DELETE FROM public.appointments WHERE tenant_id=:'tenant_a' AND id=:'appt_delete';
+RESET ROLE;
+SELECT pg_temp.assert_true(NOT EXISTS (SELECT 1 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_delete'), 'hard delete cascades reminder jobs');
+
+-- Reschedule atomically supersedes old plans and creates a new version-bound set.
+UPDATE public.appointments SET start_time='2026-08-10 07:00+00', end_time='2026-08-10 08:00+00' WHERE id=:'appt_a';
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_a' AND state='superseded'), 'reschedule supersedes old jobs');
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_a' AND state='scheduled'), 'reschedule creates new jobs');
+SELECT pg_temp.assert_true((SELECT count(DISTINCT appointment_updated_at)=2 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_a'), 'jobs bind to exact appointment versions');
+
+-- Completed history survives later cancellation while active jobs are cancelled.
+SELECT set_config('app.reminder_job_internal','on',true);
+UPDATE public.appointment_reminder_jobs
+SET state='completed', completed_at=now(), terminal_reason='manual_test_completion'
+WHERE id=(SELECT id FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_cancel' AND false LIMIT 1);
+SELECT set_config('app.reminder_job_internal','off',true);
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_cancel','2026-07-01 00:00+00');
+RESET ROLE;
+SELECT set_config('app.reminder_job_internal','on',true);
+UPDATE public.appointment_reminder_jobs
+SET state='completed', completed_at=now(), terminal_reason='manual_test_completion'
+WHERE id=(SELECT id FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_cancel' ORDER BY reminder_type LIMIT 1);
+SELECT set_config('app.reminder_job_internal','off',true);
+SELECT updated_at::text AS cancel_expected_updated_at FROM public.appointments WHERE id=:'appt_cancel' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.cancel_appointment(
+  :'tenant_a', :'appt_cancel', 'clinic', 'Reminder queue cancellation test',
+  :'cancel_expected_updated_at'::timestamptz, 'reminder-queue-cancel-001'
+);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_cancel' AND state='completed'), 'completed historical job preserved');
+SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_cancel' AND state='cancelled'), 'cancellation cancels remaining pending jobs');
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_noshow','2026-07-01 00:00+00');
+RESET ROLE;
+SELECT updated_at::text AS noshow_expected_updated_at FROM public.appointments WHERE id=:'appt_noshow' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.mark_appointment_no_show(
+  :'tenant_a', :'appt_noshow', 'Reminder queue no-show test',
+  :'noshow_expected_updated_at'::timestamptz, 'reminder-queue-noshow-001'
+);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)=3 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_noshow' AND state='cancelled'), 'no-show cancels pending jobs');
+
+-- Policy version changes create new plan identity only when explicitly reconciled.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.set_tenant_reminder_policy(:'tenant_a',true,true,false,true,'11:30',true,true,true,120);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_contact','2026-07-01 00:00+00');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(DISTINCT policy_version)=2 FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_contact'), 'policy change yields a new version-bound plan');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs j JOIN public.appointments a ON a.id=j.appointment_id AND a.tenant_id=j.tenant_id JOIN public.tenant_reminder_policies p ON p.tenant_id=j.tenant_id WHERE j.state IN ('scheduled','ready') AND (j.appointment_updated_at<>a.updated_at OR j.policy_version<>p.policy_version)), 'active stale jobs zero');
+
+-- Direct writes, invalid values, duplicate keys and tenant mismatches are blocked.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.expect_error(format('insert into public.appointment_reminder_jobs(tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,appointment_updated_at,policy_version,plan_key,payload_fingerprint,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L,%L,now(),%L,now(),1,%L,%L,%L::jsonb)',:'tenant_a',:'appt_a',:'patient_a','day_before_reminder','manual','scheduled',repeat('c',64),repeat('d',64),'{}'),'permission denied');
+SELECT pg_temp.expect_error(format('update public.appointment_reminder_jobs set state=%L where tenant_id=%L::uuid','completed',:'tenant_a'),'permission denied');
+RESET ROLE;
+SELECT set_config('app.reminder_job_internal','on',true);
+SELECT pg_temp.expect_error(format('insert into public.appointment_reminder_jobs(tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,appointment_updated_at,policy_version,plan_key,payload_fingerprint,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L,%L,now(),%L,now(),1,%L,%L,%L::jsonb)',:'tenant_a',:'appt_a',:'patient_a','marketing','manual','scheduled',repeat('e',64),repeat('f',64),'{}'),'appointment_reminder_jobs_type_check');
+SELECT pg_temp.expect_error(format('insert into public.appointment_reminder_jobs(tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,appointment_updated_at,policy_version,plan_key,payload_fingerprint,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L,%L,now(),%L,now(),1,%L,%L,%L::jsonb)',:'tenant_a',:'appt_a',:'patient_a','day_before_reminder','manual','sent',repeat('1',64),repeat('2',64),'{}'),'appointment_reminder_jobs_state_check');
+SELECT pg_temp.expect_error(format('insert into public.appointment_reminder_jobs(tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,appointment_updated_at,policy_version,plan_key,payload_fingerprint,metadata) values(%L::uuid,%L::uuid,%L::uuid,%L,%L,now(),%L,now(),1,%L,%L,%L::jsonb)',:'tenant_a',:'appt_a',:'patient_b','day_before_reminder','manual','scheduled',repeat('3',64),repeat('4',64),'{}'),'appointment_reminder_jobs_patient_fk');
+SELECT set_config('app.reminder_job_internal','off',true);
+
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointment_reminder_jobs GROUP BY tenant_id,plan_key HAVING count(*)>1 LIMIT 1) IS NULL, 'duplicate plan keys zero');
+SELECT pg_temp.assert_true((SELECT count(*) FROM (SELECT tenant_id,appointment_id,reminder_type,due_at,appointment_updated_at,policy_version,count(*) FROM public.appointment_reminder_jobs GROUP BY 1,2,3,4,5,6 HAVING count(*)>1) d)=0, 'duplicate logical jobs zero');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a1 JOIN public.appointments a2 ON a1.tenant_id=a2.tenant_id AND a1.id<a2.id AND a1.doctor_id=a2.doctor_id AND a1.status NOT IN ('cancelled','no_show','completed') AND a2.status NOT IN ('cancelled','no_show','completed') AND a1.start_time<a2.end_time AND a1.end_time>a2.start_time)=0, 'doctor overlaps remain zero');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments WHERE end_time<=start_time)=0, 'invalid appointment intervals zero');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.patient_visits)=:'visits_before', 'no visit side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.clinical_encounters)=:'encounters_before', 'no encounter side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.completed_services)=:'services_before', 'no completed service side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.invoices)=:'invoices_before', 'no invoice side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.payments)=:'payments_before', 'no payment side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.refunds)=:'refunds_before', 'no refund side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.financial_adjustments)=:'adjustments_before', 'no adjustment side effects');
+SELECT pg_temp.assert_true((SELECT balance::text FROM public.patients WHERE id=:'patient_a')=:'balance_before', 'patient balance unchanged');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointment_confirmation_attempts)=0, 'planner creates no confirmation attempt');
+
+ROLLBACK;
+\echo 'APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Adds a durable tenant-scoped reminder queue foundation without sending any message. Includes disabled-by-default tenant policy, version-bound manual reminder jobs, idempotent appointment planner, bounded tenant reconciliation, appointment/visit/policy lifecycle invalidation, RLS, audit/activity, tenant-scoped repository reads, full SQL and concurrency validation, local browser/database smoke, and a detailed QA report.

This pull request is published for review evidence only. A merge action is outside the scope of this task and has not been performed. Cloud Supabase was not touched. No SMS, WhatsApp, email, provider SDK, worker, cron, webhook, retry engine, template, delivery attempt, or provider state was added.

## Checks

- Local reset applies migrations 0001-0029
- SQL suites 0024-0029 passed
- Concurrency suites 0025/0026/0027/0029 passed
- 42/42 schema assertions passed
- ESLint passed
- 91 Vitest files / 1016 tests passed
- Production build passed
- HeadlessChrome/local Supabase smoke passed
- Duplicate plan keys 0; active stale jobs 0; deadlocks 0

## Limitations

- callback_requested creates no job because the current model has no explicit callback due time
- ready is derived from due_at; no background state transition exists
- Chrome DevTools MCP was unavailable; equivalent isolated HeadlessChrome was used
- Cloud Supabase remains untouched
