### PR TITLE
APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001: manual reminder queue

### DIFF
--- a/_ai_work/REPORTS/APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001_operations.md
+++ b/_ai_work/REPORTS/APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001_operations.md
@@ -1,14 +1,20 @@
-# QA Report: APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001
+# APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001
 
-- Verdict: **PASSED**
+## 1. Final verdict
+
+Final verdict: **PASS**
+
+Task verdict: **MANUAL APPOINTMENT REMINDER OPERATIONS IMPLEMENTED AND VERIFIED**
 
 ## Branch
 
 feature/appointment-reminder-manual-operations-001
 
-## Pr Url
+## PR URL
 
+https://github.com/NckNA/codex-test/pull/355
 
+The pull request is a draft, remains open and unmerged, and is explicitly protected by `DO NOT MERGE`.
 
 ## Environment
 
@@ -167,30 +173,51 @@ Implemented and verified a tenant-scoped manual reminder operations queue at /re
 - Automated delivery remains blocked until normalized contact, language, consent, suppression, and opt-out facts exist.
 - Build still emits the pre-existing large-chunk warning; it is unrelated to reminder correctness.
 
-## Ci
+## Browser smoke
 
-```json
-{
-  "status": "pending until branch is pushed and PR checks run"
-}
-```
+- admin: `no_answer`, `confirmed`, manual `message_sent`, explicit defer, skip, and history verified;
+- registrar: tenant A queue access verified;
+- clinic owner: tenant B data visible, tenant A data absent;
+- doctor and cashier: direct `/reminders` access blocked;
+- no-tenant user: blocked at clinic assignment;
+- stale optimistic conflict: safe Russian message shown without console error or failed request;
+- all final role scenarios: console errors `0`, failed requests `0`, secrets visible `false`;
+- database proof: operations `5`, confirmation attempts `3`, audit/activity `5/5`;
+- clinical and financial side effects: `0`.
 
-## Recommended Next Task
+## CI on implementation head
 
-APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001: add normalized patient contact channels, preferred language, consent provenance, suppression/opt-out records, tenant-scoped RLS and audit, without provider sending.
+- workflow: `CI`;
+- run number: `#722`;
+- run ID: `29212262930`;
+- tested commit: `b99e85bd28eac57987885d01a3294ee9d6e04b31`;
+- validate job: **success**;
+- ESLint: **success**;
+- tests: **success**;
+- build: **success**;
+- Merge guard: **expected failure**, because the draft PR is explicitly protected by `DO NOT MERGE`;
+- overall workflow conclusion: `failure` only because the merge protection worked as designed;
+- PR merge state: `BLOCKED`;
+- implementation correctness checks passed.
 
-## Implementation Head
+## Recommended next task
 
+Recommended next task: **APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001**
 
+Add normalized patient contact channels, preferred language, consent provenance, suppression/opt-out records, tenant-scoped RLS and audit, without provider sending.
 
-## Reviewed Head
+## Implementation head
 
+`b99e85bd28eac57987885d01a3294ee9d6e04b31`
 
+## Reviewed head
 
-## Final Report Update Head
+`b99e85bd28eac57987885d01a3294ee9d6e04b31`
 
+The reviewed head exactly matched CI run #722 and the locally validated implementation.
 
+## Report update commit
 
-## Latest Ci After Update
+Report update commit: N/A because a report-only commit cannot contain its own future SHA or the fresh CI result that tests it.
 
-
+The exact final report-only commit and fresh CI run are recorded in the final task response.

--- a/_ai_work/REPORTS/APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001_operations.md
+++ b/_ai_work/REPORTS/APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001_operations.md
@@ -1,0 +1,196 @@
+# QA Report: APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001
+
+- Verdict: **PASSED**
+
+## Branch
+
+feature/appointment-reminder-manual-operations-001
+
+## Pr Url
+
+
+
+## Environment
+
+local Supabase only; cloud forbidden and untouched
+
+## Summary
+
+Implemented and verified a tenant-scoped manual reminder operations queue at /reminders. Authorized clinic owners, admins, and registrars can view due work, record manual contact outcomes, confirm an appointment, defer work to an explicit tenant-local time, skip work with a reason, and review administrative history. All mutations use controlled RPCs, appointment/job optimistic versions, tenant-scoped idempotency keys, audit/activity events, and RLS. No SMS, WhatsApp, email, provider, cron, worker, webhook, cloud migration, finance, clinical, document, stock, or automatic delivery behavior was introduced.
+
+## Checks
+
+```json
+{
+  "baseline": "03d1f101d238a557a1ab4cfa2c1441f030660fbf",
+  "cloudTouched": false,
+  "npmLint": "passed",
+  "frontendTestFiles": 93,
+  "frontendTests": 1038,
+  "productionBuild": "passed",
+  "schemaAssertions": "45/45 passed",
+  "sqlRegression": "0024-0030 passed",
+  "concurrencySuites": "0025/0026/0027/0029/0030 passed",
+  "manualConcurrencyCompleted": 8,
+  "manualConcurrencySkipped": 1,
+  "manualConcurrencyDeferred": 1,
+  "manualConcurrencyAttempts": 8,
+  "manualConcurrencyReplays": 1,
+  "manualConcurrencyConflicts": 5,
+  "manualConcurrencyAudit": "10/10 activity parity",
+  "duplicateActiveJobs": 0,
+  "activeStaleJobs": 0,
+  "deadlocks": 0,
+  "browserOperations": 5,
+  "browserConfirmationAttempts": 3,
+  "browserAudit": "5/5 activity parity",
+  "browserConsoleErrors": 0,
+  "browserFailedRequests": 0,
+  "browserSecretsVisible": false,
+  "browserClinicalFinancialSideEffects": 0
+}
+```
+
+## Validation Sections
+
+```json
+{
+  "database": {
+    "migration": "0030_appointment_reminder_manual_operations.sql",
+    "operations": [
+      "complete_appointment_reminder_job",
+      "defer_appointment_reminder_job",
+      "skip_appointment_reminder_job",
+      "get_appointment_operation recovery extension"
+    ],
+    "guarantees": [
+      "direct authenticated writes to reminder jobs remain forbidden",
+      "completed/skipped/deferred actor and reason metadata are durable",
+      "manual completion can create exactly one shared confirmation attempt",
+      "same-key replay returns one logical result",
+      "different-key races produce one winner and one structured conflict",
+      "stale and concurrent optimistic conflicts return structured RPC results without HTTP errors",
+      "reschedule/cancellation/no-show and visit lifecycle invalidate active work",
+      "manual due override survives planner replay",
+      "skipped plan identity is not recreated unchanged"
+    ]
+  },
+  "frontend": {
+    "route": "/reminders",
+    "groups": [
+      "overdue",
+      "today",
+      "upcoming"
+    ],
+    "filters": [
+      "patient or phone search",
+      "bucket",
+      "reminder type",
+      "doctor",
+      "confirmation state"
+    ],
+    "actions": [
+      "record manual result",
+      "defer to explicit tenant-local time",
+      "skip with reason"
+    ],
+    "history": [
+      "actor",
+      "result",
+      "reason or note",
+      "confirmation attempt reference",
+      "original due time"
+    ],
+    "recovery": [
+      "same operation key retained after ambiguous response",
+      "operation lookup before user retry",
+      "tenant switch clears stale data and ignores late responses"
+    ]
+  },
+  "browser": {
+    "admin": [
+      "no_answer",
+      "confirmed",
+      "message_sent warning and completion",
+      "defer",
+      "skip",
+      "history"
+    ],
+    "registrar": "queue access in tenant A",
+    "owner": "tenant B queue only",
+    "doctor": "direct route blocked",
+    "cashier": "direct route blocked",
+    "noTenant": "clinic assignment block",
+    "stale": "safe stale message shown with console errors 0 and failed requests 0"
+  },
+  "sideEffects": {
+    "patientVisits": 0,
+    "clinicalEncounters": 0,
+    "completedServices": 0,
+    "invoices": 0,
+    "payments": 0,
+    "financialAdjustments": 0,
+    "providerCalls": 0,
+    "cloudApplies": 0
+  }
+}
+```
+
+## Changed Files
+- src/App.tsx
+- src/components/layout/Sidebar.tsx
+- src/data/hooks/useAppointmentReminderQueue.test.tsx
+- src/data/hooks/useAppointmentReminderQueue.ts
+- src/data/repositories/AppointmentReminderRepository.test.ts
+- src/data/repositories/AppointmentReminderRepository.ts
+- src/pages/ReminderOperationsPage.test.tsx
+- src/pages/ReminderOperationsPage.tsx
+- src/types/index.ts
+- supabase/migrations/0030_appointment_reminder_manual_operations.sql
+- supabase/tests/0030_appointment_reminder_manual_operations_concurrency.ps1
+- supabase/tests/0030_appointment_reminder_manual_operations_test.sql
+- _ai_work/REPORTS/APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001_operations.md
+
+## Roles Tested
+- clinic_admin
+- registrar
+- clinic_owner
+- doctor blocked
+- cashier blocked
+- unknown/no tenant blocked
+- cross-tenant owner isolation
+
+## Limitations
+- No SMS, WhatsApp, email, provider adapter, automatic send, worker, cron, webhook, delivery receipt, retry daemon, or cloud apply is included.
+- The queue is manual-first by design. A browser tab does not claim jobs or act as a distributed worker.
+- Callback-specific due timestamps are not invented; defer requires an explicit tenant-local time.
+- Automated delivery remains blocked until normalized contact, language, consent, suppression, and opt-out facts exist.
+- Build still emits the pre-existing large-chunk warning; it is unrelated to reminder correctness.
+
+## Ci
+
+```json
+{
+  "status": "pending until branch is pushed and PR checks run"
+}
+```
+
+## Recommended Next Task
+
+APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001: add normalized patient contact channels, preferred language, consent provenance, suppression/opt-out records, tenant-scoped RLS and audit, without provider sending.
+
+## Implementation Head
+
+
+
+## Reviewed Head
+
+
+
+## Final Report Update Head
+
+
+
+## Latest Ci After Update
+
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { useTenant } from './contexts/TenantContext';
 import { LoginPage } from './pages/LoginPage';
 import { Layout } from './components/layout/Layout';
 import { SchedulePage } from './pages/SchedulePage';
+import { ReminderOperationsPage } from './pages/ReminderOperationsPage';
 import { CrmPage } from './pages/CrmPage';
 import { AppointmentsPage } from './pages/AppointmentsPage';
 import { DocumentsPage } from './pages/DocumentsPage';
@@ -98,6 +99,7 @@ function AppContent() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<SchedulePage />} />
+          <Route path="reminders" element={<ReminderOperationsPage />} />
           <Route path="crm" element={<CrmPage />} />
           <Route path="appointments" element={<AppointmentsPage />} />
           <Route path="documents" element={<DocumentsPage />} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { clsx } from 'clsx';
 import {
   CalendarDays,
+  BellRing,
   Users,
   ClipboardList,
   FileText,
@@ -47,9 +48,13 @@ const adminNavItems = [
 
 export function Sidebar() {
   const { activeTenant } = useTenant();
+  const reminderItems = !activeTenant || ['clinic_owner', 'clinic_admin', 'registrar'].includes(activeTenant.role ?? '')
+    ? [{ to: '/reminders', icon: BellRing, label: 'Напоминания' }]
+    : [];
+  const operationalItems = [navItems[0], ...reminderItems, ...navItems.slice(1)];
   const visibleItems = canViewAdminAudit(activeTenant?.role)
-    ? [...navItems, ...adminNavItems]
-    : navItems;
+    ? [...operationalItems, ...adminNavItems]
+    : operationalItems;
 
   return (
     <aside className="w-64 bg-slate-900 text-slate-300 flex flex-col h-full overflow-y-auto shrink-0 border-r border-slate-800">

--- a/src/data/hooks/useAppointmentReminderQueue.test.tsx
+++ b/src/data/hooks/useAppointmentReminderQueue.test.tsx
@@ -1,0 +1,269 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import type { AppointmentReminderOperationResult, AppointmentReminderQueueItem } from '../../types';
+import {
+  AppointmentReminderRepositoryError,
+  createAppointmentReminderRepository,
+} from '../repositories/AppointmentReminderRepository';
+import { useAppointmentReminderQueue } from './useAppointmentReminderQueue';
+
+vi.mock('../../lib/supabaseClient', () => ({ isSupabaseConfigured: true, supabase: {} }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../repositories/AppointmentReminderRepository', async () => {
+  const actual = await vi.importActual('../repositories/AppointmentReminderRepository');
+  return { ...actual as object, createAppointmentReminderRepository: vi.fn() };
+});
+
+const tenantA = '11111111-1111-4111-8111-111111111111';
+const tenantB = '22222222-2222-4222-8222-222222222222';
+const patientId = '33333333-3333-4333-8333-333333333333';
+const appointmentId = '44444444-4444-4444-8444-444444444444';
+const jobId = '55555555-5555-4555-8555-555555555555';
+
+const makeItem = (id = jobId, tenantId = tenantA, state: 'scheduled' | 'completed' = 'scheduled'): AppointmentReminderQueueItem => ({
+  job: {
+    id,
+    tenantId,
+    appointmentId,
+    patientId,
+    reminderType: 'confirmation_request',
+    executionMode: 'manual',
+    dueAt: '2026-07-12T09:00:00+00:00',
+    originalDueAt: '2026-07-12T09:00:00+00:00',
+    state,
+    operationalState: state === 'scheduled' ? 'ready' : state,
+    appointmentUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+    policyVersion: 2,
+    planKey: 'a'.repeat(64),
+    payloadFingerprint: 'b'.repeat(64),
+    priority: 50,
+    createdAt: '2026-07-11T08:00:00+00:00',
+    updatedAt: '2026-07-11T08:00:00.123456+00:00',
+    completedAt: state === 'completed' ? '2026-07-12T10:00:00+00:00' : undefined,
+    completedBy: state === 'completed' ? 'user-a' : undefined,
+    completionOutcome: state === 'completed' ? 'no_answer' : undefined,
+    terminalReason: state === 'completed' ? 'manual_completed' : undefined,
+    metadata: {},
+  },
+  appointment: {
+    id: appointmentId,
+    patientId,
+    doctorId: 'doctor-a',
+    cabinet: 'A1',
+    service: 'Осмотр',
+    status: 'new',
+    start: '2026-07-20T10:00:00+00:00',
+    end: '2026-07-20T11:00:00+00:00',
+    confirmationState: 'unconfirmed',
+    confirmationAttemptCount: 0,
+    createdAt: '2026-07-01T09:00:00+00:00',
+    updatedAt: '2026-07-11T08:00:00.123456+00:00',
+  },
+  patient: { id: patientId, fullName: 'Пациент Тестовый', phone: '+77000000000' },
+  doctor: { id: 'doctor-a', fullName: 'Врач Тестовый', specialization: 'Терапевт', cabinet: 'A1' },
+  attemptCount: 0,
+});
+
+const makeResult = (item = makeItem(jobId, tenantA, 'completed')): AppointmentReminderOperationResult => ({
+  job: item.job,
+  appointment: item.appointment,
+  replayed: false,
+  recovered: false,
+  operationType: 'reminder_complete',
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+};
+
+const makeRepository = () => ({
+  listActiveReminderJobs: vi.fn().mockResolvedValue([makeItem()]),
+  listReminderJobHistory: vi.fn().mockResolvedValue([]),
+  listReminderJobs: vi.fn(),
+  listReminderJobsByAppointment: vi.fn(),
+  planAppointmentReminderJobs: vi.fn(),
+  reconcileTenantReminderJobs: vi.fn(),
+  completeReminderJob: vi.fn().mockResolvedValue(makeResult()),
+  deferReminderJob: vi.fn().mockResolvedValue({ ...makeResult(), operationType: 'reminder_defer' }),
+  skipReminderJob: vi.fn().mockResolvedValue({ ...makeResult(), operationType: 'reminder_skip' }),
+  getReminderOperation: vi.fn().mockResolvedValue(null),
+});
+
+describe('useAppointmentReminderQueue', () => {
+  let authState: any;
+  let tenantState: any;
+  let repository: ReturnType<typeof makeRepository>;
+  let current: ReturnType<typeof useAppointmentReminderQueue> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
+    tenantState = { activeTenant: { tenantId: tenantA, tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'registrar' } };
+    repository = makeRepository();
+    vi.mocked(useAuth).mockImplementation(() => authState);
+    vi.mocked(useTenant).mockImplementation(() => tenantState);
+    vi.mocked(createAppointmentReminderRepository).mockReturnValue(repository as any);
+  });
+
+  const mount = async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const Harness = ({ tick = 0 }: { tick?: number }) => {
+      void tick;
+      current = useAppointmentReminderQueue();
+      return null;
+    };
+    await act(async () => { root.render(<Harness />); });
+    return { root, Harness };
+  };
+
+  it('does not create a repository or fetch without a tenant', async () => {
+    tenantState = { activeTenant: null };
+    const { root } = await mount();
+    expect(createAppointmentReminderRepository).not.toHaveBeenCalled();
+    expect(current).toMatchObject({ jobs: [], history: [], loading: false });
+    await act(async () => root.unmount());
+  });
+
+  it('loads active jobs and terminal history with tenant scope', async () => {
+    const { root } = await mount();
+    expect(createAppointmentReminderRepository).toHaveBeenCalledWith({ backend: 'supabase', tenantId: tenantA });
+    expect(repository.listActiveReminderJobs).toHaveBeenCalledTimes(1);
+    expect(repository.listReminderJobHistory).toHaveBeenCalledWith(100, expect.any(String));
+    expect(current?.jobs).toHaveLength(1);
+    await act(async () => root.unmount());
+  });
+
+  it('blocks doctor access before repository creation', async () => {
+    tenantState.activeTenant.role = 'doctor';
+    const { root } = await mount();
+    expect(current?.canAccess).toBe(false);
+    expect(createAppointmentReminderRepository).not.toHaveBeenCalled();
+    expect(current?.jobs).toEqual([]);
+    await act(async () => root.unmount());
+  });
+
+  it('clears the old queue on tenant switch and ignores stale responses', async () => {
+    const activeA = deferred<AppointmentReminderQueueItem[]>();
+    const historyA = deferred<AppointmentReminderQueueItem[]>();
+    const activeB = deferred<AppointmentReminderQueueItem[]>();
+    const historyB = deferred<AppointmentReminderQueueItem[]>();
+    const repoA = { ...makeRepository(), listActiveReminderJobs: vi.fn(() => activeA.promise), listReminderJobHistory: vi.fn(() => historyA.promise) };
+    const repoB = { ...makeRepository(), listActiveReminderJobs: vi.fn(() => activeB.promise), listReminderJobHistory: vi.fn(() => historyB.promise) };
+    vi.mocked(createAppointmentReminderRepository).mockImplementation(({ tenantId }) => (tenantId === tenantA ? repoA : repoB) as any);
+    const { root, Harness } = await mount();
+
+    tenantState = { activeTenant: { tenantId: tenantB, tenantName: 'Clinic B', timezone: 'Asia/Almaty', role: 'registrar' } };
+    await act(async () => { root.render(<Harness tick={1} />); });
+    expect(current?.jobs).toEqual([]);
+
+    await act(async () => { activeA.resolve([makeItem('old', tenantA)]); historyA.resolve([]); });
+    expect(current?.jobs).toEqual([]);
+    await act(async () => { activeB.resolve([makeItem('new', tenantB)]); historyB.resolve([]); });
+    expect(current?.jobs[0].job.id).toBe('new');
+    await act(async () => root.unmount());
+  });
+
+  it('blocks duplicate and mutually exclusive actions for the same job', async () => {
+    const pending = deferred<AppointmentReminderOperationResult>();
+    repository.completeReminderJob.mockImplementation(() => pending.promise);
+    const { root } = await mount();
+    const item = current!.jobs[0];
+    let first!: Promise<AppointmentReminderOperationResult>;
+    await act(async () => { first = current!.completeJob({ item, channel: 'phone', outcome: 'no_answer' }); });
+
+    await expect(current!.completeJob({ item, channel: 'phone', outcome: 'no_answer' }))
+      .rejects.toMatchObject({ code: 'concurrent' });
+    await expect(current!.deferJob({ item, newDueAt: '2026-07-15T09:00:00+00:00', reason: 'Позже' }))
+      .rejects.toMatchObject({ code: 'concurrent' });
+    expect(repository.completeReminderJob).toHaveBeenCalledTimes(1);
+    expect(repository.deferReminderJob).not.toHaveBeenCalled();
+
+    repository.listActiveReminderJobs.mockResolvedValueOnce([]);
+    repository.listReminderJobHistory.mockResolvedValueOnce([makeItem(jobId, tenantA, 'completed')]);
+    await act(async () => { pending.resolve(makeResult()); await first; });
+    await act(async () => root.unmount());
+  });
+
+  it('retains the operation key after an ambiguous failure and reuses it on retry', async () => {
+    repository.completeReminderJob
+      .mockRejectedValueOnce(new AppointmentReminderRepositoryError('operation_failed', 'Не удалось сохранить действие. Обновите очередь и проверьте результат.'))
+      .mockResolvedValueOnce(makeResult());
+    repository.getReminderOperation.mockResolvedValueOnce(null);
+    const { root } = await mount();
+    const item = current!.jobs[0];
+
+    await act(async () => {
+      await expect(current!.completeJob({ item, channel: 'phone', outcome: 'no_answer' })).rejects.toMatchObject({ code: 'operation_failed' });
+    });
+    const firstKey = repository.completeReminderJob.mock.calls[0][0].operationKey;
+    repository.listActiveReminderJobs.mockResolvedValueOnce([]);
+    repository.listReminderJobHistory.mockResolvedValueOnce([makeItem(jobId, tenantA, 'completed')]);
+    await act(async () => { await current!.completeJob({ item, channel: 'phone', outcome: 'no_answer' }); });
+    const secondKey = repository.completeReminderJob.mock.calls[1][0].operationKey;
+    expect(secondKey).toBe(firstKey);
+    await act(async () => root.unmount());
+  });
+
+  it('clears the operation key after a definitive domain failure', async () => {
+    repository.skipReminderJob
+      .mockRejectedValueOnce(new AppointmentReminderRepositoryError('stale', 'Задача устарела из-за изменения записи. Обновите очередь.'))
+      .mockResolvedValueOnce({ ...makeResult(), operationType: 'reminder_skip' });
+    const { root } = await mount();
+    const item = current!.jobs[0];
+
+    await act(async () => {
+      await expect(current!.skipJob({ item, reason: 'Причина' })).rejects.toMatchObject({ code: 'stale' });
+    });
+    const firstKey = repository.skipReminderJob.mock.calls[0][0].operationKey;
+    repository.listActiveReminderJobs.mockResolvedValueOnce([]);
+    repository.listReminderJobHistory.mockResolvedValueOnce([makeItem(jobId, tenantA, 'completed')]);
+    await act(async () => { await current!.skipJob({ item, reason: 'Причина' }); });
+    const secondKey = repository.skipReminderJob.mock.calls[1][0].operationKey;
+    expect(secondKey).not.toBe(firstKey);
+    await act(async () => root.unmount());
+  });
+
+  it('recovers a committed ambiguous action and refreshes active/history once', async () => {
+    repository.completeReminderJob.mockRejectedValueOnce(
+      new AppointmentReminderRepositoryError('operation_failed', 'Не удалось сохранить действие. Обновите очередь и проверьте результат.'),
+    );
+    repository.getReminderOperation.mockResolvedValueOnce({ ...makeResult(), replayed: true, recovered: true });
+    repository.listActiveReminderJobs.mockResolvedValueOnce([makeItem()]).mockResolvedValueOnce([]);
+    repository.listReminderJobHistory.mockResolvedValueOnce([]).mockResolvedValueOnce([makeItem(jobId, tenantA, 'completed')]);
+    const { root } = await mount();
+    const item = current!.jobs[0];
+
+    await act(async () => { await current!.completeJob({ item, channel: 'phone', outcome: 'no_answer' }); });
+    expect(repository.getReminderOperation).toHaveBeenCalledTimes(1);
+    expect(repository.listActiveReminderJobs).toHaveBeenCalledTimes(2);
+    expect(repository.listReminderJobHistory).toHaveBeenCalledTimes(2);
+    expect(current?.jobs).toEqual([]);
+    expect(current?.history[0].job.state).toBe('completed');
+    await act(async () => root.unmount());
+  });
+
+  it('surfaces safe action errors while keeping queue data available', async () => {
+    repository.deferReminderJob.mockRejectedValueOnce(
+      new AppointmentReminderRepositoryError('invalid_time', 'Новое время должно быть позже текущего момента и раньше записи.'),
+    );
+    const { root } = await mount();
+    const item = current!.jobs[0];
+    await act(async () => {
+      await expect(current!.deferJob({ item, newDueAt: '2026-07-15T09:00:00+00:00', reason: 'Позже' })).rejects.toMatchObject({ code: 'invalid_time' });
+    });
+    expect(current?.error).toBe('Новое время должно быть позже текущего момента и раньше записи.');
+    expect(current?.jobs).toHaveLength(1);
+    await act(async () => root.unmount());
+  });
+});

--- a/src/data/hooks/useAppointmentReminderQueue.ts
+++ b/src/data/hooks/useAppointmentReminderQueue.ts
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import type {
+  AppointmentContactChannel,
+  AppointmentContactOutcome,
+  AppointmentReminderOperationResult,
+  AppointmentReminderQueueItem,
+} from '../../types';
+import {
+  AppointmentReminderRepositoryError,
+  createAppointmentReminderRepository,
+  type AppointmentReminderRepository,
+} from '../repositories/AppointmentReminderRepository';
+
+const ACCESS_ROLES = new Set(['clinic_owner', 'clinic_admin', 'registrar']);
+const ACTION_FAILED = 'Не удалось сохранить действие. Обновите очередь и проверьте результат.';
+
+type ManualAction = 'complete' | 'defer' | 'skip';
+
+const createOperationKey = (action: ManualAction, jobId: string): string => {
+  const random = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `reminder-${action}-${jobId}-${random}`;
+};
+
+const isDefinitiveFailure = (error: unknown): boolean => (
+  error instanceof AppointmentReminderRepositoryError
+  && error.code !== 'operation_failed'
+);
+
+export interface CompleteReminderActionInput {
+  item: AppointmentReminderQueueItem;
+  channel: AppointmentContactChannel;
+  outcome: AppointmentContactOutcome;
+  note?: string;
+}
+
+export interface DeferReminderActionInput {
+  item: AppointmentReminderQueueItem;
+  newDueAt: string;
+  reason: string;
+}
+
+export interface SkipReminderActionInput {
+  item: AppointmentReminderQueueItem;
+  reason: string;
+}
+
+export interface UseAppointmentReminderQueueResult {
+  jobs: AppointmentReminderQueueItem[];
+  history: AppointmentReminderQueueItem[];
+  loading: boolean;
+  error: string | null;
+  completingJobId: string | null;
+  deferringJobId: string | null;
+  skippingJobId: string | null;
+  reconcilingOperation: boolean;
+  canAccess: boolean;
+  refresh: () => Promise<void>;
+  completeJob: (input: CompleteReminderActionInput) => Promise<AppointmentReminderOperationResult>;
+  deferJob: (input: DeferReminderActionInput) => Promise<AppointmentReminderOperationResult>;
+  skipJob: (input: SkipReminderActionInput) => Promise<AppointmentReminderOperationResult>;
+  clearError: () => void;
+}
+
+export function useAppointmentReminderQueue(): UseAppointmentReminderQueueResult {
+  const { authMode, user } = useAuth();
+  const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const role = activeTenant?.role;
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
+  const canAccess = authMode === 'dev' || ACCESS_ROLES.has(role ?? '');
+
+  const repository = useMemo<AppointmentReminderRepository | null>(() => {
+    if (!canAccess) return null;
+    if (authMode === 'dev') {
+      return createAppointmentReminderRepository({ backend: 'local' });
+    }
+    if (isSupabaseMode && user?.id && tenantId) {
+      return createAppointmentReminderRepository({ backend: 'supabase', tenantId });
+    }
+    return null;
+  }, [authMode, canAccess, isSupabaseMode, tenantId, user?.id]);
+
+  const [jobs, setJobs] = useState<AppointmentReminderQueueItem[]>([]);
+  const [history, setHistory] = useState<AppointmentReminderQueueItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [completingJobId, setCompletingJobId] = useState<string | null>(null);
+  const [deferringJobId, setDeferringJobId] = useState<string | null>(null);
+  const [skippingJobId, setSkippingJobId] = useState<string | null>(null);
+  const [reconcilingOperation, setReconcilingOperation] = useState(false);
+  const requestSequence = useRef(0);
+  const busyJobs = useRef(new Set<string>());
+  const operationKeys = useRef(new Map<string, string>());
+
+  const loadQueue = useCallback(async (clearPrevious = false): Promise<void> => {
+    const sequence = ++requestSequence.current;
+    if (clearPrevious) {
+      setJobs([]);
+      setHistory([]);
+      setError(null);
+      setCompletingJobId(null);
+      setDeferringJobId(null);
+      setSkippingJobId(null);
+      setReconcilingOperation(false);
+    }
+    if (!repository || !tenantId || !canAccess) {
+      setJobs([]);
+      setHistory([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const referenceTime = new Date().toISOString();
+      const [nextJobs, nextHistory] = await Promise.all([
+        repository.listActiveReminderJobs(referenceTime),
+        repository.listReminderJobHistory(100, referenceTime),
+      ]);
+      if (sequence !== requestSequence.current) return;
+      setJobs(nextJobs);
+      setHistory(nextHistory);
+    } catch (cause) {
+      if (sequence !== requestSequence.current) return;
+      setJobs([]);
+      setHistory([]);
+      setError(cause instanceof Error ? cause.message : 'Не удалось загрузить очередь напоминаний.');
+    } finally {
+      if (sequence === requestSequence.current) setLoading(false);
+    }
+  }, [canAccess, repository, tenantId]);
+
+  useEffect(() => {
+    const scheduledSequence = ++requestSequence.current;
+    busyJobs.current.clear();
+    operationKeys.current.clear();
+    void Promise.resolve().then(() => {
+      if (scheduledSequence !== requestSequence.current) return;
+      return loadQueue(true);
+    });
+  }, [loadQueue, tenantId]);
+
+  const finishSuccess = useCallback(async (
+    result: AppointmentReminderOperationResult,
+  ): Promise<AppointmentReminderOperationResult> => {
+    setJobs((current) => current.filter((item) => item.job.id !== result.job.id));
+    await loadQueue();
+    return result;
+  }, [loadQueue]);
+
+  const runAction = useCallback(async (
+    action: ManualAction,
+    item: AppointmentReminderQueueItem,
+    execute: (repositoryValue: AppointmentReminderRepository, key: string) => Promise<AppointmentReminderOperationResult>,
+  ): Promise<AppointmentReminderOperationResult> => {
+    if (!repository || !tenantId || !canAccess) {
+      throw new AppointmentReminderRepositoryError(
+        'permission',
+        'Недостаточно прав для работы с очередью напоминаний.',
+      );
+    }
+    const jobId = item.job.id;
+    if (busyJobs.current.has(jobId)) {
+      throw new AppointmentReminderRepositoryError(
+        'concurrent',
+        'Задача была изменена другим пользователем. Обновите очередь.',
+      );
+    }
+
+    const keySlot = `${tenantId}:${action}:${jobId}`;
+    const operationKey = operationKeys.current.get(keySlot) ?? createOperationKey(action, jobId);
+    operationKeys.current.set(keySlot, operationKey);
+    busyJobs.current.add(jobId);
+    setError(null);
+    if (action === 'complete') setCompletingJobId(jobId);
+    if (action === 'defer') setDeferringJobId(jobId);
+    if (action === 'skip') setSkippingJobId(jobId);
+
+    try {
+      const result = await execute(repository, operationKey);
+      operationKeys.current.delete(keySlot);
+      return await finishSuccess(result);
+    } catch (cause) {
+      if (isDefinitiveFailure(cause)) {
+        operationKeys.current.delete(keySlot);
+        const message = cause instanceof Error ? cause.message : ACTION_FAILED;
+        setError(message);
+        throw cause;
+      }
+
+      setReconcilingOperation(true);
+      try {
+        const recovered = await repository.getReminderOperation(operationKey);
+        if (recovered) {
+          operationKeys.current.delete(keySlot);
+          return await finishSuccess(recovered);
+        }
+      } catch {
+        // Keep the same key. The next user retry must reconcile the same logical operation.
+      } finally {
+        setReconcilingOperation(false);
+      }
+
+      const ambiguousError = cause instanceof AppointmentReminderRepositoryError
+        ? cause
+        : new AppointmentReminderRepositoryError('operation_failed', ACTION_FAILED);
+      setError(ambiguousError.message);
+      throw ambiguousError;
+    } finally {
+      busyJobs.current.delete(jobId);
+      if (action === 'complete') setCompletingJobId(null);
+      if (action === 'defer') setDeferringJobId(null);
+      if (action === 'skip') setSkippingJobId(null);
+    }
+  }, [canAccess, finishSuccess, repository, tenantId]);
+
+  const completeJob = useCallback((input: CompleteReminderActionInput) => runAction(
+    'complete',
+    input.item,
+    (repositoryValue, operationKey) => repositoryValue.completeReminderJob({
+      jobId: input.item.job.id,
+      channel: input.channel,
+      outcome: input.outcome,
+      note: input.note,
+      expectedJobUpdatedAt: input.item.job.updatedAt,
+      expectedAppointmentUpdatedAt: input.item.appointment.updatedAt ?? input.item.job.appointmentUpdatedAt,
+      operationKey,
+    }),
+  ), [runAction]);
+
+  const deferJob = useCallback((input: DeferReminderActionInput) => runAction(
+    'defer',
+    input.item,
+    (repositoryValue, operationKey) => repositoryValue.deferReminderJob({
+      jobId: input.item.job.id,
+      newDueAt: input.newDueAt,
+      reason: input.reason,
+      expectedJobUpdatedAt: input.item.job.updatedAt,
+      expectedAppointmentUpdatedAt: input.item.appointment.updatedAt ?? input.item.job.appointmentUpdatedAt,
+      operationKey,
+    }),
+  ), [runAction]);
+
+  const skipJob = useCallback((input: SkipReminderActionInput) => runAction(
+    'skip',
+    input.item,
+    (repositoryValue, operationKey) => repositoryValue.skipReminderJob({
+      jobId: input.item.job.id,
+      reason: input.reason,
+      expectedJobUpdatedAt: input.item.job.updatedAt,
+      expectedAppointmentUpdatedAt: input.item.appointment.updatedAt ?? input.item.job.appointmentUpdatedAt,
+      operationKey,
+    }),
+  ), [runAction]);
+
+  return {
+    jobs,
+    history,
+    loading,
+    error,
+    completingJobId,
+    deferringJobId,
+    skippingJobId,
+    reconcilingOperation,
+    canAccess,
+    refresh: loadQueue,
+    completeJob,
+    deferJob,
+    skipJob,
+    clearError: () => setError(null),
+  };
+}

--- a/src/data/repositories/AppointmentReminderRepository.test.ts
+++ b/src/data/repositories/AppointmentReminderRepository.test.ts
@@ -154,10 +154,166 @@ describe('AppointmentReminderRepository', () => {
     expect(rpc).not.toHaveBeenCalled();
   });
 
+  it('maps manual operation metadata and preserves exact plan identity', () => {
+    const mapped = mapAppointmentReminderJob(row({
+      original_due_at: '2026-07-11T09:00:00+00:00',
+      completed_by: '55555555-5555-4555-8555-555555555555',
+      completion_outcome: 'no_answer',
+      completion_note: 'Не ответил',
+      confirmation_attempt_id: '66666666-6666-4666-8666-666666666666',
+      deferred_at: '2026-07-11T10:00:00+00:00',
+      deferred_by: '55555555-5555-4555-8555-555555555555',
+      defer_reason: 'Позже',
+      operation_key: 'reminder-complete-test-001',
+      operation_fingerprint: 'c'.repeat(64),
+      last_manual_action_at: '2026-07-12T09:00:00+00:00',
+    }), now);
+    expect(mapped).toMatchObject({
+      originalDueAt: '2026-07-11T09:00:00+00:00',
+      completedBy: '55555555-5555-4555-8555-555555555555',
+      completionOutcome: 'no_answer',
+      confirmationAttemptId: '66666666-6666-4666-8666-666666666666',
+      deferReason: 'Позже',
+      operationKey: 'reminder-complete-test-001',
+    });
+  });
+
+  it('uses only controlled RPCs for complete, defer and skip and preserves operation keys', async () => {
+    const appointmentRow = {
+      id: appointmentId,
+      tenant_id: tenantId,
+      patient_id: patientId,
+      doctor_id: '77777777-7777-4777-8777-777777777777',
+      cabinet: 'A1', service: 'Consultation', status: 'new',
+      start_time: '2026-07-20T10:00:00+00:00', end_time: '2026-07-20T11:00:00+00:00',
+      created_at: '2026-07-01T00:00:00+00:00', updated_at: '2026-07-11T08:00:00.123456+00:00',
+      confirmation_state: 'contact_in_progress', confirmation_attempt_count: 1,
+    };
+    const result = (operationType: string, jobOverrides: Record<string, unknown> = {}) => ({
+      job: row(jobOverrides),
+      appointment: appointmentRow,
+      confirmationAttempt: operationType === 'reminder_complete' ? {
+        id: '88888888-8888-4888-8888-888888888888', tenant_id: tenantId,
+        appointment_id: appointmentId, patient_id: patientId,
+        actor_user_id: '99999999-9999-4999-8999-999999999999',
+        channel: 'phone', outcome: 'no_answer', attempted_at: now, created_at: now,
+      } : null,
+      replayed: false, recovered: false, operationType,
+    });
+    const rpc = vi.fn()
+      .mockResolvedValueOnce({ data: result('reminder_complete', { state: 'completed', completed_at: now, completed_by: patientId, completion_outcome: 'no_answer', terminal_reason: 'manual_completed' }), error: null })
+      .mockResolvedValueOnce({ data: result('reminder_defer', { due_at: '2026-07-15T09:00:00+00:00', deferred_at: now, deferred_by: patientId, defer_reason: 'Позже' }), error: null })
+      .mockResolvedValueOnce({ data: result('reminder_skip', { state: 'skipped', skipped_at: now, skipped_by: patientId, terminal_reason: 'Не требуется' }), error: null });
+    const repository = new SupabaseAppointmentReminderRepository(
+      tenantId,
+      { rpc, from: vi.fn() } as unknown as SupabaseClient,
+    );
+
+    await repository.completeReminderJob({
+      jobId: row().id as string,
+      channel: 'phone', outcome: 'no_answer', note: '  Не ответил  ',
+      expectedJobUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      expectedAppointmentUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      operationKey: 'complete-key-001',
+    });
+    await repository.deferReminderJob({
+      jobId: row().id as string,
+      newDueAt: '2026-07-15T09:00:00+00:00', reason: '  Позже  ',
+      expectedJobUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      expectedAppointmentUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      operationKey: 'defer-key-001',
+    });
+    await repository.skipReminderJob({
+      jobId: row().id as string,
+      reason: '  Не требуется  ',
+      expectedJobUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      expectedAppointmentUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      operationKey: 'skip-key-001',
+    });
+
+    expect(rpc).toHaveBeenNthCalledWith(1, 'complete_appointment_reminder_job', expect.objectContaining({
+      p_tenant_id: tenantId, p_operation_key: 'complete-key-001', p_note: 'Не ответил',
+    }));
+    expect(rpc).toHaveBeenNthCalledWith(2, 'defer_appointment_reminder_job', expect.objectContaining({
+      p_tenant_id: tenantId, p_operation_key: 'defer-key-001', p_reason: 'Позже',
+    }));
+    expect(rpc).toHaveBeenNthCalledWith(3, 'skip_appointment_reminder_job', expect.objectContaining({
+      p_tenant_id: tenantId, p_operation_key: 'skip-key-001', p_reason: 'Не требуется',
+    }));
+  });
+
+  it('maps a structured optimistic conflict result without relying on an HTTP error', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        errorCode: 'stale',
+        errorMessage: 'Задача устарела из-за изменения записи. Обновите очередь.',
+      },
+      error: null,
+    });
+    const repository = new SupabaseAppointmentReminderRepository(
+      tenantId,
+      { rpc, from: vi.fn() } as unknown as SupabaseClient,
+    );
+
+    await expect(repository.completeReminderJob({
+      jobId: row().id as string,
+      channel: 'phone',
+      outcome: 'no_answer',
+      expectedJobUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      expectedAppointmentUpdatedAt: '2026-07-11T08:00:00.123456+00:00',
+      operationKey: 'structured-stale-001',
+    })).rejects.toMatchObject({
+      code: 'stale',
+      message: 'Задача устарела из-за изменения записи. Обновите очередь.',
+    });
+  });
+
+  it('recovers a committed reminder operation by the same tenant-scoped key', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        found: true,
+        operationType: 'reminder_skip',
+        reminderJob: row({ state: 'skipped', skipped_at: now, skipped_by: patientId, terminal_reason: 'Причина' }),
+        appointment: {
+          id: appointmentId, patient_id: patientId, doctor_id: '77777777-7777-4777-8777-777777777777',
+          cabinet: 'A1', service: 'Consultation', status: 'new',
+          start_time: '2026-07-20T10:00:00+00:00', end_time: '2026-07-20T11:00:00+00:00',
+          created_at: now, updated_at: now,
+        },
+        confirmationAttempt: null,
+        replayed: true,
+        recovered: true,
+      },
+      error: null,
+    });
+    const repository = new SupabaseAppointmentReminderRepository(
+      tenantId,
+      { rpc, from: vi.fn() } as unknown as SupabaseClient,
+    );
+    const recovered = await repository.getReminderOperation('skip-key-001');
+    expect(rpc).toHaveBeenCalledWith('get_appointment_operation', {
+      p_tenant_id: tenantId,
+      p_operation_key: 'skip-key-001',
+    });
+    expect(recovered).toMatchObject({ replayed: true, recovered: true, operationType: 'reminder_skip' });
+  });
+
+  it('maps all manual-operation domain failures without exposing database details', () => {
+    expect(toSafeAppointmentReminderError({ message: 'Задача устарела из-за изменения записи.' }, 'complete')).toMatchObject({ code: 'stale' });
+    expect(toSafeAppointmentReminderError({ code: '55000', message: 'garbled', hint: 'reminder_stale' }, 'complete')).toMatchObject({ code: 'stale' });
+    expect(toSafeAppointmentReminderError({ message: 'Задача уже завершена.' }, 'complete')).toMatchObject({ code: 'already_completed' });
+    expect(toSafeAppointmentReminderError({ message: 'Эта задача больше не доступна.' }, 'skip')).toMatchObject({ code: 'terminal' });
+    expect(toSafeAppointmentReminderError({ message: 'Укажите причину.' }, 'defer')).toMatchObject({ code: 'reason_required' });
+    expect(toSafeAppointmentReminderError({ message: 'Задача была изменена другим пользователем.' }, 'skip')).toMatchObject({ code: 'concurrent' });
+    expect(toSafeAppointmentReminderError({ code: '55000', message: 'garbled', hint: 'reminder_concurrent' }, 'skip')).toMatchObject({ code: 'concurrent' });
+    expect(toSafeAppointmentReminderError({ message: '23505 secret constraint' }, 'complete'))
+      .toEqual(new AppointmentReminderRepositoryError('idempotency_conflict', 'Эта операция уже выполнена с другими параметрами.'));
+  });
+
   it('contains no direct insert or update path for reminder jobs', () => {
     expect(repositorySource).not.toMatch(/\.insert\s*\(/);
     expect(repositorySource).not.toMatch(/\.update\s*\(/);
     expect(repositorySource).not.toMatch(/service[_-]?role/i);
-    expect(repositorySource).not.toMatch(/sms|whatsapp|email|provider_message_id|delivered/i);
+    expect(repositorySource).not.toMatch(/provider_message_id|delivered|send_sms|send_whatsapp|send_email/i);
   });
 });

--- a/src/data/repositories/AppointmentReminderRepository.ts
+++ b/src/data/repositories/AppointmentReminderRepository.ts
@@ -1,163 +1,91 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '../../lib/supabaseClient';
+import { isOffsetAwareInstant } from '../../domain/timezone';
 import type {
+  Appointment,
+  AppointmentConfirmationAttempt,
+  AppointmentContactChannel,
+  AppointmentContactOutcome,
   AppointmentReminderJob,
   AppointmentReminderJobState,
+  AppointmentReminderOperationResult,
   AppointmentReminderPlanResult,
+  AppointmentReminderQueueItem,
+  AppointmentReminderType,
+  CompleteAppointmentReminderJobInput,
+  DeferAppointmentReminderJobInput,
+  Doctor,
+  Patient,
+  SkipAppointmentReminderJobInput,
   TenantReminderReconcileResult,
 } from '../../types';
-import { isOffsetAwareInstant } from '../../domain/timezone';
-import { supabase } from '../../lib/supabaseClient';
 
 export type AppointmentReminderRepositoryBackend = 'local' | 'supabase';
-
-export interface AppointmentReminderListOptions {
-  appointmentId?: string;
-  includeTerminal?: boolean;
-  referenceTime?: string;
-}
-
-export interface IAppointmentReminderRepository {
-  listReminderJobs(options?: AppointmentReminderListOptions): Promise<AppointmentReminderJob[]>;
-  listReminderJobsByAppointment(appointmentId: string, includeTerminal?: boolean): Promise<AppointmentReminderJob[]>;
-  planAppointmentReminderJobs(appointmentId: string, referenceTime?: string): Promise<AppointmentReminderPlanResult>;
-  reconcileTenantReminderJobs(from: string, to: string, limit: number, referenceTime?: string): Promise<TenantReminderReconcileResult>;
-}
-
-export interface CreateAppointmentReminderRepositoryOptions {
-  tenantId?: string | null;
-  backend: AppointmentReminderRepositoryBackend;
-}
-
-export type AppointmentReminderRepositoryErrorCode =
-  | 'tenant_required'
+export type AppointmentReminderErrorCode =
+  | 'read_failed'
   | 'permission'
   | 'invalid_time'
-  | 'read_failed'
-  | 'plan_failed'
-  | 'reconcile_failed';
+  | 'stale'
+  | 'already_completed'
+  | 'terminal'
+  | 'reason_required'
+  | 'concurrent'
+  | 'idempotency_conflict'
+  | 'operation_failed';
+export type AppointmentReminderErrorContext = 'read' | 'plan' | 'complete' | 'defer' | 'skip' | 'recover';
 
 export class AppointmentReminderRepositoryError extends Error {
-  readonly code: AppointmentReminderRepositoryErrorCode;
+  readonly code: AppointmentReminderErrorCode;
 
-  constructor(code: AppointmentReminderRepositoryErrorCode, message: string) {
+  constructor(code: AppointmentReminderErrorCode, message: string) {
     super(message);
     this.name = 'AppointmentReminderRepositoryError';
     this.code = code;
   }
 }
 
-const TERMINAL_STATES = new Set<AppointmentReminderJobState>(['completed', 'cancelled', 'superseded', 'skipped']);
+export interface AppointmentReminderRepository {
+  listReminderJobs(includeTerminal?: boolean, referenceTime?: string): Promise<AppointmentReminderJob[]>;
+  listReminderJobsByAppointment(
+    appointmentId: string,
+    includeTerminal?: boolean,
+    referenceTime?: string,
+  ): Promise<AppointmentReminderJob[]>;
+  listActiveReminderJobs(referenceTime?: string): Promise<AppointmentReminderQueueItem[]>;
+  listReminderJobHistory(limit?: number, referenceTime?: string): Promise<AppointmentReminderQueueItem[]>;
+  planAppointmentReminderJobs(appointmentId: string, referenceTime?: string): Promise<AppointmentReminderPlanResult>;
+  reconcileTenantReminderJobs(
+    from: string,
+    to: string,
+    limit?: number,
+    referenceTime?: string,
+  ): Promise<TenantReminderReconcileResult>;
+  completeReminderJob(input: CompleteAppointmentReminderJobInput): Promise<AppointmentReminderOperationResult>;
+  deferReminderJob(input: DeferAppointmentReminderJobInput): Promise<AppointmentReminderOperationResult>;
+  skipReminderJob(input: SkipAppointmentReminderJobInput): Promise<AppointmentReminderOperationResult>;
+  getReminderOperation(operationKey: string): Promise<AppointmentReminderOperationResult | null>;
+}
 
-const errorText = (error: unknown): string => {
-  if (!error) return '';
-  if (error instanceof Error) return error.message.toLowerCase();
-  if (typeof error !== 'object') return String(error).toLowerCase();
-  const candidate = error as { message?: unknown; details?: unknown; hint?: unknown; code?: unknown };
-  return [candidate.message, candidate.details, candidate.hint, candidate.code]
-    .filter((part): part is string => typeof part === 'string')
-    .join(' ')
-    .toLowerCase();
-};
+export interface CreateAppointmentReminderRepositoryOptions {
+  backend: AppointmentReminderRepositoryBackend;
+  tenantId?: string | null;
+}
 
-export const toSafeAppointmentReminderError = (
-  error: unknown,
-  fallback: 'read' | 'plan' | 'reconcile',
-): AppointmentReminderRepositoryError => {
-  if (error instanceof AppointmentReminderRepositoryError) return error;
-  const text = errorText(error);
-  if (text.includes('недостаточно прав') || text.includes('permission denied') || text.includes('42501')) {
-    return new AppointmentReminderRepositoryError('permission', 'Недостаточно прав для работы с очередью напоминаний.');
-  }
-  if (text.includes('контрольное время') || text.includes('ограниченный период') || text.includes('часовой пояс')) {
-    return new AppointmentReminderRepositoryError('invalid_time', 'Не удалось обработать период или время напоминания.');
-  }
-  if (fallback === 'read') {
-    return new AppointmentReminderRepositoryError('read_failed', 'Не удалось загрузить очередь напоминаний.');
-  }
-  if (fallback === 'reconcile') {
-    return new AppointmentReminderRepositoryError('reconcile_failed', 'Не удалось выполнить сверку очереди напоминаний.');
-  }
-  return new AppointmentReminderRepositoryError('plan_failed', 'Не удалось спланировать напоминания для записи.');
-};
+type Row = Record<string, unknown>;
 
-const requireInstant = (value: string, label: string): string => {
-  if (!isOffsetAwareInstant(value)) {
-    throw new AppointmentReminderRepositoryError('invalid_time', `Некорректное время: ${label}.`);
-  }
-  return value;
-};
-
-const asObject = (value: unknown): Record<string, unknown> => (
-  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
-);
-
-const asNumber = (value: unknown): number => Number(value ?? 0);
-
-export const mapAppointmentReminderJob = (
-  row: Record<string, unknown>,
-  referenceTime = new Date().toISOString(),
-): AppointmentReminderJob => {
-  const dueAt = requireInstant(String(row.due_at ?? row.dueAt ?? ''), 'due_at');
-  const appointmentUpdatedAt = requireInstant(
-    String(row.appointment_updated_at ?? row.appointmentUpdatedAt ?? ''),
-    'appointment_updated_at',
-  );
-  const createdAt = requireInstant(String(row.created_at ?? row.createdAt ?? ''), 'created_at');
-  const updatedAt = requireInstant(String(row.updated_at ?? row.updatedAt ?? ''), 'updated_at');
-  const state = String(row.state ?? 'scheduled') as AppointmentReminderJobState;
-  const explicitOperational = row.operationalState ?? row.operational_state;
-  const operationalState = explicitOperational
-    ? String(explicitOperational) as AppointmentReminderJobState
-    : state === 'scheduled' && new Date(dueAt).getTime() <= new Date(referenceTime).getTime()
-      ? 'ready'
-      : state;
-
-  return {
-    id: String(row.id),
-    tenantId: String(row.tenant_id ?? row.tenantId),
-    appointmentId: String(row.appointment_id ?? row.appointmentId),
-    patientId: String(row.patient_id ?? row.patientId),
-    reminderType: String(row.reminder_type ?? row.reminderType) as AppointmentReminderJob['reminderType'],
-    executionMode: String(row.execution_mode ?? row.executionMode ?? 'manual') as AppointmentReminderJob['executionMode'],
-    dueAt,
-    state,
-    operationalState,
-    appointmentUpdatedAt,
-    policyVersion: asNumber(row.policy_version ?? row.policyVersion),
-    planKey: String(row.plan_key ?? row.planKey),
-    payloadFingerprint: String(row.payload_fingerprint ?? row.payloadFingerprint),
-    priority: asNumber(row.priority),
-    createdBy: (row.created_by ?? row.createdBy) ? String(row.created_by ?? row.createdBy) : undefined,
-    createdAt,
-    updatedAt,
-    supersededAt: row.superseded_at || row.supersededAt
-      ? requireInstant(String(row.superseded_at ?? row.supersededAt), 'superseded_at')
-      : undefined,
-    cancelledAt: row.cancelled_at || row.cancelledAt
-      ? requireInstant(String(row.cancelled_at ?? row.cancelledAt), 'cancelled_at')
-      : undefined,
-    skippedAt: row.skipped_at || row.skippedAt
-      ? requireInstant(String(row.skipped_at ?? row.skippedAt), 'skipped_at')
-      : undefined,
-    completedAt: row.completed_at || row.completedAt
-      ? requireInstant(String(row.completed_at ?? row.completedAt), 'completed_at')
-      : undefined,
-    terminalReason: (row.terminal_reason ?? row.terminalReason)
-      ? String(row.terminal_reason ?? row.terminalReason)
-      : undefined,
-    metadata: asObject(row.metadata),
-  };
-};
-
-export const compareReminderJobs = (left: AppointmentReminderJob, right: AppointmentReminderJob): number => {
-  const leftReady = left.operationalState === 'ready' ? 0 : 1;
-  const rightReady = right.operationalState === 'ready' ? 0 : 1;
-  if (leftReady !== rightReady) return leftReady - rightReady;
-  const byDue = new Date(left.dueAt).getTime() - new Date(right.dueAt).getTime();
-  if (byDue !== 0) return byDue;
-  if (left.priority !== right.priority) return left.priority - right.priority;
-  const byCreated = new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
-  return byCreated !== 0 ? byCreated : left.id.localeCompare(right.id);
+const ACTIVE_STATES: AppointmentReminderJobState[] = ['scheduled', 'ready'];
+const TERMINAL_STATES: AppointmentReminderJobState[] = ['completed', 'skipped', 'cancelled', 'superseded'];
+const SAFE_MESSAGES: Record<AppointmentReminderErrorCode, string> = {
+  read_failed: 'Не удалось загрузить очередь напоминаний.',
+  permission: 'Недостаточно прав для работы с очередью напоминаний.',
+  invalid_time: 'Новое время должно быть позже текущего момента и раньше записи.',
+  stale: 'Задача устарела из-за изменения записи. Обновите очередь.',
+  already_completed: 'Задача уже завершена.',
+  terminal: 'Эта задача больше не доступна для выполнения.',
+  reason_required: 'Укажите причину.',
+  concurrent: 'Задача была изменена другим пользователем. Обновите очередь.',
+  idempotency_conflict: 'Эта операция уже выполнена с другими параметрами.',
+  operation_failed: 'Не удалось сохранить действие. Обновите очередь и проверьте результат.',
 };
 
 const emptyPlan = (): AppointmentReminderPlanResult => ({
@@ -167,27 +95,254 @@ const emptyPlan = (): AppointmentReminderPlanResult => ({
   cancelled: [],
   skipped: [],
   desired: [],
-  appointmentVersion: new Date(0).toISOString(),
+  appointmentVersion: '',
   policyVersion: 0,
   policyEnabled: false,
   callbackDeferred: false,
 });
 
-export const LocalAppointmentReminderRepository: IAppointmentReminderRepository = {
-  listReminderJobs: async () => [],
-  listReminderJobsByAppointment: async () => [],
-  planAppointmentReminderJobs: async () => emptyPlan(),
-  reconcileTenantReminderJobs: async () => ({
-    processed: 0,
-    created: 0,
-    reused: 0,
-    superseded: 0,
-    cancelled: 0,
-    skipped: 0,
-  }),
+const optionalText = (value: unknown): string | undefined => (
+  typeof value === 'string' && value.length > 0 ? value : undefined
+);
+
+const optionalNumber = (value: unknown): number | undefined => (
+  typeof value === 'number' ? value : undefined
+);
+
+export const mapAppointmentReminderJob = (
+  row: Row,
+  referenceTime = new Date().toISOString(),
+): AppointmentReminderJob => {
+  const state = row.state as AppointmentReminderJobState;
+  const dueAt = String(row.due_at ?? row.dueAt ?? '');
+  const ready = state === 'scheduled' && Date.parse(dueAt) <= Date.parse(referenceTime);
+  return {
+    id: String(row.id),
+    tenantId: String(row.tenant_id ?? row.tenantId),
+    appointmentId: String(row.appointment_id ?? row.appointmentId),
+    patientId: String(row.patient_id ?? row.patientId),
+    reminderType: (row.reminder_type ?? row.reminderType) as AppointmentReminderType,
+    executionMode: 'manual',
+    dueAt,
+    originalDueAt: String(row.original_due_at ?? row.originalDueAt ?? dueAt),
+    state,
+    operationalState: ready ? 'ready' : state,
+    appointmentUpdatedAt: String(row.appointment_updated_at ?? row.appointmentUpdatedAt),
+    policyVersion: Number(row.policy_version ?? row.policyVersion ?? 0),
+    planKey: String(row.plan_key ?? row.planKey),
+    payloadFingerprint: String(row.payload_fingerprint ?? row.payloadFingerprint),
+    priority: Number(row.priority ?? 100),
+    createdBy: optionalText(row.created_by ?? row.createdBy),
+    createdAt: String(row.created_at ?? row.createdAt),
+    updatedAt: String(row.updated_at ?? row.updatedAt),
+    supersededAt: optionalText(row.superseded_at ?? row.supersededAt),
+    cancelledAt: optionalText(row.cancelled_at ?? row.cancelledAt),
+    skippedAt: optionalText(row.skipped_at ?? row.skippedAt),
+    completedAt: optionalText(row.completed_at ?? row.completedAt),
+    completedBy: optionalText(row.completed_by ?? row.completedBy),
+    completionOutcome: optionalText(row.completion_outcome ?? row.completionOutcome) as AppointmentContactOutcome | undefined,
+    completionNote: optionalText(row.completion_note ?? row.completionNote),
+    confirmationAttemptId: optionalText(row.confirmation_attempt_id ?? row.confirmationAttemptId),
+    deferredAt: optionalText(row.deferred_at ?? row.deferredAt),
+    deferredBy: optionalText(row.deferred_by ?? row.deferredBy),
+    deferReason: optionalText(row.defer_reason ?? row.deferReason),
+    skippedBy: optionalText(row.skipped_by ?? row.skippedBy),
+    operationKey: optionalText(row.operation_key ?? row.operationKey),
+    operationFingerprint: optionalText(row.operation_fingerprint ?? row.operationFingerprint),
+    lastManualActionAt: optionalText(row.last_manual_action_at ?? row.lastManualActionAt),
+    terminalReason: optionalText(row.terminal_reason ?? row.terminalReason),
+    metadata: ((row.metadata as Record<string, unknown> | null) ?? {}),
+  };
 };
 
-export class SupabaseAppointmentReminderRepository implements IAppointmentReminderRepository {
+export const compareReminderJobs = (left: AppointmentReminderJob, right: AppointmentReminderJob): number => {
+  const leftActiveRank = left.operationalState === 'ready' ? 0 : 1;
+  const rightActiveRank = right.operationalState === 'ready' ? 0 : 1;
+  if (leftActiveRank !== rightActiveRank) return leftActiveRank - rightActiveRank;
+  const dueDifference = Date.parse(left.dueAt) - Date.parse(right.dueAt);
+  if (dueDifference !== 0) return dueDifference;
+  if (left.priority !== right.priority) return left.priority - right.priority;
+  const createdDifference = Date.parse(left.createdAt) - Date.parse(right.createdAt);
+  if (createdDifference !== 0) return createdDifference;
+  return left.id.localeCompare(right.id);
+};
+
+const terminalMoment = (job: AppointmentReminderJob): number => Date.parse(
+  job.completedAt
+  ?? job.skippedAt
+  ?? job.cancelledAt
+  ?? job.supersededAt
+  ?? job.updatedAt,
+);
+
+const mapAppointment = (row: Row): Appointment => ({
+  id: String(row.id),
+  patientId: optionalText(row.patient_id ?? row.patientId),
+  doctorId: String(row.doctor_id ?? row.doctorId),
+  cabinet: String(row.cabinet ?? ''),
+  service: String(row.service ?? ''),
+  start: String(row.start_time ?? row.start),
+  end: String(row.end_time ?? row.end),
+  status: row.status as Appointment['status'],
+  paymentType: optionalText(row.payment_type ?? row.paymentType) as Appointment['paymentType'],
+  source: optionalText(row.source) as Appointment['source'],
+  comment: optionalText(row.comment),
+  price: optionalNumber(row.price),
+  cancelledAt: optionalText(row.cancelled_at ?? row.cancelledAt),
+  cancelledBy: optionalText(row.cancelled_by ?? row.cancelledBy),
+  cancellationSource: optionalText(row.cancellation_source ?? row.cancellationSource) as Appointment['cancellationSource'],
+  cancellationReason: optionalText(row.cancellation_reason ?? row.cancellationReason),
+  noShowAt: optionalText(row.no_show_at ?? row.noShowAt),
+  noShowBy: optionalText(row.no_show_by ?? row.noShowBy),
+  noShowReason: optionalText(row.no_show_reason ?? row.noShowReason),
+  lifecycleMetadataVersion: optionalNumber(row.lifecycle_metadata_version ?? row.lifecycleMetadataVersion),
+  confirmationState: optionalText(row.confirmation_state ?? row.confirmationState) as Appointment['confirmationState'],
+  confirmedAt: optionalText(row.confirmed_at ?? row.confirmedAt),
+  confirmedBy: optionalText(row.confirmed_by ?? row.confirmedBy),
+  confirmationChannel: optionalText(row.confirmation_channel ?? row.confirmationChannel) as AppointmentContactChannel | undefined,
+  confirmationNote: optionalText(row.confirmation_note ?? row.confirmationNote),
+  lastConfirmationAttemptAt: optionalText(row.last_confirmation_attempt_at ?? row.lastConfirmationAttemptAt),
+  confirmationAttemptCount: optionalNumber(row.confirmation_attempt_count ?? row.confirmationAttemptCount),
+  confirmationMetadataVersion: optionalNumber(row.confirmation_metadata_version ?? row.confirmationMetadataVersion),
+  lastConfirmationOutcome: optionalText(row.last_confirmation_outcome ?? row.lastConfirmationOutcome) as AppointmentContactOutcome | undefined,
+  lastConfirmationNote: optionalText(row.last_confirmation_note ?? row.lastConfirmationNote),
+  createdAt: String(row.created_at ?? row.createdAt),
+  updatedAt: optionalText(row.updated_at ?? row.updatedAt),
+});
+
+const mapAttempt = (row: Row): AppointmentConfirmationAttempt => ({
+  id: String(row.id),
+  tenantId: String(row.tenant_id ?? row.tenantId),
+  appointmentId: optionalText(row.appointment_id ?? row.appointmentId),
+  patientId: String(row.patient_id ?? row.patientId),
+  actorUserId: String(row.actor_user_id ?? row.actorUserId),
+  channel: (row.channel as AppointmentContactChannel),
+  outcome: (row.outcome as AppointmentContactOutcome),
+  note: optionalText(row.note),
+  attemptedAt: String(row.attempted_at ?? row.attemptedAt),
+  operationKey: optionalText(row.operation_key ?? row.operationKey),
+  createdAt: String(row.created_at ?? row.createdAt),
+});
+
+const mapPatient = (row: Row): Pick<Patient, 'id' | 'fullName' | 'phone'> => ({
+  id: String(row.id),
+  fullName: String(row.full_name ?? row.fullName ?? ''),
+  phone: String(row.phone ?? ''),
+});
+
+const mapDoctor = (row: Row): Pick<Doctor, 'id' | 'fullName' | 'specialization' | 'cabinet'> => ({
+  id: String(row.id),
+  fullName: String(row.full_name ?? row.fullName ?? ''),
+  specialization: String(row.specialization ?? ''),
+  cabinet: String(row.cabinet ?? ''),
+});
+
+const assertOffsetAware = (value: string | undefined, context: AppointmentReminderErrorContext): void => {
+  if (value && !isOffsetAwareInstant(value)) {
+    throw new AppointmentReminderRepositoryError(
+      'invalid_time',
+      context === 'read' ? SAFE_MESSAGES.read_failed : SAFE_MESSAGES.invalid_time,
+    );
+  }
+};
+
+export const toSafeAppointmentReminderError = (
+  error: unknown,
+  context: AppointmentReminderErrorContext,
+): AppointmentReminderRepositoryError => {
+  if (error instanceof AppointmentReminderRepositoryError) return error;
+  const errorRecord = typeof error === 'object' && error !== null
+    ? error as Record<string, unknown>
+    : {};
+  const message = error instanceof Error
+    ? error.message
+    : 'message' in errorRecord
+      ? String(errorRecord.message ?? '')
+      : String(error ?? '');
+  const code = String(errorRecord.code ?? '');
+  const hint = String(errorRecord.hint ?? '');
+  const details = String(errorRecord.details ?? '');
+  const normalized = `${message} ${code} ${hint} ${details}`.toLowerCase();
+
+  if (normalized.includes('недостаточно прав') || normalized.includes('permission denied') || normalized.includes('42501')) {
+    return new AppointmentReminderRepositoryError('permission', SAFE_MESSAGES.permission);
+  }
+  if (
+    normalized.includes('reminder_stale')
+    || normalized.includes('устарела из-за изменения')
+    || normalized.includes('задача устарела')
+  ) {
+    return new AppointmentReminderRepositoryError('stale', SAFE_MESSAGES.stale);
+  }
+  if (normalized.includes('задача уже завершена')) {
+    return new AppointmentReminderRepositoryError('already_completed', SAFE_MESSAGES.already_completed);
+  }
+  if (normalized.includes('больше не доступна') || normalized.includes('текущий статус записи')) {
+    return new AppointmentReminderRepositoryError('terminal', SAFE_MESSAGES.terminal);
+  }
+  if (normalized.includes('укажите причину')) {
+    return new AppointmentReminderRepositoryError('reason_required', SAFE_MESSAGES.reason_required);
+  }
+  if (
+    normalized.includes('reminder_concurrent')
+    || normalized.includes('изменена другим пользователем')
+  ) {
+    return new AppointmentReminderRepositoryError('concurrent', SAFE_MESSAGES.concurrent);
+  }
+  if (normalized.includes('другими параметрами') || normalized.includes('23505')) {
+    return new AppointmentReminderRepositoryError('idempotency_conflict', SAFE_MESSAGES.idempotency_conflict);
+  }
+  if (
+    normalized.includes('новое время')
+    || normalized.includes('часовой пояс')
+    || normalized.includes('ещё не наступила')
+  ) {
+    return new AppointmentReminderRepositoryError('invalid_time', SAFE_MESSAGES.invalid_time);
+  }
+  return new AppointmentReminderRepositoryError(
+    context === 'read' ? 'read_failed' : 'operation_failed',
+    context === 'read' ? SAFE_MESSAGES.read_failed : SAFE_MESSAGES.operation_failed,
+  );
+};
+
+const mapPlanResult = (data: unknown, referenceTime: string): AppointmentReminderPlanResult => {
+  const value = (data ?? {}) as Record<string, unknown>;
+  const mapRows = (key: string): AppointmentReminderJob[] => (
+    Array.isArray(value[key]) ? (value[key] as Row[]).map((row) => mapAppointmentReminderJob(row, referenceTime)) : []
+  );
+  return {
+    created: mapRows('created'),
+    reused: mapRows('reused'),
+    superseded: mapRows('superseded'),
+    cancelled: mapRows('cancelled'),
+    skipped: mapRows('skipped'),
+    desired: Array.isArray(value.desired) ? value.desired as Array<Record<string, unknown>> : [],
+    appointmentVersion: String(value.appointmentVersion ?? ''),
+    policyVersion: Number(value.policyVersion ?? 0),
+    policyEnabled: Boolean(value.policyEnabled),
+    callbackDeferred: Boolean(value.callbackDeferred),
+  };
+};
+
+const mapOperationResult = (data: unknown, referenceTime: string): AppointmentReminderOperationResult => {
+  const value = (data ?? {}) as Record<string, unknown>;
+  const jobRow = (value.job ?? value.reminderJob) as Row | undefined;
+  const appointmentRow = value.appointment as Row | undefined;
+  if (!jobRow || !appointmentRow) {
+    throw new AppointmentReminderRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed);
+  }
+  const attemptRow = value.confirmationAttempt as Row | null | undefined;
+  return {
+    job: mapAppointmentReminderJob(jobRow, referenceTime),
+    appointment: mapAppointment(appointmentRow),
+    confirmationAttempt: attemptRow ? mapAttempt(attemptRow) : undefined,
+    replayed: Boolean(value.replayed),
+    recovered: Boolean(value.recovered),
+    operationType: value.operationType as AppointmentReminderOperationResult['operationType'],
+  };
+};
+
+export class SupabaseAppointmentReminderRepository implements AppointmentReminderRepository {
   private readonly tenantId: string;
   private readonly client: SupabaseClient;
 
@@ -196,42 +351,77 @@ export class SupabaseAppointmentReminderRepository implements IAppointmentRemind
     this.client = client;
   }
 
-  async listReminderJobs(options: AppointmentReminderListOptions = {}): Promise<AppointmentReminderJob[]> {
-    const referenceTime = options.referenceTime ?? new Date().toISOString();
-    requireInstant(referenceTime, 'reference_time');
-
-    let query = this.client
-      .from('appointment_reminder_jobs')
-      .select('*')
-      .eq('tenant_id', this.tenantId);
-
-    if (options.appointmentId) query = query.eq('appointment_id', options.appointmentId);
-    if (!options.includeTerminal) {
-      query = query.in('state', ['scheduled', 'ready']);
+  async listReminderJobs(includeTerminal = false, referenceTime = new Date().toISOString()): Promise<AppointmentReminderJob[]> {
+    assertOffsetAware(referenceTime, 'read');
+    try {
+      let query = this.client
+        .from('appointment_reminder_jobs')
+        .select('*')
+        .eq('tenant_id', this.tenantId);
+      query = includeTerminal
+        ? query.in('state', TERMINAL_STATES)
+        : query.in('state', ACTIVE_STATES);
+      const { data, error } = await query
+        .order('due_at', { ascending: true })
+        .order('priority', { ascending: true })
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true });
+      if (error) throw error;
+      const jobs = ((data ?? []) as Row[]).map((row) => mapAppointmentReminderJob(row, referenceTime));
+      return includeTerminal
+        ? jobs.sort((left, right) => terminalMoment(right) - terminalMoment(left) || left.id.localeCompare(right.id))
+        : jobs.sort(compareReminderJobs);
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, 'read');
     }
-
-    const { data, error } = await query
-      .order('due_at', { ascending: true })
-      .order('priority', { ascending: true })
-      .order('created_at', { ascending: true })
-      .order('id', { ascending: true });
-
-    if (error) throw toSafeAppointmentReminderError(error, 'read');
-    return (data || [])
-      .map((row) => mapAppointmentReminderJob(row as Record<string, unknown>, referenceTime))
-      .filter((job) => options.includeTerminal || !TERMINAL_STATES.has(job.state))
-      .sort(compareReminderJobs);
   }
 
-  listReminderJobsByAppointment(appointmentId: string, includeTerminal = true): Promise<AppointmentReminderJob[]> {
-    return this.listReminderJobs({ appointmentId, includeTerminal });
+  async listReminderJobsByAppointment(
+    appointmentId: string,
+    includeTerminal = false,
+    referenceTime = new Date().toISOString(),
+  ): Promise<AppointmentReminderJob[]> {
+    assertOffsetAware(referenceTime, 'read');
+    try {
+      let query = this.client
+        .from('appointment_reminder_jobs')
+        .select('*')
+        .eq('tenant_id', this.tenantId)
+        .eq('appointment_id', appointmentId);
+      query = includeTerminal
+        ? query.in('state', TERMINAL_STATES)
+        : query.in('state', ACTIVE_STATES);
+      const { data, error } = await query
+        .order('due_at', { ascending: true })
+        .order('priority', { ascending: true })
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true });
+      if (error) throw error;
+      return ((data ?? []) as Row[])
+        .map((row) => mapAppointmentReminderJob(row, referenceTime))
+        .sort(includeTerminal
+          ? (left, right) => terminalMoment(right) - terminalMoment(left) || left.id.localeCompare(right.id)
+          : compareReminderJobs);
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, 'read');
+    }
+  }
+
+  async listActiveReminderJobs(referenceTime = new Date().toISOString()): Promise<AppointmentReminderQueueItem[]> {
+    const jobs = await this.listReminderJobs(false, referenceTime);
+    return this.enrichJobs(jobs);
+  }
+
+  async listReminderJobHistory(limit = 100, referenceTime = new Date().toISOString()): Promise<AppointmentReminderQueueItem[]> {
+    const jobs = (await this.listReminderJobs(true, referenceTime)).slice(0, Math.max(1, Math.min(limit, 500)));
+    return this.enrichJobs(jobs);
   }
 
   async planAppointmentReminderJobs(
     appointmentId: string,
     referenceTime = new Date().toISOString(),
   ): Promise<AppointmentReminderPlanResult> {
-    requireInstant(referenceTime, 'reference_time');
+    assertOffsetAware(referenceTime, 'plan');
     try {
       const { data, error } = await this.client.rpc('plan_appointment_reminder_jobs', {
         p_tenant_id: this.tenantId,
@@ -239,7 +429,7 @@ export class SupabaseAppointmentReminderRepository implements IAppointmentRemind
         p_reference_time: referenceTime,
       });
       if (error) throw error;
-      return this.mapPlanResult(data, referenceTime);
+      return mapPlanResult(data, referenceTime);
     } catch (error) {
       throw toSafeAppointmentReminderError(error, 'plan');
     }
@@ -248,12 +438,12 @@ export class SupabaseAppointmentReminderRepository implements IAppointmentRemind
   async reconcileTenantReminderJobs(
     from: string,
     to: string,
-    limit: number,
+    limit = 100,
     referenceTime = new Date().toISOString(),
   ): Promise<TenantReminderReconcileResult> {
-    requireInstant(from, 'from');
-    requireInstant(to, 'to');
-    requireInstant(referenceTime, 'reference_time');
+    assertOffsetAware(from, 'plan');
+    assertOffsetAware(to, 'plan');
+    assertOffsetAware(referenceTime, 'plan');
     try {
       const { data, error } = await this.client.rpc('reconcile_tenant_appointment_reminders', {
         p_tenant_id: this.tenantId,
@@ -263,51 +453,191 @@ export class SupabaseAppointmentReminderRepository implements IAppointmentRemind
         p_reference_time: referenceTime,
       });
       if (error) throw error;
-      const payload = asObject(data);
-      return {
-        processed: asNumber(payload.processed),
-        created: asNumber(payload.created),
-        reused: asNumber(payload.reused),
-        superseded: asNumber(payload.superseded),
-        cancelled: asNumber(payload.cancelled),
-        skipped: asNumber(payload.skipped),
-      };
+      return data as TenantReminderReconcileResult;
     } catch (error) {
-      throw toSafeAppointmentReminderError(error, 'reconcile');
+      throw toSafeAppointmentReminderError(error, 'plan');
     }
   }
 
-  private mapPlanResult(data: unknown, referenceTime: string): AppointmentReminderPlanResult {
-    const payload = asObject(data);
-    const mapRows = (value: unknown): AppointmentReminderJob[] => (
-      Array.isArray(value)
-        ? value.map((row) => mapAppointmentReminderJob(asObject(row), referenceTime))
-        : []
-    );
-    const appointmentVersion = String(payload.appointmentVersion ?? payload.appointment_version ?? '');
-    if (appointmentVersion) requireInstant(appointmentVersion, 'appointment_version');
+  async completeReminderJob(input: CompleteAppointmentReminderJobInput): Promise<AppointmentReminderOperationResult> {
+    return this.runOperation('complete_appointment_reminder_job', {
+      p_tenant_id: this.tenantId,
+      p_job_id: input.jobId,
+      p_channel: input.channel,
+      p_outcome: input.outcome,
+      p_note: input.note?.trim() || null,
+      p_expected_job_updated_at: input.expectedJobUpdatedAt,
+      p_expected_appointment_updated_at: input.expectedAppointmentUpdatedAt,
+      p_operation_key: input.operationKey,
+    }, 'complete', input.expectedJobUpdatedAt);
+  }
 
-    return {
-      created: mapRows(payload.created),
-      reused: mapRows(payload.reused),
-      superseded: mapRows(payload.superseded),
-      cancelled: mapRows(payload.cancelled),
-      skipped: mapRows(payload.skipped),
-      desired: Array.isArray(payload.desired) ? payload.desired.map(asObject) : [],
-      appointmentVersion,
-      policyVersion: asNumber(payload.policyVersion ?? payload.policy_version),
-      policyEnabled: payload.policyEnabled === true || payload.policy_enabled === true,
-      callbackDeferred: payload.callbackDeferred === true || payload.callback_deferred === true,
-    };
+  async deferReminderJob(input: DeferAppointmentReminderJobInput): Promise<AppointmentReminderOperationResult> {
+    assertOffsetAware(input.newDueAt, 'defer');
+    return this.runOperation('defer_appointment_reminder_job', {
+      p_tenant_id: this.tenantId,
+      p_job_id: input.jobId,
+      p_new_due_at: input.newDueAt,
+      p_reason: input.reason.trim(),
+      p_expected_job_updated_at: input.expectedJobUpdatedAt,
+      p_expected_appointment_updated_at: input.expectedAppointmentUpdatedAt,
+      p_operation_key: input.operationKey,
+    }, 'defer', input.expectedJobUpdatedAt);
+  }
+
+  async skipReminderJob(input: SkipAppointmentReminderJobInput): Promise<AppointmentReminderOperationResult> {
+    return this.runOperation('skip_appointment_reminder_job', {
+      p_tenant_id: this.tenantId,
+      p_job_id: input.jobId,
+      p_reason: input.reason.trim(),
+      p_expected_job_updated_at: input.expectedJobUpdatedAt,
+      p_expected_appointment_updated_at: input.expectedAppointmentUpdatedAt,
+      p_operation_key: input.operationKey,
+    }, 'skip', input.expectedJobUpdatedAt);
+  }
+
+  async getReminderOperation(operationKey: string): Promise<AppointmentReminderOperationResult | null> {
+    try {
+      const { data, error } = await this.client.rpc('get_appointment_operation', {
+        p_tenant_id: this.tenantId,
+        p_operation_key: operationKey,
+      });
+      if (error) throw error;
+      const value = (data ?? {}) as Record<string, unknown>;
+      if (!value.found || !value.reminderJob) return null;
+      return mapOperationResult(value, new Date().toISOString());
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, 'recover');
+    }
+  }
+
+  private async runOperation(
+    rpcName: string,
+    args: Record<string, unknown>,
+    context: 'complete' | 'defer' | 'skip',
+    referenceTime: string,
+  ): Promise<AppointmentReminderOperationResult> {
+    assertOffsetAware(String(args.p_expected_job_updated_at ?? ''), context);
+    assertOffsetAware(String(args.p_expected_appointment_updated_at ?? ''), context);
+    try {
+      const { data, error } = await this.client.rpc(rpcName, args);
+      if (error) throw error;
+      const operationResult = (data ?? {}) as Record<string, unknown>;
+      const operationErrorCode = String(operationResult.errorCode ?? '');
+      if (operationErrorCode) {
+        throw toSafeAppointmentReminderError({
+          code: '55000',
+          hint: `reminder_${operationErrorCode}`,
+          message: String(operationResult.errorMessage ?? ''),
+        }, context);
+      }
+      return mapOperationResult(data, referenceTime);
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, context);
+    }
+  }
+
+  private async enrichJobs(jobs: AppointmentReminderJob[]): Promise<AppointmentReminderQueueItem[]> {
+    if (jobs.length === 0) return [];
+    const appointmentIds = [...new Set(jobs.map((job) => job.appointmentId))];
+    const patientIds = [...new Set(jobs.map((job) => job.patientId))];
+
+    try {
+      const [{ data: appointmentRows, error: appointmentError }, { data: patientRows, error: patientError }] = await Promise.all([
+        this.client
+          .from('appointments')
+          .select('*')
+          .eq('tenant_id', this.tenantId)
+          .in('id', appointmentIds),
+        this.client
+          .from('patients')
+          .select('id, full_name, phone')
+          .eq('tenant_id', this.tenantId)
+          .in('id', patientIds),
+      ]);
+      if (appointmentError) throw appointmentError;
+      if (patientError) throw patientError;
+
+      const appointments = ((appointmentRows ?? []) as Row[]).map(mapAppointment);
+      const doctorIds = [...new Set(appointments.map((appointment) => appointment.doctorId))];
+      const [{ data: doctorRows, error: doctorError }, { data: attemptRows, error: attemptError }] = await Promise.all([
+        this.client
+          .from('doctors')
+          .select('id, full_name, specialization, cabinet')
+          .eq('tenant_id', this.tenantId)
+          .in('id', doctorIds),
+        this.client
+          .from('appointment_confirmation_attempts')
+          .select('*')
+          .eq('tenant_id', this.tenantId)
+          .in('appointment_id', appointmentIds)
+          .order('attempted_at', { ascending: false })
+          .order('id', { ascending: true }),
+      ]);
+      if (doctorError) throw doctorError;
+      if (attemptError) throw attemptError;
+
+      const appointmentMap = new Map(appointments.map((appointment) => [appointment.id, appointment]));
+      const patientMap = new Map(((patientRows ?? []) as Row[]).map(mapPatient).map((patient) => [patient.id, patient]));
+      const doctorMap = new Map(((doctorRows ?? []) as Row[]).map(mapDoctor).map((doctor) => [doctor.id, doctor]));
+      const attempts = ((attemptRows ?? []) as Row[]).map(mapAttempt);
+      const lastAttemptMap = new Map<string, AppointmentConfirmationAttempt>();
+      for (const attempt of attempts) {
+        if (attempt.appointmentId && !lastAttemptMap.has(attempt.appointmentId)) {
+          lastAttemptMap.set(attempt.appointmentId, attempt);
+        }
+      }
+
+      return jobs.flatMap((job) => {
+        const appointment = appointmentMap.get(job.appointmentId);
+        const patient = patientMap.get(job.patientId);
+        const doctor = appointment ? doctorMap.get(appointment.doctorId) : undefined;
+        if (!appointment || !patient || !doctor) return [];
+        return [{
+          job,
+          appointment,
+          patient,
+          doctor,
+          attemptCount: appointment.confirmationAttemptCount ?? 0,
+          lastAttempt: lastAttemptMap.get(appointment.id),
+        }];
+      });
+    } catch (error) {
+      throw toSafeAppointmentReminderError(error, 'read');
+    }
   }
 }
 
+export const LocalAppointmentReminderRepository: AppointmentReminderRepository = {
+  async listReminderJobs() { return []; },
+  async listReminderJobsByAppointment() { return []; },
+  async listActiveReminderJobs() { return []; },
+  async listReminderJobHistory() { return []; },
+  async planAppointmentReminderJobs() { return emptyPlan(); },
+  async reconcileTenantReminderJobs() {
+    return { processed: 0, created: 0, reused: 0, superseded: 0, cancelled: 0, skipped: 0 };
+  },
+  async completeReminderJob() {
+    throw new AppointmentReminderRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed);
+  },
+  async deferReminderJob() {
+    throw new AppointmentReminderRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed);
+  },
+  async skipReminderJob() {
+    throw new AppointmentReminderRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed);
+  },
+  async getReminderOperation() { return null; },
+};
+
 export function createAppointmentReminderRepository(
   options: CreateAppointmentReminderRepositoryOptions,
-): IAppointmentReminderRepository {
+): AppointmentReminderRepository {
   if (options.backend === 'local') return LocalAppointmentReminderRepository;
-  if (!options.tenantId || !supabase) {
-    throw new AppointmentReminderRepositoryError('tenant_required', 'Клиника не выбрана.');
+  if (!options.tenantId) {
+    throw new AppointmentReminderRepositoryError('permission', 'Клиника не выбрана.');
   }
-  return new SupabaseAppointmentReminderRepository(options.tenantId, supabase as SupabaseClient);
+  if (!supabase) {
+    throw new AppointmentReminderRepositoryError('read_failed', SAFE_MESSAGES.read_failed);
+  }
+  return new SupabaseAppointmentReminderRepository(options.tenantId, supabase);
 }

--- a/src/pages/ReminderOperationsPage.test.tsx
+++ b/src/pages/ReminderOperationsPage.test.tsx
@@ -1,0 +1,311 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTenant } from '../contexts/TenantContext';
+import { useAppointmentReminderQueue } from '../data/hooks/useAppointmentReminderQueue';
+import type { AppointmentReminderQueueItem } from '../types';
+import { ReminderOperationsPage } from './ReminderOperationsPage';
+
+vi.mock('../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../data/hooks/useAppointmentReminderQueue', () => ({ useAppointmentReminderQueue: vi.fn() }));
+
+const makeItem = (
+  id: string,
+  dueAt: string,
+  options: Partial<{
+    patientName: string;
+    phone: string;
+    doctorId: string;
+    doctorName: string;
+    reminderType: AppointmentReminderQueueItem['job']['reminderType'];
+    confirmationState: NonNullable<AppointmentReminderQueueItem['appointment']['confirmationState']>;
+    terminal: boolean;
+  }> = {},
+): AppointmentReminderQueueItem => ({
+  job: {
+    id,
+    tenantId: 'tenant-a',
+    appointmentId: `appointment-${id}`,
+    patientId: `patient-${id}`,
+    reminderType: options.reminderType ?? 'confirmation_request',
+    executionMode: 'manual',
+    dueAt,
+    originalDueAt: dueAt,
+    state: options.terminal ? 'completed' : 'scheduled',
+    operationalState: options.terminal ? 'completed' : (Date.parse(dueAt) <= Date.parse('2026-07-13T05:00:00+00:00') ? 'ready' : 'scheduled'),
+    appointmentUpdatedAt: '2026-07-12T08:00:00.123456+00:00',
+    policyVersion: 2,
+    planKey: id.padEnd(64, 'a').slice(0, 64),
+    payloadFingerprint: id.padEnd(64, 'b').slice(0, 64),
+    priority: 50,
+    createdAt: '2026-07-12T08:00:00+00:00',
+    updatedAt: '2026-07-12T08:00:00.123456+00:00',
+    completedAt: options.terminal ? '2026-07-13T05:30:00+00:00' : undefined,
+    completedBy: options.terminal ? 'staff-a' : undefined,
+    completionOutcome: options.terminal ? 'no_answer' : undefined,
+    completionNote: options.terminal ? 'Не ответил' : undefined,
+    confirmationAttemptId: options.terminal ? 'attempt-a' : undefined,
+    terminalReason: options.terminal ? 'manual_completed' : undefined,
+    metadata: {},
+  },
+  appointment: {
+    id: `appointment-${id}`,
+    patientId: `patient-${id}`,
+    doctorId: options.doctorId ?? 'doctor-a',
+    cabinet: 'A1',
+    service: 'Осмотр',
+    status: 'new',
+    start: '2026-07-20T10:00:00+00:00',
+    end: '2026-07-20T11:00:00+00:00',
+    confirmationState: options.confirmationState ?? 'unconfirmed',
+    confirmationAttemptCount: 1,
+    createdAt: '2026-07-01T09:00:00+00:00',
+    updatedAt: '2026-07-12T08:00:00.123456+00:00',
+  },
+  patient: {
+    id: `patient-${id}`,
+    fullName: options.patientName ?? `Пациент ${id}`,
+    phone: options.phone ?? `+7700${id}`,
+  },
+  doctor: {
+    id: options.doctorId ?? 'doctor-a',
+    fullName: options.doctorName ?? 'Врач А',
+    specialization: 'Терапевт',
+    cabinet: 'A1',
+  },
+  attemptCount: 1,
+  lastAttempt: {
+    id: `attempt-${id}`,
+    tenantId: 'tenant-a',
+    appointmentId: `appointment-${id}`,
+    patientId: `patient-${id}`,
+    actorUserId: 'staff-a',
+    channel: 'phone',
+    outcome: 'no_answer',
+    attemptedAt: '2026-07-12T07:00:00+00:00',
+    createdAt: '2026-07-12T07:00:00+00:00',
+  },
+});
+
+const overdue = makeItem('overdue', '2026-07-13T04:00:00+00:00', { patientName: 'Алина Просроченная' });
+const today = makeItem('today', '2026-07-13T06:00:00+00:00', {
+  patientName: 'Борис Сегодня',
+  doctorId: 'doctor-b',
+  doctorName: 'Врач Б',
+  reminderType: 'day_before_reminder',
+  confirmationState: 'contact_in_progress',
+});
+const upcoming = makeItem('upcoming', '2026-07-14T05:00:00+00:00', {
+  patientName: 'Вера Будущая',
+  reminderType: 'control_call_task',
+});
+const historyItem = makeItem('history', '2026-07-12T05:00:00+00:00', { patientName: 'Галина История', terminal: true });
+
+function baseHook(overrides: Record<string, unknown> = {}) {
+  return {
+    jobs: [overdue, today, upcoming],
+    history: [historyItem],
+    loading: false,
+    error: null,
+    completingJobId: null,
+    deferringJobId: null,
+    skippingJobId: null,
+    reconcilingOperation: false,
+    canAccess: true,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    completeJob: vi.fn().mockResolvedValue({}),
+    deferJob: vi.fn().mockResolvedValue({}),
+    skipJob: vi.fn().mockResolvedValue({}),
+    clearError: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useAppointmentReminderQueue>;
+}
+
+function renderPage() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<MemoryRouter><ReminderOperationsPage /></MemoryRouter>));
+  return { container, root };
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll('button')].find((element) => element.textContent?.includes(text));
+  if (!button) throw new Error(`Button not found: ${text}`);
+  return button as HTMLButtonElement;
+}
+
+function setInput(element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement, value: string) {
+  act(() => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      element instanceof HTMLSelectElement ? HTMLSelectElement.prototype
+        : element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype,
+      'value',
+    );
+    descriptor?.set?.call(element, value);
+    element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? 'change' : 'input', { bubbles: true }));
+  });
+}
+
+describe('ReminderOperationsPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-13T05:00:00+00:00'));
+    vi.mocked(useTenant).mockReturnValue({
+      activeTenant: { tenantId: 'tenant-a', tenantName: 'Clinic A', timezone: 'Asia/Almaty', role: 'registrar' },
+    } as any);
+    vi.mocked(useAppointmentReminderQueue).mockReturnValue(baseHook());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('shows overdue, today and upcoming work with required patient context', () => {
+    const { container, root } = renderPage();
+    expect(container.textContent).toContain('Просрочено');
+    expect(container.textContent).toContain('Сегодня');
+    expect(container.textContent).toContain('Предстоящее');
+    expect(container.textContent).toContain('Алина Просроченная');
+    expect(container.textContent).toContain('Борис Сегодня');
+    expect(container.textContent).toContain('Вера Будущая');
+    expect(container.textContent).toContain('Попыток: 1');
+    expect([...container.querySelectorAll('button')].map((item) => item.textContent)).not.toContain('Отправить SMS');
+    expect([...container.querySelectorAll('button')].map((item) => item.textContent)).not.toContain('Отправить WhatsApp');
+    act(() => root.unmount());
+  });
+
+  it('filters by patient search, bucket, reminder type, doctor and confirmation state', () => {
+    const { container, root } = renderPage();
+    const filterSection = container.querySelector('[aria-label="Фильтры очереди"]')!;
+    const input = filterSection.querySelector('input')!;
+    const selects = filterSection.querySelectorAll('select');
+
+    setInput(input, 'Борис');
+    expect(container.querySelectorAll('[data-testid^="reminder-job-"]')).toHaveLength(1);
+    expect(container.textContent).toContain('Борис Сегодня');
+
+    setInput(input, '');
+    setInput(selects[0], 'upcoming');
+    expect(container.querySelectorAll('[data-testid^="reminder-job-"]')).toHaveLength(1);
+    expect(container.textContent).toContain('Вера Будущая');
+
+    setInput(selects[0], 'all');
+    setInput(selects[1], 'day_before_reminder');
+    expect(container.querySelectorAll('[data-testid^="reminder-job-"]')).toHaveLength(1);
+    expect(container.textContent).toContain('Борис Сегодня');
+
+    setInput(selects[1], 'all');
+    setInput(selects[2], 'doctor-b');
+    expect(container.querySelectorAll('[data-testid^="reminder-job-"]')).toHaveLength(1);
+
+    setInput(selects[2], 'all');
+    setInput(selects[3], 'contact_in_progress');
+    expect(container.querySelectorAll('[data-testid^="reminder-job-"]')).toHaveLength(1);
+    act(() => root.unmount());
+  });
+
+  it('validates completion, shows message_sent warning and records through the hook', async () => {
+    const completeJob = vi.fn().mockResolvedValue({});
+    vi.mocked(useAppointmentReminderQueue).mockReturnValue(baseHook({ completeJob }));
+    const { container, root } = renderPage();
+    act(() => buttonByText(container, 'Зафиксировать результат').click());
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.textContent).toContain('Канал ручного контакта');
+
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Сохранить результат').click(); });
+    expect(dialog.textContent).toContain('Выберите результат связи.');
+
+    const selects = dialog.querySelectorAll('select');
+    setInput(selects[1], 'message_sent');
+    expect(dialog.textContent).toContain('не подтверждает запись');
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Сохранить результат').click(); });
+    expect(completeJob).toHaveBeenCalledWith(expect.objectContaining({
+      item: overdue,
+      channel: 'phone',
+      outcome: 'message_sent',
+    }));
+    expect(container.textContent).toContain('Задача завершена.');
+    act(() => root.unmount());
+  });
+
+  it('validates tenant-local defer time and requires an explicit reason', async () => {
+    const deferJob = vi.fn().mockResolvedValue({});
+    vi.mocked(useAppointmentReminderQueue).mockReturnValue(baseHook({ deferJob }));
+    const { container, root } = renderPage();
+    act(() => buttonByText(container, 'Отложить').click());
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.textContent).toContain('Значение «через час» автоматически не подставляется.');
+
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Отложить').click(); });
+    expect(dialog.textContent).toContain('Укажите причину.');
+    const datetime = dialog.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+    const textarea = dialog.querySelector('textarea')!;
+    setInput(textarea, 'Согласовано с пациентом');
+    setInput(datetime, '2026-07-14T12:00');
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Отложить').click(); });
+    expect(deferJob).toHaveBeenCalledWith(expect.objectContaining({
+      item: overdue,
+      reason: 'Согласовано с пациентом',
+      newDueAt: expect.stringMatching(/Z|[+-]\d{2}:\d{2}$/),
+    }));
+    expect(container.textContent).toContain('Задача отложена.');
+    act(() => root.unmount());
+  });
+
+  it('requires a skip reason, preserves the history warning and calls skip', async () => {
+    const skipJob = vi.fn().mockResolvedValue({});
+    vi.mocked(useAppointmentReminderQueue).mockReturnValue(baseHook({ skipJob }));
+    const { container, root } = renderPage();
+    act(() => buttonByText(container, 'Пропустить').click());
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog.textContent).toContain('останется в истории');
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Пропустить').click(); });
+    expect(dialog.textContent).toContain('Укажите причину.');
+    setInput(dialog.querySelector('textarea')!, 'Не требуется');
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Пропустить').click(); });
+    expect(skipJob).toHaveBeenCalledWith({ item: overdue, reason: 'Не требуется' });
+    expect(container.textContent).toContain('Задача пропущена.');
+    act(() => root.unmount());
+  });
+
+  it('keeps the completion dialog open and displays a safe backend error', async () => {
+    const completeJob = vi.fn().mockRejectedValue(new Error('Задача устарела из-за изменения записи. Обновите очередь.'));
+    vi.mocked(useAppointmentReminderQueue).mockReturnValue(baseHook({ completeJob }));
+    const { container, root } = renderPage();
+    act(() => buttonByText(container, 'Зафиксировать результат').click());
+    const dialog = container.querySelector('[role="dialog"]')!;
+    setInput(dialog.querySelectorAll('select')[1], 'no_answer');
+    await act(async () => { buttonByText(dialog as HTMLElement, 'Сохранить результат').click(); });
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(dialog.textContent).toContain('Задача устарела из-за изменения записи. Обновите очередь.');
+    act(() => root.unmount());
+  });
+
+  it('blocks unauthorized roles without rendering queue actions', () => {
+    vi.mocked(useAppointmentReminderQueue).mockReturnValue(baseHook({ canAccess: false, jobs: [], history: [] }));
+    const { container, root } = renderPage();
+    expect(container.textContent).toContain('Очередь напоминаний недоступна');
+    expect(container.textContent).toContain('Недостаточно прав');
+    expect(container.textContent).not.toContain('Зафиксировать результат');
+    act(() => root.unmount());
+  });
+
+  it('shows terminal administrative history with actor, result, reason and attempt', () => {
+    const { container, root } = renderPage();
+    act(() => buttonByText(container, 'История').click());
+    expect(container.querySelector('[aria-label="История напоминаний"]')).not.toBeNull();
+    expect(container.textContent).toContain('Галина История');
+    expect(container.textContent).toContain('Завершена');
+    expect(container.textContent).toContain('Результат: Не ответил');
+    expect(container.textContent).toContain('Сотрудник: staff-a');
+    expect(container.textContent).toContain('Попытка связи: attempt-a');
+    act(() => root.unmount());
+  });
+});

--- a/src/pages/ReminderOperationsPage.tsx
+++ b/src/pages/ReminderOperationsPage.tsx
@@ -1,0 +1,554 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertCircle,
+  BellRing,
+  CalendarClock,
+  ChevronRight,
+  Clock3,
+  History,
+  PhoneCall,
+  RefreshCw,
+  Search,
+  SkipForward,
+  UserRound,
+  X,
+} from 'lucide-react';
+import { useAppointmentReminderQueue } from '../data/hooks/useAppointmentReminderQueue';
+import { useTenant } from '../contexts/TenantContext';
+import {
+  compareInstantToTenantDay,
+  formatInstantInTenant,
+  tenantDateTimeToInstant,
+  tenantNowDate,
+} from '../domain/timezone';
+import type {
+  AppointmentContactChannel,
+  AppointmentContactOutcome,
+  AppointmentReminderQueueItem,
+  AppointmentReminderType,
+} from '../types';
+
+const TYPE_LABELS: Record<AppointmentReminderType, string> = {
+  confirmation_request: 'Запрос подтверждения',
+  day_before_reminder: 'Напоминание за день',
+  control_call_task: 'Контрольный звонок',
+  callback_task: 'Обратный звонок',
+};
+
+const OUTCOME_LABELS: Record<AppointmentContactOutcome, string> = {
+  confirmed: 'Подтвердил запись',
+  no_answer: 'Не ответил',
+  unreachable: 'Недоступен',
+  callback_requested: 'Просит перезвонить',
+  declined: 'Отказался от записи',
+  wrong_number: 'Неверный номер',
+  message_sent: 'Сообщение отправлено вручную',
+  other: 'Другой результат',
+};
+
+const CHANNEL_LABELS: Record<AppointmentContactChannel, string> = {
+  phone: 'Телефонный звонок',
+  whatsapp: 'WhatsApp вручную',
+  sms: 'SMS вручную',
+  email: 'Email вручную',
+  in_person: 'Лично',
+  other: 'Другой канал',
+};
+
+const CONFIRMATION_LABELS: Record<string, string> = {
+  unconfirmed: 'Не подтверждена',
+  contact_in_progress: 'Связь выполняется',
+  callback_requested: 'Нужно перезвонить',
+  confirmed: 'Подтверждена',
+  unreachable: 'Недоступен',
+};
+
+type QueueBucket = 'all' | 'overdue' | 'today' | 'upcoming';
+type PageTab = 'active' | 'history';
+
+const bucketForItem = (
+  item: AppointmentReminderQueueItem,
+  timezone: string,
+  nowMillis: number,
+): Exclude<QueueBucket, 'all'> => {
+  if (Date.parse(item.job.dueAt) < nowMillis) return 'overdue';
+  const today = tenantNowDate(timezone, new Date(nowMillis));
+  return compareInstantToTenantDay(item.job.dueAt, today, timezone) === 0 ? 'today' : 'upcoming';
+};
+
+const overdueLabel = (dueAt: string, nowMillis: number): string => {
+  const differenceMinutes = Math.max(0, Math.floor((nowMillis - Date.parse(dueAt)) / 60000));
+  if (differenceMinutes < 60) return `${differenceMinutes} мин.`;
+  const hours = Math.floor(differenceMinutes / 60);
+  if (hours < 24) return `${hours} ч. ${differenceMinutes % 60} мин.`;
+  const days = Math.floor(hours / 24);
+  return `${days} дн. ${hours % 24} ч.`;
+};
+
+const terminalMoment = (item: AppointmentReminderQueueItem): string => (
+  item.job.completedAt
+  ?? item.job.skippedAt
+  ?? item.job.cancelledAt
+  ?? item.job.supersededAt
+  ?? item.job.updatedAt
+);
+
+const terminalLabel = (item: AppointmentReminderQueueItem): string => {
+  switch (item.job.state) {
+    case 'completed': return 'Завершена';
+    case 'skipped': return 'Пропущена';
+    case 'cancelled': return 'Отменена';
+    case 'superseded': return 'Устарела';
+    default: return item.job.state;
+  }
+};
+
+function ModalShell({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 p-4" role="presentation">
+      <section className="max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-2xl bg-white shadow-2xl" role="dialog" aria-modal="true" aria-label={title}>
+        <header className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+          <button type="button" onClick={onClose} className="rounded-lg p-2 text-slate-500 hover:bg-slate-100" aria-label="Закрыть">
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+        {children}
+      </section>
+    </div>
+  );
+}
+
+function ItemContext({ item, timezone }: { item: AppointmentReminderQueueItem; timezone: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm">
+      <div className="font-semibold text-slate-900">{item.patient.fullName}</div>
+      <div className="mt-1 text-slate-600">{item.patient.phone || 'Телефон не указан'}</div>
+      <div className="mt-2 grid gap-1 text-slate-600 sm:grid-cols-2">
+        <span>Запись: {formatInstantInTenant(item.appointment.start, timezone)}</span>
+        <span>Врач: {item.doctor.fullName}</span>
+        <span>Задача: {TYPE_LABELS[item.job.reminderType]}</span>
+        <span>Статус: {CONFIRMATION_LABELS[item.appointment.confirmationState ?? 'unconfirmed']}</span>
+      </div>
+      {item.lastAttempt && (
+        <div className="mt-2 text-xs text-slate-500">
+          Последняя попытка: {OUTCOME_LABELS[item.lastAttempt.outcome]} · {formatInstantInTenant(item.lastAttempt.attemptedAt, timezone)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ReminderOperationsPage() {
+  const { activeTenant } = useTenant();
+  const timezone = activeTenant?.timezone ?? 'Asia/Almaty';
+  const {
+    jobs,
+    history,
+    loading,
+    error,
+    completingJobId,
+    deferringJobId,
+    skippingJobId,
+    reconcilingOperation,
+    canAccess,
+    refresh,
+    completeJob,
+    deferJob,
+    skipJob,
+    clearError,
+  } = useAppointmentReminderQueue();
+
+  const [tab, setTab] = useState<PageTab>('active');
+  const [bucket, setBucket] = useState<QueueBucket>('all');
+  const [typeFilter, setTypeFilter] = useState<'all' | AppointmentReminderType>('all');
+  const [doctorFilter, setDoctorFilter] = useState('all');
+  const [confirmationFilter, setConfirmationFilter] = useState('all');
+  const [search, setSearch] = useState('');
+  const [completeItem, setCompleteItem] = useState<AppointmentReminderQueueItem | null>(null);
+  const [deferItem, setDeferItem] = useState<AppointmentReminderQueueItem | null>(null);
+  const [skipItem, setSkipItem] = useState<AppointmentReminderQueueItem | null>(null);
+  const [channel, setChannel] = useState<AppointmentContactChannel>('phone');
+  const [outcome, setOutcome] = useState<AppointmentContactOutcome | ''>('');
+  const [note, setNote] = useState('');
+  const [deferLocalTime, setDeferLocalTime] = useState('');
+  const [deferReason, setDeferReason] = useState('');
+  const [skipReason, setSkipReason] = useState('');
+  const [dialogError, setDialogError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [nowMillis] = useState(() => Date.now());
+
+  const doctors = useMemo(() => (
+    [...new Map(jobs.map((item) => [item.doctor.id, item.doctor])).values()]
+      .sort((left, right) => left.fullName.localeCompare(right.fullName, 'ru'))
+  ), [jobs]);
+
+  const filteredJobs = useMemo(() => {
+    const normalizedSearch = search.trim().toLocaleLowerCase('ru');
+    return jobs.filter((item) => {
+      const itemBucket = bucketForItem(item, timezone, nowMillis);
+      if (bucket !== 'all' && itemBucket !== bucket) return false;
+      if (typeFilter !== 'all' && item.job.reminderType !== typeFilter) return false;
+      if (doctorFilter !== 'all' && item.doctor.id !== doctorFilter) return false;
+      if (confirmationFilter !== 'all' && (item.appointment.confirmationState ?? 'unconfirmed') !== confirmationFilter) return false;
+      if (normalizedSearch && !`${item.patient.fullName} ${item.patient.phone}`.toLocaleLowerCase('ru').includes(normalizedSearch)) return false;
+      return true;
+    });
+  }, [bucket, confirmationFilter, doctorFilter, jobs, nowMillis, search, timezone, typeFilter]);
+
+  const groups = useMemo(() => ({
+    overdue: filteredJobs.filter((item) => bucketForItem(item, timezone, nowMillis) === 'overdue'),
+    today: filteredJobs.filter((item) => bucketForItem(item, timezone, nowMillis) === 'today'),
+    upcoming: filteredJobs.filter((item) => bucketForItem(item, timezone, nowMillis) === 'upcoming'),
+  }), [filteredJobs, nowMillis, timezone]);
+
+  const resetDialog = () => {
+    setCompleteItem(null);
+    setDeferItem(null);
+    setSkipItem(null);
+    setChannel('phone');
+    setOutcome('');
+    setNote('');
+    setDeferLocalTime('');
+    setDeferReason('');
+    setSkipReason('');
+    setDialogError(null);
+  };
+
+  const submitCompletion = async () => {
+    if (!completeItem) return;
+    if (!channel || !outcome) {
+      setDialogError(!channel ? 'Выберите способ связи.' : 'Выберите результат связи.');
+      return;
+    }
+    setDialogError(null);
+    try {
+      await completeJob({ item: completeItem, channel, outcome, note });
+      resetDialog();
+      setSuccess('Задача завершена.');
+    } catch (cause) {
+      setDialogError(cause instanceof Error ? cause.message : 'Не удалось сохранить действие. Обновите очередь и проверьте результат.');
+    }
+  };
+
+  const submitDefer = async () => {
+    if (!deferItem) return;
+    if (!deferReason.trim()) {
+      setDialogError('Укажите причину.');
+      return;
+    }
+    try {
+      const newDueAt = tenantDateTimeToInstant(deferLocalTime, timezone);
+      const newDueMillis = Date.parse(newDueAt);
+      if (
+        !deferLocalTime
+        || newDueMillis <= Date.now()
+        || newDueMillis >= Date.parse(deferItem.appointment.start)
+        || newDueMillis === Date.parse(deferItem.job.dueAt)
+      ) {
+        setDialogError('Новое время должно быть позже текущего момента и раньше записи.');
+        return;
+      }
+      setDialogError(null);
+      await deferJob({ item: deferItem, newDueAt, reason: deferReason });
+      resetDialog();
+      setSuccess('Задача отложена.');
+    } catch (cause) {
+      setDialogError(cause instanceof Error ? cause.message : 'Новое время должно быть позже текущего момента и раньше записи.');
+    }
+  };
+
+  const submitSkip = async () => {
+    if (!skipItem) return;
+    if (!skipReason.trim()) {
+      setDialogError('Укажите причину.');
+      return;
+    }
+    setDialogError(null);
+    try {
+      await skipJob({ item: skipItem, reason: skipReason });
+      resetDialog();
+      setSuccess('Задача пропущена.');
+    } catch (cause) {
+      setDialogError(cause instanceof Error ? cause.message : 'Не удалось сохранить действие. Обновите очередь и проверьте результат.');
+    }
+  };
+
+  if (!canAccess) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center p-6">
+        <div className="max-w-lg rounded-2xl border border-amber-200 bg-amber-50 p-8 text-center">
+          <AlertCircle className="mx-auto h-10 w-10 text-amber-600" />
+          <h1 className="mt-4 text-xl font-semibold text-slate-900">Очередь напоминаний недоступна</h1>
+          <p className="mt-2 text-sm text-slate-600">Недостаточно прав для работы с очередью напоминаний.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const renderCard = (item: AppointmentReminderQueueItem) => {
+    const itemBucket = bucketForItem(item, timezone, nowMillis);
+    const busy = [completingJobId, deferringJobId, skippingJobId].includes(item.job.id);
+    return (
+      <article key={item.job.id} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm" data-testid={`reminder-job-${item.job.id}`}>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${
+                itemBucket === 'overdue' ? 'bg-red-100 text-red-700'
+                  : itemBucket === 'today' ? 'bg-amber-100 text-amber-800'
+                    : 'bg-blue-100 text-blue-700'
+              }`}>
+                {itemBucket === 'overdue' ? `Просрочено на ${overdueLabel(item.job.dueAt, nowMillis)}` : itemBucket === 'today' ? 'Сегодня' : 'Предстоит'}
+              </span>
+              <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+                {TYPE_LABELS[item.job.reminderType]}
+              </span>
+              {item.job.deferredAt && (
+                <span className="rounded-full bg-purple-100 px-2.5 py-1 text-xs font-medium text-purple-700">Отложена вручную</span>
+              )}
+            </div>
+            <h3 className="mt-3 truncate text-lg font-semibold text-slate-900">{item.patient.fullName}</h3>
+            <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-sm text-slate-600">
+              <span className="flex items-center gap-1.5"><PhoneCall className="h-4 w-4" />{item.patient.phone || 'Телефон не указан'}</span>
+              <span className="flex items-center gap-1.5"><CalendarClock className="h-4 w-4" />{formatInstantInTenant(item.appointment.start, timezone)}</span>
+              <span className="flex items-center gap-1.5"><UserRound className="h-4 w-4" />{item.doctor.fullName}</span>
+            </div>
+            <div className="mt-3 grid gap-2 text-sm text-slate-600 sm:grid-cols-2 xl:grid-cols-4">
+              <div><span className="text-slate-400">Выполнить:</span> {formatInstantInTenant(item.job.dueAt, timezone)}</div>
+              <div><span className="text-slate-400">Подтверждение:</span> {CONFIRMATION_LABELS[item.appointment.confirmationState ?? 'unconfirmed']}</div>
+              <div><span className="text-slate-400">Попыток:</span> {item.attemptCount}</div>
+              <div><span className="text-slate-400">Состояние:</span> {item.job.operationalState === 'ready' ? 'Готова к работе' : 'Запланирована'}</div>
+            </div>
+            {item.lastAttempt && (
+              <div className="mt-3 rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                Последняя попытка: {OUTCOME_LABELS[item.lastAttempt.outcome]} · {formatInstantInTenant(item.lastAttempt.attemptedAt, timezone)}
+              </div>
+            )}
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-2 lg:max-w-sm lg:justify-end">
+            <button
+              type="button"
+              data-testid={`complete-${item.job.id}`}
+              disabled={busy || item.job.operationalState !== 'ready'}
+              onClick={() => { clearError(); setSuccess(null); setDialogError(null); setCompleteItem(item); }}
+              className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Зафиксировать результат
+            </button>
+            <button
+              type="button"
+              data-testid={`defer-${item.job.id}`}
+              disabled={busy}
+              onClick={() => { clearError(); setSuccess(null); setDialogError(null); setDeferItem(item); setDeferLocalTime(''); }}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Отложить
+            </button>
+            <button
+              type="button"
+              data-testid={`skip-${item.job.id}`}
+              disabled={busy}
+              onClick={() => { clearError(); setSuccess(null); setDialogError(null); setSkipItem(item); }}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Пропустить
+            </button>
+            <Link to="/" className="inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50">
+              Открыть запись <ChevronRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </article>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-4 sm:p-6 lg:p-8">
+      <div className="mx-auto max-w-7xl">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-blue-700"><BellRing className="h-6 w-6" /><span className="text-sm font-semibold uppercase tracking-wide">Ручные операции</span></div>
+            <h1 className="mt-2 text-3xl font-bold text-slate-900">Напоминания</h1>
+            <p className="mt-2 max-w-3xl text-sm text-slate-600">
+              Очередь показывает работу для сотрудников. Фиксация канала не отправляет SMS, WhatsApp или email автоматически.
+            </p>
+          </div>
+          <button type="button" onClick={() => void refresh()} disabled={loading} className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 disabled:opacity-50">
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Обновить
+          </button>
+        </header>
+
+        {(error || success || reconcilingOperation) && (
+          <div className="mt-5 space-y-2">
+            {error && <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
+            {success && <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{success}</div>}
+            {reconcilingOperation && <div className="rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">Проверяем, была ли задача завершена…</div>}
+          </div>
+        )}
+
+        <div className="mt-6 flex gap-2 border-b border-slate-200">
+          <button type="button" data-testid="reminder-tab-active" onClick={() => setTab('active')} className={`flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-semibold ${tab === 'active' ? 'border-blue-600 text-blue-700' : 'border-transparent text-slate-500'}`}>
+            <Clock3 className="h-4 w-4" /> Активные ({jobs.length})
+          </button>
+          <button type="button" data-testid="reminder-tab-history" onClick={() => setTab('history')} className={`flex items-center gap-2 border-b-2 px-4 py-3 text-sm font-semibold ${tab === 'history' ? 'border-blue-600 text-blue-700' : 'border-transparent text-slate-500'}`}>
+            <History className="h-4 w-4" /> История ({history.length})
+          </button>
+        </div>
+
+        {tab === 'active' ? (
+          <>
+            <section className="mt-5 grid gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-2 xl:grid-cols-5" aria-label="Фильтры очереди">
+              <label className="relative md:col-span-2 xl:col-span-1">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-slate-400" />
+                <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Пациент или телефон" className="w-full rounded-lg border border-slate-300 py-2.5 pl-9 pr-3 text-sm outline-none focus:border-blue-500" />
+              </label>
+              <select value={bucket} onChange={(event) => setBucket(event.target.value as QueueBucket)} className="rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                <option value="all">Все активные</option><option value="overdue">Просроченные</option><option value="today">Сегодня</option><option value="upcoming">Предстоящие</option>
+              </select>
+              <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as 'all' | AppointmentReminderType)} className="rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                <option value="all">Все типы</option>{Object.entries(TYPE_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+              <select value={doctorFilter} onChange={(event) => setDoctorFilter(event.target.value)} className="rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                <option value="all">Все врачи</option>{doctors.map((doctor) => <option key={doctor.id} value={doctor.id}>{doctor.fullName}</option>)}
+              </select>
+              <select value={confirmationFilter} onChange={(event) => setConfirmationFilter(event.target.value)} className="rounded-lg border border-slate-300 px-3 py-2.5 text-sm">
+                <option value="all">Все подтверждения</option>{Object.entries(CONFIRMATION_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </section>
+
+            {loading ? (
+              <div className="mt-10 text-center text-sm text-slate-500">Загружаем очередь…</div>
+            ) : filteredJobs.length === 0 ? (
+              <div className="mt-8 rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-500">Активных задач по выбранным фильтрам нет.</div>
+            ) : (
+              <div className="mt-6 space-y-8">
+                {([
+                  ['overdue', 'Просрочено', groups.overdue, 'text-red-700'],
+                  ['today', 'Сегодня', groups.today, 'text-amber-700'],
+                  ['upcoming', 'Предстоящее', groups.upcoming, 'text-blue-700'],
+                ] as const).map(([key, label, items, color]) => items.length > 0 && (
+                  <section key={key} aria-label={label}>
+                    <h2 className={`mb-3 flex items-center gap-2 text-lg font-semibold ${color}`}><Clock3 className="h-5 w-5" />{label} <span className="text-sm font-normal text-slate-400">{items.length}</span></h2>
+                    <div className="space-y-3">{items.map(renderCard)}</div>
+                  </section>
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <section className="mt-6 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm" aria-label="История напоминаний">
+            {history.length === 0 ? (
+              <div className="p-12 text-center text-slate-500">История пока пуста.</div>
+            ) : (
+              <div className="divide-y divide-slate-200">
+                {history.map((item) => (
+                  <article key={item.job.id} className="grid gap-3 p-5 md:grid-cols-[1.4fr_1fr_1fr]">
+                    <div>
+                      <div className="font-semibold text-slate-900">{item.patient.fullName}</div>
+                      <div className="mt-1 text-sm text-slate-500">{TYPE_LABELS[item.job.reminderType]} · исходно {formatInstantInTenant(item.job.originalDueAt, timezone)}</div>
+                    </div>
+                    <div className="text-sm">
+                      <div className="font-medium text-slate-800">{terminalLabel(item)}</div>
+                      <div className="mt-1 text-slate-500">{formatInstantInTenant(terminalMoment(item), timezone)}</div>
+                    </div>
+                    <div className="text-sm text-slate-600">
+                      {item.job.completionOutcome && <div>Результат: {OUTCOME_LABELS[item.job.completionOutcome]}</div>}
+                      {(item.job.completionNote || item.job.deferReason || item.job.terminalReason) && <div className="mt-1">Причина/заметка: {item.job.completionNote ?? item.job.deferReason ?? item.job.terminalReason}</div>}
+                      {(item.job.completedBy || item.job.skippedBy || item.job.deferredBy) && <div className="mt-1 text-xs text-slate-400">Сотрудник: {item.job.completedBy ?? item.job.skippedBy ?? item.job.deferredBy}</div>}
+                      {item.job.confirmationAttemptId && <div className="mt-1 text-xs text-slate-400">Попытка связи: {item.job.confirmationAttemptId}</div>}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+
+      {completeItem && (
+        <ModalShell title="Зафиксировать результат" onClose={resetDialog}>
+          <div className="space-y-4 p-6">
+            <ItemContext item={completeItem} timezone={timezone} />
+            <label className="block text-sm font-medium text-slate-700">Канал ручного контакта
+              <select data-testid="complete-channel" value={channel} onChange={(event) => setChannel(event.target.value as AppointmentContactChannel)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2.5">
+                {Object.entries(CHANNEL_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+            <label className="block text-sm font-medium text-slate-700">Результат
+              <select data-testid="complete-outcome" value={outcome} onChange={(event) => setOutcome(event.target.value as AppointmentContactOutcome)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2.5">
+                <option value="">Выберите результат</option>{Object.entries(OUTCOME_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+            <label className="block text-sm font-medium text-slate-700">Заметка
+              <textarea data-testid="complete-note" value={note} onChange={(event) => setNote(event.target.value)} rows={3} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2.5" placeholder="Необязательно" />
+            </label>
+            {outcome === 'message_sent' && <div className="rounded-lg bg-amber-50 p-3 text-sm text-amber-800">«Сообщение отправлено» фиксируется сотрудником и не подтверждает запись.</div>}
+            {outcome === 'declined' && <div className="rounded-lg bg-amber-50 p-3 text-sm text-amber-800">Отказ не отменяет запись автоматически. Отмена выполняется отдельным действием.</div>}
+            {outcome === 'callback_requested' && <div className="rounded-lg bg-blue-50 p-3 text-sm text-blue-800">Запрос обратного звонка требует отдельной задачи с явным временем. Система не придумывает его автоматически.</div>}
+            <div className="rounded-lg bg-slate-50 p-3 text-xs text-slate-600">Выбор SMS, WhatsApp или email здесь только записывает ручной способ контакта. Автоматической отправки нет.</div>
+            {dialogError && <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{dialogError}</div>}
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={resetDialog} className="rounded-lg border border-slate-300 px-4 py-2 text-sm">Отмена</button>
+              <button type="button" data-testid="complete-submit" onClick={() => void submitCompletion()} disabled={completingJobId === completeItem.job.id || reconcilingOperation} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                {reconcilingOperation ? 'Проверяем, была ли задача завершена…' : completingJobId === completeItem.job.id ? 'Сохраняем результат…' : 'Сохранить результат'}
+              </button>
+            </div>
+          </div>
+        </ModalShell>
+      )}
+
+      {deferItem && (
+        <ModalShell title="Отложить задачу" onClose={resetDialog}>
+          <div className="space-y-4 p-6">
+            <ItemContext item={deferItem} timezone={timezone} />
+            <label className="block text-sm font-medium text-slate-700">Новое время клиники ({timezone})
+              <input data-testid="defer-time" type="datetime-local" value={deferLocalTime} onChange={(event) => setDeferLocalTime(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2.5" />
+            </label>
+            <label className="block text-sm font-medium text-slate-700">Причина
+              <textarea data-testid="defer-reason" value={deferReason} onChange={(event) => setDeferReason(event.target.value)} rows={3} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2.5" />
+            </label>
+            <div className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600">Укажите точное время. Значение «через час» автоматически не подставляется.</div>
+            {dialogError && <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{dialogError}</div>}
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={resetDialog} className="rounded-lg border border-slate-300 px-4 py-2 text-sm">Отмена</button>
+              <button type="button" data-testid="defer-submit" onClick={() => void submitDefer()} disabled={deferringJobId === deferItem.job.id || reconcilingOperation} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                {deferringJobId === deferItem.job.id ? 'Переносим задачу…' : 'Отложить'}
+              </button>
+            </div>
+          </div>
+        </ModalShell>
+      )}
+
+      {skipItem && (
+        <ModalShell title="Пропустить задачу" onClose={resetDialog}>
+          <div className="space-y-4 p-6">
+            <ItemContext item={skipItem} timezone={timezone} />
+            <label className="block text-sm font-medium text-slate-700">Причина
+              <textarea data-testid="skip-reason" value={skipReason} onChange={(event) => setSkipReason(event.target.value)} rows={3} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2.5" />
+            </label>
+            <div className="rounded-lg bg-amber-50 p-3 text-sm text-amber-800">Задача останется в истории и не будет выполнена автоматически.</div>
+            {dialogError && <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{dialogError}</div>}
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={resetDialog} className="rounded-lg border border-slate-300 px-4 py-2 text-sm">Отмена</button>
+              <button type="button" data-testid="skip-submit" onClick={() => void submitSkip()} disabled={skippingJobId === skipItem.job.id || reconcilingOperation} className="inline-flex items-center gap-2 rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                <SkipForward className="h-4 w-4" />{skippingJobId === skipItem.job.id ? 'Пропускаем задачу…' : 'Пропустить'}
+              </button>
+            </div>
+          </div>
+        </ModalShell>
+      )}
+    </div>
+  );
+}
+
+export default ReminderOperationsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,8 +137,67 @@ export interface AppointmentReminderJob {
   cancelledAt?: string;
   skippedAt?: string;
   completedAt?: string;
+  originalDueAt: string;
+  completedBy?: string;
+  completionOutcome?: AppointmentContactOutcome;
+  completionNote?: string;
+  confirmationAttemptId?: string;
+  deferredAt?: string;
+  deferredBy?: string;
+  deferReason?: string;
+  skippedBy?: string;
+  operationKey?: string;
+  operationFingerprint?: string;
+  lastManualActionAt?: string;
   terminalReason?: string;
   metadata: Record<string, unknown>;
+}
+
+export interface AppointmentReminderQueueItem {
+  job: AppointmentReminderJob;
+  appointment: Appointment;
+  patient: Pick<Patient, 'id' | 'fullName' | 'phone'>;
+  doctor: Pick<Doctor, 'id' | 'fullName' | 'specialization' | 'cabinet'>;
+  attemptCount: number;
+  lastAttempt?: AppointmentConfirmationAttempt;
+}
+
+export type AppointmentReminderOperationType = 'reminder_complete' | 'reminder_defer' | 'reminder_skip';
+
+export interface CompleteAppointmentReminderJobInput {
+  jobId: string;
+  channel: AppointmentContactChannel;
+  outcome: AppointmentContactOutcome;
+  note?: string;
+  expectedJobUpdatedAt: string;
+  expectedAppointmentUpdatedAt: string;
+  operationKey: string;
+}
+
+export interface DeferAppointmentReminderJobInput {
+  jobId: string;
+  newDueAt: string;
+  reason: string;
+  expectedJobUpdatedAt: string;
+  expectedAppointmentUpdatedAt: string;
+  operationKey: string;
+}
+
+export interface SkipAppointmentReminderJobInput {
+  jobId: string;
+  reason: string;
+  expectedJobUpdatedAt: string;
+  expectedAppointmentUpdatedAt: string;
+  operationKey: string;
+}
+
+export interface AppointmentReminderOperationResult {
+  job: AppointmentReminderJob;
+  appointment: Appointment;
+  confirmationAttempt?: AppointmentConfirmationAttempt;
+  replayed: boolean;
+  recovered: boolean;
+  operationType: AppointmentReminderOperationType;
 }
 
 export interface AppointmentReminderPlanResult {

--- a/supabase/migrations/0030_appointment_reminder_manual_operations.sql
+++ b/supabase/migrations/0030_appointment_reminder_manual_operations.sql
@@ -1,0 +1,1342 @@
+-- 0030_appointment_reminder_manual_operations.sql
+-- Tenant-scoped manual reminder operations. This migration sends no messages.
+
+ALTER TABLE public.appointment_reminder_jobs
+  ADD COLUMN original_due_at timestamptz,
+  ADD COLUMN completed_by uuid REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD COLUMN completion_outcome text,
+  ADD COLUMN completion_note text,
+  ADD COLUMN confirmation_attempt_id uuid REFERENCES public.appointment_confirmation_attempts(id) ON DELETE SET NULL,
+  ADD COLUMN deferred_at timestamptz,
+  ADD COLUMN deferred_by uuid REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD COLUMN defer_reason text,
+  ADD COLUMN skipped_by uuid REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD COLUMN operation_key text,
+  ADD COLUMN operation_fingerprint text,
+  ADD COLUMN last_manual_action_at timestamptz;
+
+UPDATE public.appointment_reminder_jobs
+SET original_due_at = due_at
+WHERE original_due_at IS NULL;
+
+ALTER TABLE public.appointment_reminder_jobs
+  ALTER COLUMN original_due_at SET NOT NULL,
+  DROP CONSTRAINT appointment_reminder_jobs_channel_check,
+  DROP CONSTRAINT appointment_reminder_jobs_terminal_fields_check,
+  DROP CONSTRAINT appointment_reminder_jobs_terminal_reason_check,
+  ADD CONSTRAINT appointment_reminder_jobs_channel_check
+    CHECK (channel IS NULL OR channel IN ('phone', 'whatsapp', 'sms', 'email', 'in_person', 'other')),
+  ADD CONSTRAINT appointment_reminder_jobs_completion_outcome_check
+    CHECK (
+      completion_outcome IS NULL OR completion_outcome IN (
+        'confirmed', 'no_answer', 'unreachable', 'callback_requested',
+        'declined', 'wrong_number', 'message_sent', 'other'
+      )
+    ),
+  ADD CONSTRAINT appointment_reminder_jobs_completion_note_check
+    CHECK (completion_note IS NULL OR (length(btrim(completion_note)) > 0 AND length(completion_note) <= 2000)),
+  ADD CONSTRAINT appointment_reminder_jobs_defer_reason_check
+    CHECK (defer_reason IS NULL OR (length(btrim(defer_reason)) > 0 AND length(defer_reason) <= 1000)),
+  ADD CONSTRAINT appointment_reminder_jobs_operation_key_check
+    CHECK (
+      operation_key IS NULL OR (
+        length(operation_key) BETWEEN 8 AND 160
+        AND operation_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+      )
+    ),
+  ADD CONSTRAINT appointment_reminder_jobs_operation_fingerprint_check
+    CHECK (operation_fingerprint IS NULL OR operation_fingerprint ~ '^[0-9a-f]{64}$'),
+  ADD CONSTRAINT appointment_reminder_jobs_operation_pair_check
+    CHECK (
+      (operation_key IS NULL AND operation_fingerprint IS NULL AND last_manual_action_at IS NULL)
+      OR (operation_key IS NOT NULL AND operation_fingerprint IS NOT NULL AND last_manual_action_at IS NOT NULL)
+    ),
+  ADD CONSTRAINT appointment_reminder_jobs_terminal_fields_check
+    CHECK (
+      (
+        state = 'superseded'
+        AND superseded_at IS NOT NULL
+        AND cancelled_at IS NULL AND skipped_at IS NULL AND completed_at IS NULL
+        AND completed_by IS NULL AND completion_outcome IS NULL AND completion_note IS NULL
+        AND confirmation_attempt_id IS NULL AND skipped_by IS NULL
+      )
+      OR (
+        state = 'cancelled'
+        AND cancelled_at IS NOT NULL
+        AND superseded_at IS NULL AND skipped_at IS NULL AND completed_at IS NULL
+        AND completed_by IS NULL AND completion_outcome IS NULL AND completion_note IS NULL
+        AND confirmation_attempt_id IS NULL AND skipped_by IS NULL
+      )
+      OR (
+        state = 'skipped'
+        AND skipped_at IS NOT NULL AND skipped_by IS NOT NULL
+        AND superseded_at IS NULL AND cancelled_at IS NULL AND completed_at IS NULL
+        AND completed_by IS NULL AND completion_outcome IS NULL AND completion_note IS NULL
+        AND confirmation_attempt_id IS NULL
+        AND deferred_at IS NULL AND deferred_by IS NULL AND defer_reason IS NULL
+      )
+      OR (
+        state = 'completed'
+        AND completed_at IS NOT NULL
+        AND superseded_at IS NULL AND cancelled_at IS NULL AND skipped_at IS NULL
+        AND skipped_by IS NULL
+        AND (
+          (
+            terminal_reason = 'manual_completed'
+            AND completed_by IS NOT NULL
+            AND completion_outcome IS NOT NULL
+            AND channel IS NOT NULL
+            AND confirmation_attempt_id IS NOT NULL
+            AND deferred_at IS NULL AND deferred_by IS NULL AND defer_reason IS NULL
+          )
+          OR terminal_reason <> 'manual_completed'
+          OR terminal_reason IS NULL
+        )
+      )
+      OR (
+        state IN ('scheduled', 'ready')
+        AND superseded_at IS NULL AND cancelled_at IS NULL AND skipped_at IS NULL AND completed_at IS NULL
+        AND completed_by IS NULL AND completion_outcome IS NULL AND completion_note IS NULL
+        AND confirmation_attempt_id IS NULL AND skipped_by IS NULL
+        AND (
+          (deferred_at IS NULL AND deferred_by IS NULL AND defer_reason IS NULL)
+          OR (deferred_at IS NOT NULL AND deferred_by IS NOT NULL AND defer_reason IS NOT NULL)
+        )
+      )
+    ),
+  ADD CONSTRAINT appointment_reminder_jobs_terminal_reason_check
+    CHECK (
+      (state IN ('scheduled', 'ready') AND terminal_reason IS NULL)
+      OR (state IN ('completed', 'cancelled', 'superseded', 'skipped') AND terminal_reason IS NOT NULL AND length(btrim(terminal_reason)) > 0)
+    );
+
+CREATE INDEX idx_appointment_reminder_jobs_history
+  ON public.appointment_reminder_jobs (tenant_id, state, COALESCE(completed_at, skipped_at, cancelled_at, superseded_at, updated_at) DESC, id);
+CREATE INDEX idx_appointment_reminder_jobs_confirmation_attempt
+  ON public.appointment_reminder_jobs (tenant_id, confirmation_attempt_id)
+  WHERE confirmation_attempt_id IS NOT NULL;
+
+ALTER TABLE public.appointment_operations
+  DROP CONSTRAINT appointment_operations_operation_type_check,
+  ADD COLUMN reminder_job_id uuid REFERENCES public.appointment_reminder_jobs(id) ON DELETE SET NULL,
+  ADD COLUMN result_reminder_job jsonb,
+  ADD CONSTRAINT appointment_operations_operation_type_check
+    CHECK (operation_type IN (
+      'create', 'reschedule', 'cancel', 'no_show', 'confirmation_attempt', 'confirm',
+      'reminder_complete', 'reminder_defer', 'reminder_skip'
+    )),
+  ADD CONSTRAINT appointment_operations_reminder_result_check
+    CHECK (result_reminder_job IS NULL OR jsonb_typeof(result_reminder_job) = 'object');
+
+ALTER TABLE public.appointments
+  DROP CONSTRAINT appointments_confirmation_metadata_check,
+  ADD CONSTRAINT appointments_confirmation_metadata_check
+    CHECK (
+      (
+        confirmation_metadata_version = 0
+        AND confirmation_state = 'unconfirmed'
+        AND confirmation_attempt_count = 0
+        AND confirmed_at IS NULL
+        AND confirmed_by IS NULL
+        AND confirmation_channel IS NULL
+        AND confirmation_note IS NULL
+        AND last_confirmation_attempt_at IS NULL
+        AND last_confirmation_outcome IS NULL
+        AND last_confirmation_note IS NULL
+      )
+      OR
+      (
+        confirmation_metadata_version = 1
+        AND confirmation_attempt_count > 0
+        AND last_confirmation_attempt_at IS NOT NULL
+        AND last_confirmation_outcome IS NOT NULL
+        AND (
+          (
+            confirmation_state = 'confirmed'
+            AND confirmed_at IS NOT NULL
+            AND confirmed_by IS NOT NULL
+            AND confirmation_channel IS NOT NULL
+          )
+          OR
+          (
+            confirmation_state <> 'confirmed'
+            AND confirmed_at IS NULL
+            AND confirmed_by IS NULL
+            AND confirmation_channel IS NULL
+            AND confirmation_note IS NULL
+          )
+        )
+      )
+    );
+
+CREATE OR REPLACE FUNCTION public.set_appointment_reminder_original_due_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog, pg_temp
+AS $original_due$
+BEGIN
+  IF NEW.original_due_at IS NULL THEN
+    NEW.original_due_at := NEW.due_at;
+  END IF;
+  RETURN NEW;
+END;
+$original_due$;
+
+CREATE TRIGGER appointment_reminder_jobs_original_due_default
+BEFORE INSERT ON public.appointment_reminder_jobs
+FOR EACH ROW EXECUTE FUNCTION public.set_appointment_reminder_original_due_at();
+
+CREATE OR REPLACE FUNCTION public.appointment_reminder_job_row_json(p_job public.appointment_reminder_jobs)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_catalog, pg_temp
+AS $job_json$
+  SELECT jsonb_build_object(
+    'id', p_job.id,
+    'tenantId', p_job.tenant_id,
+    'appointmentId', p_job.appointment_id,
+    'patientId', p_job.patient_id,
+    'reminderType', p_job.reminder_type,
+    'executionMode', p_job.execution_mode,
+    'channel', p_job.channel,
+    'dueAt', p_job.due_at,
+    'originalDueAt', p_job.original_due_at,
+    'state', p_job.state,
+    'appointmentUpdatedAt', p_job.appointment_updated_at,
+    'policyVersion', p_job.policy_version,
+    'planKey', p_job.plan_key,
+    'payloadFingerprint', p_job.payload_fingerprint,
+    'priority', p_job.priority,
+    'createdBy', p_job.created_by,
+    'createdAt', p_job.created_at,
+    'updatedAt', p_job.updated_at,
+    'supersededAt', p_job.superseded_at,
+    'cancelledAt', p_job.cancelled_at,
+    'skippedAt', p_job.skipped_at,
+    'completedAt', p_job.completed_at,
+    'completedBy', p_job.completed_by,
+    'completionOutcome', p_job.completion_outcome,
+    'completionNote', p_job.completion_note,
+    'confirmationAttemptId', p_job.confirmation_attempt_id,
+    'deferredAt', p_job.deferred_at,
+    'deferredBy', p_job.deferred_by,
+    'deferReason', p_job.defer_reason,
+    'skippedBy', p_job.skipped_by,
+    'operationKey', p_job.operation_key,
+    'operationFingerprint', p_job.operation_fingerprint,
+    'lastManualActionAt', p_job.last_manual_action_at,
+    'terminalReason', p_job.terminal_reason,
+    'metadata', p_job.metadata,
+    'operationalState', CASE
+      WHEN p_job.state = 'scheduled' AND p_job.due_at <= now() THEN 'ready'
+      ELSE p_job.state
+    END
+  );
+$job_json$;
+
+CREATE OR REPLACE FUNCTION public.transition_active_appointment_reminder_jobs_internal(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_target_state text,
+  p_reason text,
+  p_actor uuid,
+  p_source text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $transition_jobs$
+DECLARE
+  v_job public.appointment_reminder_jobs%ROWTYPE;
+  v_count integer := 0;
+  v_action text;
+  v_rows jsonb := '[]'::jsonb;
+BEGIN
+  IF p_target_state NOT IN ('cancelled', 'superseded', 'skipped') THEN
+    RAISE EXCEPTION 'Unsupported reminder transition state';
+  END IF;
+  IF p_target_state = 'skipped' AND p_actor IS NULL THEN
+    RAISE EXCEPTION 'Reminder skip transition requires an actor.' USING ERRCODE = '42501';
+  END IF;
+
+  v_action := CASE p_target_state
+    WHEN 'cancelled' THEN 'appointment_reminder_cancelled'
+    WHEN 'superseded' THEN 'appointment_reminder_superseded'
+    ELSE 'appointment_reminder_skipped'
+  END;
+
+  FOR v_job IN
+    SELECT *
+    FROM public.appointment_reminder_jobs
+    WHERE tenant_id = p_tenant_id
+      AND appointment_id = p_appointment_id
+      AND state IN ('scheduled', 'ready')
+    ORDER BY due_at, priority, created_at, id
+    FOR UPDATE
+  LOOP
+    PERFORM set_config('app.reminder_job_internal', 'on', true);
+    UPDATE public.appointment_reminder_jobs
+    SET state = p_target_state,
+        superseded_at = CASE WHEN p_target_state = 'superseded' THEN now() ELSE NULL END,
+        cancelled_at = CASE WHEN p_target_state = 'cancelled' THEN now() ELSE NULL END,
+        skipped_at = CASE WHEN p_target_state = 'skipped' THEN now() ELSE NULL END,
+        skipped_by = CASE WHEN p_target_state = 'skipped' THEN p_actor ELSE NULL END,
+        completed_at = NULL,
+        completed_by = NULL,
+        completion_outcome = NULL,
+        completion_note = NULL,
+        confirmation_attempt_id = NULL,
+        deferred_at = CASE WHEN p_target_state = 'skipped' THEN NULL ELSE deferred_at END,
+        deferred_by = CASE WHEN p_target_state = 'skipped' THEN NULL ELSE deferred_by END,
+        defer_reason = CASE WHEN p_target_state = 'skipped' THEN NULL ELSE defer_reason END,
+        terminal_reason = p_reason
+    WHERE id = v_job.id
+    RETURNING * INTO v_job;
+    PERFORM set_config('app.reminder_job_internal', 'off', true);
+
+    PERFORM public.record_appointment_reminder_transition_internal(
+      v_job, v_action, 'scheduled', p_target_state, p_actor, p_source
+    );
+    v_count := v_count + 1;
+    v_rows := v_rows || jsonb_build_array(public.appointment_reminder_job_row_json(v_job));
+  END LOOP;
+
+  RETURN jsonb_build_object('count', v_count, 'jobs', v_rows);
+END;
+$transition_jobs$;
+
+CREATE OR REPLACE FUNCTION public.record_appointment_reminder_manual_event_internal(
+  p_job public.appointment_reminder_jobs,
+  p_action text,
+  p_actor uuid,
+  p_actor_role text,
+  p_before_data jsonb,
+  p_after_data jsonb,
+  p_operation_key text,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $manual_event$
+DECLARE
+  v_audit_id uuid;
+  v_title text;
+BEGIN
+  v_title := CASE p_action
+    WHEN 'appointment_reminder_completed' THEN 'Задача напоминания завершена'
+    WHEN 'appointment_reminder_deferred' THEN 'Задача напоминания отложена'
+    WHEN 'appointment_reminder_skipped' THEN 'Задача напоминания пропущена'
+    ELSE 'Изменена ручная задача напоминания'
+  END;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_job.tenant_id,
+    p_action => p_action,
+    p_category => 'appointment',
+    p_target_type => 'appointment_reminder_job',
+    p_target_id => p_job.id::text,
+    p_actor_user_id => p_actor,
+    p_actor_tenant_role => p_actor_role,
+    p_patient_id => p_job.patient_id,
+    p_appointment_id => p_job.appointment_id::text,
+    p_before_data => COALESCE(p_before_data, '{}'::jsonb),
+    p_after_data => COALESCE(p_after_data, '{}'::jsonb),
+    p_request_id => p_operation_key,
+    p_redaction_level => 'standard',
+    p_metadata => jsonb_build_object(
+      'jobId', p_job.id,
+      'planKey', p_job.plan_key,
+      'operationKey', p_operation_key,
+      'executionMode', p_job.execution_mode
+    ) || COALESCE(p_metadata, '{}'::jsonb)
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_job.tenant_id,
+    p_category => 'appointment',
+    p_type => p_action,
+    p_title => v_title,
+    p_source_type => 'appointment_reminder_job',
+    p_source_id => p_job.id::text,
+    p_patient_id => p_job.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => p_actor,
+    p_source_status => p_job.state,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_job.appointment_id,
+      'reminderType', p_job.reminder_type,
+      'dueAt', p_job.due_at,
+      'originalDueAt', p_job.original_due_at,
+      'state', p_job.state,
+      'operationKey', p_operation_key
+    ) || COALESCE(p_metadata, '{}'::jsonb)
+  );
+END;
+$manual_event$;
+
+CREATE OR REPLACE FUNCTION public.apply_appointment_confirmation_attempt_internal(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_actor uuid,
+  p_actor_role text,
+  p_channel text,
+  p_outcome text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_attempt_operation_key text,
+  p_attempt_fingerprint text,
+  p_allow_confirmed_followup boolean DEFAULT false,
+  p_source text DEFAULT 'confirmation_rpc'
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+SET timezone = 'UTC'
+AS $confirmation_internal$
+DECLARE
+  v_before public.appointments%ROWTYPE;
+  v_after public.appointments%ROWTYPE;
+  v_attempt public.appointment_confirmation_attempts%ROWTYPE;
+  v_next_state text;
+  v_now timestamptz := transaction_timestamp();
+  v_audit_id uuid;
+  v_action text;
+  v_title text;
+BEGIN
+  SELECT * INTO v_before
+  FROM public.appointments a
+  WHERE a.id = p_appointment_id
+    AND a.tenant_id = p_tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для подтверждения записи.' USING ERRCODE = '42501';
+  END IF;
+  IF v_before.status NOT IN ('new', 'confirmed') THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before.confirmation_state = 'confirmed' AND NOT p_allow_confirmed_followup THEN
+    RAISE EXCEPTION 'Запись уже подтверждена.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.' USING ERRCODE = '40001';
+  END IF;
+  IF v_before.patient_id IS NULL THEN
+    RAISE EXCEPTION 'Текущий статус записи не позволяет выполнить это действие.' USING ERRCODE = '55000';
+  END IF;
+
+  v_next_state := CASE
+    WHEN v_before.confirmation_state = 'confirmed' AND p_allow_confirmed_followup THEN 'confirmed'
+    WHEN p_outcome = 'confirmed' THEN 'confirmed'
+    WHEN p_outcome = 'callback_requested' THEN 'callback_requested'
+    WHEN p_outcome IN ('unreachable', 'wrong_number', 'declined') THEN 'unreachable'
+    ELSE 'contact_in_progress'
+  END;
+
+  INSERT INTO public.appointment_confirmation_attempts (
+    tenant_id, appointment_id, patient_id, actor_user_id,
+    channel, outcome, note, attempted_at, operation_key, fingerprint
+  ) VALUES (
+    p_tenant_id, p_appointment_id, v_before.patient_id, p_actor,
+    p_channel, p_outcome, p_note, v_now, p_attempt_operation_key, p_attempt_fingerprint
+  )
+  RETURNING * INTO v_attempt;
+
+  UPDATE public.appointments
+  SET confirmation_state = v_next_state,
+      confirmed_at = CASE
+        WHEN v_next_state = 'confirmed' AND v_before.confirmation_state = 'confirmed' THEN v_before.confirmed_at
+        WHEN v_next_state = 'confirmed' THEN v_now
+        ELSE NULL
+      END,
+      confirmed_by = CASE
+        WHEN v_next_state = 'confirmed' AND v_before.confirmation_state = 'confirmed' THEN v_before.confirmed_by
+        WHEN v_next_state = 'confirmed' THEN p_actor
+        ELSE NULL
+      END,
+      confirmation_channel = CASE
+        WHEN v_next_state = 'confirmed' AND v_before.confirmation_state = 'confirmed' THEN v_before.confirmation_channel
+        WHEN v_next_state = 'confirmed' THEN p_channel
+        ELSE NULL
+      END,
+      confirmation_note = CASE
+        WHEN v_next_state = 'confirmed' AND v_before.confirmation_state = 'confirmed' THEN v_before.confirmation_note
+        WHEN v_next_state = 'confirmed' THEN p_note
+        ELSE NULL
+      END,
+      last_confirmation_attempt_at = v_now,
+      confirmation_attempt_count = confirmation_attempt_count + 1,
+      confirmation_metadata_version = 1,
+      last_confirmation_outcome = p_outcome,
+      last_confirmation_note = p_note
+  WHERE id = p_appointment_id
+    AND tenant_id = p_tenant_id
+  RETURNING * INTO v_after;
+
+  v_action := CASE WHEN p_outcome = 'confirmed'
+    THEN 'appointment_confirmed'
+    ELSE 'appointment_confirmation_attempted'
+  END;
+  v_title := CASE WHEN p_outcome = 'confirmed'
+    THEN 'Запись подтверждена'
+    ELSE 'Зафиксирована попытка связи'
+  END;
+
+  v_audit_id := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => v_action,
+    p_category => 'appointment',
+    p_target_type => 'appointment',
+    p_target_id => p_appointment_id::text,
+    p_actor_user_id => p_actor,
+    p_actor_tenant_role => p_actor_role,
+    p_patient_id => v_before.patient_id,
+    p_appointment_id => p_appointment_id::text,
+    p_before_data => jsonb_build_object(
+      'confirmationState', v_before.confirmation_state,
+      'confirmationAttemptCount', v_before.confirmation_attempt_count,
+      'updatedAt', v_before.updated_at
+    ),
+    p_after_data => jsonb_build_object(
+      'confirmationState', v_after.confirmation_state,
+      'confirmationAttemptCount', v_after.confirmation_attempt_count,
+      'lastConfirmationAttemptAt', v_after.last_confirmation_attempt_at,
+      'confirmedAt', v_after.confirmed_at,
+      'confirmedBy', v_after.confirmed_by,
+      'confirmationChannel', v_after.confirmation_channel
+    ),
+    p_request_id => p_attempt_operation_key,
+    p_metadata => jsonb_build_object(
+      'operationKey', p_attempt_operation_key,
+      'confirmationAttemptId', v_attempt.id,
+      'channel', p_channel,
+      'outcome', p_outcome,
+      'previousConfirmationState', v_before.confirmation_state,
+      'newConfirmationState', v_after.confirmation_state,
+      'source', p_source,
+      'replayed', false
+    )
+  );
+
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'appointment',
+    p_type => v_action,
+    p_title => v_title,
+    p_source_type => 'appointment',
+    p_source_id => p_appointment_id::text,
+    p_patient_id => v_before.patient_id,
+    p_audit_event_id => v_audit_id,
+    p_actor_user_id => p_actor,
+    p_source_status => v_after.status,
+    p_visibility => 'admin',
+    p_metadata => jsonb_build_object(
+      'appointmentId', p_appointment_id,
+      'confirmationAttemptId', v_attempt.id,
+      'channel', p_channel,
+      'outcome', p_outcome,
+      'previousConfirmationState', v_before.confirmation_state,
+      'newConfirmationState', v_after.confirmation_state,
+      'operationKey', p_attempt_operation_key,
+      'source', p_source,
+      'replayed', false
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', public.appointment_row_json(v_after),
+    'confirmationAttempt', public.appointment_confirmation_attempt_row_json(v_attempt)
+  );
+END;
+$confirmation_internal$;
+
+CREATE OR REPLACE FUNCTION public.apply_appointment_confirmation_action(
+  p_operation_type text,
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_channel text,
+  p_outcome text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+SET timezone = 'UTC'
+AS $confirmation_action$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_operation_type text := NULLIF(btrim(p_operation_type), '');
+  v_channel text := NULLIF(btrim(p_channel), '');
+  v_outcome text := NULLIF(btrim(p_outcome), '');
+  v_note text := NULLIF(btrim(p_note), '');
+  v_key text;
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_result jsonb;
+  v_appointment jsonb;
+  v_attempt jsonb;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для подтверждения записи.' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id
+    AND tu.user_id = v_actor;
+
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для подтверждения записи.' USING ERRCODE = '42501';
+  END IF;
+  IF v_operation_type NOT IN ('confirmation_attempt', 'confirm') THEN
+    RAISE EXCEPTION 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.' USING ERRCODE = '22023';
+  END IF;
+  IF v_channel IS NULL OR v_channel NOT IN ('phone', 'whatsapp', 'sms', 'email', 'in_person', 'other') THEN
+    RAISE EXCEPTION 'Выберите способ связи.' USING ERRCODE = '22023';
+  END IF;
+  IF v_outcome IS NULL OR v_outcome NOT IN (
+    'confirmed', 'no_answer', 'unreachable', 'callback_requested',
+    'declined', 'wrong_number', 'message_sent', 'other'
+  ) THEN
+    RAISE EXCEPTION 'Выберите результат связи.' USING ERRCODE = '22023';
+  END IF;
+  IF v_operation_type = 'confirm' AND v_outcome <> 'confirmed' THEN
+    RAISE EXCEPTION 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.' USING ERRCODE = '22023';
+  END IF;
+  IF v_note IS NOT NULL AND length(v_note) > 2000 THEN
+    RAISE EXCEPTION 'Не удалось сохранить подтверждение. Обновите расписание и проверьте результат.' USING ERRCODE = '22023';
+  END IF;
+  IF p_expected_updated_at IS NULL THEN
+    RAISE EXCEPTION 'Запись была изменена другим пользователем. Обновите расписание.' USING ERRCODE = '40001';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', v_operation_type,
+    'tenantId', p_tenant_id,
+    'appointmentId', p_appointment_id,
+    'expectedUpdatedEpoch', extract(epoch FROM p_expected_updated_at),
+    'channel', v_channel,
+    'outcome', v_outcome,
+    'note', v_note
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0)
+  );
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id
+    AND ao.operation_key = v_key;
+
+  IF FOUND THEN
+    IF v_operation.operation_type <> v_operation_type OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже была выполнена с другими параметрами.' USING ERRCODE = '23505';
+    END IF;
+    RETURN jsonb_build_object(
+      'appointment', v_operation.result_appointment,
+      'confirmationAttempt', v_operation.result_confirmation_attempt,
+      'replayed', true,
+      'recovered', false,
+      'operationType', v_operation_type
+    );
+  END IF;
+
+  v_result := public.apply_appointment_confirmation_attempt_internal(
+    p_tenant_id, p_appointment_id, v_actor, v_actor_role,
+    v_channel, v_outcome, v_note, p_expected_updated_at,
+    v_key, v_fingerprint, false, 'confirmation_rpc'
+  );
+  v_appointment := v_result->'appointment';
+  v_attempt := v_result->'confirmationAttempt';
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id, confirmation_attempt_id, result_confirmation_attempt
+  ) VALUES (
+    p_tenant_id, v_key, v_operation_type, v_fingerprint, p_appointment_id,
+    (v_appointment->>'patient_id')::uuid,
+    (v_appointment->>'doctor_id')::uuid,
+    (v_appointment->>'start_time')::timestamptz,
+    (v_appointment->>'end_time')::timestamptz,
+    v_appointment->>'status',
+    v_appointment, v_actor, (v_attempt->>'id')::uuid, v_attempt
+  );
+
+  RETURN jsonb_build_object(
+    'appointment', v_appointment,
+    'confirmationAttempt', v_attempt,
+    'replayed', false,
+    'recovered', false,
+    'operationType', v_operation_type
+  );
+END;
+$confirmation_action$;
+
+CREATE OR REPLACE FUNCTION public.record_appointment_confirmation_attempt(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_channel text,
+  p_outcome text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $record_confirmation$
+  SELECT public.apply_appointment_confirmation_action(
+    'confirmation_attempt', p_tenant_id, p_appointment_id,
+    p_channel, p_outcome, p_note, p_expected_updated_at, p_operation_key
+  );
+$record_confirmation$;
+
+CREATE OR REPLACE FUNCTION public.confirm_appointment(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_channel text,
+  p_note text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $confirm_appointment$
+  SELECT public.apply_appointment_confirmation_action(
+    'confirm', p_tenant_id, p_appointment_id,
+    p_channel, 'confirmed', p_note, p_expected_updated_at, p_operation_key
+  );
+$confirm_appointment$;
+
+CREATE OR REPLACE FUNCTION public.complete_appointment_reminder_job(
+  p_tenant_id uuid,
+  p_job_id uuid,
+  p_channel text,
+  p_outcome text,
+  p_note text,
+  p_expected_job_updated_at timestamptz,
+  p_expected_appointment_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+SET timezone = 'UTC'
+AS $complete_reminder$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_channel text := NULLIF(btrim(p_channel), '');
+  v_outcome text := NULLIF(btrim(p_outcome), '');
+  v_note text := NULLIF(btrim(p_note), '');
+  v_key text;
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_job_snapshot public.appointment_reminder_jobs%ROWTYPE;
+  v_before_job public.appointment_reminder_jobs%ROWTYPE;
+  v_after_job public.appointment_reminder_jobs%ROWTYPE;
+  v_appointment public.appointments%ROWTYPE;
+  v_policy public.tenant_reminder_policies%ROWTYPE;
+  v_confirmation_result jsonb;
+  v_result_appointment jsonb;
+  v_attempt jsonb;
+  v_now timestamptz := transaction_timestamp();
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT tu.role::text INTO v_actor_role
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor;
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF v_channel IS NULL OR v_channel NOT IN ('phone', 'whatsapp', 'sms', 'email', 'in_person', 'other') THEN
+    RAISE EXCEPTION 'Выберите способ связи.' USING ERRCODE = '22023';
+  END IF;
+  IF v_outcome IS NULL OR v_outcome NOT IN (
+    'confirmed', 'no_answer', 'unreachable', 'callback_requested',
+    'declined', 'wrong_number', 'message_sent', 'other'
+  ) THEN
+    RAISE EXCEPTION 'Выберите результат связи.' USING ERRCODE = '22023';
+  END IF;
+  IF v_note IS NOT NULL AND length(v_note) > 2000 THEN
+    RAISE EXCEPTION 'Не удалось сохранить действие. Обновите очередь и проверьте результат.' USING ERRCODE = '22023';
+  END IF;
+  IF p_expected_job_updated_at IS NULL OR p_expected_appointment_updated_at IS NULL THEN
+    RETURN jsonb_build_object('errorCode', 'concurrent', 'errorMessage', 'Задача была изменена другим пользователем. Обновите очередь.');
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'reminder_complete',
+    'tenantId', p_tenant_id,
+    'jobId', p_job_id,
+    'expectedJobUpdatedEpoch', extract(epoch FROM p_expected_job_updated_at),
+    'expectedAppointmentUpdatedEpoch', extract(epoch FROM p_expected_appointment_updated_at),
+    'channel', v_channel,
+    'outcome', v_outcome,
+    'note', v_note
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0));
+
+  SELECT * INTO v_operation
+  FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id AND ao.operation_key = v_key;
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'reminder_complete' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже выполнена с другими параметрами.' USING ERRCODE = '23505';
+    END IF;
+    RETURN jsonb_build_object(
+      'job', v_operation.result_reminder_job,
+      'appointment', v_operation.result_appointment,
+      'confirmationAttempt', v_operation.result_confirmation_attempt,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'reminder_complete'
+    );
+  END IF;
+
+  SELECT * INTO v_job_snapshot
+  FROM public.appointment_reminder_jobs j
+  WHERE j.tenant_id = p_tenant_id AND j.id = p_job_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-reminder-job:' || p_tenant_id::text || ':' || p_job_id::text, 0));
+
+  SELECT * INTO v_appointment
+  FROM public.appointments a
+  WHERE a.tenant_id = p_tenant_id AND a.id = v_job_snapshot.appointment_id
+  FOR UPDATE;
+  IF NOT FOUND OR v_appointment.patient_id IS DISTINCT FROM v_job_snapshot.patient_id THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_policy
+  FROM public.tenant_reminder_policies p
+  WHERE p.tenant_id = p_tenant_id
+  FOR SHARE;
+
+  SELECT * INTO v_before_job
+  FROM public.appointment_reminder_jobs j
+  WHERE j.tenant_id = p_tenant_id AND j.id = p_job_id
+  FOR UPDATE;
+
+  IF v_before_job.appointment_id IS DISTINCT FROM v_appointment.id
+     OR v_before_job.patient_id IS DISTINCT FROM v_appointment.patient_id THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF v_appointment.updated_at IS DISTINCT FROM p_expected_appointment_updated_at
+     OR v_before_job.appointment_updated_at IS DISTINCT FROM v_appointment.updated_at
+     OR v_policy.policy_version IS DISTINCT FROM v_before_job.policy_version THEN
+    RETURN jsonb_build_object('errorCode', 'stale', 'errorMessage', 'Задача устарела из-за изменения записи. Обновите очередь.');
+  END IF;
+  IF v_before_job.state = 'completed' THEN
+    RAISE EXCEPTION 'Задача уже завершена.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.state NOT IN ('scheduled', 'ready') THEN
+    RAISE EXCEPTION 'Эта задача больше не доступна для выполнения.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.updated_at IS DISTINCT FROM p_expected_job_updated_at THEN
+    RETURN jsonb_build_object('errorCode', 'concurrent', 'errorMessage', 'Задача была изменена другим пользователем. Обновите очередь.');
+  END IF;
+  IF v_appointment.status NOT IN ('new', 'confirmed') OR v_appointment.patient_id IS NULL THEN
+    RAISE EXCEPTION 'Эта задача больше не доступна для выполнения.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.due_at > v_now THEN
+    RAISE EXCEPTION 'Задача ещё не наступила.' USING ERRCODE = '55000';
+  END IF;
+
+  PERFORM set_config('app.reminder_job_internal', 'on', true);
+  UPDATE public.appointment_reminder_jobs
+  SET state = 'completed',
+      channel = v_channel,
+      completed_at = v_now,
+      completed_by = v_actor,
+      completion_outcome = v_outcome,
+      completion_note = v_note,
+      confirmation_attempt_id = NULL,
+      deferred_at = NULL,
+      deferred_by = NULL,
+      defer_reason = NULL,
+      skipped_by = NULL,
+      operation_key = v_key,
+      operation_fingerprint = v_fingerprint,
+      last_manual_action_at = v_now,
+      terminal_reason = 'manual_completion_pending'
+  WHERE tenant_id = p_tenant_id AND id = p_job_id
+  RETURNING * INTO v_after_job;
+  PERFORM set_config('app.reminder_job_internal', 'off', true);
+
+  v_confirmation_result := public.apply_appointment_confirmation_attempt_internal(
+    p_tenant_id, v_appointment.id, v_actor, v_actor_role,
+    v_channel, v_outcome, v_note, p_expected_appointment_updated_at,
+    v_key, v_fingerprint, true, 'reminder_manual_completion'
+  );
+  v_result_appointment := v_confirmation_result->'appointment';
+  v_attempt := v_confirmation_result->'confirmationAttempt';
+
+  PERFORM set_config('app.reminder_job_internal', 'on', true);
+  UPDATE public.appointment_reminder_jobs
+  SET confirmation_attempt_id = (v_attempt->>'id')::uuid,
+      terminal_reason = 'manual_completed'
+  WHERE tenant_id = p_tenant_id AND id = p_job_id
+  RETURNING * INTO v_after_job;
+  PERFORM set_config('app.reminder_job_internal', 'off', true);
+
+  PERFORM public.record_appointment_reminder_manual_event_internal(
+    v_after_job,
+    'appointment_reminder_completed',
+    v_actor,
+    v_actor_role,
+    jsonb_build_object('state', v_before_job.state, 'dueAt', v_before_job.due_at),
+    jsonb_build_object(
+      'state', v_after_job.state,
+      'dueAt', v_after_job.due_at,
+      'completedAt', v_after_job.completed_at,
+      'completedBy', v_after_job.completed_by,
+      'channel', v_channel,
+      'outcome', v_outcome,
+      'confirmationAttemptId', v_after_job.confirmation_attempt_id
+    ),
+    v_key,
+    jsonb_build_object('channel', v_channel, 'outcome', v_outcome, 'confirmationAttemptId', v_after_job.confirmation_attempt_id)
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id, confirmation_attempt_id, result_confirmation_attempt,
+    reminder_job_id, result_reminder_job
+  ) VALUES (
+    p_tenant_id, v_key, 'reminder_complete', v_fingerprint, v_appointment.id,
+    v_appointment.patient_id, v_appointment.doctor_id, v_appointment.start_time, v_appointment.end_time,
+    v_result_appointment->>'status', v_result_appointment, v_actor,
+    (v_attempt->>'id')::uuid, v_attempt, v_after_job.id,
+    public.appointment_reminder_job_row_json(v_after_job)
+  );
+
+  RETURN jsonb_build_object(
+    'job', public.appointment_reminder_job_row_json(v_after_job),
+    'appointment', v_result_appointment,
+    'confirmationAttempt', v_attempt,
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'reminder_complete'
+  );
+END;
+$complete_reminder$;
+
+CREATE OR REPLACE FUNCTION public.defer_appointment_reminder_job(
+  p_tenant_id uuid,
+  p_job_id uuid,
+  p_new_due_at timestamptz,
+  p_reason text,
+  p_expected_job_updated_at timestamptz,
+  p_expected_appointment_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+SET timezone = 'UTC'
+AS $defer_reminder$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_reason text := NULLIF(btrim(p_reason), '');
+  v_key text;
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_job_snapshot public.appointment_reminder_jobs%ROWTYPE;
+  v_before_job public.appointment_reminder_jobs%ROWTYPE;
+  v_after_job public.appointment_reminder_jobs%ROWTYPE;
+  v_appointment public.appointments%ROWTYPE;
+  v_policy public.tenant_reminder_policies%ROWTYPE;
+  v_now timestamptz := transaction_timestamp();
+  v_appointment_json jsonb;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT tu.role::text INTO v_actor_role FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor;
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'Укажите причину.' USING ERRCODE = '22023';
+  END IF;
+  IF length(v_reason) > 1000 THEN
+    RAISE EXCEPTION 'Укажите причину.' USING ERRCODE = '22023';
+  END IF;
+  IF p_new_due_at IS NULL OR p_expected_job_updated_at IS NULL OR p_expected_appointment_updated_at IS NULL THEN
+    RAISE EXCEPTION 'Новое время должно быть позже текущего момента и раньше записи.' USING ERRCODE = '22023';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'reminder_defer',
+    'tenantId', p_tenant_id,
+    'jobId', p_job_id,
+    'newDueEpoch', extract(epoch FROM p_new_due_at),
+    'reason', v_reason,
+    'expectedJobUpdatedEpoch', extract(epoch FROM p_expected_job_updated_at),
+    'expectedAppointmentUpdatedEpoch', extract(epoch FROM p_expected_appointment_updated_at)
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0));
+  SELECT * INTO v_operation FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id AND ao.operation_key = v_key;
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'reminder_defer' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже выполнена с другими параметрами.' USING ERRCODE = '23505';
+    END IF;
+    RETURN jsonb_build_object(
+      'job', v_operation.result_reminder_job,
+      'appointment', v_operation.result_appointment,
+      'confirmationAttempt', NULL,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'reminder_defer'
+    );
+  END IF;
+
+  SELECT * INTO v_job_snapshot FROM public.appointment_reminder_jobs j
+  WHERE j.tenant_id = p_tenant_id AND j.id = p_job_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-reminder-job:' || p_tenant_id::text || ':' || p_job_id::text, 0));
+
+  SELECT * INTO v_appointment FROM public.appointments a
+  WHERE a.tenant_id = p_tenant_id AND a.id = v_job_snapshot.appointment_id
+  FOR UPDATE;
+  IF NOT FOUND OR v_appointment.patient_id IS DISTINCT FROM v_job_snapshot.patient_id THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT * INTO v_policy FROM public.tenant_reminder_policies p
+  WHERE p.tenant_id = p_tenant_id FOR SHARE;
+  SELECT * INTO v_before_job FROM public.appointment_reminder_jobs j
+  WHERE j.tenant_id = p_tenant_id AND j.id = p_job_id FOR UPDATE;
+
+  IF v_before_job.appointment_id IS DISTINCT FROM v_appointment.id
+     OR v_before_job.patient_id IS DISTINCT FROM v_appointment.patient_id THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF v_appointment.updated_at IS DISTINCT FROM p_expected_appointment_updated_at
+     OR v_before_job.appointment_updated_at IS DISTINCT FROM v_appointment.updated_at
+     OR v_policy.policy_version IS DISTINCT FROM v_before_job.policy_version THEN
+    RETURN jsonb_build_object('errorCode', 'stale', 'errorMessage', 'Задача устарела из-за изменения записи. Обновите очередь.');
+  END IF;
+  IF v_before_job.state = 'completed' THEN
+    RAISE EXCEPTION 'Задача уже завершена.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.state NOT IN ('scheduled', 'ready') THEN
+    RAISE EXCEPTION 'Эта задача больше не доступна для выполнения.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.updated_at IS DISTINCT FROM p_expected_job_updated_at THEN
+    RETURN jsonb_build_object('errorCode', 'concurrent', 'errorMessage', 'Задача была изменена другим пользователем. Обновите очередь.');
+  END IF;
+  IF v_appointment.status NOT IN ('new', 'confirmed') OR v_appointment.patient_id IS NULL THEN
+    RAISE EXCEPTION 'Эта задача больше не доступна для выполнения.' USING ERRCODE = '55000';
+  END IF;
+  IF p_new_due_at <= v_now OR p_new_due_at >= v_appointment.start_time OR p_new_due_at = v_before_job.due_at THEN
+    RAISE EXCEPTION 'Новое время должно быть позже текущего момента и раньше записи.' USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM set_config('app.reminder_job_internal', 'on', true);
+  UPDATE public.appointment_reminder_jobs
+  SET due_at = p_new_due_at,
+      state = 'scheduled',
+      deferred_at = v_now,
+      deferred_by = v_actor,
+      defer_reason = v_reason,
+      operation_key = v_key,
+      operation_fingerprint = v_fingerprint,
+      last_manual_action_at = v_now,
+      metadata = metadata || jsonb_build_object(
+        'manualDueOverride', true,
+        'manualDueAt', p_new_due_at,
+        'deferReason', v_reason
+      )
+  WHERE tenant_id = p_tenant_id AND id = p_job_id
+  RETURNING * INTO v_after_job;
+  PERFORM set_config('app.reminder_job_internal', 'off', true);
+
+  v_appointment_json := public.appointment_row_json(v_appointment);
+  PERFORM public.record_appointment_reminder_manual_event_internal(
+    v_after_job,
+    'appointment_reminder_deferred',
+    v_actor,
+    v_actor_role,
+    jsonb_build_object('state', v_before_job.state, 'dueAt', v_before_job.due_at),
+    jsonb_build_object('state', v_after_job.state, 'dueAt', v_after_job.due_at, 'deferredAt', v_after_job.deferred_at, 'deferredBy', v_after_job.deferred_by, 'reason', v_reason),
+    v_key,
+    jsonb_build_object('oldDueAt', v_before_job.due_at, 'newDueAt', v_after_job.due_at, 'reason', v_reason)
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id, reminder_job_id, result_reminder_job
+  ) VALUES (
+    p_tenant_id, v_key, 'reminder_defer', v_fingerprint, v_appointment.id,
+    v_appointment.patient_id, v_appointment.doctor_id, v_appointment.start_time, v_appointment.end_time,
+    v_appointment.status, v_appointment_json, v_actor, v_after_job.id,
+    public.appointment_reminder_job_row_json(v_after_job)
+  );
+
+  RETURN jsonb_build_object(
+    'job', public.appointment_reminder_job_row_json(v_after_job),
+    'appointment', v_appointment_json,
+    'confirmationAttempt', NULL,
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'reminder_defer'
+  );
+END;
+$defer_reminder$;
+
+CREATE OR REPLACE FUNCTION public.skip_appointment_reminder_job(
+  p_tenant_id uuid,
+  p_job_id uuid,
+  p_reason text,
+  p_expected_job_updated_at timestamptz,
+  p_expected_appointment_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+SET timezone = 'UTC'
+AS $skip_reminder$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_reason text := NULLIF(btrim(p_reason), '');
+  v_key text;
+  v_fingerprint text;
+  v_operation public.appointment_operations%ROWTYPE;
+  v_job_snapshot public.appointment_reminder_jobs%ROWTYPE;
+  v_before_job public.appointment_reminder_jobs%ROWTYPE;
+  v_after_job public.appointment_reminder_jobs%ROWTYPE;
+  v_appointment public.appointments%ROWTYPE;
+  v_policy public.tenant_reminder_policies%ROWTYPE;
+  v_now timestamptz := transaction_timestamp();
+  v_appointment_json jsonb;
+BEGIN
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT tu.role::text INTO v_actor_role FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor;
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF v_reason IS NULL OR length(v_reason) > 1000 THEN
+    RAISE EXCEPTION 'Укажите причину.' USING ERRCODE = '22023';
+  END IF;
+  IF p_expected_job_updated_at IS NULL OR p_expected_appointment_updated_at IS NULL THEN
+    RETURN jsonb_build_object('errorCode', 'concurrent', 'errorMessage', 'Задача была изменена другим пользователем. Обновите очередь.');
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'operationType', 'reminder_skip',
+    'tenantId', p_tenant_id,
+    'jobId', p_job_id,
+    'reason', v_reason,
+    'expectedJobUpdatedEpoch', extract(epoch FROM p_expected_job_updated_at),
+    'expectedAppointmentUpdatedEpoch', extract(epoch FROM p_expected_appointment_updated_at)
+  )::text, 'sha256'), 'hex');
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-operation:' || p_tenant_id::text || ':' || v_key, 0));
+  SELECT * INTO v_operation FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id AND ao.operation_key = v_key;
+  IF FOUND THEN
+    IF v_operation.operation_type <> 'reminder_skip' OR v_operation.fingerprint <> v_fingerprint THEN
+      RAISE EXCEPTION 'Эта операция уже выполнена с другими параметрами.' USING ERRCODE = '23505';
+    END IF;
+    RETURN jsonb_build_object(
+      'job', v_operation.result_reminder_job,
+      'appointment', v_operation.result_appointment,
+      'confirmationAttempt', NULL,
+      'replayed', true,
+      'recovered', false,
+      'operationType', 'reminder_skip'
+    );
+  END IF;
+
+  SELECT * INTO v_job_snapshot FROM public.appointment_reminder_jobs j
+  WHERE j.tenant_id = p_tenant_id AND j.id = p_job_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('appointment-reminder-job:' || p_tenant_id::text || ':' || p_job_id::text, 0));
+
+  SELECT * INTO v_appointment FROM public.appointments a
+  WHERE a.tenant_id = p_tenant_id AND a.id = v_job_snapshot.appointment_id
+  FOR UPDATE;
+  IF NOT FOUND OR v_appointment.patient_id IS DISTINCT FROM v_job_snapshot.patient_id THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  SELECT * INTO v_policy FROM public.tenant_reminder_policies p
+  WHERE p.tenant_id = p_tenant_id FOR SHARE;
+  SELECT * INTO v_before_job FROM public.appointment_reminder_jobs j
+  WHERE j.tenant_id = p_tenant_id AND j.id = p_job_id FOR UPDATE;
+
+  IF v_before_job.appointment_id IS DISTINCT FROM v_appointment.id
+     OR v_before_job.patient_id IS DISTINCT FROM v_appointment.patient_id THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с очередью напоминаний.' USING ERRCODE = '42501';
+  END IF;
+  IF v_appointment.updated_at IS DISTINCT FROM p_expected_appointment_updated_at
+     OR v_before_job.appointment_updated_at IS DISTINCT FROM v_appointment.updated_at
+     OR v_policy.policy_version IS DISTINCT FROM v_before_job.policy_version THEN
+    RETURN jsonb_build_object('errorCode', 'stale', 'errorMessage', 'Задача устарела из-за изменения записи. Обновите очередь.');
+  END IF;
+  IF v_before_job.state = 'completed' THEN
+    RAISE EXCEPTION 'Задача уже завершена.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.state NOT IN ('scheduled', 'ready') THEN
+    RAISE EXCEPTION 'Эта задача больше не доступна для выполнения.' USING ERRCODE = '55000';
+  END IF;
+  IF v_before_job.updated_at IS DISTINCT FROM p_expected_job_updated_at THEN
+    RETURN jsonb_build_object('errorCode', 'concurrent', 'errorMessage', 'Задача была изменена другим пользователем. Обновите очередь.');
+  END IF;
+  IF v_appointment.status NOT IN ('new', 'confirmed') OR v_appointment.patient_id IS NULL THEN
+    RAISE EXCEPTION 'Эта задача больше не доступна для выполнения.' USING ERRCODE = '55000';
+  END IF;
+
+  PERFORM set_config('app.reminder_job_internal', 'on', true);
+  UPDATE public.appointment_reminder_jobs
+  SET state = 'skipped',
+      skipped_at = v_now,
+      skipped_by = v_actor,
+      deferred_at = NULL,
+      deferred_by = NULL,
+      defer_reason = NULL,
+      operation_key = v_key,
+      operation_fingerprint = v_fingerprint,
+      last_manual_action_at = v_now,
+      terminal_reason = v_reason
+  WHERE tenant_id = p_tenant_id AND id = p_job_id
+  RETURNING * INTO v_after_job;
+  PERFORM set_config('app.reminder_job_internal', 'off', true);
+
+  v_appointment_json := public.appointment_row_json(v_appointment);
+  PERFORM public.record_appointment_reminder_manual_event_internal(
+    v_after_job,
+    'appointment_reminder_skipped',
+    v_actor,
+    v_actor_role,
+    jsonb_build_object('state', v_before_job.state, 'dueAt', v_before_job.due_at),
+    jsonb_build_object('state', v_after_job.state, 'dueAt', v_after_job.due_at, 'skippedAt', v_after_job.skipped_at, 'skippedBy', v_after_job.skipped_by, 'reason', v_reason),
+    v_key,
+    jsonb_build_object('reason', v_reason)
+  );
+
+  INSERT INTO public.appointment_operations (
+    tenant_id, operation_key, operation_type, fingerprint, appointment_id,
+    patient_id, doctor_id, start_time, end_time, status,
+    result_appointment, actor_user_id, reminder_job_id, result_reminder_job
+  ) VALUES (
+    p_tenant_id, v_key, 'reminder_skip', v_fingerprint, v_appointment.id,
+    v_appointment.patient_id, v_appointment.doctor_id, v_appointment.start_time, v_appointment.end_time,
+    v_appointment.status, v_appointment_json, v_actor, v_after_job.id,
+    public.appointment_reminder_job_row_json(v_after_job)
+  );
+
+  RETURN jsonb_build_object(
+    'job', public.appointment_reminder_job_row_json(v_after_job),
+    'appointment', v_appointment_json,
+    'confirmationAttempt', NULL,
+    'replayed', false,
+    'recovered', false,
+    'operationType', 'reminder_skip'
+  );
+END;
+$skip_reminder$;
+
+CREATE OR REPLACE FUNCTION public.get_appointment_operation(
+  p_tenant_id uuid,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_catalog, pg_temp
+AS $get_operation$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_key text;
+  v_operation public.appointment_operations%ROWTYPE;
+BEGIN
+  IF v_actor IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.tenant_users tu
+    WHERE tu.tenant_id = p_tenant_id AND tu.user_id = v_actor
+  ) THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения записи.' USING ERRCODE = '42501';
+  END IF;
+
+  v_key := public.normalize_appointment_operation_key(p_operation_key);
+  SELECT * INTO v_operation FROM public.appointment_operations ao
+  WHERE ao.tenant_id = p_tenant_id AND ao.operation_key = v_key;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('found', false);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'found', true,
+    'operationType', v_operation.operation_type,
+    'appointment', v_operation.result_appointment,
+    'confirmationAttempt', v_operation.result_confirmation_attempt,
+    'reminderJob', v_operation.result_reminder_job,
+    'replayed', true,
+    'recovered', true
+  );
+END;
+$get_operation$;
+
+DROP TRIGGER IF EXISTS appointments_reconcile_reminders_after_change ON public.appointments;
+CREATE TRIGGER appointments_reconcile_reminders_after_change
+AFTER INSERT OR UPDATE ON public.appointments
+FOR EACH ROW EXECUTE FUNCTION public.reconcile_appointment_reminders_after_change();
+
+REVOKE ALL ON FUNCTION public.set_appointment_reminder_original_due_at() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.record_appointment_reminder_manual_event_internal(public.appointment_reminder_jobs,text,uuid,text,jsonb,jsonb,text,jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_appointment_confirmation_attempt_internal(uuid,uuid,uuid,text,text,text,text,timestamptz,text,text,boolean,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.apply_appointment_confirmation_action(text,uuid,uuid,text,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.record_appointment_confirmation_attempt(uuid,uuid,text,text,text,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.confirm_appointment(uuid,uuid,text,text,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.complete_appointment_reminder_job(uuid,uuid,text,text,text,timestamptz,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.defer_appointment_reminder_job(uuid,uuid,timestamptz,text,timestamptz,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.skip_appointment_reminder_job(uuid,uuid,text,timestamptz,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_appointment_operation(uuid,text) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.record_appointment_confirmation_attempt(uuid,uuid,text,text,text,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.confirm_appointment(uuid,uuid,text,text,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.complete_appointment_reminder_job(uuid,uuid,text,text,text,timestamptz,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.defer_appointment_reminder_job(uuid,uuid,timestamptz,text,timestamptz,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.skip_appointment_reminder_job(uuid,uuid,text,timestamptz,timestamptz,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_appointment_operation(uuid,text) TO authenticated, service_role;
+
+COMMENT ON COLUMN public.appointment_reminder_jobs.channel IS 'Manual contact channel recorded by staff. It is not provider delivery.';
+COMMENT ON COLUMN public.appointment_reminder_jobs.original_due_at IS 'Planner-produced due time before any manual defer override.';
+COMMENT ON COLUMN public.appointment_reminder_jobs.operation_key IS 'Latest manual operation key; immutable operation history remains in appointment_operations.';
+COMMENT ON FUNCTION public.complete_appointment_reminder_job(uuid,uuid,text,text,text,timestamptz,timestamptz,text) IS 'Atomically records one authoritative confirmation attempt and completes one due manual reminder job. Sends no message.';
+COMMENT ON FUNCTION public.defer_appointment_reminder_job(uuid,uuid,timestamptz,text,timestamptz,timestamptz,text) IS 'Moves one active manual job to an explicit future due time while preserving its plan identity and original due time.';
+COMMENT ON FUNCTION public.skip_appointment_reminder_job(uuid,uuid,text,timestamptz,timestamptz,text) IS 'Terminates one active manual reminder job with a required reason. Planner reuses the same skipped plan identity and does not recreate it unchanged.';

--- a/supabase/tests/0030_appointment_reminder_manual_operations_concurrency.ps1
+++ b/supabase/tests/0030_appointment_reminder_manual_operations_concurrency.ps1
@@ -1,0 +1,337 @@
+$ErrorActionPreference = 'Stop'
+
+# APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001 local-only concurrency validation.
+$container = (docker ps --format '{{.Names}}' | Where-Object { $_ -like 'supabase_db_*' } | Select-Object -First 1)
+if (-not $container) { throw 'Local Supabase DB container is not running.' }
+
+$tenantA = 'e3010000-0000-4000-8000-000000000001'
+$tenantB = 'e3010000-0000-4000-8000-000000000002'
+$adminA = 'e3020000-0000-4000-8000-000000000001'
+$adminB = 'e3020000-0000-4000-8000-000000000002'
+$patientA = 'e3030000-0000-4000-8000-000000000001'
+$patientB = 'e3030000-0000-4000-8000-000000000002'
+$doctorA = 'e3040000-0000-4000-8000-000000000001'
+$doctorB = 'e3040000-0000-4000-8000-000000000002'
+
+$appointments = @{
+  A = 'e3050000-0000-4000-8000-000000000001'
+  B = 'e3050000-0000-4000-8000-000000000002'
+  C = 'e3050000-0000-4000-8000-000000000003'
+  D = 'e3050000-0000-4000-8000-000000000004'
+  E = 'e3050000-0000-4000-8000-000000000005'
+  F = 'e3050000-0000-4000-8000-000000000006'
+  G = 'e3050000-0000-4000-8000-000000000007'
+  H = 'e3050000-0000-4000-8000-000000000008'
+  IA = 'e3050000-0000-4000-8000-000000000009'
+  IB = 'e3050000-0000-4000-8000-000000000010'
+}
+$jobs = @{
+  A = 'e3060000-0000-4000-8000-000000000001'
+  B = 'e3060000-0000-4000-8000-000000000002'
+  C = 'e3060000-0000-4000-8000-000000000003'
+  D = 'e3060000-0000-4000-8000-000000000004'
+  E = 'e3060000-0000-4000-8000-000000000005'
+  F = 'e3060000-0000-4000-8000-000000000006'
+  IA = 'e3060000-0000-4000-8000-000000000009'
+  IB = 'e3060000-0000-4000-8000-000000000010'
+}
+
+function Invoke-Sql([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "SQL failed:`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = $LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return (($output | Where-Object { $_ -ne $null -and $_.ToString().Trim() -ne '' } | Select-Object -Last 1).ToString().Trim())
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function AuthContext([string]$userId) {
+  return "BEGIN; SET LOCAL ROLE authenticated; SET LOCAL `"request.jwt.claim.sub`"='$userId'; "
+}
+
+function CompleteSql([string]$tenantId, [string]$userId, [string]$jobId, [string]$jobExpected, [string]$appointmentExpected, [string]$key, [string]$outcome = 'no_answer') {
+  return (AuthContext $userId) + "SELECT coalesce('ERROR:'||(r->>'errorCode'),r->>'replayed') FROM (SELECT public.complete_appointment_reminder_job('$tenantId','$jobId','phone','$outcome','Concurrent manual completion','$jobExpected','$appointmentExpected','$key') r) q; COMMIT;"
+}
+
+function SkipSql([string]$tenantId, [string]$userId, [string]$jobId, [string]$jobExpected, [string]$appointmentExpected, [string]$key) {
+  return (AuthContext $userId) + "SELECT coalesce('ERROR:'||(r->>'errorCode'),r->>'replayed') FROM (SELECT public.skip_appointment_reminder_job('$tenantId','$jobId','Concurrent manual skip','$jobExpected','$appointmentExpected','$key') r) q; COMMIT;"
+}
+
+function DeferSql([string]$tenantId, [string]$userId, [string]$jobId, [string]$newDueAt, [string]$jobExpected, [string]$appointmentExpected, [string]$key) {
+  return (AuthContext $userId) + "SELECT coalesce('ERROR:'||(r->>'errorCode'),r->>'replayed') FROM (SELECT public.defer_appointment_reminder_job('$tenantId','$jobId','$newDueAt','Concurrent manual defer','$jobExpected','$appointmentExpected','$key') r) q; COMMIT;"
+}
+
+function PlanSql([string]$tenantId, [string]$userId, [string]$appointmentId) {
+  return (AuthContext $userId) + "SELECT jsonb_array_length(r->'created')||'|'||jsonb_array_length(r->'reused') FROM (SELECT public.plan_appointment_reminder_jobs('$tenantId','$appointmentId',transaction_timestamp()) r) q; COMMIT;"
+}
+
+function CancelSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.cancel_appointment('$tenantA','$appointmentId','clinic','Concurrent manual reminder cancellation','$expected','$key') r) q; COMMIT;"
+}
+
+function RescheduleSql([string]$appointmentId, [string]$expected, [string]$key) {
+  return (AuthContext $adminA) + "SELECT r->>'operationType' FROM (SELECT public.reschedule_appointment('$tenantA','$appointmentId','$patientA','$doctorA','2027-04-20 10:00+00','2027-04-20 11:00+00','A1','Concurrent moved','new','unpaid','phone',1,null,'$expected','$key') r) q; COMMIT;"
+}
+
+function Count-Success([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 -and $_.Text.Trim() -notmatch '^ERROR:' }).Count }
+function Count-Failure([object[]]$results) { return @($results | Where-Object { $_.Code -ne 0 -or $_.Text.Trim() -match '^ERROR:' }).Count }
+function Count-Replay([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 -and $_.Text.Trim() -eq 'true' }).Count }
+function Count-Deadlocks([object[]]$results) { return @($results | Where-Object { $_.Text -match 'deadlock detected' }).Count }
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id IN ('$tenantA'::uuid,'$tenantB'::uuid);
+DELETE FROM auth.users WHERE id IN ('$adminA'::uuid,'$adminB'::uuid);
+"@
+
+$appointmentRows = @(
+  @($appointments.A,$tenantA,$patientA,$doctorA,'2027-03-01 08:00+00','2027-03-01 09:00+00'),
+  @($appointments.B,$tenantA,$patientA,$doctorA,'2027-03-02 08:00+00','2027-03-02 09:00+00'),
+  @($appointments.C,$tenantA,$patientA,$doctorA,'2027-03-03 08:00+00','2027-03-03 09:00+00'),
+  @($appointments.D,$tenantA,$patientA,$doctorA,'2027-03-04 08:00+00','2027-03-04 09:00+00'),
+  @($appointments.E,$tenantA,$patientA,$doctorA,'2027-03-05 08:00+00','2027-03-05 09:00+00'),
+  @($appointments.F,$tenantA,$patientA,$doctorA,'2027-03-06 08:00+00','2027-03-06 09:00+00'),
+  @($appointments.G,$tenantA,$patientA,$doctorA,'2027-03-07 08:00+00','2027-03-07 09:00+00'),
+  @($appointments.H,$tenantA,$patientA,$doctorA,'2027-03-08 08:00+00','2027-03-08 09:00+00'),
+  @($appointments.IA,$tenantA,$patientA,$doctorA,'2027-03-09 08:00+00','2027-03-09 09:00+00'),
+  @($appointments.IB,$tenantB,$patientB,$doctorB,'2027-03-09 08:00+00','2027-03-09 09:00+00')
+)
+$appointmentValues = ($appointmentRows | ForEach-Object { "('$($_[0])','$($_[1])','$($_[2])','$($_[3])','A1','Manual concurrency','new','unpaid','phone',1,'$($_[4])','$($_[5])')" }) -join ",`n"
+
+$directJobRows = @(
+  @($jobs.A,$tenantA,$appointments.A,$patientA,'A'),
+  @($jobs.B,$tenantA,$appointments.B,$patientA,'B'),
+  @($jobs.C,$tenantA,$appointments.C,$patientA,'C'),
+  @($jobs.D,$tenantA,$appointments.D,$patientA,'D'),
+  @($jobs.E,$tenantA,$appointments.E,$patientA,'E'),
+  @($jobs.F,$tenantA,$appointments.F,$patientA,'F'),
+  @($jobs.IA,$tenantA,$appointments.IA,$patientA,'IA'),
+  @($jobs.IB,$tenantB,$appointments.IB,$patientB,'IB')
+)
+$directJobValues = ($directJobRows | ForEach-Object {
+  "('$($_[0])','$($_[1])','$($_[2])','$($_[3])','confirmation_request','manual',transaction_timestamp()-interval '1 hour','scheduled',(select updated_at from public.appointments where id='$($_[2])'),(select policy_version from public.tenant_reminder_policies where tenant_id='$($_[1])'),encode(extensions.digest('manual-conc-plan-$($_[4])','sha256'),'hex'),encode(extensions.digest('manual-conc-payload-$($_[4])','sha256'),'hex'),50,jsonb_build_object('fixture','$($_[4])'))"
+}) -join ",`n"
+
+$setup = @"
+BEGIN;
+$cleanup
+INSERT INTO public.tenants(id,name,timezone) VALUES ('$tenantA','Manual concurrency A','Asia/Almaty'),('$tenantB','Manual concurrency B','Asia/Almaty');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+ ('$adminA','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-conc-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+ ('$adminB','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-conc-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$adminA'),('$adminB');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES ('$tenantA','$adminA','clinic_admin'),('$tenantB','$adminB','clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status) VALUES
+ ('$patientA','$tenantA','Manual Concurrent A','+77003020001','phone','active'),
+ ('$patientB','$tenantB','Manual Concurrent B','+77003020002','phone','active');
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+ ('$doctorA','$tenantA','Manual Doctor A','General','A1','#111111',true),
+ ('$doctorB','$tenantB','Manual Doctor B','General','B1','#222222',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,payment_type,source,price,start_time,end_time) VALUES
+$appointmentValues;
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claim.sub"='$adminA';
+SELECT public.set_tenant_reminder_policy('$tenantA',true,true,false,true,'12:00',true,true,true,180);
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SET LOCAL "request.jwt.claim.sub"='$adminB';
+SELECT public.set_tenant_reminder_policy('$tenantB',true,true,false,true,'12:00',true,true,true,180);
+RESET ROLE;
+INSERT INTO public.appointment_reminder_jobs(
+  id,tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,
+  appointment_updated_at,policy_version,plan_key,payload_fingerprint,priority,metadata
+) VALUES
+$directJobValues;
+COMMIT;
+"@
+
+$allResults = @()
+$conflicts = 0
+$replays = 0
+try {
+  Invoke-Sql $setup | Out-Null
+
+  # A. Same completion key: one logical completion and one safe replay.
+  $jobExpectedA = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.A)'"
+  $appointmentExpectedA = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.A)'"
+  $aSql1 = CompleteSql $tenantA $adminA $jobs.A $jobExpectedA $appointmentExpectedA 'manual-conc-same-key-001'
+  $aSql2 = CompleteSql $tenantA $adminA $jobs.A $jobExpectedA $appointmentExpectedA 'manual-conc-same-key-001'
+  $a = @(Invoke-ConcurrentPair $aSql1 $aSql2)
+  $allResults += $a
+  if ((Count-Success $a) -ne 2) { throw "A same-key completion failed: $($a.Text -join ' || ')" }
+  $attemptCountA = [int](Invoke-Scalar "select count(*) from public.appointment_confirmation_attempts where appointment_id='$($appointments.A)'")
+  if ($attemptCountA -ne 1) { throw "A expected one confirmation attempt, found $attemptCountA; outputs=$($a.Text -join ' || ')" }
+  $operationCountA = [int](Invoke-Scalar "select count(*) from public.appointment_operations where tenant_id='$tenantA' and operation_key='manual-conc-same-key-001'")
+  if ($operationCountA -ne 1) { throw "A expected one operation row, found $operationCountA; outputs=$($a.Text -join ' || ')" }
+  $aReplay = Count-Replay $a; if ($aReplay -ne 1) { throw "A expected one replay, found $aReplay" }; $replays += $aReplay
+  Write-Output 'A_SAME_COMPLETION_KEY success=2 replay=1 attempts=1 completed=1'
+
+  # B. Different completion keys: one winner, one terminal/stale conflict.
+  $jobExpectedB = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.B)'"
+  $appointmentExpectedB = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.B)'"
+  $bSql1 = CompleteSql $tenantA $adminA $jobs.B $jobExpectedB $appointmentExpectedB 'manual-conc-different-b1'
+  $bSql2 = CompleteSql $tenantA $adminA $jobs.B $jobExpectedB $appointmentExpectedB 'manual-conc-different-b2'
+  $b = @(Invoke-ConcurrentPair $bSql1 $bSql2)
+  $allResults += $b
+  if ((Count-Success $b) -ne 1 -or (Count-Failure $b) -ne 1) { throw "B expected one winner: $($b.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_confirmation_attempts where appointment_id='$($appointments.B)'") -ne 1) { throw 'B duplicate confirmation attempt' }
+  $conflicts += Count-Failure $b
+  Write-Output 'B_DIFFERENT_COMPLETION_KEYS success=1 conflicts=1 attempts=1'
+
+  # C. Complete versus skip: exactly one terminal action wins.
+  $jobExpectedC = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.C)'"
+  $appointmentExpectedC = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.C)'"
+  $cSql1 = CompleteSql $tenantA $adminA $jobs.C $jobExpectedC $appointmentExpectedC 'manual-conc-c-complete'
+  $cSql2 = SkipSql $tenantA $adminA $jobs.C $jobExpectedC $appointmentExpectedC 'manual-conc-c-skip'
+  $c = @(Invoke-ConcurrentPair $cSql1 $cSql2)
+  $allResults += $c
+  if ((Count-Success $c) -ne 1) { throw "C complete/skip expected one winner: $($c.Text -join ' || ')" }
+  $stateC = Invoke-Scalar "select state from public.appointment_reminder_jobs where id='$($jobs.C)'"
+  if ($stateC -notin @('completed','skipped')) { throw "C invalid final state $stateC" }
+  $conflicts += Count-Failure $c
+  Write-Output "C_COMPLETE_VS_SKIP success=1 conflicts=1 finalState=$stateC"
+
+  # D. Complete versus defer: exactly one mutation wins.
+  $jobExpectedD = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.D)'"
+  $appointmentExpectedD = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.D)'"
+  $dSql1 = CompleteSql $tenantA $adminA $jobs.D $jobExpectedD $appointmentExpectedD 'manual-conc-d-complete'
+  $dSql2 = DeferSql $tenantA $adminA $jobs.D '2027-01-15 10:00+00' $jobExpectedD $appointmentExpectedD 'manual-conc-d-defer'
+  $d = @(Invoke-ConcurrentPair $dSql1 $dSql2)
+  $allResults += $d
+  if ((Count-Success $d) -ne 1) { throw "D complete/defer expected one winner: $($d.Text -join ' || ')" }
+  $stateD = Invoke-Scalar "select state||'|'||(deferred_at is not null)::text from public.appointment_reminder_jobs where id='$($jobs.D)'"
+  $conflicts += Count-Failure $d
+  Write-Output "D_COMPLETE_VS_DEFER success=1 conflicts=1 final=$stateD"
+
+  # E. Complete versus cancellation: cancellation wins or follows an already committed completion.
+  $jobExpectedE = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.E)'"
+  $appointmentExpectedE = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.E)'"
+  $eSql1 = CompleteSql $tenantA $adminA $jobs.E $jobExpectedE $appointmentExpectedE 'manual-conc-e-complete'
+  $eSql2 = CancelSql $appointments.E $appointmentExpectedE 'manual-conc-e-cancel'
+  $e = @(Invoke-ConcurrentPair $eSql1 $eSql2)
+  $allResults += $e
+  $eSuccess = Count-Success $e
+  if ($eSuccess -ne 1) { throw "E expected exactly one winner: $($e.Text -join ' || ')" }
+  $appointmentStateE = Invoke-Scalar "select status from public.appointments where id='$($appointments.E)'"
+  $jobStateE = Invoke-Scalar "select state from public.appointment_reminder_jobs where id='$($jobs.E)'"
+  $attemptsE = [int](Invoke-Scalar "select count(*) from public.appointment_confirmation_attempts where appointment_id='$($appointments.E)'")
+  $completionWon = $appointmentStateE -eq 'new' -and $jobStateE -eq 'completed' -and $attemptsE -eq 1
+  $cancellationWon = $appointmentStateE -eq 'cancelled' -and $jobStateE -eq 'cancelled' -and $attemptsE -eq 0
+  if (-not ($completionWon -or $cancellationWon)) { throw "E inconsistent final state appointment=$appointmentStateE job=$jobStateE attempts=$attemptsE" }
+  $conflicts += Count-Failure $e
+  Write-Output "E_COMPLETE_VS_CANCELLATION success=1 finalAppointment=$appointmentStateE finalJob=$jobStateE attempts=$attemptsE"
+
+  # F. Complete versus reschedule: one transaction wins and old work cannot survive as active stale work.
+  $jobExpectedF = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.F)'"
+  $appointmentExpectedF = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.F)'"
+  $fSql1 = CompleteSql $tenantA $adminA $jobs.F $jobExpectedF $appointmentExpectedF 'manual-conc-f-complete'
+  $fSql2 = RescheduleSql $appointments.F $appointmentExpectedF 'manual-conc-f-reschedule'
+  $f = @(Invoke-ConcurrentPair $fSql1 $fSql2)
+  $allResults += $f
+  if ((Count-Success $f) -ne 1) { throw "F complete/reschedule expected one winner: $($f.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs j join public.appointments a on a.id=j.appointment_id and a.tenant_id=j.tenant_id where j.appointment_id='$($appointments.F)' and j.state in ('scheduled','ready') and j.appointment_updated_at<>a.updated_at") -ne 0) { throw 'F stale active job remains' }
+  $conflicts += Count-Failure $f
+  Write-Output 'F_COMPLETE_VS_RESCHEDULE success=1 conflicts=1 activeStale=0'
+
+  # G. Skip versus planner: skipped identity is never recreated unchanged.
+  Invoke-Sql (PlanSql $tenantA $adminA $appointments.G) | Out-Null
+  $jobG = Invoke-Scalar "select id from public.appointment_reminder_jobs where appointment_id='$($appointments.G)' order by priority,created_at,id limit 1"
+  $jobExpectedG = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$jobG'"
+  $appointmentExpectedG = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.G)'"
+  $planKeyG = Invoke-Scalar "select plan_key from public.appointment_reminder_jobs where id='$jobG'"
+  $gSql1 = SkipSql $tenantA $adminA $jobG $jobExpectedG $appointmentExpectedG 'manual-conc-g-skip'
+  $gSql2 = PlanSql $tenantA $adminA $appointments.G
+  $g = @(Invoke-ConcurrentPair $gSql1 $gSql2)
+  $allResults += $g
+  if ((Count-Success $g) -ne 2) { throw "G skip/planner failed: $($g.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id='$tenantA' and plan_key='$planKeyG'") -ne 1) { throw 'G planner recreated skipped identity' }
+  if ((Invoke-Scalar "select state from public.appointment_reminder_jobs where id='$jobG'") -ne 'skipped') { throw 'G job not skipped' }
+  Write-Output 'G_SKIP_VS_PLANNER success=2 skippedIdentityRows=1'
+
+  # H. Defer versus planner: manual due override survives and no duplicate active identity exists.
+  Invoke-Sql (PlanSql $tenantA $adminA $appointments.H) | Out-Null
+  $jobH = Invoke-Scalar "select id from public.appointment_reminder_jobs where appointment_id='$($appointments.H)' order by priority,created_at,id limit 1"
+  $jobExpectedH = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$jobH'"
+  $appointmentExpectedH = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.H)'"
+  $planKeyH = Invoke-Scalar "select plan_key from public.appointment_reminder_jobs where id='$jobH'"
+  $hSql1 = DeferSql $tenantA $adminA $jobH '2027-02-01 10:00+00' $jobExpectedH $appointmentExpectedH 'manual-conc-h-defer'
+  $hSql2 = PlanSql $tenantA $adminA $appointments.H
+  $h = @(Invoke-ConcurrentPair $hSql1 $hSql2)
+  $allResults += $h
+  if ((Count-Success $h) -ne 2) { throw "H defer/planner failed: $($h.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id='$tenantA' and plan_key='$planKeyH'") -ne 1) { throw 'H duplicate deferred identity' }
+  if ((Invoke-Scalar "select due_at='2027-02-01 10:00+00'::timestamptz and deferred_at is not null from public.appointment_reminder_jobs where id='$jobH'") -ne 't') { throw 'H defer override was lost' }
+  Write-Output 'H_DEFER_VS_PLANNER success=2 activeIdentityRows=1 overridePreserved=true'
+
+  # I. Same operation key in different tenants is independent.
+  $jobExpectedIA = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.IA)'"
+  $appointmentExpectedIA = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.IA)'"
+  $jobExpectedIB = Invoke-Scalar "select updated_at from public.appointment_reminder_jobs where id='$($jobs.IB)'"
+  $appointmentExpectedIB = Invoke-Scalar "select updated_at from public.appointments where id='$($appointments.IB)'"
+  $iSql1 = CompleteSql $tenantA $adminA $jobs.IA $jobExpectedIA $appointmentExpectedIA 'manual-conc-cross-tenant-001'
+  $iSql2 = CompleteSql $tenantB $adminB $jobs.IB $jobExpectedIB $appointmentExpectedIB 'manual-conc-cross-tenant-001'
+  $i = @(Invoke-ConcurrentPair $iSql1 $iSql2)
+  $allResults += $i
+  if ((Count-Success $i) -ne 2) { throw "I cross-tenant same key failed: $($i.Text -join ' || ')" }
+  if ([int](Invoke-Scalar "select count(*) from public.appointment_operations where operation_key='manual-conc-cross-tenant-001' and tenant_id in ('$tenantA','$tenantB')") -ne 2) { throw 'I operation key was not tenant scoped' }
+  Write-Output 'I_CROSS_TENANT_SAME_KEY success=2 operations=2 tenants=2'
+
+  # J. Aggregate invariants and deadlock count.
+  $completed = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') and state='completed'")
+  $skipped = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') and state='skipped'")
+  $deferred = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') and deferred_at is not null")
+  $attempts = [int](Invoke-Scalar "select count(*) from public.appointment_confirmation_attempts where tenant_id in ('$tenantA','$tenantB')")
+  $audit = [int](Invoke-Scalar "select count(*) from public.audit_events where tenant_id in ('$tenantA','$tenantB') and action in ('appointment_reminder_completed','appointment_reminder_deferred','appointment_reminder_skipped')")
+  $activity = [int](Invoke-Scalar "select count(*) from public.activity_events where tenant_id in ('$tenantA','$tenantB') and type in ('appointment_reminder_completed','appointment_reminder_deferred','appointment_reminder_skipped')")
+  $duplicateActive = [int](Invoke-Scalar "select count(*) from (select tenant_id,plan_key,count(*) from public.appointment_reminder_jobs where tenant_id in ('$tenantA','$tenantB') and state in ('scheduled','ready') group by 1,2 having count(*)>1) q")
+  $activeStale = [int](Invoke-Scalar "select count(*) from public.appointment_reminder_jobs j join public.appointments a on a.id=j.appointment_id and a.tenant_id=j.tenant_id join public.tenant_reminder_policies p on p.tenant_id=j.tenant_id where j.tenant_id in ('$tenantA','$tenantB') and j.state in ('scheduled','ready') and (j.appointment_updated_at<>a.updated_at or j.policy_version<>p.policy_version)")
+  $deadlocks = Count-Deadlocks $allResults
+
+  if ($audit -ne $activity) { throw "Audit/activity mismatch audit=$audit activity=$activity" }
+  if ($duplicateActive -ne 0 -or $activeStale -ne 0) { throw "Queue invariant failed duplicateActive=$duplicateActive activeStale=$activeStale" }
+  if ($deadlocks -ne 0) { throw "Deadlocks detected: $deadlocks" }
+
+  Write-Output "J_AGGREGATE completed=$completed skipped=$skipped deferred=$deferred attempts=$attempts replays=$replays conflicts=$conflicts audit=$audit activity=$activity duplicateActive=$duplicateActive activeStale=$activeStale deadlocks=$deadlocks"
+  Write-Output 'APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001 CONCURRENCY VALIDATION PASSED'
+}
+finally {
+  Invoke-Sql $cleanup | Out-Null
+  $remaining = Invoke-Scalar "select (select count(*) from public.tenants where id in ('$tenantA','$tenantB')) + (select count(*) from auth.users where id in ('$adminA','$adminB'))"
+  if ([int]$remaining -ne 0) { throw "Concurrency cleanup failed: remaining=$remaining" }
+}
+

--- a/supabase/tests/0030_appointment_reminder_manual_operations_test.sql
+++ b/supabase/tests/0030_appointment_reminder_manual_operations_test.sql
@@ -1,0 +1,556 @@
+\set ON_ERROR_STOP on
+\echo 'APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001 local SQL validation'
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $assert$
+BEGIN
+  IF COALESCE(p_condition, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$assert$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $expect$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'ASSERTION FAILED: expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    v_message := SQLERRM;
+    IF v_message LIKE 'ASSERTION FAILED:%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'ASSERTION FAILED: expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$expect$;
+
+CREATE OR REPLACE FUNCTION pg_temp.make_job(
+  p_tenant_id uuid,
+  p_appointment_id uuid,
+  p_patient_id uuid,
+  p_type text,
+  p_due_at timestamptz,
+  p_label text
+) RETURNS uuid
+LANGUAGE plpgsql
+AS $job$
+DECLARE
+  v_job_id uuid;
+  v_appointment_updated_at timestamptz;
+  v_policy_version integer;
+BEGIN
+  SELECT updated_at INTO v_appointment_updated_at
+  FROM public.appointments
+  WHERE tenant_id = p_tenant_id AND id = p_appointment_id;
+
+  SELECT policy_version INTO v_policy_version
+  FROM public.tenant_reminder_policies
+  WHERE tenant_id = p_tenant_id;
+
+  INSERT INTO public.appointment_reminder_jobs (
+    tenant_id, appointment_id, patient_id, reminder_type, execution_mode,
+    due_at, state, appointment_updated_at, policy_version,
+    plan_key, payload_fingerprint, priority, metadata
+  ) VALUES (
+    p_tenant_id, p_appointment_id, p_patient_id, p_type, 'manual',
+    p_due_at, 'scheduled', v_appointment_updated_at, v_policy_version,
+    encode(extensions.digest('plan|' || p_label, 'sha256'), 'hex'),
+    encode(extensions.digest('payload|' || p_label, 'sha256'), 'hex'),
+    50, jsonb_build_object('fixture', p_label)
+  ) RETURNING id INTO v_job_id;
+
+  RETURN v_job_id;
+END;
+$job$;
+
+\set tenant_a 'd3010000-0000-4000-8000-000000000001'
+\set tenant_b 'd3010000-0000-4000-8000-000000000002'
+\set owner_a 'd3020000-0000-4000-8000-000000000001'
+\set admin_a 'd3020000-0000-4000-8000-000000000002'
+\set registrar_a 'd3020000-0000-4000-8000-000000000003'
+\set doctor_user_a 'd3020000-0000-4000-8000-000000000004'
+\set cashier_a 'd3020000-0000-4000-8000-000000000005'
+\set no_tenant 'd3020000-0000-4000-8000-000000000006'
+\set owner_b 'd3020000-0000-4000-8000-000000000007'
+\set patient_a 'd3030000-0000-4000-8000-000000000001'
+\set patient_b 'd3030000-0000-4000-8000-000000000002'
+\set doctor_a 'd3040000-0000-4000-8000-000000000001'
+\set doctor_b 'd3040000-0000-4000-8000-000000000002'
+
+\set appt_no_answer 'd3050000-0000-4000-8000-000000000001'
+\set appt_confirm 'd3050000-0000-4000-8000-000000000002'
+\set appt_message 'd3050000-0000-4000-8000-000000000003'
+\set appt_callback 'd3050000-0000-4000-8000-000000000004'
+\set appt_defer 'd3050000-0000-4000-8000-000000000005'
+\set appt_skip 'd3050000-0000-4000-8000-000000000006'
+\set appt_future 'd3050000-0000-4000-8000-000000000007'
+\set appt_stale 'd3050000-0000-4000-8000-000000000008'
+\set appt_cancel 'd3050000-0000-4000-8000-000000000009'
+\set appt_noshow 'd3050000-0000-4000-8000-000000000010'
+\set appt_completed 'd3050000-0000-4000-8000-000000000011'
+\set appt_arrived 'd3050000-0000-4000-8000-000000000012'
+\set appt_progress 'd3050000-0000-4000-8000-000000000013'
+\set appt_blocked 'd3050000-0000-4000-8000-000000000014'
+\set appt_b 'd3050000-0000-4000-8000-000000000015'
+\set appt_planner_skip 'd3050000-0000-4000-8000-000000000016'
+\set appt_planner_defer 'd3050000-0000-4000-8000-000000000017'
+\set appt_existing_confirmed 'd3050000-0000-4000-8000-000000000018'
+
+SELECT pg_temp.assert_true(to_regprocedure('public.complete_appointment_reminder_job(uuid,uuid,text,text,text,timestamptz,timestamptz,text)') IS NOT NULL, 'complete RPC exists');
+SELECT pg_temp.assert_true(to_regprocedure('public.defer_appointment_reminder_job(uuid,uuid,timestamptz,text,timestamptz,timestamptz,text)') IS NOT NULL, 'defer RPC exists');
+SELECT pg_temp.assert_true(to_regprocedure('public.skip_appointment_reminder_job(uuid,uuid,text,timestamptz,timestamptz,text)') IS NOT NULL, 'skip RPC exists');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointment_reminder_jobs'::regclass), 'job RLS remains enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.appointment_confirmation_attempts'::regclass), 'attempt RLS remains enabled');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_reminder_jobs','UPDATE'), 'authenticated direct job update blocked');
+SELECT pg_temp.assert_true(NOT has_table_privilege('authenticated','public.appointment_confirmation_attempts','INSERT'), 'authenticated direct attempt insert blocked');
+
+INSERT INTO public.tenants(id,name,timezone) VALUES
+  (:'tenant_a','Manual Reminder Clinic A','Asia/Almaty'),
+  (:'tenant_b','Manual Reminder Clinic B','Europe/Berlin');
+
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+  (:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-owner-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-admin-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-reg-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'doctor_user_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-doc-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-cash-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'no_tenant','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-none@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+  (:'owner_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','manual-owner-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id,first_name,last_name) VALUES
+  (:'owner_a','Owner','A'),(:'admin_a','Admin','A'),(:'registrar_a','Registrar','A'),
+  (:'doctor_user_a','Doctor','A'),(:'cashier_a','Cashier','A'),(:'no_tenant','No','Tenant'),(:'owner_b','Owner','B');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+  (:'tenant_a',:'owner_a','clinic_owner'),(:'tenant_a',:'admin_a','clinic_admin'),
+  (:'tenant_a',:'registrar_a','registrar'),(:'tenant_a',:'doctor_user_a','doctor'),
+  (:'tenant_a',:'cashier_a','cashier'),(:'tenant_b',:'owner_b','clinic_owner');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+  (:'patient_a',:'tenant_a','Manual Reminder Patient A','+77003010001','phone','active',1250),
+  (:'patient_b',:'tenant_b','Manual Reminder Patient B','+49003010001','phone','active',0);
+INSERT INTO public.doctors(id,tenant_id,user_id,full_name,specialization,cabinet,color,active) VALUES
+  (:'doctor_a',:'tenant_a',:'doctor_user_a','Manual Reminder Doctor A','General','A1','#111111',true),
+  (:'doctor_b',:'tenant_b',NULL,'Manual Reminder Doctor B','General','B1','#222222',true);
+
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time) VALUES
+  (:'appt_no_answer',:'tenant_a',:'patient_a',:'doctor_a','A1','No answer', 'new', transaction_timestamp()+interval '2 days', transaction_timestamp()+interval '2 days 1 hour'),
+  (:'appt_confirm',:'tenant_a',:'patient_a',:'doctor_a','A1','Confirm', 'new', transaction_timestamp()+interval '3 days', transaction_timestamp()+interval '3 days 1 hour'),
+  (:'appt_message',:'tenant_a',:'patient_a',:'doctor_a','A1','Message', 'new', transaction_timestamp()+interval '4 days', transaction_timestamp()+interval '4 days 1 hour'),
+  (:'appt_callback',:'tenant_a',:'patient_a',:'doctor_a','A1','Callback', 'new', transaction_timestamp()+interval '5 days', transaction_timestamp()+interval '5 days 1 hour'),
+  (:'appt_defer',:'tenant_a',:'patient_a',:'doctor_a','A1','Defer', 'new', transaction_timestamp()+interval '6 days', transaction_timestamp()+interval '6 days 1 hour'),
+  (:'appt_skip',:'tenant_a',:'patient_a',:'doctor_a','A1','Skip', 'new', transaction_timestamp()+interval '7 days', transaction_timestamp()+interval '7 days 1 hour'),
+  (:'appt_future',:'tenant_a',:'patient_a',:'doctor_a','A1','Future', 'new', transaction_timestamp()+interval '8 days', transaction_timestamp()+interval '8 days 1 hour'),
+  (:'appt_stale',:'tenant_a',:'patient_a',:'doctor_a','A1','Stale', 'new', transaction_timestamp()+interval '9 days', transaction_timestamp()+interval '9 days 1 hour'),
+  (:'appt_cancel',:'tenant_a',:'patient_a',:'doctor_a','A1','Cancel', 'new', transaction_timestamp()+interval '10 days', transaction_timestamp()+interval '10 days 1 hour'),
+  (:'appt_noshow',:'tenant_a',:'patient_a',:'doctor_a','A1','No show', 'new', transaction_timestamp()+interval '11 days', transaction_timestamp()+interval '11 days 1 hour'),
+  (:'appt_completed',:'tenant_a',:'patient_a',:'doctor_a','A1','Completed', 'completed', transaction_timestamp()+interval '12 days', transaction_timestamp()+interval '12 days 1 hour'),
+  (:'appt_arrived',:'tenant_a',:'patient_a',:'doctor_a','A1','Arrived', 'arrived', transaction_timestamp()+interval '13 days', transaction_timestamp()+interval '13 days 1 hour'),
+  (:'appt_progress',:'tenant_a',:'patient_a',:'doctor_a','A1','Progress', 'in_progress', transaction_timestamp()+interval '14 days', transaction_timestamp()+interval '14 days 1 hour'),
+  (:'appt_blocked',:'tenant_a',NULL,:'doctor_a','A1','Blocked', 'blocked', transaction_timestamp()+interval '15 days', transaction_timestamp()+interval '15 days 1 hour'),
+  (:'appt_b',:'tenant_b',:'patient_b',:'doctor_b','B1','Tenant B', 'new', transaction_timestamp()+interval '16 days', transaction_timestamp()+interval '16 days 1 hour'),
+  (:'appt_planner_skip',:'tenant_a',:'patient_a',:'doctor_a','A1','Planner skip', 'new', transaction_timestamp()+interval '17 days', transaction_timestamp()+interval '17 days 1 hour'),
+  (:'appt_planner_defer',:'tenant_a',:'patient_a',:'doctor_a','A1','Planner defer', 'new', transaction_timestamp()+interval '18 days', transaction_timestamp()+interval '18 days 1 hour');
+
+INSERT INTO public.appointments(
+  id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time,
+  confirmation_state,confirmed_at,confirmed_by,confirmation_channel,
+  last_confirmation_attempt_at,confirmation_attempt_count,confirmation_metadata_version,last_confirmation_outcome
+) VALUES (
+  :'appt_existing_confirmed',:'tenant_a',:'patient_a',:'doctor_a','A1','Already confirmed','new',
+  transaction_timestamp()+interval '19 days',transaction_timestamp()+interval '19 days 1 hour',
+  'confirmed',transaction_timestamp()-interval '1 day',:'owner_a','phone',
+  transaction_timestamp()-interval '1 day',1,1,'confirmed'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.set_tenant_reminder_policy(:'tenant_a',true,true,false,true,'12:00',true,true,true,180);
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT public.set_tenant_reminder_policy(:'tenant_b',true,true,false,true,'12:00',true,true,true,180);
+RESET ROLE;
+
+SELECT pg_temp.make_job(:'tenant_a',:'appt_no_answer',:'patient_a','confirmation_request',transaction_timestamp()-interval '2 hours','no-answer') AS job_no_answer \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_confirm',:'patient_a','confirmation_request',transaction_timestamp()-interval '90 minutes','confirm') AS job_confirm \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_message',:'patient_a','day_before_reminder',transaction_timestamp()-interval '60 minutes','message') AS job_message \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_callback',:'patient_a','control_call_task',transaction_timestamp()-interval '30 minutes','callback') AS job_callback \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_defer',:'patient_a','control_call_task',transaction_timestamp()+interval '2 days','defer') AS job_defer \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_skip',:'patient_a','day_before_reminder',transaction_timestamp()+interval '3 days','skip') AS job_skip \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_future',:'patient_a','confirmation_request',transaction_timestamp()+interval '1 day','future') AS job_future \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_stale',:'patient_a','confirmation_request',transaction_timestamp()-interval '1 hour','stale') AS job_stale \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_cancel',:'patient_a','confirmation_request',transaction_timestamp()-interval '1 hour','cancel') AS job_cancel \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_noshow',:'patient_a','confirmation_request',transaction_timestamp()-interval '1 hour','noshow') AS job_noshow \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_completed',:'patient_a','confirmation_request',transaction_timestamp()-interval '1 hour','completed') AS job_completed_appt \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_arrived',:'patient_a','confirmation_request',transaction_timestamp()-interval '1 hour','arrived') AS job_arrived \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_progress',:'patient_a','confirmation_request',transaction_timestamp()-interval '1 hour','progress') AS job_progress \gset
+SELECT pg_temp.make_job(:'tenant_b',:'appt_b',:'patient_b','confirmation_request',transaction_timestamp()-interval '1 hour','tenant-b') AS job_b \gset
+SELECT pg_temp.make_job(:'tenant_a',:'appt_existing_confirmed',:'patient_a','day_before_reminder',transaction_timestamp()-interval '1 hour','confirmed-followup') AS job_existing_confirmed \gset
+
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS plans_before FROM public.treatment_plans \gset
+SELECT count(*)::text AS findings_before FROM public.findings \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS refunds_before FROM public.refunds \gset
+SELECT count(*)::text AS adjustments_before FROM public.financial_adjustments \gset
+SELECT balance::text AS balance_before FROM public.patients WHERE id=:'patient_a' \gset
+
+-- Queue read matrix.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)>0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'owner views active queue');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)>0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'admin views active queue');
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)>0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'registrar views active queue');
+SELECT set_config('request.jwt.claim.sub',:'doctor_user_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'doctor cannot view queue');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_a'), 'cashier cannot view queue');
+SELECT set_config('request.jwt.claim.sub',:'no_tenant',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs), 'unknown/no-tenant cannot view queue');
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_reminder_jobs WHERE tenant_id=:'tenant_b'), 'tenant B sees only tenant B jobs');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,%L,(select updated_at from public.appointment_reminder_jobs where id=%L::uuid),(select updated_at from public.appointments where id=%L::uuid),%L)',
+  :'tenant_a',:'job_no_answer','phone','no_answer','cross tenant',:'job_no_answer',:'appt_no_answer','manual-cross-tenant-001'
+),'Недостаточно прав');
+RESET ROLE;
+
+-- Validation: required fields, due policy and direct writes.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT updated_at::text AS future_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_future' \gset
+SELECT updated_at::text AS future_appt_updated FROM public.appointments WHERE id=:'appt_future' \gset
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,NULL,%L,NULL,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_future','no_answer',:'future_job_updated',:'future_appt_updated','manual-channel-required-001'
+),'Выберите способ связи');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,NULL,NULL,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_future','phone',:'future_job_updated',:'future_appt_updated','manual-outcome-required-001'
+),'Выберите результат связи');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,NULL,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_future','phone','no_answer',:'future_job_updated',:'future_appt_updated','manual-future-not-due-001'
+),'ещё не наступила');
+SELECT pg_temp.expect_error(format('update public.appointment_reminder_jobs set state=%L where id=%L::uuid','completed',:'job_future'),'permission denied');
+SELECT pg_temp.expect_error(format(
+  'insert into public.appointment_confirmation_attempts(tenant_id,appointment_id,patient_id,actor_user_id,channel,outcome,operation_key,fingerprint) values(%L::uuid,%L::uuid,%L::uuid,%L::uuid,%L,%L,%L,%L)',
+  :'tenant_a',:'appt_future',:'patient_a',:'owner_a','phone','no_answer','illegal-attempt-001',repeat('a',64)
+),'permission denied');
+RESET ROLE;
+
+-- Complete no-answer and replay exactly once.
+SELECT updated_at::text AS no_answer_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_no_answer' \gset
+SELECT updated_at::text AS no_answer_appt_updated FROM public.appointments WHERE id=:'appt_no_answer' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_no_answer','phone','no_answer','  Не ответил  ',
+  :'no_answer_job_updated'::timestamptz,:'no_answer_appt_updated'::timestamptz,'manual-complete-no-answer-001'
+) AS no_answer_result \gset
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_no_answer','phone','no_answer','  Не ответил  ',
+  :'no_answer_job_updated'::timestamptz,:'no_answer_appt_updated'::timestamptz,'manual-complete-no-answer-001'
+) AS no_answer_replay \gset
+RESET ROLE;
+SELECT pg_temp.assert_true((:'no_answer_result'::jsonb->>'replayed')::boolean IS FALSE, 'first completion is not replay');
+SELECT pg_temp.assert_true((:'no_answer_replay'::jsonb->>'replayed')::boolean, 'same completion key replays safely');
+SELECT pg_temp.assert_true((SELECT state='completed' AND completed_by=:'registrar_a' AND completion_outcome='no_answer' AND completion_note='Не ответил' AND completed_at IS NOT NULL FROM public.appointment_reminder_jobs WHERE id=:'job_no_answer'), 'no-answer job completion metadata stored and note trimmed');
+SELECT pg_temp.assert_true((SELECT confirmation_state='contact_in_progress' AND confirmation_attempt_count=1 AND last_confirmation_outcome='no_answer' FROM public.appointments WHERE id=:'appt_no_answer'), 'no-answer updates authoritative confirmation state');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_confirmation_attempts WHERE appointment_id=:'appt_no_answer'), 'one confirmation attempt created');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.audit_events WHERE action='appointment_reminder_completed' AND target_id=:'job_no_answer'::text), 'completion audit exactly once');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.activity_events WHERE type='appointment_reminder_completed' AND source_id=:'job_no_answer'::text), 'completion activity exactly once');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_operations WHERE tenant_id=:'tenant_a' AND operation_key='manual-complete-no-answer-001'), 'one operation row stored');
+
+-- Changed payload under same key is rejected.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_no_answer','phone','confirmed','different',:'no_answer_job_updated',:'no_answer_appt_updated','manual-complete-no-answer-001'
+),'другими параметрами');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,%L,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_no_answer','whatsapp','no_answer','Не ответил',:'no_answer_job_updated',:'no_answer_appt_updated','manual-complete-no-answer-001'
+),'другими параметрами');
+RESET ROLE;
+
+-- Confirmed outcome confirms appointment atomically.
+SELECT updated_at::text AS confirm_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_confirm' \gset
+SELECT updated_at::text AS confirm_appt_updated FROM public.appointments WHERE id=:'appt_confirm' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_confirm','phone','confirmed','Подтверждено',
+  :'confirm_job_updated'::timestamptz,:'confirm_appt_updated'::timestamptz,'manual-complete-confirm-001'
+);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT confirmation_state='confirmed' AND confirmed_by=:'owner_a' AND confirmation_attempt_count=1 FROM public.appointments WHERE id=:'appt_confirm'), 'confirmed outcome confirms appointment');
+SELECT pg_temp.assert_true((SELECT state='completed' AND confirmation_attempt_id IS NOT NULL FROM public.appointment_reminder_jobs WHERE id=:'job_confirm'), 'confirmed completion links attempt');
+
+-- message_sent and callback_requested preserve their domain semantics.
+SELECT updated_at::text AS message_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_message' \gset
+SELECT updated_at::text AS message_appt_updated FROM public.appointments WHERE id=:'appt_message' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_message','whatsapp','message_sent','Сообщение отправлено вручную',
+  :'message_job_updated'::timestamptz,:'message_appt_updated'::timestamptz,'manual-complete-message-001'
+);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT confirmation_state='contact_in_progress' AND last_confirmation_outcome='message_sent' AND confirmed_at IS NULL FROM public.appointments WHERE id=:'appt_message'), 'message_sent does not confirm appointment');
+
+SELECT updated_at::text AS callback_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_callback' \gset
+SELECT updated_at::text AS callback_appt_updated FROM public.appointments WHERE id=:'appt_callback' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_callback','phone','callback_requested','Просит перезвонить позже',
+  :'callback_job_updated'::timestamptz,:'callback_appt_updated'::timestamptz,'manual-complete-callback-001'
+);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT confirmation_state='callback_requested' AND last_confirmation_outcome='callback_requested' FROM public.appointments WHERE id=:'appt_callback'), 'callback_requested updates confirmation workflow without invented time');
+
+-- Completing an ordinary reminder for an already confirmed appointment records follow-up without unconfirming it.
+SELECT updated_at::text AS existing_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_existing_confirmed' \gset
+SELECT updated_at::text AS existing_appt_updated FROM public.appointments WHERE id=:'appt_existing_confirmed' \gset
+SELECT confirmed_at::text AS existing_confirmed_at FROM public.appointments WHERE id=:'appt_existing_confirmed' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_existing_confirmed','phone','message_sent','Напомнили о визите',
+  :'existing_job_updated'::timestamptz,:'existing_appt_updated'::timestamptz,'manual-complete-confirmed-followup-001'
+);
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT confirmation_state='confirmed' AND confirmed_at::text=:'existing_confirmed_at' AND last_confirmation_outcome='message_sent' AND confirmation_attempt_count=2 FROM public.appointments WHERE id=:'appt_existing_confirmed'), 'follow-up does not unconfirm an already confirmed appointment');
+
+-- Defer preserves identity, validates time/reason and creates no attempt.
+SELECT updated_at::text AS defer_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_defer' \gset
+SELECT updated_at::text AS defer_appt_updated FROM public.appointments WHERE id=:'appt_defer' \gset
+SELECT due_at::text AS defer_old_due FROM public.appointment_reminder_jobs WHERE id=:'job_defer' \gset
+SELECT (transaction_timestamp()+interval '4 days')::text AS defer_new_due \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.expect_error(format(
+  'select public.defer_appointment_reminder_job(%L::uuid,%L::uuid,%L::timestamptz,%L,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_defer',:'defer_new_due','',:'defer_job_updated',:'defer_appt_updated','manual-defer-reason-001'
+),'Укажите причину');
+SELECT pg_temp.expect_error(format(
+  'select public.defer_appointment_reminder_job(%L::uuid,%L::uuid,%L::timestamptz,%L,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_defer',(transaction_timestamp()-interval '1 minute')::text,'past',:'defer_job_updated',:'defer_appt_updated','manual-defer-past-001'
+),'Новое время');
+SELECT pg_temp.expect_error(format(
+  'select public.defer_appointment_reminder_job(%L::uuid,%L::uuid,%L::timestamptz,%L,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_defer',(transaction_timestamp()+interval '7 days')::text,'after appointment',:'defer_job_updated',:'defer_appt_updated','manual-defer-after-001'
+),'Новое время');
+SELECT public.defer_appointment_reminder_job(
+  :'tenant_a',:'job_defer',:'defer_new_due'::timestamptz,'  Перезвонить в согласованное время  ',
+  :'defer_job_updated'::timestamptz,:'defer_appt_updated'::timestamptz,'manual-defer-valid-001'
+) AS defer_result \gset
+SELECT public.defer_appointment_reminder_job(
+  :'tenant_a',:'job_defer',:'defer_new_due'::timestamptz,'  Перезвонить в согласованное время  ',
+  :'defer_job_updated'::timestamptz,:'defer_appt_updated'::timestamptz,'manual-defer-valid-001'
+) AS defer_replay \gset
+RESET ROLE;
+SELECT pg_temp.assert_true((:'defer_replay'::jsonb->>'replayed')::boolean, 'defer replay safe');
+SELECT pg_temp.assert_true((SELECT id=:'job_defer'::uuid AND state='scheduled' AND due_at=:'defer_new_due'::timestamptz AND original_due_at=:'defer_old_due'::timestamptz AND defer_reason='Перезвонить в согласованное время' AND deferred_by=:'registrar_a' FROM public.appointment_reminder_jobs WHERE id=:'job_defer'), 'defer preserves identity and original due time');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_confirmation_attempts WHERE appointment_id=:'appt_defer'), 'defer creates no confirmation attempt');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.audit_events WHERE action='appointment_reminder_deferred' AND target_id=:'job_defer'::text), 'defer audit exactly once');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.activity_events WHERE type='appointment_reminder_deferred' AND source_id=:'job_defer'::text), 'defer activity exactly once');
+
+-- Skip remains terminal history and replay safe.
+SELECT updated_at::text AS skip_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_skip' \gset
+SELECT updated_at::text AS skip_appt_updated FROM public.appointments WHERE id=:'appt_skip' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.expect_error(format(
+  'select public.skip_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L::timestamptz,%L::timestamptz,%L)',
+  :'tenant_a',:'job_skip','',:'skip_job_updated',:'skip_appt_updated','manual-skip-reason-001'
+),'Укажите причину');
+SELECT public.skip_appointment_reminder_job(
+  :'tenant_a',:'job_skip','  Дубликат ручной задачи  ',
+  :'skip_job_updated'::timestamptz,:'skip_appt_updated'::timestamptz,'manual-skip-valid-001'
+) AS skip_result \gset
+SELECT public.skip_appointment_reminder_job(
+  :'tenant_a',:'job_skip','  Дубликат ручной задачи  ',
+  :'skip_job_updated'::timestamptz,:'skip_appt_updated'::timestamptz,'manual-skip-valid-001'
+) AS skip_replay \gset
+RESET ROLE;
+SELECT pg_temp.assert_true((:'skip_replay'::jsonb->>'replayed')::boolean, 'skip replay safe');
+SELECT pg_temp.assert_true((SELECT state='skipped' AND skipped_by=:'admin_a' AND skipped_at IS NOT NULL AND terminal_reason='Дубликат ручной задачи' FROM public.appointment_reminder_jobs WHERE id=:'job_skip'), 'skip actor/time/reason stored');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_confirmation_attempts WHERE appointment_id=:'appt_skip'), 'skip creates no confirmation attempt');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.audit_events WHERE action='appointment_reminder_skipped' AND target_id=:'job_skip'::text), 'skip audit exactly once');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.activity_events WHERE type='appointment_reminder_skipped' AND source_id=:'job_skip'::text), 'skip activity exactly once');
+
+-- Planner-generated skip is not recreated unchanged; appointment version change may produce a new plan identity.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_planner_skip',transaction_timestamp()) AS planner_skip_plan \gset
+RESET ROLE;
+SELECT (:'planner_skip_plan'::jsonb->'created'->0->>'id')::uuid AS planner_skip_job \gset
+SELECT updated_at::text AS planner_skip_job_updated FROM public.appointment_reminder_jobs WHERE id=:'planner_skip_job' \gset
+SELECT updated_at::text AS planner_skip_appt_updated FROM public.appointments WHERE id=:'appt_planner_skip' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.skip_appointment_reminder_job(
+  :'tenant_a',:'planner_skip_job','Не требуется',
+  :'planner_skip_job_updated'::timestamptz,:'planner_skip_appt_updated'::timestamptz,'manual-planner-skip-001'
+);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_planner_skip',transaction_timestamp()) AS planner_skip_replan \gset
+RESET ROLE;
+SELECT pg_temp.assert_true(jsonb_array_length(:'planner_skip_replan'::jsonb->'created')=0, 'planner does not recreate unchanged skipped plan');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.appointment_reminder_jobs WHERE id=:'planner_skip_job' AND state='skipped'), 'skipped planner job remains history');
+UPDATE public.appointments SET comment='new version for skipped plan' WHERE id=:'appt_planner_skip';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_planner_skip',transaction_timestamp()) AS planner_skip_new_version \gset
+RESET ROLE;
+SELECT pg_temp.assert_true(
+  (SELECT count(*)>0 FROM public.appointment_reminder_jobs j JOIN public.appointments a ON a.id=j.appointment_id AND a.tenant_id=j.tenant_id WHERE j.appointment_id=:'appt_planner_skip' AND j.state IN ('scheduled','ready') AND j.appointment_updated_at=a.updated_at)
+  AND jsonb_array_length(:'planner_skip_new_version'::jsonb->'created')=0
+  AND jsonb_array_length(:'planner_skip_new_version'::jsonb->'reused')>0,
+  'appointment version change creates a new active plan atomically and explicit replay reuses it'
+);
+
+-- Planner-generated defer keeps manual due override and produces no duplicate active work.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_planner_defer',transaction_timestamp()) AS planner_defer_plan \gset
+RESET ROLE;
+SELECT (:'planner_defer_plan'::jsonb->'created'->0->>'id')::uuid AS planner_defer_job \gset
+SELECT updated_at::text AS planner_defer_job_updated FROM public.appointment_reminder_jobs WHERE id=:'planner_defer_job' \gset
+SELECT updated_at::text AS planner_defer_appt_updated FROM public.appointments WHERE id=:'appt_planner_defer' \gset
+SELECT (transaction_timestamp()+interval '10 days')::text AS planner_defer_new_due \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.defer_appointment_reminder_job(
+  :'tenant_a',:'planner_defer_job',:'planner_defer_new_due'::timestamptz,'Согласованный срок',
+  :'planner_defer_job_updated'::timestamptz,:'planner_defer_appt_updated'::timestamptz,'manual-planner-defer-001'
+);
+SELECT public.plan_appointment_reminder_jobs(:'tenant_a',:'appt_planner_defer',transaction_timestamp()) AS planner_defer_replan \gset
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT due_at=:'planner_defer_new_due'::timestamptz AND (metadata->>'manualDueOverride')::boolean FROM public.appointment_reminder_jobs WHERE id=:'planner_defer_job'), 'planner preserves explicit defer override');
+SELECT pg_temp.assert_true((SELECT count(*)=jsonb_array_length(:'planner_defer_plan'::jsonb->'created') FROM public.appointment_reminder_jobs WHERE appointment_id=:'appt_planner_defer' AND state IN ('scheduled','ready')), 'defer plus planner creates no duplicate active work');
+
+-- Stale and terminal protections.
+SELECT updated_at::text AS stale_job_updated FROM public.appointment_reminder_jobs WHERE id=:'job_stale' \gset
+SELECT updated_at::text AS stale_appt_old FROM public.appointments WHERE id=:'appt_stale' \gset
+UPDATE public.appointments SET comment='rescheduled version marker' WHERE id=:'appt_stale';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_stale','phone','no_answer',NULL,
+  :'stale_job_updated'::timestamptz,:'stale_appt_old'::timestamptz,'manual-stale-complete-001'
+) AS stale_complete_result \gset
+SELECT pg_temp.assert_true(:'stale_complete_result'::jsonb->>'errorCode'='stale', 'stale completion returns structured conflict');
+RESET ROLE;
+
+SELECT updated_at::text AS cancel_expected FROM public.appointments WHERE id=:'appt_cancel' \gset
+SELECT updated_at::text AS noshow_expected FROM public.appointments WHERE id=:'appt_noshow' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.cancel_appointment(
+  :'tenant_a',:'appt_cancel','clinic','Manual reminder terminal validation',
+  :'cancel_expected'::timestamptz,'manual-terminal-cancel-lifecycle-001'
+);
+SELECT public.mark_appointment_no_show(
+  :'tenant_a',:'appt_noshow','Manual reminder no-show validation',
+  :'noshow_expected'::timestamptz,'manual-terminal-noshow-lifecycle-001'
+);
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_cancel','phone','no_answer',NULL,
+  (select updated_at from public.appointment_reminder_jobs where id=:'job_cancel'),
+  (select updated_at from public.appointments where id=:'appt_cancel'),
+  'manual-terminal-cancel-001'
+) AS cancel_conflict_result \gset
+SELECT pg_temp.assert_true(:'cancel_conflict_result'::jsonb->>'errorCode'='stale', 'cancelled appointment returns structured stale conflict');
+SELECT public.complete_appointment_reminder_job(
+  :'tenant_a',:'job_noshow','phone','no_answer',NULL,
+  (select updated_at from public.appointment_reminder_jobs where id=:'job_noshow'),
+  (select updated_at from public.appointments where id=:'appt_noshow'),
+  'manual-terminal-noshow-001'
+) AS noshow_conflict_result \gset
+SELECT pg_temp.assert_true(:'noshow_conflict_result'::jsonb->>'errorCode'='stale', 'no-show appointment returns structured stale conflict');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,NULL,(select updated_at from public.appointment_reminder_jobs where id=%L::uuid),(select updated_at from public.appointments where id=%L::uuid),%L)',
+  :'tenant_a',:'job_completed_appt','phone','no_answer',:'job_completed_appt',:'appt_completed','manual-terminal-completed-001'
+),'больше не доступна');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,NULL,(select updated_at from public.appointment_reminder_jobs where id=%L::uuid),(select updated_at from public.appointments where id=%L::uuid),%L)',
+  :'tenant_a',:'job_arrived','phone','no_answer',:'job_arrived',:'appt_arrived','manual-terminal-arrived-001'
+),'больше не доступна');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,NULL,(select updated_at from public.appointment_reminder_jobs where id=%L::uuid),(select updated_at from public.appointments where id=%L::uuid),%L)',
+  :'tenant_a',:'job_progress','phone','no_answer',:'job_progress',:'appt_progress','manual-terminal-progress-001'
+),'больше не доступна');
+SELECT pg_temp.expect_error(format(
+  'select public.complete_appointment_reminder_job(%L::uuid,%L::uuid,%L,%L,NULL,(select updated_at from public.appointment_reminder_jobs where id=%L::uuid),(select updated_at from public.appointments where id=%L::uuid),%L)',
+  :'tenant_a',:'job_skip','phone','no_answer',:'job_skip',:'appt_skip','manual-terminal-skipped-001'
+),'больше не доступна');
+RESET ROLE;
+
+-- Existing confirmation RPC still uses shared rules.
+SELECT updated_at::text AS future_confirm_expected FROM public.appointments WHERE id=:'appt_future' \gset
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.record_appointment_confirmation_attempt(
+  :'tenant_a',:'appt_future','phone','other','Shared helper regression',
+  :'future_confirm_expected'::timestamptz,'manual-shared-confirmation-001'
+) AS shared_confirmation_result \gset
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT confirmation_attempt_count=1 AND last_confirmation_outcome='other' FROM public.appointments WHERE id=:'appt_future'), 'existing confirmation RPC still works through shared helper');
+
+-- Operation recovery returns reminder job and does not reveal cross-tenant data.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT public.get_appointment_operation(:'tenant_a','manual-complete-no-answer-001') AS recovered_operation \gset
+SELECT pg_temp.assert_true((:'recovered_operation'::jsonb->>'found')::boolean AND :'recovered_operation'::jsonb->'reminderJob'->>'id'=:'job_no_answer', 'operation recovery returns reminder job');
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT public.get_appointment_operation(:'tenant_b','manual-complete-no-answer-001') AS other_tenant_recovery \gset
+SELECT pg_temp.assert_true((:'other_tenant_recovery'::jsonb->>'found')::boolean IS FALSE, 'operation keys are tenant scoped');
+RESET ROLE;
+
+-- Database invariants and side effects.
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM (SELECT tenant_id,operation_key,count(*) FROM public.appointment_operations GROUP BY 1,2 HAVING count(*)>1) q), 'duplicate operation keys zero');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM (SELECT tenant_id,appointment_id,reminder_type,due_at,appointment_updated_at,policy_version,count(*) FROM public.appointment_reminder_jobs WHERE state IN ('scheduled','ready') GROUP BY 1,2,3,4,5,6 HAVING count(*)>1) q), 'duplicate active jobs zero');
+SELECT j.id,j.appointment_id,j.reminder_type,j.state,j.appointment_updated_at,a.updated_at AS current_appointment_updated_at,j.policy_version,p.policy_version AS current_policy_version,j.due_at,j.metadata
+FROM public.appointment_reminder_jobs j
+JOIN public.appointments a ON a.tenant_id=j.tenant_id AND a.id=j.appointment_id
+JOIN public.tenant_reminder_policies p ON p.tenant_id=j.tenant_id
+WHERE j.state IN ('scheduled','ready') AND (j.appointment_updated_at<>a.updated_at OR j.policy_version<>p.policy_version);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs j JOIN public.appointments a ON a.tenant_id=j.tenant_id AND a.id=j.appointment_id JOIN public.tenant_reminder_policies p ON p.tenant_id=j.tenant_id WHERE j.state IN ('scheduled','ready') AND (j.appointment_updated_at<>a.updated_at OR j.policy_version<>p.policy_version)), 'stale active jobs zero');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointment_reminder_jobs j JOIN public.appointments a ON a.id=j.appointment_id AND a.tenant_id=j.tenant_id WHERE j.patient_id<>a.patient_id), 'job appointment patient tenant integrity');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.appointments WHERE end_time<=start_time), 'invalid appointment intervals zero');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a1 JOIN public.appointments a2 ON a1.tenant_id=a2.tenant_id AND a1.id<a2.id AND a1.doctor_id=a2.doctor_id AND a1.status NOT IN ('cancelled','no_show','completed') AND a2.status NOT IN ('cancelled','no_show','completed') AND a1.start_time<a2.end_time AND a1.end_time>a2.start_time)=0, 'doctor overlaps zero');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.appointments a1 JOIN public.appointments a2 ON a1.tenant_id=a2.tenant_id AND a1.id<a2.id AND a1.patient_id=a2.patient_id AND a1.status NOT IN ('cancelled','no_show','completed') AND a2.status NOT IN ('cancelled','no_show','completed') AND a1.start_time<a2.end_time AND a1.end_time>a2.start_time)=0, 'patient overlaps zero');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.patient_visits)=:'visits_before', 'no visit side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.clinical_encounters)=:'encounters_before', 'no encounter side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.completed_services)=:'services_before', 'no completed service side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.treatment_plans)=:'plans_before', 'no treatment plan side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.findings)=:'findings_before', 'no finding side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.invoices)=:'invoices_before', 'no invoice side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.payments)=:'payments_before', 'no payment side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.refunds)=:'refunds_before', 'no refund side effects');
+SELECT pg_temp.assert_true((SELECT count(*)::text FROM public.financial_adjustments)=:'adjustments_before', 'no adjustment side effects');
+SELECT pg_temp.assert_true((SELECT balance::text FROM public.patients WHERE id=:'patient_a')=:'balance_before', 'patient balance unchanged');
+
+SELECT
+  (SELECT count(*) FROM public.appointment_reminder_jobs WHERE state IN ('scheduled','ready')) AS active_jobs,
+  (SELECT count(*) FROM public.appointment_reminder_jobs WHERE state='completed') AS completed_jobs,
+  (SELECT count(*) FROM public.appointment_reminder_jobs WHERE state='skipped') AS skipped_jobs,
+  (SELECT count(*) FROM public.appointment_reminder_jobs WHERE deferred_at IS NOT NULL) AS deferred_jobs,
+  (SELECT count(*) FROM public.appointment_confirmation_attempts) AS confirmation_attempts,
+  (SELECT count(*) FROM public.audit_events WHERE action IN ('appointment_reminder_completed','appointment_reminder_deferred','appointment_reminder_skipped')) AS manual_audit,
+  (SELECT count(*) FROM public.activity_events WHERE type IN ('appointment_reminder_completed','appointment_reminder_deferred','appointment_reminder_skipped')) AS manual_activity;
+
+ROLLBACK;
+\echo 'APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Implements the manual-first reminder operations slice on top of PR #354 baseline `03d1f101d238a557a1ab4cfa2c1441f030660fbf`.

Adds `/reminders` with overdue/today/upcoming groups, patient/phone/type/doctor/confirmation filters, controlled complete/defer/skip dialogs, manual-contact warnings, role-aware navigation, administrative history, tenant isolation, and safe optimistic-conflict UX.

Database migration `0030` adds durable manual-operation metadata, controlled RPCs, shared confirmation-attempt integration, tenant-scoped idempotency/recovery, audit/activity events, planner-safe defer/skip semantics, and structured stale/concurrent results without provider sends.

No SMS, WhatsApp, email, provider adapter, worker, cron, webhook, cloud apply, finance, clinical, document, or stock mutation is included.

Full QA evidence is in `_ai_work/REPORTS/APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001_operations.md`.

## Checks

- ESLint passed
- 93 frontend test files / 1038 tests passed
- Production build passed
- SQL regression 0024-0030 passed
- Concurrency suites 0025/0026/0027/0029/0030 passed
- Manual concurrency: 8 completed, 1 skipped, 1 deferred, 8 attempts, 1 replay, 5 conflicts, audit/activity 10/10, duplicates/stale/deadlocks 0
- Browser: admin operations/history, registrar, owner tenant isolation, doctor/cashier/no-tenant blocks, stale conflict; console errors 0, failed requests 0, secrets 0
- Browser database proof: 5 operations, 3 attempts, audit/activity 5/5, clinical/finance side effects 0

## Limitations

- Cloud Supabase was forbidden and untouched.
- Automated delivery remains blocked until normalized contact, language, consent, suppression and opt-out facts exist.
- The pre-existing large Vite chunk warning remains unrelated to this task.
