### PR TITLE
APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001: add communication contact and consent foundation

### DIFF
--- a/_ai_work/REPORTS/APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001_foundation.md
@@ -20,7 +20,9 @@ Patient cards now include a minimal communication section for authorized staff. 
 
 ## 4. PR URL
 
-Pending until the implementation branch is pushed and the pull request is opened.
+https://github.com/NckNA/codex-test/pull/356
+
+PR #356 is open, ready for review and remains unmerged.
 
 ## 5. Baseline
 
@@ -35,9 +37,15 @@ Pending until the implementation branch is pushed and the pull request is opened
 
 ## 6. PR head reviewed before final report update
 
-Pending until the implementation commit is pushed and fresh CI completes.
-
-The exact implementation head and CI run will be inserted after GitHub validates the branch.
+- implementation head: `7a9e5c4397fb5cd44037e36b9bd4464a4553b9f3`;
+- workflow: `CI`;
+- run number: `#726`;
+- run ID: `29229999819`;
+- conclusion: `success`;
+- tested commit: `7a9e5c4397fb5cd44037e36b9bd4464a4553b9f3`;
+- tested commit matched the implementation head exactly;
+- ESLint, tests, build and Merge guard passed;
+- PR #356 remained open and unmerged.
 
 ## 7. Report update commit
 
@@ -572,6 +580,10 @@ Completed:
 
 Baseline seed patients and their unverified legacy contacts remain because they are part of normal migration/seed behavior, not QA residue.
 
+## Checks
+
+All required local implementation, schema, SQL, concurrency, TypeScript, browser, network, cleanup and side-effect checks passed. Detailed evidence follows in sections 30–38.
+
 ## 37. Lint/test/build
 
 Final local quality gate:
@@ -584,16 +596,24 @@ Final local quality gate:
 
 ## 38. Fresh CI
 
-Pending until the branch is pushed and GitHub Actions tests the exact implementation head.
+Implementation CI completed successfully on the exact reviewed head:
 
-Required final checks:
+- workflow: `CI`;
+- run number: `#726`;
+- run ID: `29229999819`;
+- tested commit: `7a9e5c4397fb5cd44037e36b9bd4464a4553b9f3`;
+- ESLint: passed;
+- tests: passed;
+- build: passed;
+- Merge guard: passed;
+- conclusion: `success`;
+- PR remained open and unmerged.
 
-- exact PR head tested;
-- ESLint passed;
-- tests passed;
-- build passed;
-- merge guard passed;
-- PR remains open and unmerged.
+A second fresh CI run will validate the report-only metadata commit. Its exact head and run are recorded outside this self-referential report in the final task response and immutable receipt.
+
+## Limitations
+
+The known limitations are explicit and do not invalidate the verified contact/consent foundation. They are listed below.
 
 ## 39. Known limitations
 

--- a/_ai_work/REPORTS/APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001_foundation.md
@@ -1,0 +1,635 @@
+# APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001
+
+## 1. Final verdict
+
+Final verdict: **PASS**
+
+Task verdict: **PATIENT COMMUNICATION CONTACT AND CONSENT FOUNDATION IMPLEMENTED AND VERIFIED**
+
+The tenant-scoped contact, preference, consent, suppression and provider-neutral eligibility foundation is implemented and verified locally. It does not send SMS, WhatsApp or email, select a provider, create a delivery attempt, run a worker, register cron, expose a webhook, build templates, apply cloud migrations or start HEP-V2.
+
+## 2. Summary
+
+The task introduces authoritative communication facts that are separate from the legacy `patients.phone` display field. Raw and normalized phone/email values are stored separately, representative ownership is explicit, consent is channel-specific and defaults to `unknown`, suppression has higher precedence than preference, and every changed consent fact is append-only and idempotent.
+
+Patient cards now include a minimal communication section for authorized staff. Reminder queue rows receive provider-neutral eligibility badges without changing reminder job state or sending anything.
+
+## 3. Branch
+
+`feature/appointment-reminder-contact-consent-foundation-001`
+
+## 4. PR URL
+
+Pending until the implementation branch is pushed and the pull request is opened.
+
+## 5. Baseline
+
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- required baseline: `112f9990ed486201a3d86648521867c20ddd1aff`;
+- verified `origin/main`: `112f9990ed486201a3d86648521867c20ddd1aff`;
+- PR #355 was confirmed merged into `main`;
+- the source checkout was clean;
+- the feature worktree was created directly from current `origin/main`;
+- cloud Supabase remained forbidden and untouched.
+
+## 6. PR head reviewed before final report update
+
+Pending until the implementation commit is pushed and fresh CI completes.
+
+The exact implementation head and CI run will be inserted after GitHub validates the branch.
+
+## 7. Report update commit
+
+Report update commit: N/A because a report-only commit cannot contain its own future SHA and the CI run that tests it.
+
+The exact final report-only head and fresh CI run will be recorded in the final task response and an immutable local finalization receipt.
+
+## 8. Changed files
+
+Expected final changed files:
+
+- `_ai_work/REPORTS/APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001_foundation.md`;
+- `src/components/patients/patient-card/PatientCommunicationSection.tsx`;
+- `src/components/patients/patient-card/PatientCommunicationSection.test.tsx`;
+- `src/data/hooks/usePatientCommunicationProfile.ts`;
+- `src/data/hooks/usePatientCommunicationProfile.test.tsx`;
+- `src/data/repositories/PatientCommunicationRepository.ts`;
+- `src/data/repositories/PatientCommunicationRepository.test.ts`;
+- `src/data/repositories/AppointmentReminderRepository.ts`;
+- `src/pages/PatientCardPage.tsx`;
+- `src/pages/ReminderOperationsPage.tsx`;
+- `src/types/index.ts`;
+- `supabase/migrations/0031_patient_communication_contact_consent_foundation.sql`;
+- `supabase/tests/0031_patient_communication_contact_consent_foundation_test.sql`.
+
+No historical migration, package file, lockfile, generated type, provider SDK, environment file, screenshot, browser fixture, temporary script or cloud configuration belongs in the final diff.
+
+## 9. Pre-read
+
+Reports read and reconciled:
+
+- `APPOINTMENT-CONFIRMATION-WORKFLOW-001`;
+- `APPOINTMENT-REMINDER-OPERATIONS-RECON-001`;
+- `TENANT-TIMEZONE-SCHEDULING-FOUNDATION-001`;
+- `APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001`;
+- `APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001`.
+
+Architecture and implementation sources reviewed:
+
+- role and permission rules;
+- multi-tenant and data-isolation rules;
+- patient model and patient repository;
+- patient create/edit/card UI;
+- appointment and schedule contracts;
+- reminder repository and manual queue;
+- confirmation workflow;
+- audit/activity internal helpers;
+- Supabase-active authentication and repository conventions;
+- testing strategy;
+- `/sms` and `/mailing` placeholders.
+
+## 10. Existing contact inventory
+
+Before this task:
+
+| Surface | Classification | Actual behavior | Safe for automation |
+|---|---|---|---|
+| `patients.phone` | legacy free text | created/edited by patient forms, displayed on patient pages and reminder UI | no |
+| patient repository `phone` | compatibility field | tenant-scoped patient CRUD, no authoritative normalization or consent | no |
+| manual reminder channel `phone/sms/whatsapp/email` | operational outcome label | staff records how a manual contact was attempted | no automatic delivery |
+| `/sms` page | placeholder | no provider and no send contract | no |
+| `/mailing` page | placeholder | no provider and no send contract | no |
+| language/locale | missing as patient communication authority | UI language is not patient consent/preference | no |
+| guardian/representative | missing as structured communication ownership | no authoritative relation | no |
+| consent/opt-out | missing | no channel-specific evidence or suppression | no |
+
+There was no normalized contact table, no append-only consent history, no explicit representative ownership, no suppression precedence and no provider-neutral eligibility function.
+
+## 11. Legacy phone behavior
+
+`patients.phone` remains unchanged for compatibility.
+
+Migration `0031`:
+
+- creates one patient-owned `import_legacy` phone contact when the legacy value is non-empty;
+- preserves `contact_value_raw` exactly after trimming;
+- stores a normalized value only when deterministic E.164 validation succeeds;
+- sets `is_verified = false`;
+- sets all automated consent states to `unknown`;
+- does not fabricate representative ownership;
+- does not fabricate opt-in;
+- does not delete or rewrite `patients.phone`.
+
+A narrow legacy synchronization trigger handles patients created after migration/seeding and later legacy phone edits. It may update only an active, unverified, patient-owned `import_legacy` contact. It cannot overwrite a verified or separately managed authoritative contact.
+
+A clean reset proved two legacy patient phones produced two unverified `import_legacy` contacts and unknown consent states.
+
+## 12. Contact data model
+
+`public.patient_communication_contacts` stores:
+
+- tenant and patient identity;
+- contact type `phone` or `email`;
+- raw value and separately normalized value;
+- country code where deterministically known;
+- primary and verification flags;
+- verification source;
+- owner type `patient` or `representative`;
+- representative name and stable relation;
+- contact-specific language;
+- possible-duplicate warning;
+- actor/timestamps;
+- soft archive timestamp.
+
+Composite tenant/patient foreign keys prevent cross-tenant ownership. Archived contacts cannot be primary. Verified contacts require a normalized destination and verification source.
+
+## 13. Phone normalization
+
+The database is authoritative.
+
+`normalize_patient_phone_e164(text)`:
+
+- requires an explicit leading `+`;
+- strips spaces, parentheses and hyphens after the plus;
+- validates `+` followed by 8–15 digits with a non-zero country prefix;
+- accepts Kazakhstan and international E.164 values;
+- rejects extensions and extension markers;
+- does not silently convert `8...` or guess a country;
+- preserves the original raw value separately.
+
+Verified examples:
+
+- `+7 (700) 123-45-67` → `+77001234567`;
+- `+49 151 12345678` → `+4915112345678`;
+- `87001234567` → invalid because no explicit country code;
+- `+77001234567 ext 4` → invalid.
+
+Frontend validation is only an early UX check; RPC/database validation remains final.
+
+## 14. Email normalization
+
+`normalize_patient_email(text)`:
+
+- trims whitespace;
+- lowercases the canonical representation;
+- performs syntactic validation;
+- preserves the raw value separately;
+- preserves plus addressing;
+- performs no domain-specific rewriting or alias collapse;
+- does not claim verification.
+
+Verified example:
+
+` Patient+tag@Example.COM ` → `patient+tag@example.com`.
+
+## 15. Representative model
+
+Representative ownership is explicit and never inferred from a phone string.
+
+A representative contact requires:
+
+- `owner_type = representative`;
+- non-empty representative name;
+- one stable relation: `parent`, `guardian`, `spouse`, `child`, `caregiver` or `other`.
+
+The model records communication ownership, not legal guardianship. A representative contact may be primary only when staff explicitly selects it. Eligibility marks representative automated destinations as `representative_review_required` and `requiresManualReview = true`.
+
+The patient card displays a clear warning that the contact belongs to a representative.
+
+## 16. Primary contact rules
+
+Partial unique indexes enforce:
+
+- at most one active primary phone per tenant/patient;
+- at most one active primary email per tenant/patient.
+
+Primary changes are transactional through controlled RPCs. Other active contacts of the same type are demoted before the selected contact is promoted. Archived contacts cannot become primary. Tenant and patient relationships are validated under lock.
+
+## 17. Preference model
+
+`public.patient_communication_preferences` stores one row per tenant/patient with:
+
+- preferred language: `ru`, `kk` or `en`;
+- preferred channel: `phone`, `whatsapp`, `sms`, `email` or `none`;
+- explicit `allow_manual_phone`;
+- separate SMS, WhatsApp and email consent states;
+- phone/SMS/WhatsApp/email suppression facts;
+- global suppression;
+- reason, timestamp and actor for suppressions;
+- actor and timestamps for preference changes.
+
+Preferred channel is a preference only. It cannot override missing consent or suppression.
+
+## 18. Consent model
+
+Consent states are not booleans:
+
+- `unknown`;
+- `granted`;
+- `denied`;
+- `withdrawn`.
+
+SMS, WhatsApp and email consent are independent. A valid phone does not grant SMS or WhatsApp consent. A preferred channel does not grant consent. Unknown is never treated as granted.
+
+Registrar consent sources are constrained to appropriate verbal/correction paths; owner/admin have the wider approved source set.
+
+## 19. Consent evidence
+
+`public.patient_communication_consent_events` is append-only and records:
+
+- tenant and patient;
+- channel;
+- previous and new state;
+- stable source;
+- actor;
+- reason;
+- timestamp;
+- safe metadata;
+- tenant-scoped operation key and fingerprint.
+
+Authenticated users cannot insert, update or delete event rows directly. Only the controlled consent RPC appends events.
+
+Idempotency:
+
+- same operation key + same payload replays one result;
+- replay creates no second event and no second audit/activity pair;
+- same key + changed payload is rejected;
+- a genuine later transition, such as withdrawn → granted, creates a new evidence event.
+
+## 20. Suppression model
+
+Per-channel and global suppression are explicit facts with stable reasons:
+
+- `patient_request`;
+- `representative_request`;
+- `invalid_contact`;
+- `wrong_number`;
+- `duplicate_contact`;
+- `legal_restriction`;
+- `staff_decision`;
+- `other`.
+
+Registrar suppression is restricted to operational reasons such as invalid/wrong/duplicate contact or staff correction. Owner/admin may use the broader approved set.
+
+Unsuppressing removes only the selected suppression. It does not fabricate consent. Automated eligibility returns only when all remaining requirements are satisfied.
+
+## 21. Eligibility precedence
+
+`get_patient_communication_eligibility(tenant, patient, channel)` is read-only and provider-neutral.
+
+Automated channel precedence:
+
+1. global suppression;
+2. channel suppression;
+3. denied, withdrawn or unknown consent;
+4. no preferred communication channel;
+5. missing contact;
+6. invalid contact;
+7. unverified contact;
+8. representative review requirement;
+9. granted consent with a valid verified destination.
+
+Stable blocked reasons:
+
+- `no_contact`;
+- `invalid_contact`;
+- `unverified_contact`;
+- `consent_unknown`;
+- `consent_denied`;
+- `consent_withdrawn`;
+- `channel_suppressed`;
+- `global_suppression`;
+- `no_preferred_channel`;
+- `representative_review_required`.
+
+Manual phone is evaluated separately. Manual work may remain available when the contact and manual-phone policy permit it. A global `legal_restriction` blocks manual phone; ordinary automated suppression does not silently erase authorized manual work.
+
+The function never sends, reserves, claims or changes a reminder job.
+
+## 22. RPC contracts
+
+Controlled RPCs:
+
+- `upsert_patient_communication_contact(...)`;
+- `archive_patient_communication_contact(...)`;
+- `set_primary_patient_communication_contact(...)`;
+- `set_patient_communication_preferences(...)`;
+- `set_patient_communication_consent(...)`;
+- `set_patient_communication_suppression(...)`;
+- `get_patient_communication_eligibility(...)`.
+
+Mutating RPCs authenticate, resolve tenant role, lock patient/contact/preferences where required, validate tenant relationships, normalize input server-side, preserve raw values, enforce state rules, record audit/activity, append consent evidence where applicable, and use tenant-scoped operation keys.
+
+During SQL validation, a real PostgreSQL `NULL NOT IN (...)` authorization defect was detected and fixed. All role checks now explicitly reject `NULL` membership before evaluating allowed roles.
+
+## 23. Role matrix
+
+| Capability | Owner | Admin | Registrar | Doctor | Cashier | Unknown/no tenant |
+|---|---:|---:|---:|---:|---:|---:|
+| View contacts/preferences | yes | yes | yes | read-only | no | no |
+| View consent history | yes | yes | yes | no | no | no |
+| Add/edit/archive/primary contact | yes | yes | yes | no | no | no |
+| Change language/channel/manual phone | yes | yes | yes | no | no | no |
+| Record consent | yes | yes | verbal/correction sources | no | no | no |
+| Suppress/unsuppress | yes | yes | operational reasons only | no | no | no |
+| Read provider-neutral eligibility | yes | yes | yes | yes | no | no |
+
+Browser smoke verified owner/admin behavior, doctor read-only behavior and cross-tenant owner isolation.
+
+## 24. RLS
+
+RLS is enabled on:
+
+- `patient_communication_contacts`;
+- `patient_communication_preferences`;
+- `patient_communication_consent_events`;
+- `patient_communication_operations`.
+
+Authenticated reads are tenant-scoped and role-scoped. Direct authenticated INSERT/UPDATE/DELETE is revoked. Consent events are append-only. Operations are not exposed for normal frontend reads. Anonymous, cashier, unknown and no-tenant access is blocked.
+
+Schema assertions passed: **45/45**.
+
+## 25. Audit/activity
+
+Events implemented:
+
+- `patient_communication_contact_added`;
+- `patient_communication_contact_updated`;
+- `patient_communication_contact_archived`;
+- `patient_communication_primary_changed`;
+- `patient_communication_preferences_changed`;
+- `patient_communication_consent_changed`;
+- `patient_communication_suppression_changed`.
+
+Audit/activity include tenant, patient, actor, role, target and safe old/new facts. General activity metadata stores only a destination suffix where needed, not the full raw contact.
+
+SQL and browser validation proved one audit and one activity event per changed logical operation. Browser result: `6/6` parity.
+
+## 26. Repository integration
+
+`PatientCommunicationRepository` provides:
+
+- `listPatientContacts(patientId)`;
+- `getPatientCommunicationProfile(patientId)`;
+- `upsertContact(...)`;
+- `archiveContact(...)`;
+- `setPrimaryContact(...)`;
+- `updatePreferences(...)`;
+- `setConsent(...)`;
+- `setSuppression(...)`;
+- `getEligibility(patientId, channel)`;
+- `getEligibilitySummary(patientId)`.
+
+Reads are tenant-filtered. Mutations are RPC-only. Supabase-active mode has no localStorage/local repository fallback when the tenant is missing. Safe error mapping does not expose SQLSTATE, constraint names, function names, stack traces, operation keys or raw contact values.
+
+## 27. Hook integration
+
+`usePatientCommunicationProfile` exposes:
+
+- profile, contacts, preferences, eligibility and consent history;
+- loading and dedicated mutation flags;
+- safe error state;
+- role-aware mutation capability;
+- refresh, contact, preference, consent and suppression actions.
+
+Behavior verified:
+
+- no tenant → no fetch;
+- no patient → no fetch;
+- tenant switch clears old data;
+- patient switch clears old data;
+- late/stale response is ignored;
+- duplicate mutation is blocked;
+- success refreshes once;
+- errors preserve the loaded profile/editor context.
+
+## 28. Patient-card UI
+
+A real `Связь` tab was added to the patient card.
+
+It displays:
+
+- primary phone and email;
+- raw and normalized values;
+- verification status;
+- patient or representative ownership;
+- representative name/relation;
+- preferred language/channel;
+- per-channel consent;
+- channel/global suppression;
+- duplicate warning;
+- provider-neutral eligibility;
+- consent history.
+
+Controlled actions include contact add/archive/primary, preferences, consent/withdrawal and suppression changes. Doctor sees the same authorized contact facts read-only.
+
+Required warnings are present. No provider/send controls exist.
+
+## 29. Reminder-queue integration
+
+Reminder enrichment fetches provider-neutral communication eligibility for each unique patient and attaches a summary without changing the reminder job.
+
+Rows show:
+
+- `Автоканал доступен`;
+- `Только вручную`;
+- `Нет согласия`;
+- `Контакт не готов`;
+- `Связь подавлена`;
+- `Автосвязь заблокирована`.
+
+Browser smoke verified a legacy/unverified row displayed `Только вручную` and a verified SMS-consented row displayed `Автоканал доступен`. Both fixture reminder jobs remained `scheduled`.
+
+## 30. SQL tests
+
+`supabase/tests/0031_patient_communication_contact_consent_foundation_test.sql` passed.
+
+Coverage includes the required role matrix, tenant isolation, Kazakhstan/international E.164, no country guessing, extension rejection, email normalization, legacy import, primary rules, representative validation, preferences, consent transitions, consent replay/conflict, per-channel/global suppression, eligibility, duplicate family number, append-only evidence, RLS, audit parity and clinical/financial/reminder invariants.
+
+Full inherited SQL regression passed:
+
+- 0024;
+- 0025;
+- 0026;
+- 0027;
+- 0028;
+- 0029;
+- 0030;
+- 0031.
+
+Required concurrency suites passed:
+
+- 0025;
+- 0026;
+- 0027;
+- 0029;
+- 0030.
+
+No overlap, duplicate active job, active stale job or deadlock regression was introduced.
+
+## 31. TypeScript tests
+
+Targeted communication/reminder tests: **54/54 passed**.
+
+Full test suite: **96 test files, 1070 tests passed**.
+
+Coverage includes repository mapping/RPC calls/safe errors/tenant filtering/no direct mutations, hook switch and stale-response behavior, UI legacy/consent/representative/duplicate/suppression/role behavior and reminder regression.
+
+## 32. Browser smoke
+
+HeadlessChrome 150 was used because a separate Chrome DevTools MCP executable was unavailable in the environment.
+
+Verified against real local Supabase Auth:
+
+- legacy phone shown unverified;
+- consent shown as unknown;
+- automation blocked for legacy/unverified contact;
+- valid E.164 contact saved with raw and normalized values;
+- SMS consent granted without granting WhatsApp;
+- WhatsApp suppression blocked only WhatsApp;
+- global suppression blocked automated channels;
+- representative ownership displayed explicitly;
+- shared family number produced a warning but remained valid;
+- tenant B could not read tenant A patient/contact;
+- doctor contact view was read-only;
+- reminder eligibility badges matched database facts;
+- no send/provider controls appeared.
+
+Final scenarios reported console errors `0`, failed requests `0` and secrets visible `false`.
+
+## 33. Network validation
+
+Local Kong/PostgREST logs for the smoke window showed:
+
+- contact upsert RPC: `2`;
+- consent RPC: `1`;
+- suppression RPC: `3`;
+- read-only eligibility RPC: `88`;
+- direct writes to contacts: `0`;
+- direct writes to preferences: `0`;
+- direct writes to consent events: `0`;
+- provider/SMS/WhatsApp/email requests: `0`.
+
+The browser received only an anon client configuration and ordinary authenticated user session. No service-role credential was exposed to the frontend.
+
+## 34. Database validation
+
+Browser-smoke database snapshot before cleanup:
+
+- communication contacts: `4`;
+- consent events: `1`;
+- idempotent communication operations: `6`;
+- communication audit events: `6`;
+- communication activity events: `6`;
+- scheduled reminder jobs: `2`;
+- duplicate consent operation keys: `0`;
+- cross-tenant contact leaks: `0`;
+- invalid normalized contacts: `0`.
+
+Eligibility snapshot:
+
+- phone: `manual_only`, manual eligible, automated false;
+- SMS: `available`, consent granted, automated eligible;
+- WhatsApp: `suppressed`, consent unknown, automated false.
+
+SQL validation also proved automated eligibility without granted consent equals zero.
+
+## 35. Side-effect validation
+
+The task created no:
+
+- appointment confirmation mutation;
+- reminder job state mutation;
+- visit;
+- clinical encounter;
+- completed service;
+- treatment plan/finding/chart fact;
+- invoice;
+- payment;
+- refund/adjustment;
+- patient balance change;
+- document;
+- stock movement;
+- provider request or delivery attempt.
+
+Browser fixture counts for visits, encounters, services, invoices and payments were all `0`.
+
+## 36. Cleanup
+
+Completed:
+
+- feature Vite processes stopped, including orphaned local Vite processes;
+- QA screenshots removed;
+- temporary browser SQL and launch scripts removed;
+- `.env.local` removed;
+- local Supabase reset without QA seed;
+- QA users: `0`;
+- browser patients: `0`;
+- task reminder jobs: `0`;
+- task communication operations: `0`;
+- task consent events: `0`.
+
+Baseline seed patients and their unverified legacy contacts remain because they are part of normal migration/seed behavior, not QA residue.
+
+## 37. Lint/test/build
+
+Final local quality gate:
+
+- ESLint: **passed with no task warning**;
+- Vitest: **96 files / 1070 tests passed**;
+- TypeScript/Vite production build: **passed**;
+- transformed modules: `1959`;
+- only the pre-existing large-chunk warning remains.
+
+## 38. Fresh CI
+
+Pending until the branch is pushed and GitHub Actions tests the exact implementation head.
+
+Required final checks:
+
+- exact PR head tested;
+- ESLint passed;
+- tests passed;
+- build passed;
+- merge guard passed;
+- PR remains open and unmerged.
+
+## 39. Known limitations
+
+- This is a contact/consent foundation, not a delivery system.
+- Phone verification is an explicit staff fact; no OTP or external verification exists.
+- Legal guardianship is not inferred or proven by the representative relation field.
+- `patients.phone` remains a compatibility field and can still differ from authoritative managed contacts; the legacy trigger only synchronizes unverified `import_legacy` data.
+- Reminder enrichment currently performs four eligibility RPCs per unique patient. It is correct and tenant-safe but should become a bounded batch/read-model RPC before high-volume provider work.
+- Contact verification/suppression policy may need tenant-level administration before automated delivery is approved.
+- No provider account, delivery evidence, inbound reply or webhook semantics were evaluated.
+
+## 40. What was intentionally not implemented
+
+Not implemented:
+
+- SMS, WhatsApp or email sending;
+- provider SDK or adapter;
+- delivery-attempt table;
+- worker, queue claim, retry or scheduler;
+- cron or Edge Function;
+- webhook;
+- message templates;
+- OTP verification;
+- marketing campaigns/subscriptions;
+- consent inference;
+- broad CRM contact redesign;
+- public portal or consent PDF;
+- clinical or financial changes;
+- cloud migration apply;
+- generated types;
+- HEP-V2.
+
+## 41. Recommended next task
+
+Recommended next task: **APPOINTMENT-REMINDER-PROVIDER-ABSTRACTION-001**
+
+Reason: normalized contacts, language, consent and suppression are now authoritative enough to design a provider-neutral outbound adapter without exposing credentials or sending from the frontend.
+
+This next task was not started.

--- a/src/components/patients/patient-card/PatientCommunicationSection.test.tsx
+++ b/src/components/patients/patient-card/PatientCommunicationSection.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePatientCommunicationProfile } from '../../../data/hooks/usePatientCommunicationProfile';
+import type { PatientCommunicationProfile } from '../../../types';
+import { PatientCommunicationSection } from './PatientCommunicationSection';
+
+vi.mock('../../../data/hooks/usePatientCommunicationProfile', () => ({ usePatientCommunicationProfile: vi.fn() }));
+
+const patientId = '22222222-2222-4222-8222-222222222222';
+const legacyContact = {
+  id: 'contact-legacy', tenantId: 'tenant-a', patientId, contactType: 'phone' as const,
+  contactValueRaw: '+7 (700) 123-45-67', contactValueNormalized: '+77001234567', countryCode: '7',
+  isPrimary: true, isVerified: false, verificationSource: 'import_legacy', ownerType: 'patient' as const,
+  possibleDuplicate: false, language: 'ru' as const,
+  createdAt: '2026-07-13T00:00:00Z', updatedAt: '2026-07-13T00:00:00Z',
+};
+
+const profile: PatientCommunicationProfile = {
+  contacts: [legacyContact],
+  preferences: {
+    tenantId: 'tenant-a', patientId, preferredLanguage: 'ru', preferredChannel: 'none', allowManualPhone: true,
+    smsConsentState: 'unknown', whatsappConsentState: 'unknown', emailConsentState: 'denied',
+    phoneSuppressed: false, smsSuppressed: false, whatsappSuppressed: true,
+    whatsappSuppressionReason: 'patient_request', emailSuppressed: false, globalSuppression: false,
+    createdAt: '', updatedAt: '',
+  },
+  consentEvents: [{
+    id: 'event-1', tenantId: 'tenant-a', patientId, channel: 'email', previousState: 'unknown',
+    newState: 'denied', source: 'patient_verbal', occurredAt: '2026-07-13T01:00:00Z', metadata: {},
+  }],
+  eligibility: {
+    phone: { eligible: true, automatedEligible: false, manualEligible: true, status: 'manual_only', channel: 'phone', selectedContactId: 'contact-legacy', normalizedDestination: '+77001234567', language: 'ru', blockedReasons: [], consentState: 'not_required', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: true },
+    sms: { eligible: false, automatedEligible: false, manualEligible: false, status: 'consent_unknown', channel: 'sms', selectedContactId: 'contact-legacy', normalizedDestination: '+77001234567', language: 'ru', blockedReasons: ['consent_unknown', 'unverified_contact'], consentState: 'unknown', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: false },
+    whatsapp: { eligible: false, automatedEligible: false, manualEligible: false, status: 'suppressed', channel: 'whatsapp', selectedContactId: 'contact-legacy', normalizedDestination: '+77001234567', language: 'ru', blockedReasons: ['channel_suppressed', 'consent_unknown'], consentState: 'unknown', suppressionState: { global: false, channel: true }, representative: false, requiresManualReview: false },
+    email: { eligible: false, automatedEligible: false, manualEligible: false, status: 'blocked', channel: 'email', language: 'ru', blockedReasons: ['no_contact', 'consent_denied'], consentState: 'denied', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: false },
+    status: 'manual_only',
+  },
+};
+
+const hook = (overrides: Record<string, unknown> = {}) => ({
+  profile,
+  contacts: profile.contacts,
+  preferences: profile.preferences,
+  eligibility: profile.eligibility,
+  consentEvents: profile.consentEvents,
+  loading: false,
+  savingContact: false,
+  updatingConsent: false,
+  updatingPreferences: false,
+  updatingSuppression: false,
+  error: null,
+  canMutate: true,
+  refresh: vi.fn(),
+  saveContact: vi.fn().mockResolvedValue({ replayed: false, duplicateWarning: false }),
+  archiveContact: vi.fn().mockResolvedValue({ replayed: false }),
+  setPrimaryContact: vi.fn().mockResolvedValue({ replayed: false }),
+  savePreferences: vi.fn().mockResolvedValue({ replayed: false }),
+  recordConsent: vi.fn().mockResolvedValue({ replayed: false, changed: true }),
+  changeSuppression: vi.fn().mockResolvedValue({ replayed: false }),
+  clearError: vi.fn(),
+  ...overrides,
+}) as unknown as ReturnType<typeof usePatientCommunicationProfile>;
+
+function renderSection() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<PatientCommunicationSection patientId={patientId} />));
+  return { container, root };
+}
+
+function change(element: HTMLInputElement | HTMLSelectElement, next: string | boolean) {
+  act(() => {
+    if (element instanceof HTMLInputElement && typeof next === 'boolean') {
+      const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked');
+      descriptor?.set?.call(element, next);
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+      return;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(
+      element instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLInputElement.prototype,
+      'value',
+    );
+    descriptor?.set?.call(element, next);
+    element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? 'change' : 'input', { bubbles: true }));
+  });
+}
+
+function button(container: HTMLElement, testId: string): HTMLButtonElement {
+  const found = container.querySelector(`[data-testid="${testId}"]`);
+  if (!found) throw new Error(`Missing ${testId}`);
+  return found as HTMLButtonElement;
+}
+
+describe('PatientCommunicationSection', () => {
+  beforeEach(() => vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook()));
+  afterEach(() => { document.body.innerHTML = ''; vi.clearAllMocks(); });
+
+  it('shows legacy phone as unverified and consent unknown', () => {
+    const { container, root } = renderSection();
+    expect(container.textContent).toContain('+7 (700) 123-45-67');
+    expect(container.textContent).toContain('Не подтверждён');
+    expect(container.textContent).toContain('Не указано');
+    expect(container.textContent).toContain('Наличие номера не означает согласие на сообщения.');
+    act(() => root.unmount());
+  });
+
+  it('shows preferred language and channel', () => {
+    const { container, root } = renderSection();
+    expect((container.querySelector('[data-testid="communication-preferred-language"]') as HTMLSelectElement).value).toBe('ru');
+    expect((container.querySelector('[data-testid="communication-preferred-channel"]') as HTMLSelectElement).value).toBe('none');
+    act(() => root.unmount());
+  });
+
+  it('shows suppression and automated eligibility warning', () => {
+    const { container, root } = renderSection();
+    expect(container.textContent).toContain('Связь подавлена');
+    expect(container.textContent).toContain('Автоматическая отправка заблокирована до получения согласия.');
+    act(() => root.unmount());
+  });
+
+  it('validates an invalid phone before RPC', async () => {
+    const saveContact = vi.fn();
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({ saveContact }));
+    const { container, root } = renderSection();
+    act(() => button(container, 'communication-add-contact').click());
+    change(container.querySelector('[data-testid="communication-contact-value"]') as HTMLInputElement, '8700');
+    await act(async () => button(container, 'communication-save-contact').click());
+    expect(container.textContent).toContain('Укажите корректный номер телефона.');
+    expect(saveContact).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it('validates an invalid email before RPC', async () => {
+    const saveContact = vi.fn();
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({ saveContact }));
+    const { container, root } = renderSection();
+    act(() => button(container, 'communication-add-contact').click());
+    change(container.querySelector('[data-testid="communication-contact-type"]') as HTMLSelectElement, 'email');
+    change(container.querySelector('[data-testid="communication-contact-value"]') as HTMLInputElement, 'bad@');
+    await act(async () => button(container, 'communication-save-contact').click());
+    expect(container.textContent).toContain('Укажите корректный адрес электронной почты.');
+    expect(saveContact).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it('saves an explicit representative contact', async () => {
+    const saveContact = vi.fn().mockResolvedValue({ replayed: false, duplicateWarning: false });
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({ saveContact }));
+    const { container, root } = renderSection();
+    act(() => button(container, 'communication-add-contact').click());
+    change(container.querySelector('[data-testid="communication-contact-value"]') as HTMLInputElement, '+77009998877');
+    change(container.querySelector('[data-testid="communication-owner-type"]') as HTMLSelectElement, 'representative');
+    change(container.querySelector('[data-testid="communication-representative-name"]') as HTMLInputElement, 'Мама пациента');
+    change(container.querySelector('[data-testid="communication-representative-relation"]') as HTMLSelectElement, 'parent');
+    await act(async () => button(container, 'communication-save-contact').click());
+    expect(saveContact).toHaveBeenCalledWith(expect.objectContaining({
+      ownerType: 'representative', representativeName: 'Мама пациента', representativeRelation: 'parent',
+    }));
+    act(() => root.unmount());
+  });
+
+  it('shows duplicate warning returned by the backend', async () => {
+    const saveContact = vi.fn().mockResolvedValue({ replayed: false, duplicateWarning: true });
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({ saveContact }));
+    const { container, root } = renderSection();
+    act(() => button(container, 'communication-add-contact').click());
+    change(container.querySelector('[data-testid="communication-contact-value"]') as HTMLInputElement, '+77009998877');
+    await act(async () => button(container, 'communication-save-contact').click());
+    expect(container.textContent).toContain('Этот контакт уже используется у другого пациента в этой клинике.');
+    act(() => root.unmount());
+  });
+
+  it('records SMS consent separately from WhatsApp', async () => {
+    const recordConsent = vi.fn().mockResolvedValue({ replayed: false, changed: true });
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({ recordConsent }));
+    const { container, root } = renderSection();
+    await act(async () => button(container, 'communication-consent-grant-sms').click());
+    expect(recordConsent).toHaveBeenCalledWith('sms', 'granted', 'patient_verbal', undefined);
+    expect(recordConsent).not.toHaveBeenCalledWith('whatsapp', 'granted', expect.anything(), expect.anything());
+    act(() => root.unmount());
+  });
+
+  it('shows representative ownership explicitly', () => {
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({
+      contacts: [{ ...legacyContact, id: 'representative', ownerType: 'representative', representativeName: 'Отец', representativeRelation: 'parent' }],
+    }));
+    const { container, root } = renderSection();
+    expect(container.textContent).toContain('Этот контакт принадлежит представителю пациента.');
+    expect(container.textContent).toContain('Родитель');
+    act(() => root.unmount());
+  });
+
+  it('renders read-only role and no provider controls', () => {
+    vi.mocked(usePatientCommunicationProfile).mockReturnValue(hook({ canMutate: false }));
+    const { container, root } = renderSection();
+    expect(container.textContent).toContain('Доступ только для просмотра.');
+    expect(container.querySelector('[data-testid="communication-add-contact"]')).toBeNull();
+    expect(container.textContent).not.toContain('Отправить SMS');
+    expect(container.textContent).not.toContain('Отправить WhatsApp');
+    expect(container.textContent).not.toContain('Отправить Email');
+    act(() => root.unmount());
+  });
+});

--- a/src/components/patients/patient-card/PatientCommunicationSection.tsx
+++ b/src/components/patients/patient-card/PatientCommunicationSection.tsx
@@ -1,0 +1,388 @@
+import { useMemo, useState } from 'react';
+import { AlertTriangle, Archive, CheckCircle2, Mail, MessageCircle, Phone, Plus, ShieldAlert, Star, UserRound } from 'lucide-react';
+import { usePatientCommunicationProfile } from '../../../data/hooks/usePatientCommunicationProfile';
+import type {
+  PatientAutomatedCommunicationChannel,
+  PatientCommunicationConsentSource,
+  PatientCommunicationConsentState,
+  PatientCommunicationContactType,
+  PatientCommunicationLanguage,
+  PatientCommunicationOwnerType,
+  PatientCommunicationSuppressionReason,
+  PatientPreferredCommunicationChannel,
+  PatientRepresentativeRelation,
+} from '../../../types';
+
+const CONSENT_LABELS: Record<PatientCommunicationConsentState, string> = {
+  unknown: 'Не указано',
+  granted: 'Согласие получено',
+  denied: 'Не согласен',
+  withdrawn: 'Согласие отозвано',
+};
+
+const CHANNEL_LABELS: Record<PatientAutomatedCommunicationChannel, string> = {
+  sms: 'SMS',
+  whatsapp: 'WhatsApp',
+  email: 'Email',
+};
+
+const ELIGIBILITY_LABELS = {
+  available: 'Автоматический канал доступен',
+  manual_only: 'Только ручная связь',
+  consent_unknown: 'Согласие не указано',
+  invalid_contact: 'Контакт не готов',
+  suppressed: 'Связь подавлена',
+  blocked: 'Автоматическая связь заблокирована',
+} as const;
+
+const RELATION_LABELS: Record<PatientRepresentativeRelation, string> = {
+  parent: 'Родитель',
+  guardian: 'Опекун',
+  spouse: 'Супруг(а)',
+  child: 'Ребёнок',
+  caregiver: 'Ухаживающее лицо',
+  other: 'Другое',
+};
+
+const makeInitialContact = () => ({
+  contactType: 'phone' as PatientCommunicationContactType,
+  contactValueRaw: '',
+  ownerType: 'patient' as PatientCommunicationOwnerType,
+  representativeName: '',
+  representativeRelation: 'parent' as PatientRepresentativeRelation,
+  language: 'ru' as PatientCommunicationLanguage,
+  isPrimary: true,
+  isVerified: false,
+});
+
+const validPhone = (raw: string) => /^\+[1-9][0-9\s()-]{7,20}$/.test(raw.trim());
+const validEmail = (raw: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw.trim());
+
+export function PatientCommunicationSection({ patientId }: { patientId: string }) {
+  const communication = usePatientCommunicationProfile(patientId);
+  const [showContactForm, setShowContactForm] = useState(false);
+  const [contactDraft, setContactDraft] = useState(makeInitialContact);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [preferenceDraft, setPreferenceDraft] = useState<{
+    language: PatientCommunicationLanguage;
+    preferredChannel: PatientPreferredCommunicationChannel;
+    allowManualPhone: boolean;
+  } | null>(null);
+  const [consentSource, setConsentSource] = useState<PatientCommunicationConsentSource>('patient_verbal');
+  const [consentReason, setConsentReason] = useState('');
+  const [suppressionReason, setSuppressionReason] = useState<PatientCommunicationSuppressionReason>('patient_request');
+  const [success, setSuccess] = useState<string | null>(null);
+  const language = preferenceDraft?.language ?? communication.preferences?.preferredLanguage ?? 'ru';
+  const preferredChannel = preferenceDraft?.preferredChannel ?? communication.preferences?.preferredChannel ?? 'none';
+  const allowManualPhone = preferenceDraft?.allowManualPhone ?? communication.preferences?.allowManualPhone ?? true;
+
+  const primaryPhone = useMemo(
+    () => communication.contacts.find((contact) => contact.contactType === 'phone' && contact.isPrimary),
+    [communication.contacts],
+  );
+  const primaryEmail = useMemo(
+    () => communication.contacts.find((contact) => contact.contactType === 'email' && contact.isPrimary),
+    [communication.contacts],
+  );
+
+  const updatePreferenceDraft = (patch: Partial<{
+    language: PatientCommunicationLanguage;
+    preferredChannel: PatientPreferredCommunicationChannel;
+    allowManualPhone: boolean;
+  }>) => setPreferenceDraft((current) => ({
+    language: current?.language ?? communication.preferences?.preferredLanguage ?? 'ru',
+    preferredChannel: current?.preferredChannel ?? communication.preferences?.preferredChannel ?? 'none',
+    allowManualPhone: current?.allowManualPhone ?? communication.preferences?.allowManualPhone ?? true,
+    ...patch,
+  }));
+
+  const saveNewContact = async () => {
+    setFormError(null);
+    setSuccess(null);
+    if (contactDraft.contactType === 'phone' && !validPhone(contactDraft.contactValueRaw)) {
+      setFormError('Укажите корректный номер телефона.');
+      return;
+    }
+    if (contactDraft.contactType === 'email' && !validEmail(contactDraft.contactValueRaw)) {
+      setFormError('Укажите корректный адрес электронной почты.');
+      return;
+    }
+    if (contactDraft.ownerType === 'representative' && !contactDraft.representativeName.trim()) {
+      setFormError('Укажите представителя и его отношение к пациенту.');
+      return;
+    }
+    try {
+      const result = await communication.saveContact({
+        contactType: contactDraft.contactType,
+        contactValueRaw: contactDraft.contactValueRaw,
+        isPrimary: contactDraft.isPrimary,
+        isVerified: contactDraft.isVerified,
+        verificationSource: contactDraft.isVerified
+          ? contactDraft.ownerType === 'representative' ? 'representative_confirmed' : 'patient_confirmed'
+          : 'staff_entered',
+        ownerType: contactDraft.ownerType,
+        representativeName: contactDraft.ownerType === 'representative' ? contactDraft.representativeName : undefined,
+        representativeRelation: contactDraft.ownerType === 'representative' ? contactDraft.representativeRelation : undefined,
+        language: contactDraft.language,
+      });
+      setShowContactForm(false);
+      setContactDraft(makeInitialContact());
+      setSuccess(result.duplicateWarning
+        ? 'Контакт сохранён. Этот контакт уже используется у другого пациента в этой клинике.'
+        : 'Контакт сохранён.');
+    } catch (cause) {
+      setFormError(cause instanceof Error ? cause.message : 'Не удалось сохранить настройки связи.');
+    }
+  };
+
+  const savePreferences = async () => {
+    setSuccess(null);
+    try {
+      await communication.savePreferences(language, preferredChannel, allowManualPhone);
+      setPreferenceDraft(null);
+      setSuccess('Предпочтения сохранены.');
+    } catch {
+      // The hook exposes a safe message and keeps the editor visible.
+    }
+  };
+
+  const updateConsent = async (channel: PatientAutomatedCommunicationChannel, state: PatientCommunicationConsentState) => {
+    setSuccess(null);
+    try {
+      await communication.recordConsent(channel, state, consentSource, consentReason || undefined);
+      setSuccess(`Статус ${CHANNEL_LABELS[channel]} сохранён.`);
+    } catch {
+      // Safe hook error remains visible.
+    }
+  };
+
+  const toggleSuppression = async (
+    channel: 'global' | 'phone' | PatientAutomatedCommunicationChannel,
+    currentlySuppressed: boolean,
+  ) => {
+    setSuccess(null);
+    try {
+      await communication.changeSuppression(
+        channel,
+        !currentlySuppressed,
+        currentlySuppressed ? undefined : suppressionReason,
+      );
+      setSuccess(currentlySuppressed ? 'Подавление снято.' : 'Подавление установлено.');
+    } catch {
+      // Safe hook error remains visible.
+    }
+  };
+
+  if (communication.loading && !communication.profile) {
+    return <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500">Загрузка настроек связи…</div>;
+  }
+
+  return (
+    <div className="space-y-6" data-testid="patient-communication-section">
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        <div className="flex items-start gap-2"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /><span>Наличие номера не означает согласие на сообщения.</span></div>
+        <div className="mt-2 flex items-start gap-2"><ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" /><span>Автоматическая отправка заблокирована до получения согласия.</span></div>
+      </div>
+
+      {(communication.error || formError || success) && (
+        <div className="space-y-2">
+          {(communication.error || formError) && <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{formError ?? communication.error}</div>}
+          {success && <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{success}</div>}
+        </div>
+      )}
+
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Контакты для связи</h2>
+            <p className="mt-1 text-sm text-slate-500">Legacy-телефон сохраняется как неподтверждённый контакт и не означает согласие.</p>
+          </div>
+          {communication.canMutate && (
+            <button type="button" data-testid="communication-add-contact" onClick={() => { setShowContactForm(true); setFormError(null); }} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700">
+              <Plus className="h-4 w-4" /> Добавить контакт
+            </button>
+          )}
+        </div>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {communication.contacts.length === 0 && <div className="col-span-full rounded-lg border border-dashed border-slate-300 p-8 text-center text-slate-500">Контактов нет.</div>}
+          {communication.contacts.map((contact) => (
+            <article key={contact.id} data-testid={`communication-contact-${contact.id}`} className="rounded-xl border border-slate-200 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {contact.contactType === 'phone' ? <Phone className="h-4 w-4 text-blue-600" /> : <Mail className="h-4 w-4 text-blue-600" />}
+                    <span className="font-medium text-slate-900">{contact.contactValueRaw}</span>
+                    {contact.isPrimary && <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">Основной</span>}
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                    <span className={`rounded-full px-2 py-1 ${contact.isVerified ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-800'}`}>
+                      {contact.isVerified ? 'Подтверждён' : contact.contactValueNormalized ? 'Не подтверждён' : 'Некорректный'}
+                    </span>
+                    <span className="rounded-full bg-slate-100 px-2 py-1 text-slate-700">
+                      {contact.ownerType === 'patient' ? 'Пациент' : `Представитель: ${contact.representativeName}`}
+                    </span>
+                    {contact.possibleDuplicate && <span className="rounded-full bg-orange-100 px-2 py-1 text-orange-800">Возможный дубль</span>}
+                  </div>
+                  {contact.contactValueNormalized && <div className="mt-2 text-xs text-slate-500">Нормализовано: {contact.contactValueNormalized}</div>}
+                  {contact.ownerType === 'representative' && (
+                    <div className="mt-2 rounded-lg bg-violet-50 px-3 py-2 text-xs text-violet-800">
+                      Этот контакт принадлежит представителю пациента. {contact.representativeRelation ? RELATION_LABELS[contact.representativeRelation] : ''}
+                    </div>
+                  )}
+                </div>
+                {communication.canMutate && (
+                  <div className="flex gap-1">
+                    {!contact.isPrimary && <button type="button" data-testid={`communication-primary-${contact.id}`} title="Сделать основным" onClick={() => void communication.setPrimaryContact(contact.id, contact.updatedAt)} className="rounded p-2 text-slate-500 hover:bg-blue-50 hover:text-blue-700"><Star className="h-4 w-4" /></button>}
+                    <button type="button" data-testid={`communication-archive-${contact.id}`} title="Архивировать" onClick={() => void communication.archiveContact(contact.id, contact.updatedAt)} className="rounded p-2 text-slate-500 hover:bg-red-50 hover:text-red-700"><Archive className="h-4 w-4" /></button>
+                  </div>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+
+        {showContactForm && communication.canMutate && (
+          <div className="mt-5 rounded-xl border border-blue-200 bg-blue-50/40 p-4" data-testid="communication-contact-editor">
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="text-sm">Тип
+                <select data-testid="communication-contact-type" value={contactDraft.contactType} onChange={(event) => setContactDraft((current) => ({ ...current, contactType: event.target.value as PatientCommunicationContactType }))} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+                  <option value="phone">Телефон</option><option value="email">Email</option>
+                </select>
+              </label>
+              <label className="text-sm">Контакт
+                <input data-testid="communication-contact-value" value={contactDraft.contactValueRaw} onChange={(event) => setContactDraft((current) => ({ ...current, contactValueRaw: event.target.value }))} placeholder={contactDraft.contactType === 'phone' ? '+77001234567' : 'patient@example.com'} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+              </label>
+              <label className="text-sm">Владелец
+                <select data-testid="communication-owner-type" value={contactDraft.ownerType} onChange={(event) => setContactDraft((current) => ({ ...current, ownerType: event.target.value as PatientCommunicationOwnerType }))} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+                  <option value="patient">Пациент</option><option value="representative">Представитель</option>
+                </select>
+              </label>
+              <label className="text-sm">Язык
+                <select value={contactDraft.language} onChange={(event) => setContactDraft((current) => ({ ...current, language: event.target.value as PatientCommunicationLanguage }))} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+                  <option value="ru">Русский</option><option value="kk">Қазақша</option><option value="en">English</option>
+                </select>
+              </label>
+              {contactDraft.ownerType === 'representative' && <>
+                <label className="text-sm">Имя представителя
+                  <input data-testid="communication-representative-name" value={contactDraft.representativeName} onChange={(event) => setContactDraft((current) => ({ ...current, representativeName: event.target.value }))} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+                </label>
+                <label className="text-sm">Отношение
+                  <select data-testid="communication-representative-relation" value={contactDraft.representativeRelation} onChange={(event) => setContactDraft((current) => ({ ...current, representativeRelation: event.target.value as PatientRepresentativeRelation }))} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+                    {Object.entries(RELATION_LABELS).map(([key, label]) => <option key={key} value={key}>{label}</option>)}
+                  </select>
+                </label>
+              </>}
+            </div>
+            <div className="mt-3 flex flex-wrap gap-4 text-sm">
+              <label className="flex items-center gap-2"><input data-testid="communication-contact-primary" type="checkbox" checked={contactDraft.isPrimary} onChange={(event) => setContactDraft((current) => ({ ...current, isPrimary: event.target.checked }))} />Основной</label>
+              <label className="flex items-center gap-2"><input data-testid="communication-contact-verified" type="checkbox" checked={contactDraft.isVerified} onChange={(event) => setContactDraft((current) => ({ ...current, isVerified: event.target.checked }))} />Подтверждён сотрудником</label>
+            </div>
+            <div className="mt-4 flex gap-2">
+              <button type="button" data-testid="communication-save-contact" disabled={communication.savingContact} onClick={() => void saveNewContact()} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">Сохранить контакт</button>
+              <button type="button" onClick={() => setShowContactForm(false)} className="rounded-lg border border-slate-300 px-4 py-2 text-sm">Отмена</button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="grid gap-5 lg:grid-cols-2">
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Предпочтения</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <label className="text-sm">Предпочитаемый язык
+              <select data-testid="communication-preferred-language" value={language} disabled={!communication.canMutate} onChange={(event) => updatePreferenceDraft({ language: event.target.value as PatientCommunicationLanguage })} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+                <option value="ru">Русский</option><option value="kk">Қазақша</option><option value="en">English</option>
+              </select>
+            </label>
+            <label className="text-sm">Предпочитаемый канал
+              <select data-testid="communication-preferred-channel" value={preferredChannel} disabled={!communication.canMutate} onChange={(event) => updatePreferenceDraft({ preferredChannel: event.target.value as PatientPreferredCommunicationChannel })} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+                <option value="none">Не выбран</option><option value="phone">Телефон</option><option value="sms">SMS</option><option value="whatsapp">WhatsApp</option><option value="email">Email</option>
+              </select>
+            </label>
+          </div>
+          <label className="mt-3 flex items-center gap-2 text-sm"><input type="checkbox" checked={allowManualPhone} disabled={!communication.canMutate} onChange={(event) => updatePreferenceDraft({ allowManualPhone: event.target.checked })} />Разрешить ручной звонок</label>
+          {communication.canMutate && <button type="button" data-testid="communication-save-preferences" disabled={communication.updatingPreferences} onClick={() => void savePreferences()} className="mt-4 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">Сохранить предпочтения</button>}
+          <div className="mt-4 border-t border-slate-200 pt-4 text-sm">
+            <div>Основной телефон: <strong>{primaryPhone?.contactValueRaw ?? 'не выбран'}</strong></div>
+            <div className="mt-1">Основной email: <strong>{primaryEmail?.contactValueRaw ?? 'не выбран'}</strong></div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Подавление связи</h2>
+          <label className="mt-4 block text-sm">Причина
+            <select data-testid="communication-suppression-reason" value={suppressionReason} disabled={!communication.canMutate} onChange={(event) => setSuppressionReason(event.target.value as PatientCommunicationSuppressionReason)} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+              <option value="patient_request">Просьба пациента</option><option value="representative_request">Просьба представителя</option><option value="invalid_contact">Некорректный контакт</option><option value="wrong_number">Неверный номер</option><option value="duplicate_contact">Дублирующий контакт</option><option value="legal_restriction">Правовое ограничение</option><option value="staff_decision">Решение сотрудника</option><option value="other">Другое</option>
+            </select>
+          </label>
+          <div className="mt-4 space-y-2 text-sm">
+            {([
+              ['global', 'Все автоматические каналы', communication.preferences?.globalSuppression ?? false],
+              ['phone', 'Ручной телефон', communication.preferences?.phoneSuppressed ?? false],
+              ['sms', 'SMS', communication.preferences?.smsSuppressed ?? false],
+              ['whatsapp', 'WhatsApp', communication.preferences?.whatsappSuppressed ?? false],
+              ['email', 'Email', communication.preferences?.emailSuppressed ?? false],
+            ] as const).map(([channel, label, suppressed]) => (
+              <div key={channel} className="flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2">
+                <span>{label}</span>
+                {communication.canMutate && <button type="button" data-testid={`communication-suppression-${channel}`} onClick={() => void toggleSuppression(channel, suppressed)} className={`rounded px-3 py-1 text-xs font-medium ${suppressed ? 'bg-emerald-100 text-emerald-700' : 'bg-red-100 text-red-700'}`}>{suppressed ? 'Снять' : 'Подавить'}</button>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Согласие по каналам</h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <label className="text-sm">Источник
+            <select data-testid="communication-consent-source" value={consentSource} disabled={!communication.canMutate} onChange={(event) => setConsentSource(event.target.value as PatientCommunicationConsentSource)} className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2">
+              <option value="patient_verbal">Пациент, устно</option><option value="patient_written">Пациент, письменно</option><option value="representative_verbal">Представитель, устно</option><option value="representative_written">Представитель, письменно</option><option value="staff_correction">Исправление сотрудником</option>
+            </select>
+          </label>
+          <label className="text-sm">Причина/заметка
+            <input value={consentReason} onChange={(event) => setConsentReason(event.target.value)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+          </label>
+        </div>
+        <div className="mt-4 grid gap-3 lg:grid-cols-3">
+          {(['sms', 'whatsapp', 'email'] as const).map((channel) => {
+            const current = communication.preferences?.[`${channel}ConsentState` as 'smsConsentState'] as PatientCommunicationConsentState | undefined;
+            const eligibility = communication.eligibility?.[channel];
+            return (
+              <article key={channel} data-testid={`communication-consent-${channel}`} className="rounded-xl border border-slate-200 p-4">
+                <div className="flex items-center gap-2 font-medium text-slate-900">{channel === 'email' ? <Mail className="h-4 w-4" /> : <MessageCircle className="h-4 w-4" />}{CHANNEL_LABELS[channel]}</div>
+                <div className="mt-2 text-sm">{CONSENT_LABELS[current ?? 'unknown']}</div>
+                <div className={`mt-2 rounded-lg px-2 py-1 text-xs ${eligibility?.automatedEligible ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-800'}`}>
+                  {eligibility ? ELIGIBILITY_LABELS[eligibility.status] : 'Проверка недоступна'}
+                </div>
+                {communication.canMutate && <div className="mt-3 flex flex-wrap gap-1">
+                  <button type="button" data-testid={`communication-consent-grant-${channel}`} onClick={() => void updateConsent(channel, 'granted')} className="rounded bg-emerald-100 px-2 py-1 text-xs text-emerald-800">Получено</button>
+                  <button type="button" data-testid={`communication-consent-deny-${channel}`} onClick={() => void updateConsent(channel, 'denied')} className="rounded bg-red-100 px-2 py-1 text-xs text-red-800">Не согласен</button>
+                  <button type="button" data-testid={`communication-consent-withdraw-${channel}`} onClick={() => void updateConsent(channel, 'withdrawn')} className="rounded bg-slate-100 px-2 py-1 text-xs text-slate-700">Отозвано</button>
+                </div>}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex items-center gap-2"><CheckCircle2 className="h-5 w-5 text-blue-600" /><h2 className="text-lg font-semibold text-slate-900">История согласий</h2></div>
+        <div className="mt-3 space-y-2">
+          {communication.consentEvents.length === 0 && <div className="text-sm text-slate-500">Изменений согласия пока нет.</div>}
+          {communication.consentEvents.map((event) => (
+            <div key={event.id} className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-slate-50 px-3 py-2 text-sm">
+              <span>{CHANNEL_LABELS[event.channel]}: {CONSENT_LABELS[event.previousState]} → {CONSENT_LABELS[event.newState]}</span>
+              <span className="text-xs text-slate-500">{new Date(event.occurredAt).toLocaleString('ru-RU')}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {!communication.canMutate && (
+        <div className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600"><UserRound className="h-4 w-4" />Доступ только для просмотра.</div>
+      )}
+    </div>
+  );
+}

--- a/src/data/hooks/usePatientCommunicationProfile.test.tsx
+++ b/src/data/hooks/usePatientCommunicationProfile.test.tsx
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import type { PatientCommunicationProfile } from '../../types';
+import { createPatientCommunicationRepository } from '../repositories/PatientCommunicationRepository';
+import { usePatientCommunicationProfile } from './usePatientCommunicationProfile';
+
+vi.mock('../../lib/supabaseClient', () => ({ isSupabaseConfigured: true, supabase: {} }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../repositories/PatientCommunicationRepository', async () => {
+  const actual = await vi.importActual('../repositories/PatientCommunicationRepository');
+  return { ...actual as object, createPatientCommunicationRepository: vi.fn() };
+});
+
+const tenantA = '11111111-1111-4111-8111-111111111111';
+const tenantB = '22222222-2222-4222-8222-222222222222';
+const patientA = '33333333-3333-4333-8333-333333333333';
+const patientB = '44444444-4444-4444-8444-444444444444';
+
+const profile = (tenantId = tenantA, patientId = patientA): PatientCommunicationProfile => ({
+  contacts: [{
+    id: 'contact-1', tenantId, patientId, contactType: 'phone', contactValueRaw: '+77001234567',
+    contactValueNormalized: '+77001234567', isPrimary: true, isVerified: false,
+    verificationSource: 'import_legacy', ownerType: 'patient', possibleDuplicate: false,
+    createdAt: '2026-07-13T00:00:00Z', updatedAt: '2026-07-13T00:00:00Z',
+  }],
+  preferences: {
+    tenantId, patientId, preferredLanguage: 'ru', preferredChannel: 'none', allowManualPhone: true,
+    smsConsentState: 'unknown', whatsappConsentState: 'unknown', emailConsentState: 'unknown',
+    phoneSuppressed: false, smsSuppressed: false, whatsappSuppressed: false, emailSuppressed: false,
+    globalSuppression: false, createdAt: '', updatedAt: '',
+  },
+  consentEvents: [],
+  eligibility: {
+    phone: { eligible: true, automatedEligible: false, manualEligible: true, status: 'manual_only', channel: 'phone', language: 'ru', blockedReasons: [], consentState: 'not_required', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: true },
+    sms: { eligible: false, automatedEligible: false, manualEligible: false, status: 'consent_unknown', channel: 'sms', language: 'ru', blockedReasons: ['consent_unknown', 'unverified_contact'], consentState: 'unknown', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: false },
+    whatsapp: { eligible: false, automatedEligible: false, manualEligible: false, status: 'consent_unknown', channel: 'whatsapp', language: 'ru', blockedReasons: ['consent_unknown', 'unverified_contact'], consentState: 'unknown', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: false },
+    email: { eligible: false, automatedEligible: false, manualEligible: false, status: 'blocked', channel: 'email', language: 'ru', blockedReasons: ['no_contact', 'consent_unknown'], consentState: 'unknown', suppressionState: { global: false, channel: false }, representative: false, requiresManualReview: false },
+    status: 'manual_only',
+  },
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+};
+
+const makeRepository = () => ({
+  listPatientContacts: vi.fn().mockResolvedValue(profile().contacts),
+  getPatientCommunicationProfile: vi.fn().mockResolvedValue(profile()),
+  upsertContact: vi.fn().mockResolvedValue({ replayed: false }),
+  archiveContact: vi.fn().mockResolvedValue({ replayed: false }),
+  setPrimaryContact: vi.fn().mockResolvedValue({ replayed: false }),
+  updatePreferences: vi.fn().mockResolvedValue({ replayed: false }),
+  setConsent: vi.fn().mockResolvedValue({ replayed: false, changed: true }),
+  setSuppression: vi.fn().mockResolvedValue({ replayed: false }),
+  getEligibility: vi.fn(),
+  getEligibilitySummary: vi.fn().mockResolvedValue(profile().eligibility),
+});
+
+describe('usePatientCommunicationProfile', () => {
+  let authState: any;
+  let tenantState: any;
+  let repository: ReturnType<typeof makeRepository>;
+  let current: ReturnType<typeof usePatientCommunicationProfile> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
+    tenantState = { activeTenant: { tenantId: tenantA, role: 'clinic_admin', timezone: 'Asia/Almaty' } };
+    repository = makeRepository();
+    vi.mocked(useAuth).mockImplementation(() => authState);
+    vi.mocked(useTenant).mockImplementation(() => tenantState);
+    vi.mocked(createPatientCommunicationRepository).mockReturnValue(repository as any);
+  });
+
+  const mount = async (initialPatientId?: string | null) => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const Harness = ({ patientId = initialPatientId, tick = 0 }: { patientId?: string | null; tick?: number }) => {
+      void tick;
+      current = usePatientCommunicationProfile(patientId);
+      return null;
+    };
+    await act(async () => { root.render(<Harness />); await Promise.resolve(); });
+    return { root, Harness };
+  };
+
+  it('does not fetch without a tenant', async () => {
+    tenantState = { activeTenant: null };
+    const { root } = await mount(patientA);
+    expect(createPatientCommunicationRepository).not.toHaveBeenCalled();
+    expect(repository.getPatientCommunicationProfile).not.toHaveBeenCalled();
+    expect(current?.profile).toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it('does not fetch without a patient', async () => {
+    const { root } = await mount(null);
+    expect(repository.getPatientCommunicationProfile).not.toHaveBeenCalled();
+    expect(current?.contacts).toEqual([]);
+    await act(async () => root.unmount());
+  });
+
+  it('loads a tenant-scoped profile', async () => {
+    const { root } = await mount(patientA);
+    expect(createPatientCommunicationRepository).toHaveBeenCalledWith({ backend: 'supabase', tenantId: tenantA });
+    expect(repository.getPatientCommunicationProfile).toHaveBeenCalledWith(patientA);
+    expect(current?.contacts[0].verificationSource).toBe('import_legacy');
+    await act(async () => root.unmount());
+  });
+
+  it('clears old tenant data and ignores stale tenant response', async () => {
+    const a = deferred<PatientCommunicationProfile>();
+    const b = deferred<PatientCommunicationProfile>();
+    const repoA = { ...makeRepository(), getPatientCommunicationProfile: vi.fn(() => a.promise) };
+    const repoB = { ...makeRepository(), getPatientCommunicationProfile: vi.fn(() => b.promise) };
+    vi.mocked(createPatientCommunicationRepository).mockImplementation(({ tenantId }) => (tenantId === tenantA ? repoA : repoB) as any);
+    const { root, Harness } = await mount(patientA);
+    tenantState = { activeTenant: { tenantId: tenantB, role: 'clinic_admin', timezone: 'Europe/Berlin' } };
+    await act(async () => { root.render(<Harness patientId={patientA} tick={1} />); await Promise.resolve(); });
+    expect(current?.profile).toBeNull();
+    await act(async () => { a.resolve(profile(tenantA, patientA)); await Promise.resolve(); });
+    expect(current?.profile).toBeNull();
+    await act(async () => { b.resolve(profile(tenantB, patientA)); await Promise.resolve(); });
+    expect(current?.profile?.preferences.tenantId).toBe(tenantB);
+    await act(async () => root.unmount());
+  });
+
+  it('clears old patient data and ignores stale patient response', async () => {
+    const a = deferred<PatientCommunicationProfile>();
+    const b = deferred<PatientCommunicationProfile>();
+    repository.getPatientCommunicationProfile.mockImplementation((id) => id === patientA ? a.promise : b.promise);
+    const { root, Harness } = await mount(patientA);
+    await act(async () => { root.render(<Harness patientId={patientB} tick={1} />); await Promise.resolve(); });
+    expect(current?.profile).toBeNull();
+    await act(async () => { a.resolve(profile(tenantA, patientA)); await Promise.resolve(); });
+    expect(current?.profile).toBeNull();
+    await act(async () => { b.resolve(profile(tenantA, patientB)); await Promise.resolve(); });
+    expect(current?.profile?.preferences.patientId).toBe(patientB);
+    await act(async () => root.unmount());
+  });
+
+  it('blocks duplicate contact saves', async () => {
+    const pending = deferred<{ replayed: boolean }>();
+    repository.upsertContact.mockImplementation(() => pending.promise);
+    const { root } = await mount(patientA);
+    let first!: Promise<unknown>;
+    await act(async () => { first = current!.saveContact({ contactType: 'phone', contactValueRaw: '+77001234567', isPrimary: true, isVerified: false, ownerType: 'patient' }); });
+    await expect(current!.saveContact({ contactType: 'phone', contactValueRaw: '+77001234567', isPrimary: true, isVerified: false, ownerType: 'patient' }))
+      .rejects.toMatchObject({ code: 'operation_failed' });
+    expect(repository.upsertContact).toHaveBeenCalledTimes(1);
+    await act(async () => { pending.resolve({ replayed: false }); await first; });
+    await act(async () => root.unmount());
+  });
+
+  it('refreshes exactly once after successful consent mutation', async () => {
+    repository.getPatientCommunicationProfile.mockResolvedValue(profile());
+    const { root } = await mount(patientA);
+    await act(async () => { await current!.recordConsent('sms', 'granted', 'patient_verbal', 'Устно'); });
+    expect(repository.setConsent).toHaveBeenCalledTimes(1);
+    expect(repository.getPatientCommunicationProfile).toHaveBeenCalledTimes(2);
+    await act(async () => root.unmount());
+  });
+
+  it('keeps safe errors visible after a failed mutation', async () => {
+    repository.setSuppression.mockRejectedValue(new Error('Недостаточно прав для изменения настроек связи.'));
+    const { root } = await mount(patientA);
+    await act(async () => {
+      await expect(current!.changeSuppression('sms', true, 'patient_request')).rejects.toThrow();
+    });
+    expect(current?.error).toBe('Недостаточно прав для изменения настроек связи.');
+    expect(current?.profile).not.toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it('makes doctor view read-only and blocks mutations before RPC', async () => {
+    tenantState.activeTenant.role = 'doctor';
+    const { root } = await mount(patientA);
+    expect(current?.canMutate).toBe(false);
+    await expect(current!.recordConsent('sms', 'granted', 'patient_verbal')).rejects.toMatchObject({ code: 'permission' });
+    expect(repository.setConsent).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+});

--- a/src/data/hooks/usePatientCommunicationProfile.ts
+++ b/src/data/hooks/usePatientCommunicationProfile.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import type {
+  PatientAutomatedCommunicationChannel,
+  PatientCommunicationConsentSource,
+  PatientCommunicationConsentState,
+  PatientCommunicationLanguage,
+  PatientCommunicationProfile,
+  PatientCommunicationSuppressionReason,
+  PatientPreferredCommunicationChannel,
+} from '../../types';
+import {
+  createPatientCommunicationRepository,
+  PatientCommunicationRepositoryError,
+  type PatientCommunicationRepository,
+  type UpsertPatientCommunicationContactInput,
+} from '../repositories/PatientCommunicationRepository';
+
+const MUTATION_ROLES = new Set(['clinic_owner', 'clinic_admin', 'registrar']);
+
+const operationKey = (action: string, patientId: string): string => {
+  const random = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `patient-communication-${action}-${patientId}-${random}`;
+};
+
+export function usePatientCommunicationProfile(patientId?: string | null) {
+  const { activeTenant } = useTenant();
+  const { authMode } = useAuth();
+  const tenantId = activeTenant?.tenantId ?? null;
+  const canMutate = MUTATION_ROLES.has(activeTenant?.role ?? '');
+  const backend = authMode === 'supabase-active' && tenantId && isSupabaseConfigured ? 'supabase' : 'local';
+
+  const repository = useMemo(() => {
+    if (authMode === 'supabase-active' && !tenantId) return null;
+    return createPatientCommunicationRepository({ backend, tenantId });
+  }, [authMode, backend, tenantId]);
+
+  const [profile, setProfile] = useState<PatientCommunicationProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [savingContact, setSavingContact] = useState(false);
+  const [updatingConsent, setUpdatingConsent] = useState(false);
+  const [updatingPreferences, setUpdatingPreferences] = useState(false);
+  const [updatingSuppression, setUpdatingSuppression] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sequence = useRef(0);
+  const busy = useRef(new Set<string>());
+
+  const load = useCallback(async (
+    repositoryValue: PatientCommunicationRepository,
+    tenantValue: string,
+    patientValue: string,
+    clearPrevious: boolean,
+  ) => {
+    const request = ++sequence.current;
+    if (clearPrevious) setProfile(null);
+    setLoading(true);
+    setError(null);
+    try {
+      const nextProfile = await repositoryValue.getPatientCommunicationProfile(patientValue);
+      if (request !== sequence.current || tenantValue !== tenantId || patientValue !== patientId) return;
+      setProfile(nextProfile);
+    } catch (cause) {
+      if (request !== sequence.current) return;
+      setError(cause instanceof Error ? cause.message : 'Не удалось загрузить настройки связи.');
+    } finally {
+      if (request === sequence.current) setLoading(false);
+    }
+  }, [patientId, tenantId]);
+
+  useEffect(() => {
+    const tenantValue = tenantId;
+    const patientValue = patientId;
+    const repositoryValue = repository;
+    queueMicrotask(() => {
+      if (!tenantValue || !patientValue || !repositoryValue) {
+        sequence.current += 1;
+        setProfile(null);
+        setLoading(false);
+        setError(null);
+        return;
+      }
+      void load(repositoryValue, tenantValue, patientValue, true);
+    });
+  }, [load, patientId, repository, tenantId]);
+
+  const refresh = useCallback(async () => {
+    if (!tenantId || !patientId || !repository) return;
+    await load(repository, tenantId, patientId, false);
+  }, [load, patientId, repository, tenantId]);
+
+  const mutate = useCallback(async <T,>(
+    key: string,
+    setter: (value: boolean) => void,
+    action: (repositoryValue: PatientCommunicationRepository, keyValue: string) => Promise<T>,
+  ): Promise<T> => {
+    if (!tenantId || !patientId || !repository || !canMutate) {
+      const failure = new PatientCommunicationRepositoryError('permission', 'Недостаточно прав для изменения настроек связи.');
+      setError(failure.message);
+      throw failure;
+    }
+    if (busy.current.has(key)) {
+      const failure = new PatientCommunicationRepositoryError('operation_failed', 'Не удалось сохранить настройки связи.');
+      setError(failure.message);
+      throw failure;
+    }
+    busy.current.add(key);
+    setter(true);
+    setError(null);
+    try {
+      const result = await action(repository, operationKey(key, patientId));
+      await refresh();
+      return result;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить настройки связи.');
+      throw cause;
+    } finally {
+      busy.current.delete(key);
+      setter(false);
+    }
+  }, [canMutate, patientId, refresh, repository, tenantId]);
+
+  const saveContact = useCallback((input: Omit<UpsertPatientCommunicationContactInput, 'patientId' | 'operationKey'>) => mutate(
+    `contact:${input.contactId ?? 'new'}`,
+    setSavingContact,
+    (repositoryValue, keyValue) => repositoryValue.upsertContact({
+      ...input,
+      patientId: patientId ?? '',
+      operationKey: keyValue,
+    }),
+  ), [mutate, patientId]);
+
+  const archiveContact = useCallback((contactId: string, expectedUpdatedAt: string) => mutate(
+    `archive:${contactId}`,
+    setSavingContact,
+    (repositoryValue, keyValue) => repositoryValue.archiveContact(patientId ?? '', contactId, expectedUpdatedAt, keyValue),
+  ), [mutate, patientId]);
+
+  const setPrimaryContact = useCallback((contactId: string, expectedUpdatedAt: string) => mutate(
+    `primary:${contactId}`,
+    setSavingContact,
+    (repositoryValue, keyValue) => repositoryValue.setPrimaryContact(patientId ?? '', contactId, expectedUpdatedAt, keyValue),
+  ), [mutate, patientId]);
+
+  const savePreferences = useCallback((
+    preferredLanguage: PatientCommunicationLanguage,
+    preferredChannel: PatientPreferredCommunicationChannel,
+    allowManualPhone: boolean,
+  ) => mutate(
+    'preferences',
+    setUpdatingPreferences,
+    (repositoryValue, keyValue) => repositoryValue.updatePreferences(
+      patientId ?? '', preferredLanguage, preferredChannel, allowManualPhone, keyValue,
+    ),
+  ), [mutate, patientId]);
+
+  const recordConsent = useCallback((
+    channel: PatientAutomatedCommunicationChannel,
+    state: PatientCommunicationConsentState,
+    source: PatientCommunicationConsentSource,
+    reason?: string,
+  ) => mutate(
+    `consent:${channel}`,
+    setUpdatingConsent,
+    (repositoryValue, keyValue) => repositoryValue.setConsent(
+      patientId ?? '', channel, state, source, reason, keyValue,
+    ),
+  ), [mutate, patientId]);
+
+  const changeSuppression = useCallback((
+    channel: 'global' | 'phone' | PatientAutomatedCommunicationChannel,
+    suppressed: boolean,
+    reason?: PatientCommunicationSuppressionReason,
+  ) => mutate(
+    `suppression:${channel}`,
+    setUpdatingSuppression,
+    (repositoryValue, keyValue) => repositoryValue.setSuppression(
+      patientId ?? '', channel, suppressed, reason, keyValue,
+    ),
+  ), [mutate, patientId]);
+
+  return {
+    profile,
+    contacts: profile?.contacts ?? [],
+    preferences: profile?.preferences ?? null,
+    eligibility: profile?.eligibility ?? null,
+    consentEvents: profile?.consentEvents ?? [],
+    loading,
+    savingContact,
+    updatingConsent,
+    updatingPreferences,
+    updatingSuppression,
+    error,
+    canMutate,
+    refresh,
+    saveContact,
+    archiveContact,
+    setPrimaryContact,
+    savePreferences,
+    recordConsent,
+    changeSuppression,
+    clearError: () => setError(null),
+  };
+}

--- a/src/data/repositories/AppointmentReminderRepository.ts
+++ b/src/data/repositories/AppointmentReminderRepository.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { supabase } from '../../lib/supabaseClient';
 import { isOffsetAwareInstant } from '../../domain/timezone';
+import { SupabasePatientCommunicationRepository } from './PatientCommunicationRepository';
 import type {
   Appointment,
   AppointmentConfirmationAttempt,
@@ -16,6 +17,7 @@ import type {
   DeferAppointmentReminderJobInput,
   Doctor,
   Patient,
+  PatientCommunicationEligibilitySummary,
   SkipAppointmentReminderJobInput,
   TenantReminderReconcileResult,
 } from '../../types';
@@ -588,6 +590,13 @@ export class SupabaseAppointmentReminderRepository implements AppointmentReminde
         }
       }
 
+      const communicationRepository = new SupabasePatientCommunicationRepository(this.tenantId, this.client);
+      const eligibilityEntries = await Promise.all(patientIds.map(async (patientId) => [
+        patientId,
+        await communicationRepository.getEligibilitySummary(patientId),
+      ] as const));
+      const eligibilityMap = new Map<string, PatientCommunicationEligibilitySummary>(eligibilityEntries);
+
       return jobs.flatMap((job) => {
         const appointment = appointmentMap.get(job.appointmentId);
         const patient = patientMap.get(job.patientId);
@@ -600,6 +609,7 @@ export class SupabaseAppointmentReminderRepository implements AppointmentReminde
           doctor,
           attemptCount: appointment.confirmationAttemptCount ?? 0,
           lastAttempt: lastAttemptMap.get(appointment.id),
+          communicationEligibility: eligibilityMap.get(job.patientId),
         }];
       });
     } catch (error) {

--- a/src/data/repositories/PatientCommunicationRepository.test.ts
+++ b/src/data/repositories/PatientCommunicationRepository.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import repositorySource from './PatientCommunicationRepository.ts?raw';
+import {
+  SupabasePatientCommunicationRepository,
+  PatientCommunicationRepositoryError,
+  createPatientCommunicationRepository,
+  defaultPatientCommunicationPreferences,
+  toSafePatientCommunicationError,
+} from './PatientCommunicationRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: { from: vi.fn(), rpc: vi.fn() },
+}));
+
+const tenantId = '11111111-1111-4111-8111-111111111111';
+const patientId = '22222222-2222-4222-8222-222222222222';
+const contactId = '33333333-3333-4333-8333-333333333333';
+
+const contactRow = (overrides: Record<string, unknown> = {}) => ({
+  id: contactId,
+  tenant_id: tenantId,
+  patient_id: patientId,
+  contact_type: 'phone',
+  contact_value_raw: '+7 (700) 123-45-67',
+  contact_value_normalized: '+77001234567',
+  country_code: '7',
+  is_primary: true,
+  is_verified: false,
+  verification_source: 'import_legacy',
+  owner_type: 'patient',
+  representative_name: null,
+  representative_relation: null,
+  language: 'ru',
+  possible_duplicate: false,
+  created_by: null,
+  updated_by: null,
+  created_at: '2026-07-13T00:00:00+00:00',
+  updated_at: '2026-07-13T00:00:00.123456+00:00',
+  archived_at: null,
+  ...overrides,
+});
+
+const preferencesRow = (overrides: Record<string, unknown> = {}) => ({
+  tenant_id: tenantId,
+  patient_id: patientId,
+  preferred_language: 'kk',
+  preferred_channel: 'sms',
+  allow_manual_phone: true,
+  sms_consent_state: 'granted',
+  whatsapp_consent_state: 'unknown',
+  email_consent_state: 'denied',
+  phone_suppressed: false,
+  sms_suppressed: false,
+  whatsapp_suppressed: true,
+  whatsapp_suppression_reason: 'patient_request',
+  email_suppressed: false,
+  global_suppression: false,
+  created_at: '2026-07-13T00:00:00+00:00',
+  updated_at: '2026-07-13T01:00:00+00:00',
+  updated_by: null,
+  ...overrides,
+});
+
+const eligibility = (channel: string, overrides: Record<string, unknown> = {}) => ({
+  eligible: channel === 'phone' || channel === 'sms',
+  automatedEligible: channel === 'sms',
+  manualEligible: channel === 'phone',
+  status: channel === 'sms' ? 'available' : channel === 'phone' ? 'manual_only' : 'consent_unknown',
+  channel,
+  selectedContactId: contactId,
+  normalizedDestination: '+77001234567',
+  language: 'kk',
+  blockedReasons: channel === 'whatsapp' ? ['consent_unknown'] : [],
+  consentState: channel === 'phone' ? 'not_required' : channel === 'sms' ? 'granted' : 'unknown',
+  suppressionState: { global: false, channel: false },
+  representative: false,
+  requiresManualReview: false,
+  ...overrides,
+});
+
+const query = (result: { data: unknown; error: unknown }) => {
+  const builder: Record<string, unknown> & PromiseLike<typeof result> = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    is: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    maybeSingle: vi.fn(() => builder),
+    then: (resolve, reject) => Promise.resolve(result).then(resolve, reject),
+  };
+  return builder;
+};
+
+describe('PatientCommunicationRepository', () => {
+  it('does not silently fall back when Supabase tenant is missing', () => {
+    expect(() => createPatientCommunicationRepository({ backend: 'supabase', tenantId: null }))
+      .toThrow('Клиника не выбрана.');
+  });
+
+  it('maps legacy unverified contact and applies tenant/patient filters', async () => {
+    const contactQuery = query({ data: [contactRow()], error: null });
+    const from = vi.fn(() => contactQuery);
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { from, rpc: vi.fn() } as unknown as SupabaseClient);
+    const contacts = await repository.listPatientContacts(patientId);
+
+    expect(from).toHaveBeenCalledWith('patient_communication_contacts');
+    expect(contactQuery.eq).toHaveBeenCalledWith('tenant_id', tenantId);
+    expect(contactQuery.eq).toHaveBeenCalledWith('patient_id', patientId);
+    expect(contacts[0]).toMatchObject({
+      contactValueRaw: '+7 (700) 123-45-67',
+      contactValueNormalized: '+77001234567',
+      isVerified: false,
+      verificationSource: 'import_legacy',
+      isPrimary: true,
+    });
+  });
+
+  it('maps preferences and consent history in a complete profile', async () => {
+    const events = [{
+      id: 'event-1', tenant_id: tenantId, patient_id: patientId, channel: 'sms',
+      previous_state: 'unknown', new_state: 'granted', source: 'patient_verbal',
+      actor_user_id: 'user-1', reason: 'Устно', occurred_at: '2026-07-13T02:00:00Z', metadata: {},
+    }];
+    const queries = [
+      query({ data: [contactRow()], error: null }),
+      query({ data: preferencesRow(), error: null }),
+      query({ data: events, error: null }),
+    ];
+    const from = vi.fn(() => queries.shift()!);
+    const rpc = vi.fn()
+      .mockResolvedValueOnce({ data: eligibility('phone'), error: null })
+      .mockResolvedValueOnce({ data: eligibility('sms'), error: null })
+      .mockResolvedValueOnce({ data: eligibility('whatsapp'), error: null })
+      .mockResolvedValueOnce({ data: eligibility('email'), error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { from, rpc } as unknown as SupabaseClient);
+
+    const profile = await repository.getPatientCommunicationProfile(patientId);
+    expect(profile.preferences).toMatchObject({ preferredLanguage: 'kk', preferredChannel: 'sms', smsConsentState: 'granted' });
+    expect(profile.consentEvents[0]).toMatchObject({ previousState: 'unknown', newState: 'granted', source: 'patient_verbal' });
+    expect(profile.eligibility.status).toBe('available');
+  });
+
+  it('uses unknown consent defaults when preferences do not exist', () => {
+    expect(defaultPatientCommunicationPreferences(tenantId, patientId)).toMatchObject({
+      smsConsentState: 'unknown', whatsappConsentState: 'unknown', emailConsentState: 'unknown', preferredChannel: 'none',
+    });
+  });
+
+  it('maps provider-neutral eligibility fields', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: eligibility('whatsapp', { representative: true, requiresManualReview: true }), error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { rpc, from: vi.fn() } as unknown as SupabaseClient);
+    await expect(repository.getEligibility(patientId, 'whatsapp')).resolves.toMatchObject({
+      channel: 'whatsapp', status: 'consent_unknown', blockedReasons: ['consent_unknown'], representative: true,
+    });
+    expect(rpc).toHaveBeenCalledWith('get_patient_communication_eligibility', {
+      p_tenant_id: tenantId, p_patient_id: patientId, p_channel: 'whatsapp',
+    });
+  });
+
+  it('calls contact upsert RPC with tenant scope and operation key', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { contact: contactRow(), duplicateWarning: true, replayed: false }, error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { rpc, from: vi.fn() } as unknown as SupabaseClient);
+    const result = await repository.upsertContact({
+      patientId, contactType: 'phone', contactValueRaw: '+77001234567', isPrimary: true,
+      isVerified: true, verificationSource: 'patient_confirmed', ownerType: 'patient', language: 'ru', operationKey: 'contact-upsert-001',
+    });
+    expect(rpc).toHaveBeenCalledWith('upsert_patient_communication_contact', expect.objectContaining({
+      p_tenant_id: tenantId, p_patient_id: patientId, p_operation_key: 'contact-upsert-001',
+    }));
+    expect(result).toMatchObject({ duplicateWarning: true, replayed: false });
+  });
+
+  it('calls archive and primary RPCs with exact versions', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { contact: contactRow(), replayed: false }, error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { rpc, from: vi.fn() } as unknown as SupabaseClient);
+    await repository.archiveContact(patientId, contactId, '2026-07-13T00:00:00.123456+00:00', 'archive-001');
+    await repository.setPrimaryContact(patientId, contactId, '2026-07-13T00:00:00.123456+00:00', 'primary-001');
+    expect(rpc).toHaveBeenNthCalledWith(1, 'archive_patient_communication_contact', expect.objectContaining({ p_expected_updated_at: '2026-07-13T00:00:00.123456+00:00' }));
+    expect(rpc).toHaveBeenNthCalledWith(2, 'set_primary_patient_communication_contact', expect.objectContaining({ p_operation_key: 'primary-001' }));
+  });
+
+  it('calls preferences RPC without inferring consent', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { preferences: preferencesRow(), replayed: false }, error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { rpc, from: vi.fn() } as unknown as SupabaseClient);
+    await repository.updatePreferences(patientId, 'kk', 'whatsapp', true, 'preferences-001');
+    expect(rpc).toHaveBeenCalledWith('set_patient_communication_preferences', {
+      p_tenant_id: tenantId, p_patient_id: patientId, p_preferred_language: 'kk',
+      p_preferred_channel: 'whatsapp', p_allow_manual_phone: true, p_operation_key: 'preferences-001',
+    });
+  });
+
+  it('calls consent RPC with channel-specific state and source', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { preferences: preferencesRow(), consentEventId: 'event-1', changed: true, replayed: false }, error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { rpc, from: vi.fn() } as unknown as SupabaseClient);
+    const result = await repository.setConsent(patientId, 'sms', 'granted', 'patient_verbal', 'Устно', 'consent-001');
+    expect(rpc).toHaveBeenCalledWith('set_patient_communication_consent', expect.objectContaining({
+      p_channel: 'sms', p_new_state: 'granted', p_source: 'patient_verbal', p_operation_key: 'consent-001',
+    }));
+    expect(result).toMatchObject({ changed: true, consentEventId: 'event-1' });
+  });
+
+  it('calls suppression RPC without provider or delivery state', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { preferences: preferencesRow(), replayed: false }, error: null });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { rpc, from: vi.fn() } as unknown as SupabaseClient);
+    await repository.setSuppression(patientId, 'whatsapp', true, 'patient_request', 'suppression-001');
+    expect(rpc).toHaveBeenCalledWith('set_patient_communication_suppression', expect.objectContaining({
+      p_channel: 'whatsapp', p_suppressed: true, p_reason: 'patient_request',
+    }));
+  });
+
+  it('maps safe phone, email, permission, stale and generic failures', () => {
+    expect(toSafePatientCommunicationError({ message: 'Укажите корректный номер телефона.' })).toMatchObject({ code: 'invalid_phone' });
+    expect(toSafePatientCommunicationError({ message: 'Укажите корректный адрес электронной почты.' })).toMatchObject({ code: 'invalid_email' });
+    expect(toSafePatientCommunicationError({ message: 'permission denied 42501' })).toMatchObject({ code: 'permission' });
+    expect(toSafePatientCommunicationError({ hint: 'communication_stale' })).toMatchObject({ code: 'stale' });
+    expect(toSafePatientCommunicationError({ message: 'secret_constraint failed' }))
+      .toEqual(new PatientCommunicationRepositoryError('operation_failed', 'Не удалось сохранить настройки связи.'));
+  });
+
+  it('keeps reads tenant-scoped and contains no direct mutation or provider path', () => {
+    expect(repositorySource).not.toMatch(/\.insert\s*\(/);
+    expect(repositorySource).not.toMatch(/\.update\s*\(/);
+    expect(repositorySource).not.toMatch(/\.delete\s*\(/);
+    expect(repositorySource).not.toMatch(/service[_-]?role/i);
+    expect(repositorySource).not.toMatch(/sendSms|sendWhatsApp|sendEmail|providerMessageId|deliveryAttempt/i);
+  });
+
+  it('does not expose raw SQL details through read failures', async () => {
+    const broken = query({ data: null, error: { message: 'relation patient_communication_contacts secret failed' } });
+    const repository = new SupabasePatientCommunicationRepository(tenantId, { from: vi.fn(() => broken), rpc: vi.fn() } as unknown as SupabaseClient);
+    await expect(repository.listPatientContacts(patientId)).rejects.toEqual(
+      new PatientCommunicationRepositoryError('read_failed', 'Не удалось загрузить настройки связи.'),
+    );
+  });
+});

--- a/src/data/repositories/PatientCommunicationRepository.ts
+++ b/src/data/repositories/PatientCommunicationRepository.ts
@@ -1,0 +1,498 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '../../lib/supabaseClient';
+import type {
+  PatientAutomatedCommunicationChannel,
+  PatientCommunicationChannel,
+  PatientCommunicationConsentEvent,
+  PatientCommunicationConsentSource,
+  PatientCommunicationConsentState,
+  PatientCommunicationContact,
+  PatientCommunicationContactType,
+  PatientCommunicationEligibility,
+  PatientCommunicationEligibilityStatus,
+  PatientCommunicationEligibilitySummary,
+  PatientCommunicationLanguage,
+  PatientCommunicationOwnerType,
+  PatientCommunicationPreferences,
+  PatientCommunicationProfile,
+  PatientCommunicationSuppressionReason,
+  PatientPreferredCommunicationChannel,
+  PatientRepresentativeRelation,
+} from '../../types';
+
+type Row = Record<string, unknown>;
+
+export type PatientCommunicationRepositoryBackend = 'local' | 'supabase';
+export type PatientCommunicationErrorCode =
+  | 'read_failed'
+  | 'invalid_phone'
+  | 'invalid_email'
+  | 'permission'
+  | 'stale'
+  | 'consent_missing'
+  | 'reason_required'
+  | 'idempotency_conflict'
+  | 'operation_failed';
+
+export class PatientCommunicationRepositoryError extends Error {
+  readonly code: PatientCommunicationErrorCode;
+
+  constructor(code: PatientCommunicationErrorCode, message: string) {
+    super(message);
+    this.name = 'PatientCommunicationRepositoryError';
+    this.code = code;
+  }
+}
+
+const SAFE_MESSAGES: Record<PatientCommunicationErrorCode, string> = {
+  read_failed: 'Не удалось загрузить настройки связи.',
+  invalid_phone: 'Укажите корректный номер телефона.',
+  invalid_email: 'Укажите корректный адрес электронной почты.',
+  permission: 'Недостаточно прав для изменения настроек связи.',
+  stale: 'Контакт был изменён другим пользователем. Обновите данные.',
+  consent_missing: 'Статус согласия не указан.',
+  reason_required: 'Укажите причину.',
+  idempotency_conflict: 'Эта операция уже выполнена с другими параметрами.',
+  operation_failed: 'Не удалось сохранить настройки связи.',
+};
+
+const value = (row: Row, camel: string, snake: string): unknown => row[camel] ?? row[snake];
+const optionalString = (raw: unknown): string | undefined => {
+  const text = typeof raw === 'string' ? raw : '';
+  return text ? text : undefined;
+};
+
+export const toSafePatientCommunicationError = (
+  error: unknown,
+  context: 'read' | 'write' = 'write',
+): PatientCommunicationRepositoryError => {
+  if (error instanceof PatientCommunicationRepositoryError) return error;
+  const record = typeof error === 'object' && error !== null ? error as Row : {};
+  const normalized = [record.message, record.code, record.hint, record.details, error]
+    .map((item) => String(item ?? ''))
+    .join(' ')
+    .toLowerCase();
+
+  if (normalized.includes('корректный номер телефона') || normalized.includes('communication_invalid_phone')) {
+    return new PatientCommunicationRepositoryError('invalid_phone', SAFE_MESSAGES.invalid_phone);
+  }
+  if (normalized.includes('корректный адрес электронной почты') || normalized.includes('communication_invalid_email')) {
+    return new PatientCommunicationRepositoryError('invalid_email', SAFE_MESSAGES.invalid_email);
+  }
+  if (normalized.includes('недостаточно прав') || normalized.includes('permission denied') || normalized.includes('42501')) {
+    return new PatientCommunicationRepositoryError('permission', SAFE_MESSAGES.permission);
+  }
+  if (normalized.includes('communication_stale') || normalized.includes('изменён другим пользователем')) {
+    return new PatientCommunicationRepositoryError('stale', SAFE_MESSAGES.stale);
+  }
+  if (normalized.includes('статус согласия не указан')) {
+    return new PatientCommunicationRepositoryError('consent_missing', SAFE_MESSAGES.consent_missing);
+  }
+  if (normalized.includes('укажите причину')) {
+    return new PatientCommunicationRepositoryError('reason_required', SAFE_MESSAGES.reason_required);
+  }
+  if (normalized.includes('другими параметрами') || normalized.includes('23505')) {
+    return new PatientCommunicationRepositoryError('idempotency_conflict', SAFE_MESSAGES.idempotency_conflict);
+  }
+  return new PatientCommunicationRepositoryError(
+    context === 'read' ? 'read_failed' : 'operation_failed',
+    context === 'read' ? SAFE_MESSAGES.read_failed : SAFE_MESSAGES.operation_failed,
+  );
+};
+
+const mapContact = (row: Row): PatientCommunicationContact => ({
+  id: String(value(row, 'id', 'id')),
+  tenantId: String(value(row, 'tenantId', 'tenant_id')),
+  patientId: String(value(row, 'patientId', 'patient_id')),
+  contactType: value(row, 'contactType', 'contact_type') as PatientCommunicationContactType,
+  contactValueRaw: String(value(row, 'contactValueRaw', 'contact_value_raw') ?? ''),
+  contactValueNormalized: optionalString(value(row, 'contactValueNormalized', 'contact_value_normalized')),
+  countryCode: optionalString(value(row, 'countryCode', 'country_code')),
+  isPrimary: Boolean(value(row, 'isPrimary', 'is_primary')),
+  isVerified: Boolean(value(row, 'isVerified', 'is_verified')),
+  verificationSource: optionalString(value(row, 'verificationSource', 'verification_source')),
+  ownerType: value(row, 'ownerType', 'owner_type') as PatientCommunicationOwnerType,
+  representativeName: optionalString(value(row, 'representativeName', 'representative_name')),
+  representativeRelation: optionalString(value(row, 'representativeRelation', 'representative_relation')) as PatientRepresentativeRelation | undefined,
+  language: optionalString(value(row, 'language', 'language')) as PatientCommunicationLanguage | undefined,
+  possibleDuplicate: Boolean(value(row, 'possibleDuplicate', 'possible_duplicate')),
+  createdBy: optionalString(value(row, 'createdBy', 'created_by')),
+  updatedBy: optionalString(value(row, 'updatedBy', 'updated_by')),
+  createdAt: String(value(row, 'createdAt', 'created_at') ?? ''),
+  updatedAt: String(value(row, 'updatedAt', 'updated_at') ?? ''),
+  archivedAt: optionalString(value(row, 'archivedAt', 'archived_at')),
+});
+
+export const defaultPatientCommunicationPreferences = (
+  tenantId: string,
+  patientId: string,
+): PatientCommunicationPreferences => ({
+  tenantId,
+  patientId,
+  preferredLanguage: 'ru',
+  preferredChannel: 'none',
+  allowManualPhone: true,
+  smsConsentState: 'unknown',
+  whatsappConsentState: 'unknown',
+  emailConsentState: 'unknown',
+  phoneSuppressed: false,
+  smsSuppressed: false,
+  whatsappSuppressed: false,
+  emailSuppressed: false,
+  globalSuppression: false,
+  createdAt: '',
+  updatedAt: '',
+});
+
+const mapPreferences = (row: Row, tenantId: string, patientId: string): PatientCommunicationPreferences => ({
+  tenantId: String(value(row, 'tenantId', 'tenant_id') ?? tenantId),
+  patientId: String(value(row, 'patientId', 'patient_id') ?? patientId),
+  preferredLanguage: (value(row, 'preferredLanguage', 'preferred_language') ?? 'ru') as PatientCommunicationLanguage,
+  preferredChannel: (value(row, 'preferredChannel', 'preferred_channel') ?? 'none') as PatientPreferredCommunicationChannel,
+  allowManualPhone: value(row, 'allowManualPhone', 'allow_manual_phone') !== false,
+  smsConsentState: (value(row, 'smsConsentState', 'sms_consent_state') ?? 'unknown') as PatientCommunicationConsentState,
+  whatsappConsentState: (value(row, 'whatsappConsentState', 'whatsapp_consent_state') ?? 'unknown') as PatientCommunicationConsentState,
+  emailConsentState: (value(row, 'emailConsentState', 'email_consent_state') ?? 'unknown') as PatientCommunicationConsentState,
+  phoneSuppressed: Boolean(value(row, 'phoneSuppressed', 'phone_suppressed')),
+  phoneSuppressionReason: optionalString(value(row, 'phoneSuppressionReason', 'phone_suppression_reason')) as PatientCommunicationSuppressionReason | undefined,
+  smsSuppressed: Boolean(value(row, 'smsSuppressed', 'sms_suppressed')),
+  smsSuppressionReason: optionalString(value(row, 'smsSuppressionReason', 'sms_suppression_reason')) as PatientCommunicationSuppressionReason | undefined,
+  whatsappSuppressed: Boolean(value(row, 'whatsappSuppressed', 'whatsapp_suppressed')),
+  whatsappSuppressionReason: optionalString(value(row, 'whatsappSuppressionReason', 'whatsapp_suppression_reason')) as PatientCommunicationSuppressionReason | undefined,
+  emailSuppressed: Boolean(value(row, 'emailSuppressed', 'email_suppressed')),
+  emailSuppressionReason: optionalString(value(row, 'emailSuppressionReason', 'email_suppression_reason')) as PatientCommunicationSuppressionReason | undefined,
+  globalSuppression: Boolean(value(row, 'globalSuppression', 'global_suppression')),
+  globalSuppressionReason: optionalString(value(row, 'globalSuppressionReason', 'global_suppression_reason')) as PatientCommunicationSuppressionReason | undefined,
+  createdAt: String(value(row, 'createdAt', 'created_at') ?? ''),
+  updatedAt: String(value(row, 'updatedAt', 'updated_at') ?? ''),
+  updatedBy: optionalString(value(row, 'updatedBy', 'updated_by')),
+});
+
+const mapConsentEvent = (row: Row): PatientCommunicationConsentEvent => ({
+  id: String(value(row, 'id', 'id')),
+  tenantId: String(value(row, 'tenantId', 'tenant_id')),
+  patientId: String(value(row, 'patientId', 'patient_id')),
+  channel: value(row, 'channel', 'channel') as PatientAutomatedCommunicationChannel,
+  previousState: value(row, 'previousState', 'previous_state') as PatientCommunicationConsentState,
+  newState: value(row, 'newState', 'new_state') as PatientCommunicationConsentState,
+  source: value(row, 'source', 'source') as PatientCommunicationConsentSource,
+  actorUserId: optionalString(value(row, 'actorUserId', 'actor_user_id')),
+  reason: optionalString(value(row, 'reason', 'reason')),
+  occurredAt: String(value(row, 'occurredAt', 'occurred_at') ?? ''),
+  metadata: (value(row, 'metadata', 'metadata') ?? {}) as Record<string, unknown>,
+});
+
+const mapEligibility = (row: unknown, channel: PatientCommunicationChannel): PatientCommunicationEligibility => {
+  const source = (row ?? {}) as Row;
+  const suppression = (value(source, 'suppressionState', 'suppression_state') ?? {}) as Row;
+  return {
+    eligible: Boolean(value(source, 'eligible', 'eligible')),
+    automatedEligible: Boolean(value(source, 'automatedEligible', 'automated_eligible')),
+    manualEligible: Boolean(value(source, 'manualEligible', 'manual_eligible')),
+    status: (value(source, 'status', 'status') ?? 'blocked') as PatientCommunicationEligibilityStatus,
+    channel: (value(source, 'channel', 'channel') ?? channel) as PatientCommunicationChannel,
+    selectedContactId: optionalString(value(source, 'selectedContactId', 'selected_contact_id')),
+    normalizedDestination: optionalString(value(source, 'normalizedDestination', 'normalized_destination')),
+    language: (value(source, 'language', 'language') ?? 'ru') as PatientCommunicationLanguage,
+    blockedReasons: ((value(source, 'blockedReasons', 'blocked_reasons') ?? []) as PatientCommunicationEligibility['blockedReasons']),
+    consentState: (value(source, 'consentState', 'consent_state') ?? (channel === 'phone' ? 'not_required' : 'unknown')) as PatientCommunicationEligibility['consentState'],
+    suppressionState: {
+      global: Boolean(value(suppression, 'global', 'global')),
+      channel: Boolean(value(suppression, 'channel', 'channel')),
+    },
+    representative: Boolean(value(source, 'representative', 'representative')),
+    requiresManualReview: Boolean(value(source, 'requiresManualReview', 'requires_manual_review')),
+  };
+};
+
+const summaryStatus = (items: PatientCommunicationEligibility[]): PatientCommunicationEligibilityStatus => {
+  if (items.some((item) => item.automatedEligible)) return 'available';
+  if (items[0]?.manualEligible) return 'manual_only';
+  if (items.some((item) => item.status === 'suppressed')) return 'suppressed';
+  if (items.some((item) => item.status === 'consent_unknown')) return 'consent_unknown';
+  if (items.some((item) => item.status === 'invalid_contact')) return 'invalid_contact';
+  return 'blocked';
+};
+
+export interface UpsertPatientCommunicationContactInput {
+  patientId: string;
+  contactId?: string;
+  contactType: PatientCommunicationContactType;
+  contactValueRaw: string;
+  isPrimary: boolean;
+  isVerified: boolean;
+  verificationSource?: string;
+  ownerType: PatientCommunicationOwnerType;
+  representativeName?: string;
+  representativeRelation?: PatientRepresentativeRelation;
+  language?: PatientCommunicationLanguage;
+  expectedUpdatedAt?: string;
+  operationKey: string;
+}
+
+export interface PatientCommunicationMutationResult {
+  contact?: PatientCommunicationContact;
+  preferences?: PatientCommunicationPreferences;
+  duplicateWarning?: boolean;
+  changed?: boolean;
+  consentEventId?: string;
+  replayed: boolean;
+}
+
+export interface PatientCommunicationRepository {
+  listPatientContacts(patientId: string): Promise<PatientCommunicationContact[]>;
+  getPatientCommunicationProfile(patientId: string): Promise<PatientCommunicationProfile>;
+  upsertContact(input: UpsertPatientCommunicationContactInput): Promise<PatientCommunicationMutationResult>;
+  archiveContact(patientId: string, contactId: string, expectedUpdatedAt: string, operationKey: string): Promise<PatientCommunicationMutationResult>;
+  setPrimaryContact(patientId: string, contactId: string, expectedUpdatedAt: string, operationKey: string): Promise<PatientCommunicationMutationResult>;
+  updatePreferences(patientId: string, preferredLanguage: PatientCommunicationLanguage, preferredChannel: PatientPreferredCommunicationChannel, allowManualPhone: boolean, operationKey: string): Promise<PatientCommunicationMutationResult>;
+  setConsent(patientId: string, channel: PatientAutomatedCommunicationChannel, state: PatientCommunicationConsentState, source: PatientCommunicationConsentSource, reason: string | undefined, operationKey: string): Promise<PatientCommunicationMutationResult>;
+  setSuppression(patientId: string, channel: 'global' | PatientCommunicationChannel, suppressed: boolean, reason: PatientCommunicationSuppressionReason | undefined, operationKey: string): Promise<PatientCommunicationMutationResult>;
+  getEligibility(patientId: string, channel: PatientCommunicationChannel): Promise<PatientCommunicationEligibility>;
+  getEligibilitySummary(patientId: string): Promise<PatientCommunicationEligibilitySummary>;
+}
+
+export class SupabasePatientCommunicationRepository implements PatientCommunicationRepository {
+  private readonly tenantId: string;
+  private readonly client: SupabaseClient;
+
+  constructor(tenantId: string, client: SupabaseClient) {
+    this.tenantId = tenantId;
+    this.client = client;
+  }
+
+  async listPatientContacts(patientId: string): Promise<PatientCommunicationContact[]> {
+    try {
+      const { data, error } = await this.client
+        .from('patient_communication_contacts')
+        .select('*')
+        .eq('tenant_id', this.tenantId)
+        .eq('patient_id', patientId)
+        .is('archived_at', null)
+        .order('contact_type', { ascending: true })
+        .order('is_primary', { ascending: false })
+        .order('created_at', { ascending: true });
+      if (error) throw error;
+      return ((data ?? []) as Row[]).map(mapContact);
+    } catch (error) {
+      throw toSafePatientCommunicationError(error, 'read');
+    }
+  }
+
+  async getPatientCommunicationProfile(patientId: string): Promise<PatientCommunicationProfile> {
+    try {
+      const contactsPromise = this.listPatientContacts(patientId);
+      const preferencesPromise = this.client
+        .from('patient_communication_preferences')
+        .select('*')
+        .eq('tenant_id', this.tenantId)
+        .eq('patient_id', patientId)
+        .maybeSingle();
+      const eventsPromise = this.client
+        .from('patient_communication_consent_events')
+        .select('*')
+        .eq('tenant_id', this.tenantId)
+        .eq('patient_id', patientId)
+        .order('occurred_at', { ascending: false })
+        .order('id', { ascending: true })
+        .limit(100);
+      const [contacts, preferencesResponse, eventsResponse, eligibility] = await Promise.all([
+        contactsPromise,
+        preferencesPromise,
+        eventsPromise,
+        this.getEligibilitySummary(patientId),
+      ]);
+      if (preferencesResponse.error) throw preferencesResponse.error;
+      if (eventsResponse.error) throw eventsResponse.error;
+      return {
+        contacts,
+        preferences: preferencesResponse.data
+          ? mapPreferences(preferencesResponse.data as Row, this.tenantId, patientId)
+          : defaultPatientCommunicationPreferences(this.tenantId, patientId),
+        consentEvents: ((eventsResponse.data ?? []) as Row[]).map(mapConsentEvent),
+        eligibility,
+      };
+    } catch (error) {
+      throw toSafePatientCommunicationError(error, 'read');
+    }
+  }
+
+  async getEligibility(patientId: string, channel: PatientCommunicationChannel): Promise<PatientCommunicationEligibility> {
+    try {
+      const { data, error } = await this.client.rpc('get_patient_communication_eligibility', {
+        p_tenant_id: this.tenantId,
+        p_patient_id: patientId,
+        p_channel: channel,
+      });
+      if (error) throw error;
+      return mapEligibility(data, channel);
+    } catch (error) {
+      throw toSafePatientCommunicationError(error, 'read');
+    }
+  }
+
+  async getEligibilitySummary(patientId: string): Promise<PatientCommunicationEligibilitySummary> {
+    const [phone, sms, whatsapp, email] = await Promise.all(
+      (['phone', 'sms', 'whatsapp', 'email'] as const).map((channel) => this.getEligibility(patientId, channel)),
+    );
+    return { phone, sms, whatsapp, email, status: summaryStatus([phone, sms, whatsapp, email]) };
+  }
+
+  async upsertContact(input: UpsertPatientCommunicationContactInput): Promise<PatientCommunicationMutationResult> {
+    return this.mutate('upsert_patient_communication_contact', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: input.patientId,
+      p_contact_id: input.contactId ?? null,
+      p_contact_type: input.contactType,
+      p_contact_value_raw: input.contactValueRaw,
+      p_is_primary: input.isPrimary,
+      p_is_verified: input.isVerified,
+      p_verification_source: input.verificationSource ?? null,
+      p_owner_type: input.ownerType,
+      p_representative_name: input.representativeName ?? null,
+      p_representative_relation: input.representativeRelation ?? null,
+      p_language: input.language ?? null,
+      p_expected_updated_at: input.expectedUpdatedAt ?? null,
+      p_operation_key: input.operationKey,
+    });
+  }
+
+  async archiveContact(patientId: string, contactId: string, expectedUpdatedAt: string, operationKey: string) {
+    return this.mutate('archive_patient_communication_contact', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: patientId,
+      p_contact_id: contactId,
+      p_expected_updated_at: expectedUpdatedAt,
+      p_operation_key: operationKey,
+    });
+  }
+
+  async setPrimaryContact(patientId: string, contactId: string, expectedUpdatedAt: string, operationKey: string) {
+    return this.mutate('set_primary_patient_communication_contact', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: patientId,
+      p_contact_id: contactId,
+      p_expected_updated_at: expectedUpdatedAt,
+      p_operation_key: operationKey,
+    });
+  }
+
+  async updatePreferences(
+    patientId: string,
+    preferredLanguage: PatientCommunicationLanguage,
+    preferredChannel: PatientPreferredCommunicationChannel,
+    allowManualPhone: boolean,
+    operationKey: string,
+  ) {
+    return this.mutate('set_patient_communication_preferences', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: patientId,
+      p_preferred_language: preferredLanguage,
+      p_preferred_channel: preferredChannel,
+      p_allow_manual_phone: allowManualPhone,
+      p_operation_key: operationKey,
+    });
+  }
+
+  async setConsent(
+    patientId: string,
+    channel: PatientAutomatedCommunicationChannel,
+    state: PatientCommunicationConsentState,
+    source: PatientCommunicationConsentSource,
+    reason: string | undefined,
+    operationKey: string,
+  ) {
+    return this.mutate('set_patient_communication_consent', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: patientId,
+      p_channel: channel,
+      p_new_state: state,
+      p_source: source,
+      p_reason: reason?.trim() || null,
+      p_operation_key: operationKey,
+    });
+  }
+
+  async setSuppression(
+    patientId: string,
+    channel: 'global' | PatientCommunicationChannel,
+    suppressed: boolean,
+    reason: PatientCommunicationSuppressionReason | undefined,
+    operationKey: string,
+  ) {
+    return this.mutate('set_patient_communication_suppression', {
+      p_tenant_id: this.tenantId,
+      p_patient_id: patientId,
+      p_channel: channel,
+      p_suppressed: suppressed,
+      p_reason: reason ?? null,
+      p_operation_key: operationKey,
+    });
+  }
+
+  private async mutate(rpcName: string, args: Row): Promise<PatientCommunicationMutationResult> {
+    try {
+      const { data, error } = await this.client.rpc(rpcName, args);
+      if (error) throw error;
+      const result = (data ?? {}) as Row;
+      return {
+        contact: result.contact ? mapContact(result.contact as Row) : undefined,
+        preferences: result.preferences ? mapPreferences(result.preferences as Row, this.tenantId, String(args.p_patient_id ?? '')) : undefined,
+        duplicateWarning: Boolean(result.duplicateWarning),
+        changed: result.changed === undefined ? undefined : Boolean(result.changed),
+        consentEventId: optionalString(result.consentEventId),
+        replayed: Boolean(result.replayed),
+      };
+    } catch (error) {
+      throw toSafePatientCommunicationError(error, 'write');
+    }
+  }
+}
+
+const blockedEligibility = (channel: PatientCommunicationChannel): PatientCommunicationEligibility => ({
+  eligible: false,
+  automatedEligible: false,
+  manualEligible: false,
+  status: 'blocked',
+  channel,
+  language: 'ru',
+  blockedReasons: ['no_contact'],
+  consentState: channel === 'phone' ? 'not_required' : 'unknown',
+  suppressionState: { global: false, channel: false },
+  representative: false,
+  requiresManualReview: false,
+});
+
+export const LocalPatientCommunicationRepository: PatientCommunicationRepository = {
+  async listPatientContacts() { return []; },
+  async getPatientCommunicationProfile(patientId) {
+    const phone = blockedEligibility('phone');
+    const sms = blockedEligibility('sms');
+    const whatsapp = blockedEligibility('whatsapp');
+    const email = blockedEligibility('email');
+    return {
+      contacts: [],
+      preferences: defaultPatientCommunicationPreferences('local', patientId),
+      consentEvents: [],
+      eligibility: { phone, sms, whatsapp, email, status: 'blocked' },
+    };
+  },
+  async upsertContact() { throw new PatientCommunicationRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed); },
+  async archiveContact() { throw new PatientCommunicationRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed); },
+  async setPrimaryContact() { throw new PatientCommunicationRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed); },
+  async updatePreferences() { throw new PatientCommunicationRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed); },
+  async setConsent() { throw new PatientCommunicationRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed); },
+  async setSuppression() { throw new PatientCommunicationRepositoryError('operation_failed', SAFE_MESSAGES.operation_failed); },
+  async getEligibility(_patientId, channel) { return blockedEligibility(channel); },
+  async getEligibilitySummary(patientId) { return (await this.getPatientCommunicationProfile(patientId)).eligibility; },
+};
+
+export function createPatientCommunicationRepository(options: {
+  backend: PatientCommunicationRepositoryBackend;
+  tenantId?: string | null;
+}): PatientCommunicationRepository {
+  if (options.backend === 'local') return LocalPatientCommunicationRepository;
+  if (!options.tenantId) throw new PatientCommunicationRepositoryError('permission', 'Клиника не выбрана.');
+  if (!supabase) throw new PatientCommunicationRepositoryError('read_failed', SAFE_MESSAGES.read_failed);
+  return new SupabasePatientCommunicationRepository(options.tenantId, supabase);
+}

--- a/src/pages/PatientCardPage.tsx
+++ b/src/pages/PatientCardPage.tsx
@@ -9,6 +9,7 @@ import { TreatmentPlansTab } from '../components/treatment/TreatmentPlansTab';
 import { FindingsRisksTab } from '../components/dental/FindingsRisksTab';
 import { PatientOverviewTab } from '../components/patients/patient-card/PatientOverviewTab';
 import { PatientHistoryTab } from '../components/patients/patient-card/PatientHistoryTab';
+import { PatientCommunicationSection } from '../components/patients/patient-card/PatientCommunicationSection';
 import { PatientTimelineTab } from '../components/patient/PatientTimelineTab';
 import { VisitCheckInPanel } from '../components/visits/VisitCheckInPanel';
 import { ClinicalEncounterPanel } from '../components/encounters/ClinicalEncounterPanel';
@@ -22,6 +23,7 @@ import type { PatientTimelineEventCategory } from '../data/aggregators/PatientTi
 
 const TABS = [
   { id: 'overview', label: 'Обзор' },
+  { id: 'communications', label: 'Связь' },
   { id: 'timeline', label: 'История' },
   { id: 'history', label: 'История приёмов' },
   { id: 'visits', label: 'Визиты' },
@@ -220,6 +222,10 @@ export function PatientCardPage() {
           />
         )}
 
+        {activeTab === 'communications' && (
+          <PatientCommunicationSection patientId={patient.id} />
+        )}
+
         {activeTab === 'timeline' && (
           <PatientTimelineTab
             events={timelineEvents}
@@ -275,7 +281,7 @@ export function PatientCardPage() {
         {activeTab === 'plan' && <TreatmentPlansTab patientId={patient.id} />}
         {activeTab === 'files' && <DentalPhotosPanel patientId={patient.id} />}
 
-        {['docs', 'communications'].includes(activeTab) && (
+        {['docs'].includes(activeTab) && (
           <div className="p-8 h-[400px] flex flex-col items-center justify-center text-slate-400 bg-white rounded-xl border border-slate-200 border-dashed">
             <div className="w-16 h-16 bg-slate-50 rounded-2xl flex items-center justify-center mb-4 border border-slate-100">
               <span className="text-2xl">🚧</span>

--- a/src/pages/ReminderOperationsPage.tsx
+++ b/src/pages/ReminderOperationsPage.tsx
@@ -64,6 +64,15 @@ const CONFIRMATION_LABELS: Record<string, string> = {
   unreachable: 'Недоступен',
 };
 
+const COMMUNICATION_STATUS = {
+  available: { label: 'Автоканал доступен', className: 'bg-emerald-100 text-emerald-700' },
+  manual_only: { label: 'Только вручную', className: 'bg-blue-100 text-blue-700' },
+  consent_unknown: { label: 'Нет согласия', className: 'bg-amber-100 text-amber-800' },
+  invalid_contact: { label: 'Контакт не готов', className: 'bg-orange-100 text-orange-800' },
+  suppressed: { label: 'Связь подавлена', className: 'bg-red-100 text-red-700' },
+  blocked: { label: 'Автосвязь заблокирована', className: 'bg-slate-200 text-slate-700' },
+} as const;
+
 type QueueBucket = 'all' | 'overdue' | 'today' | 'upcoming';
 type PageTab = 'active' | 'history';
 
@@ -298,6 +307,9 @@ export function ReminderOperationsPage() {
   const renderCard = (item: AppointmentReminderQueueItem) => {
     const itemBucket = bucketForItem(item, timezone, nowMillis);
     const busy = [completingJobId, deferringJobId, skippingJobId].includes(item.job.id);
+    const communicationStatus = item.communicationEligibility
+      ? COMMUNICATION_STATUS[item.communicationEligibility.status]
+      : COMMUNICATION_STATUS.blocked;
     return (
       <article key={item.job.id} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm" data-testid={`reminder-job-${item.job.id}`}>
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -316,6 +328,9 @@ export function ReminderOperationsPage() {
               {item.job.deferredAt && (
                 <span className="rounded-full bg-purple-100 px-2.5 py-1 text-xs font-medium text-purple-700">Отложена вручную</span>
               )}
+              <span data-testid={`communication-eligibility-${item.job.id}`} className={`rounded-full px-2.5 py-1 text-xs font-medium ${communicationStatus.className}`}>
+                {communicationStatus.label}
+              </span>
             </div>
             <h3 className="mt-3 truncate text-lg font-semibold text-slate-900">{item.patient.fullName}</h3>
             <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-sm text-slate-600">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,7 @@ export interface AppointmentReminderQueueItem {
   doctor: Pick<Doctor, 'id' | 'fullName' | 'specialization' | 'cabinet'>;
   attemptCount: number;
   lastAttempt?: AppointmentConfirmationAttempt;
+  communicationEligibility?: PatientCommunicationEligibilitySummary;
 }
 
 export type AppointmentReminderOperationType = 'reminder_complete' | 'reminder_defer' | 'reminder_skip';
@@ -220,6 +221,142 @@ export interface TenantReminderReconcileResult {
   superseded: number;
   cancelled: number;
   skipped: number;
+}
+
+export type PatientCommunicationContactType = 'phone' | 'email';
+export type PatientCommunicationOwnerType = 'patient' | 'representative';
+export type PatientRepresentativeRelation = 'parent' | 'guardian' | 'spouse' | 'child' | 'caregiver' | 'other';
+export type PatientCommunicationLanguage = 'ru' | 'kk' | 'en';
+export type PatientPreferredCommunicationChannel = 'phone' | 'whatsapp' | 'sms' | 'email' | 'none';
+export type PatientAutomatedCommunicationChannel = 'sms' | 'whatsapp' | 'email';
+export type PatientCommunicationChannel = 'phone' | PatientAutomatedCommunicationChannel;
+export type PatientCommunicationConsentState = 'unknown' | 'granted' | 'denied' | 'withdrawn';
+export type PatientCommunicationConsentSource =
+  | 'patient_verbal'
+  | 'patient_written'
+  | 'representative_verbal'
+  | 'representative_written'
+  | 'staff_correction'
+  | 'import_legacy'
+  | 'system';
+export type PatientCommunicationSuppressionReason =
+  | 'patient_request'
+  | 'representative_request'
+  | 'invalid_contact'
+  | 'wrong_number'
+  | 'duplicate_contact'
+  | 'legal_restriction'
+  | 'staff_decision'
+  | 'other';
+export type PatientCommunicationEligibilityStatus =
+  | 'available'
+  | 'blocked'
+  | 'manual_only'
+  | 'consent_unknown'
+  | 'invalid_contact'
+  | 'suppressed';
+export type PatientCommunicationBlockedReason =
+  | 'no_contact'
+  | 'invalid_contact'
+  | 'unverified_contact'
+  | 'consent_unknown'
+  | 'consent_denied'
+  | 'consent_withdrawn'
+  | 'channel_suppressed'
+  | 'global_suppression'
+  | 'no_preferred_channel'
+  | 'representative_review_required';
+
+export interface PatientCommunicationContact {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  contactType: PatientCommunicationContactType;
+  contactValueRaw: string;
+  contactValueNormalized?: string;
+  countryCode?: string;
+  isPrimary: boolean;
+  isVerified: boolean;
+  verificationSource?: string;
+  ownerType: PatientCommunicationOwnerType;
+  representativeName?: string;
+  representativeRelation?: PatientRepresentativeRelation;
+  language?: PatientCommunicationLanguage;
+  possibleDuplicate: boolean;
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt?: string;
+}
+
+export interface PatientCommunicationPreferences {
+  tenantId: string;
+  patientId: string;
+  preferredLanguage: PatientCommunicationLanguage;
+  preferredChannel: PatientPreferredCommunicationChannel;
+  allowManualPhone: boolean;
+  smsConsentState: PatientCommunicationConsentState;
+  whatsappConsentState: PatientCommunicationConsentState;
+  emailConsentState: PatientCommunicationConsentState;
+  phoneSuppressed: boolean;
+  phoneSuppressionReason?: PatientCommunicationSuppressionReason;
+  smsSuppressed: boolean;
+  smsSuppressionReason?: PatientCommunicationSuppressionReason;
+  whatsappSuppressed: boolean;
+  whatsappSuppressionReason?: PatientCommunicationSuppressionReason;
+  emailSuppressed: boolean;
+  emailSuppressionReason?: PatientCommunicationSuppressionReason;
+  globalSuppression: boolean;
+  globalSuppressionReason?: PatientCommunicationSuppressionReason;
+  createdAt: string;
+  updatedAt: string;
+  updatedBy?: string;
+}
+
+export interface PatientCommunicationConsentEvent {
+  id: string;
+  tenantId: string;
+  patientId: string;
+  channel: PatientAutomatedCommunicationChannel;
+  previousState: PatientCommunicationConsentState;
+  newState: PatientCommunicationConsentState;
+  source: PatientCommunicationConsentSource;
+  actorUserId?: string;
+  reason?: string;
+  occurredAt: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface PatientCommunicationEligibility {
+  eligible: boolean;
+  automatedEligible: boolean;
+  manualEligible: boolean;
+  status: PatientCommunicationEligibilityStatus;
+  channel: PatientCommunicationChannel;
+  selectedContactId?: string;
+  normalizedDestination?: string;
+  language: PatientCommunicationLanguage;
+  blockedReasons: PatientCommunicationBlockedReason[];
+  consentState: PatientCommunicationConsentState | 'not_required';
+  suppressionState: { global: boolean; channel: boolean };
+  representative: boolean;
+  requiresManualReview: boolean;
+}
+
+export interface PatientCommunicationEligibilitySummary {
+  phone: PatientCommunicationEligibility;
+  sms: PatientCommunicationEligibility;
+  whatsapp: PatientCommunicationEligibility;
+  email: PatientCommunicationEligibility;
+  status: PatientCommunicationEligibilityStatus;
+}
+
+export interface PatientCommunicationProfile {
+  contacts: PatientCommunicationContact[];
+  preferences: PatientCommunicationPreferences;
+  consentEvents: PatientCommunicationConsentEvent[];
+  eligibility: PatientCommunicationEligibilitySummary;
 }
 
 export type ToothNumber =

--- a/supabase/migrations/0031_patient_communication_contact_consent_foundation.sql
+++ b/supabase/migrations/0031_patient_communication_contact_consent_foundation.sql
@@ -1,0 +1,1140 @@
+-- APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001
+-- Authoritative tenant-scoped contacts, preferences, consent evidence and provider-neutral eligibility.
+-- No delivery, provider, worker, cron, webhook or cloud behavior is introduced.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.normalize_patient_phone_e164(p_raw text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_raw text := btrim(coalesce(p_raw, ''));
+  v_digits text;
+  v_normalized text;
+BEGIN
+  IF v_raw = '' OR left(v_raw, 1) <> '+' THEN
+    RETURN NULL;
+  END IF;
+  IF v_raw ~* '(ext\.?|доб\.?|x\s*[0-9]|#|;)' THEN
+    RETURN NULL;
+  END IF;
+  v_digits := regexp_replace(substr(v_raw, 2), '[^0-9]', '', 'g');
+  v_normalized := '+' || v_digits;
+  IF v_normalized ~ '^\+[1-9][0-9]{7,14}$' THEN
+    RETURN v_normalized;
+  END IF;
+  RETURN NULL;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.normalize_patient_email(p_raw text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_normalized text := lower(btrim(coalesce(p_raw, '')));
+BEGIN
+  IF v_normalized ~ '^[a-z0-9.!#$%&''*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$' THEN
+    RETURN v_normalized;
+  END IF;
+  RETURN NULL;
+END;
+$fn$;
+
+CREATE TABLE public.patient_communication_contacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  contact_type text NOT NULL CHECK (contact_type IN ('phone', 'email')),
+  contact_value_raw text NOT NULL CHECK (length(btrim(contact_value_raw)) > 0),
+  contact_value_normalized text,
+  country_code text,
+  is_primary boolean NOT NULL DEFAULT false,
+  is_verified boolean NOT NULL DEFAULT false,
+  verification_source text CHECK (verification_source IS NULL OR verification_source IN (
+    'import_legacy', 'staff_entered', 'patient_confirmed', 'representative_confirmed', 'other'
+  )),
+  owner_type text NOT NULL DEFAULT 'patient' CHECK (owner_type IN ('patient', 'representative')),
+  representative_name text,
+  representative_relation text CHECK (representative_relation IS NULL OR representative_relation IN (
+    'parent', 'guardian', 'spouse', 'child', 'caregiver', 'other'
+  )),
+  language text CHECK (language IS NULL OR language IN ('ru', 'kk', 'en')),
+  possible_duplicate boolean NOT NULL DEFAULT false,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  archived_at timestamptz,
+  UNIQUE (tenant_id, id),
+  FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CHECK (
+    (contact_type = 'phone' AND (contact_value_normalized IS NULL OR contact_value_normalized ~ '^\+[1-9][0-9]{7,14}$'))
+    OR
+    (contact_type = 'email' AND (contact_value_normalized IS NULL OR contact_value_normalized = lower(contact_value_normalized)))
+  ),
+  CHECK (
+    owner_type = 'patient'
+    OR (
+      owner_type = 'representative'
+      AND length(btrim(coalesce(representative_name, ''))) > 0
+      AND representative_relation IS NOT NULL
+    )
+  ),
+  CHECK (owner_type = 'representative' OR (representative_name IS NULL AND representative_relation IS NULL)),
+  CHECK (NOT is_primary OR archived_at IS NULL),
+  CHECK (NOT is_verified OR contact_value_normalized IS NOT NULL),
+  CHECK (NOT is_verified OR verification_source IS NOT NULL)
+);
+
+CREATE INDEX idx_patient_communication_contacts_patient
+  ON public.patient_communication_contacts(tenant_id, patient_id, contact_type, archived_at);
+CREATE INDEX idx_patient_communication_contacts_normalized
+  ON public.patient_communication_contacts(tenant_id, contact_type, contact_value_normalized)
+  WHERE archived_at IS NULL AND contact_value_normalized IS NOT NULL;
+CREATE UNIQUE INDEX uq_patient_primary_phone
+  ON public.patient_communication_contacts(tenant_id, patient_id)
+  WHERE contact_type = 'phone' AND is_primary AND archived_at IS NULL;
+CREATE UNIQUE INDEX uq_patient_primary_email
+  ON public.patient_communication_contacts(tenant_id, patient_id)
+  WHERE contact_type = 'email' AND is_primary AND archived_at IS NULL;
+
+CREATE TABLE public.patient_communication_preferences (
+  tenant_id uuid NOT NULL,
+  patient_id uuid NOT NULL,
+  preferred_language text NOT NULL DEFAULT 'ru' CHECK (preferred_language IN ('ru', 'kk', 'en')),
+  preferred_channel text NOT NULL DEFAULT 'none' CHECK (preferred_channel IN ('phone', 'whatsapp', 'sms', 'email', 'none')),
+  allow_manual_phone boolean NOT NULL DEFAULT true,
+  sms_consent_state text NOT NULL DEFAULT 'unknown' CHECK (sms_consent_state IN ('unknown', 'granted', 'denied', 'withdrawn')),
+  whatsapp_consent_state text NOT NULL DEFAULT 'unknown' CHECK (whatsapp_consent_state IN ('unknown', 'granted', 'denied', 'withdrawn')),
+  email_consent_state text NOT NULL DEFAULT 'unknown' CHECK (email_consent_state IN ('unknown', 'granted', 'denied', 'withdrawn')),
+  phone_suppressed boolean NOT NULL DEFAULT false,
+  phone_suppression_reason text,
+  phone_suppressed_at timestamptz,
+  phone_suppressed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  sms_suppressed boolean NOT NULL DEFAULT false,
+  sms_suppression_reason text,
+  sms_suppressed_at timestamptz,
+  sms_suppressed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  whatsapp_suppressed boolean NOT NULL DEFAULT false,
+  whatsapp_suppression_reason text,
+  whatsapp_suppressed_at timestamptz,
+  whatsapp_suppressed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  email_suppressed boolean NOT NULL DEFAULT false,
+  email_suppression_reason text,
+  email_suppressed_at timestamptz,
+  email_suppressed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  global_suppression boolean NOT NULL DEFAULT false,
+  global_suppression_reason text,
+  global_suppressed_at timestamptz,
+  global_suppressed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  PRIMARY KEY (tenant_id, patient_id),
+  FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  CHECK (phone_suppression_reason IS NULL OR phone_suppression_reason IN ('patient_request','representative_request','invalid_contact','wrong_number','duplicate_contact','legal_restriction','staff_decision','other')),
+  CHECK (sms_suppression_reason IS NULL OR sms_suppression_reason IN ('patient_request','representative_request','invalid_contact','wrong_number','duplicate_contact','legal_restriction','staff_decision','other')),
+  CHECK (whatsapp_suppression_reason IS NULL OR whatsapp_suppression_reason IN ('patient_request','representative_request','invalid_contact','wrong_number','duplicate_contact','legal_restriction','staff_decision','other')),
+  CHECK (email_suppression_reason IS NULL OR email_suppression_reason IN ('patient_request','representative_request','invalid_contact','wrong_number','duplicate_contact','legal_restriction','staff_decision','other')),
+  CHECK (global_suppression_reason IS NULL OR global_suppression_reason IN ('patient_request','representative_request','invalid_contact','wrong_number','duplicate_contact','legal_restriction','staff_decision','other')),
+  CHECK (phone_suppressed OR (phone_suppression_reason IS NULL AND phone_suppressed_at IS NULL)),
+  CHECK (sms_suppressed OR (sms_suppression_reason IS NULL AND sms_suppressed_at IS NULL)),
+  CHECK (whatsapp_suppressed OR (whatsapp_suppression_reason IS NULL AND whatsapp_suppressed_at IS NULL)),
+  CHECK (email_suppressed OR (email_suppression_reason IS NULL AND email_suppressed_at IS NULL)),
+  CHECK (global_suppression OR (global_suppression_reason IS NULL AND global_suppressed_at IS NULL))
+);
+
+CREATE TABLE public.patient_communication_consent_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  patient_id uuid NOT NULL,
+  channel text NOT NULL CHECK (channel IN ('sms', 'whatsapp', 'email')),
+  previous_state text NOT NULL CHECK (previous_state IN ('unknown', 'granted', 'denied', 'withdrawn')),
+  new_state text NOT NULL CHECK (new_state IN ('unknown', 'granted', 'denied', 'withdrawn')),
+  source text NOT NULL CHECK (source IN (
+    'patient_verbal', 'patient_written', 'representative_verbal', 'representative_written',
+    'staff_correction', 'import_legacy', 'system'
+  )),
+  actor_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  reason text,
+  occurred_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  operation_key text NOT NULL,
+  fingerprint text NOT NULL CHECK (fingerprint ~ '^[0-9a-f]{64}$'),
+  FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  UNIQUE (tenant_id, operation_key)
+);
+CREATE INDEX idx_patient_communication_consent_events_patient
+  ON public.patient_communication_consent_events(tenant_id, patient_id, occurred_at DESC, id);
+
+CREATE TABLE public.patient_communication_operations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  operation_key text NOT NULL,
+  operation_type text NOT NULL,
+  fingerprint text NOT NULL CHECK (fingerprint ~ '^[0-9a-f]{64}$'),
+  actor_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  patient_id uuid NOT NULL,
+  result jsonb NOT NULL CHECK (jsonb_typeof(result) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  FOREIGN KEY (tenant_id, patient_id) REFERENCES public.patients(tenant_id, id) ON DELETE CASCADE,
+  UNIQUE (tenant_id, operation_key)
+);
+CREATE INDEX idx_patient_communication_operations_patient
+  ON public.patient_communication_operations(tenant_id, patient_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.patient_communication_touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $fn$
+BEGIN
+  NEW.updated_at := transaction_timestamp();
+  RETURN NEW;
+END;
+$fn$;
+
+CREATE TRIGGER patient_communication_contacts_touch_updated_at
+BEFORE UPDATE ON public.patient_communication_contacts
+FOR EACH ROW EXECUTE FUNCTION public.patient_communication_touch_updated_at();
+CREATE TRIGGER patient_communication_preferences_touch_updated_at
+BEFORE UPDATE ON public.patient_communication_preferences
+FOR EACH ROW EXECUTE FUNCTION public.patient_communication_touch_updated_at();
+
+CREATE OR REPLACE FUNCTION public.patient_communication_consent_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $fn$
+BEGIN
+  IF current_user IN ('postgres', 'service_role') THEN
+    RETURN OLD;
+  END IF;
+  RAISE EXCEPTION 'Consent history is append-only.' USING ERRCODE = '42501';
+END;
+$fn$;
+CREATE TRIGGER patient_communication_consent_append_only_guard
+BEFORE UPDATE OR DELETE ON public.patient_communication_consent_events
+FOR EACH ROW EXECUTE FUNCTION public.patient_communication_consent_append_only();
+
+CREATE OR REPLACE FUNCTION public.patient_communication_role(p_tenant_id uuid)
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+  SELECT tu.role::text
+  FROM public.tenant_users tu
+  WHERE tu.tenant_id = p_tenant_id AND tu.user_id = auth.uid()
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.patient_communication_assert_patient(p_tenant_id uuid, p_patient_id uuid)
+RETURNS public.patients
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_patient public.patients%ROWTYPE;
+BEGIN
+  SELECT * INTO v_patient
+  FROM public.patients p
+  WHERE p.tenant_id = p_tenant_id AND p.id = p_patient_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE = '42501';
+  END IF;
+  RETURN v_patient;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.patient_communication_operation_replay(
+  p_tenant_id uuid,
+  p_operation_key text,
+  p_operation_type text,
+  p_fingerprint text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_operation public.patient_communication_operations%ROWTYPE;
+BEGIN
+  IF p_operation_key IS NULL OR length(btrim(p_operation_key)) < 8 OR length(p_operation_key) > 200 THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE = '22023';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('patient-communication:' || p_tenant_id::text || ':' || p_operation_key, 0));
+  SELECT * INTO v_operation
+  FROM public.patient_communication_operations o
+  WHERE o.tenant_id = p_tenant_id AND o.operation_key = p_operation_key;
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+  IF v_operation.operation_type <> p_operation_type OR v_operation.fingerprint <> p_fingerprint THEN
+    RAISE EXCEPTION 'Эта операция уже выполнена с другими параметрами.' USING ERRCODE = '23505';
+  END IF;
+  RETURN v_operation.result || jsonb_build_object('replayed', true);
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.patient_communication_store_operation(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_operation_key text,
+  p_operation_type text,
+  p_fingerprint text,
+  p_result jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+BEGIN
+  INSERT INTO public.patient_communication_operations(
+    tenant_id, patient_id, operation_key, operation_type, fingerprint, actor_user_id, result
+  ) VALUES (
+    p_tenant_id, p_patient_id, btrim(p_operation_key), p_operation_type, p_fingerprint, auth.uid(), p_result
+  );
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.record_patient_communication_audit_internal(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_action text,
+  p_target_type text,
+  p_target_id text,
+  p_before jsonb,
+  p_after jsonb,
+  p_reason text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_audit uuid;
+  v_role text := public.patient_communication_role(p_tenant_id);
+BEGIN
+  v_audit := public.record_audit_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_action => p_action,
+    p_category => 'patient',
+    p_target_type => p_target_type,
+    p_target_id => p_target_id,
+    p_actor_user_id => auth.uid(),
+    p_actor_role => 'authenticated',
+    p_actor_tenant_role => v_role,
+    p_severity => 'info',
+    p_patient_id => p_patient_id,
+    p_before_data => p_before,
+    p_after_data => p_after,
+    p_redaction_level => 'restricted',
+    p_reason => p_reason,
+    p_metadata => coalesce(p_metadata, '{}'::jsonb)
+  );
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id => p_tenant_id,
+    p_category => 'patient',
+    p_type => p_action,
+    p_title => 'Настройки связи пациента изменены',
+    p_source_type => p_target_type,
+    p_source_id => p_target_id,
+    p_patient_id => p_patient_id,
+    p_audit_event_id => v_audit,
+    p_actor_user_id => auth.uid(),
+    p_description => p_reason,
+    p_visibility => 'admin',
+    p_severity => 'info',
+    p_metadata => coalesce(p_metadata, '{}'::jsonb)
+  );
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.patient_communication_contact_json(p_contact public.patient_communication_contacts)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $fn$
+  SELECT jsonb_build_object(
+    'id', p_contact.id,
+    'tenantId', p_contact.tenant_id,
+    'patientId', p_contact.patient_id,
+    'contactType', p_contact.contact_type,
+    'contactValueRaw', p_contact.contact_value_raw,
+    'contactValueNormalized', p_contact.contact_value_normalized,
+    'countryCode', p_contact.country_code,
+    'isPrimary', p_contact.is_primary,
+    'isVerified', p_contact.is_verified,
+    'verificationSource', p_contact.verification_source,
+    'ownerType', p_contact.owner_type,
+    'representativeName', p_contact.representative_name,
+    'representativeRelation', p_contact.representative_relation,
+    'language', p_contact.language,
+    'possibleDuplicate', p_contact.possible_duplicate,
+    'createdBy', p_contact.created_by,
+    'updatedBy', p_contact.updated_by,
+    'createdAt', p_contact.created_at,
+    'updatedAt', p_contact.updated_at,
+    'archivedAt', p_contact.archived_at
+  )
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.patient_communication_preferences_json(p_preferences public.patient_communication_preferences)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $fn$
+  SELECT jsonb_build_object(
+    'tenantId', p_preferences.tenant_id,
+    'patientId', p_preferences.patient_id,
+    'preferredLanguage', p_preferences.preferred_language,
+    'preferredChannel', p_preferences.preferred_channel,
+    'allowManualPhone', p_preferences.allow_manual_phone,
+    'smsConsentState', p_preferences.sms_consent_state,
+    'whatsappConsentState', p_preferences.whatsapp_consent_state,
+    'emailConsentState', p_preferences.email_consent_state,
+    'phoneSuppressed', p_preferences.phone_suppressed,
+    'phoneSuppressionReason', p_preferences.phone_suppression_reason,
+    'smsSuppressed', p_preferences.sms_suppressed,
+    'smsSuppressionReason', p_preferences.sms_suppression_reason,
+    'whatsappSuppressed', p_preferences.whatsapp_suppressed,
+    'whatsappSuppressionReason', p_preferences.whatsapp_suppression_reason,
+    'emailSuppressed', p_preferences.email_suppressed,
+    'emailSuppressionReason', p_preferences.email_suppression_reason,
+    'globalSuppression', p_preferences.global_suppression,
+    'globalSuppressionReason', p_preferences.global_suppression_reason,
+    'createdAt', p_preferences.created_at,
+    'updatedAt', p_preferences.updated_at,
+    'updatedBy', p_preferences.updated_by
+  )
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.upsert_patient_communication_contact(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_contact_id uuid,
+  p_contact_type text,
+  p_contact_value_raw text,
+  p_is_primary boolean,
+  p_is_verified boolean,
+  p_verification_source text,
+  p_owner_type text,
+  p_representative_name text,
+  p_representative_relation text,
+  p_language text,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_patient public.patients%ROWTYPE;
+  v_before public.patient_communication_contacts%ROWTYPE;
+  v_after public.patient_communication_contacts%ROWTYPE;
+  v_normalized text;
+  v_country text;
+  v_fingerprint text;
+  v_replay jsonb;
+  v_duplicate boolean;
+  v_action text;
+  v_result jsonb;
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner', 'clinic_admin', 'registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE = '42501';
+  END IF;
+  v_patient := public.patient_communication_assert_patient(p_tenant_id, p_patient_id);
+  IF p_contact_type = 'phone' THEN
+    v_normalized := public.normalize_patient_phone_e164(p_contact_value_raw);
+    IF v_normalized IS NULL THEN
+      RAISE EXCEPTION 'Укажите корректный номер телефона.' USING ERRCODE = '22023';
+    END IF;
+    v_country := CASE WHEN v_normalized LIKE '+7%' THEN '7' ELSE NULL END;
+  ELSIF p_contact_type = 'email' THEN
+    v_normalized := public.normalize_patient_email(p_contact_value_raw);
+    IF v_normalized IS NULL THEN
+      RAISE EXCEPTION 'Укажите корректный адрес электронной почты.' USING ERRCODE = '22023';
+    END IF;
+    v_country := NULL;
+  ELSE
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE = '22023';
+  END IF;
+  IF p_owner_type NOT IN ('patient', 'representative') THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE = '22023';
+  END IF;
+  IF p_owner_type = 'representative' AND (
+    length(btrim(coalesce(p_representative_name, ''))) = 0
+    OR p_representative_relation IS NULL
+    OR p_representative_relation NOT IN ('parent','guardian','spouse','child','caregiver','other')
+  ) THEN
+    RAISE EXCEPTION 'Укажите представителя и его отношение к пациенту.' USING ERRCODE = '22023';
+  END IF;
+  IF p_language IS NOT NULL AND p_language NOT IN ('ru','kk','en') THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE = '22023';
+  END IF;
+  IF p_is_verified AND p_verification_source IS NULL THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE = '22023';
+  END IF;
+
+  v_fingerprint := encode(extensions.digest(jsonb_build_object(
+    'patientId', p_patient_id, 'contactId', p_contact_id, 'type', p_contact_type,
+    'normalized', v_normalized, 'primary', coalesce(p_is_primary, false),
+    'verified', coalesce(p_is_verified, false), 'verificationSource', p_verification_source,
+    'ownerType', p_owner_type, 'representativeName', nullif(btrim(coalesce(p_representative_name,'')),''),
+    'representativeRelation', p_representative_relation, 'language', p_language,
+    'expectedUpdatedAt', p_expected_updated_at
+  )::text, 'sha256'), 'hex');
+  v_replay := public.patient_communication_operation_replay(p_tenant_id, p_operation_key, 'contact_upsert', v_fingerprint);
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+
+  IF p_contact_id IS NOT NULL THEN
+    SELECT * INTO v_before FROM public.patient_communication_contacts c
+    WHERE c.tenant_id = p_tenant_id AND c.patient_id = p_patient_id AND c.id = p_contact_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE = '42501';
+    END IF;
+    IF p_expected_updated_at IS NULL OR v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+      RAISE EXCEPTION 'Контакт был изменён другим пользователем. Обновите данные.' USING ERRCODE = '55000', HINT = 'communication_stale';
+    END IF;
+  END IF;
+
+  IF coalesce(p_is_primary, false) THEN
+    UPDATE public.patient_communication_contacts
+    SET is_primary = false, updated_by = auth.uid()
+    WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id
+      AND contact_type = p_contact_type AND archived_at IS NULL AND is_primary
+      AND (p_contact_id IS NULL OR id <> p_contact_id);
+  END IF;
+
+  IF p_contact_id IS NULL THEN
+    INSERT INTO public.patient_communication_contacts(
+      tenant_id, patient_id, contact_type, contact_value_raw, contact_value_normalized, country_code,
+      is_primary, is_verified, verification_source, owner_type, representative_name,
+      representative_relation, language, created_by, updated_by
+    ) VALUES (
+      p_tenant_id, p_patient_id, p_contact_type, btrim(p_contact_value_raw), v_normalized, v_country,
+      coalesce(p_is_primary, false), coalesce(p_is_verified, false), p_verification_source,
+      p_owner_type, CASE WHEN p_owner_type='representative' THEN nullif(btrim(p_representative_name),'') END,
+      CASE WHEN p_owner_type='representative' THEN p_representative_relation END,
+      p_language, auth.uid(), auth.uid()
+    ) RETURNING * INTO v_after;
+    v_action := 'patient_communication_contact_added';
+  ELSE
+    UPDATE public.patient_communication_contacts
+    SET contact_type = p_contact_type,
+        contact_value_raw = btrim(p_contact_value_raw),
+        contact_value_normalized = v_normalized,
+        country_code = v_country,
+        is_primary = coalesce(p_is_primary, false),
+        is_verified = coalesce(p_is_verified, false),
+        verification_source = p_verification_source,
+        owner_type = p_owner_type,
+        representative_name = CASE WHEN p_owner_type='representative' THEN nullif(btrim(p_representative_name),'') END,
+        representative_relation = CASE WHEN p_owner_type='representative' THEN p_representative_relation END,
+        language = p_language,
+        updated_by = auth.uid(),
+        archived_at = NULL
+    WHERE tenant_id = p_tenant_id AND patient_id = p_patient_id AND id = p_contact_id
+    RETURNING * INTO v_after;
+    v_action := 'patient_communication_contact_updated';
+  END IF;
+
+  SELECT EXISTS(
+    SELECT 1 FROM public.patient_communication_contacts c
+    WHERE c.tenant_id = p_tenant_id AND c.contact_type = p_contact_type
+      AND c.contact_value_normalized = v_normalized AND c.archived_at IS NULL
+      AND c.id <> v_after.id AND c.patient_id <> p_patient_id
+  ) INTO v_duplicate;
+  UPDATE public.patient_communication_contacts
+  SET possible_duplicate = true, updated_by = coalesce(updated_by, auth.uid())
+  WHERE tenant_id = p_tenant_id AND contact_type = p_contact_type
+    AND contact_value_normalized = v_normalized AND archived_at IS NULL
+    AND (v_duplicate OR id = v_after.id);
+  IF NOT v_duplicate THEN
+    UPDATE public.patient_communication_contacts
+    SET possible_duplicate = false, updated_by = auth.uid()
+    WHERE tenant_id = p_tenant_id AND id = v_after.id;
+  END IF;
+  SELECT * INTO v_after FROM public.patient_communication_contacts WHERE id = v_after.id;
+
+  PERFORM public.record_patient_communication_audit_internal(
+    p_tenant_id, p_patient_id, v_action, 'patient_communication_contact', v_after.id::text,
+    CASE WHEN p_contact_id IS NULL THEN NULL ELSE jsonb_build_object('type',v_before.contact_type,'primary',v_before.is_primary,'verified',v_before.is_verified,'ownerType',v_before.owner_type) END,
+    jsonb_build_object('type',v_after.contact_type,'primary',v_after.is_primary,'verified',v_after.is_verified,'ownerType',v_after.owner_type,'possibleDuplicate',v_after.possible_duplicate),
+    NULL,
+    jsonb_build_object('contactId',v_after.id,'destinationSuffix',right(coalesce(v_after.contact_value_normalized,''),4))
+  );
+  v_result := jsonb_build_object('contact', public.patient_communication_contact_json(v_after), 'duplicateWarning', v_duplicate, 'replayed', false);
+  PERFORM public.patient_communication_store_operation(p_tenant_id,p_patient_id,p_operation_key,'contact_upsert',v_fingerprint,v_result);
+  RETURN v_result;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.archive_patient_communication_contact(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_contact_id uuid,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_before public.patient_communication_contacts%ROWTYPE;
+  v_after public.patient_communication_contacts%ROWTYPE;
+  v_fingerprint text;
+  v_replay jsonb;
+  v_result jsonb;
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.patient_communication_assert_patient(p_tenant_id,p_patient_id);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object('patientId',p_patient_id,'contactId',p_contact_id,'expectedUpdatedAt',p_expected_updated_at)::text,'sha256'),'hex');
+  v_replay := public.patient_communication_operation_replay(p_tenant_id,p_operation_key,'contact_archive',v_fingerprint);
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  SELECT * INTO v_before FROM public.patient_communication_contacts
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id AND id=p_contact_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501'; END IF;
+  IF p_expected_updated_at IS NULL OR v_before.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Контакт был изменён другим пользователем. Обновите данные.' USING ERRCODE='55000', HINT='communication_stale';
+  END IF;
+  UPDATE public.patient_communication_contacts
+  SET archived_at=transaction_timestamp(), is_primary=false, updated_by=auth.uid()
+  WHERE id=p_contact_id RETURNING * INTO v_after;
+  PERFORM public.record_patient_communication_audit_internal(
+    p_tenant_id,p_patient_id,'patient_communication_contact_archived','patient_communication_contact',p_contact_id::text,
+    jsonb_build_object('type',v_before.contact_type,'primary',v_before.is_primary,'verified',v_before.is_verified),
+    jsonb_build_object('type',v_after.contact_type,'archived',true),NULL,
+    jsonb_build_object('contactId',p_contact_id)
+  );
+  v_result := jsonb_build_object('contact',public.patient_communication_contact_json(v_after),'replayed',false);
+  PERFORM public.patient_communication_store_operation(p_tenant_id,p_patient_id,p_operation_key,'contact_archive',v_fingerprint,v_result);
+  RETURN v_result;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.set_primary_patient_communication_contact(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_contact_id uuid,
+  p_expected_updated_at timestamptz,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_contact public.patient_communication_contacts%ROWTYPE;
+  v_after public.patient_communication_contacts%ROWTYPE;
+  v_fingerprint text;
+  v_replay jsonb;
+  v_result jsonb;
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.patient_communication_assert_patient(p_tenant_id,p_patient_id);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object('patientId',p_patient_id,'contactId',p_contact_id,'expectedUpdatedAt',p_expected_updated_at)::text,'sha256'),'hex');
+  v_replay := public.patient_communication_operation_replay(p_tenant_id,p_operation_key,'contact_primary',v_fingerprint);
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  SELECT * INTO v_contact FROM public.patient_communication_contacts
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id AND id=p_contact_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501'; END IF;
+  IF v_contact.archived_at IS NOT NULL THEN RAISE EXCEPTION 'Архивный контакт нельзя сделать основным.' USING ERRCODE='22023'; END IF;
+  IF p_expected_updated_at IS NULL OR v_contact.updated_at IS DISTINCT FROM p_expected_updated_at THEN
+    RAISE EXCEPTION 'Контакт был изменён другим пользователем. Обновите данные.' USING ERRCODE='55000', HINT='communication_stale';
+  END IF;
+  UPDATE public.patient_communication_contacts
+  SET is_primary=false, updated_by=auth.uid()
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id AND contact_type=v_contact.contact_type AND archived_at IS NULL AND is_primary;
+  UPDATE public.patient_communication_contacts
+  SET is_primary=true, updated_by=auth.uid()
+  WHERE id=p_contact_id RETURNING * INTO v_after;
+  PERFORM public.record_patient_communication_audit_internal(
+    p_tenant_id,p_patient_id,'patient_communication_primary_changed','patient_communication_contact',p_contact_id::text,
+    jsonb_build_object('primary',v_contact.is_primary,'type',v_contact.contact_type),
+    jsonb_build_object('primary',true,'type',v_contact.contact_type),NULL,jsonb_build_object('contactId',p_contact_id)
+  );
+  v_result := jsonb_build_object('contact',public.patient_communication_contact_json(v_after),'replayed',false);
+  PERFORM public.patient_communication_store_operation(p_tenant_id,p_patient_id,p_operation_key,'contact_primary',v_fingerprint,v_result);
+  RETURN v_result;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.set_patient_communication_preferences(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_preferred_language text,
+  p_preferred_channel text,
+  p_allow_manual_phone boolean,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_before public.patient_communication_preferences%ROWTYPE;
+  v_after public.patient_communication_preferences%ROWTYPE;
+  v_fingerprint text;
+  v_replay jsonb;
+  v_result jsonb;
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.patient_communication_assert_patient(p_tenant_id,p_patient_id);
+  IF p_preferred_language NOT IN ('ru','kk','en') OR p_preferred_channel NOT IN ('phone','whatsapp','sms','email','none') THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE='22023';
+  END IF;
+  v_fingerprint := encode(extensions.digest(jsonb_build_object('patientId',p_patient_id,'language',p_preferred_language,'channel',p_preferred_channel,'allowManualPhone',p_allow_manual_phone)::text,'sha256'),'hex');
+  v_replay := public.patient_communication_operation_replay(p_tenant_id,p_operation_key,'preferences_set',v_fingerprint);
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  INSERT INTO public.patient_communication_preferences(tenant_id,patient_id,updated_by)
+  VALUES(p_tenant_id,p_patient_id,auth.uid()) ON CONFLICT (tenant_id,patient_id) DO NOTHING;
+  SELECT * INTO v_before FROM public.patient_communication_preferences
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id FOR UPDATE;
+  UPDATE public.patient_communication_preferences
+  SET preferred_language=p_preferred_language,preferred_channel=p_preferred_channel,
+      allow_manual_phone=coalesce(p_allow_manual_phone,true),updated_by=auth.uid()
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id RETURNING * INTO v_after;
+  PERFORM public.record_patient_communication_audit_internal(
+    p_tenant_id,p_patient_id,'patient_communication_preferences_changed','patient_communication_preferences',p_patient_id::text,
+    jsonb_build_object('preferredLanguage',v_before.preferred_language,'preferredChannel',v_before.preferred_channel,'allowManualPhone',v_before.allow_manual_phone),
+    jsonb_build_object('preferredLanguage',v_after.preferred_language,'preferredChannel',v_after.preferred_channel,'allowManualPhone',v_after.allow_manual_phone),
+    NULL,'{}'::jsonb
+  );
+  v_result := jsonb_build_object('preferences',public.patient_communication_preferences_json(v_after),'replayed',false);
+  PERFORM public.patient_communication_store_operation(p_tenant_id,p_patient_id,p_operation_key,'preferences_set',v_fingerprint,v_result);
+  RETURN v_result;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.set_patient_communication_consent(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_channel text,
+  p_new_state text,
+  p_source text,
+  p_reason text,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_before public.patient_communication_preferences%ROWTYPE;
+  v_after public.patient_communication_preferences%ROWTYPE;
+  v_previous text;
+  v_event public.patient_communication_consent_events%ROWTYPE;
+  v_fingerprint text;
+  v_replay jsonb;
+  v_result jsonb;
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  IF p_channel NOT IN ('sms','whatsapp','email') OR p_new_state NOT IN ('unknown','granted','denied','withdrawn') THEN
+    RAISE EXCEPTION 'Статус согласия не указан.' USING ERRCODE='22023';
+  END IF;
+  IF p_source NOT IN ('patient_verbal','patient_written','representative_verbal','representative_written','staff_correction','import_legacy','system') THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE='22023';
+  END IF;
+  IF v_role='registrar' AND p_source NOT IN ('patient_verbal','representative_verbal','staff_correction') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.patient_communication_assert_patient(p_tenant_id,p_patient_id);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object('patientId',p_patient_id,'channel',p_channel,'newState',p_new_state,'source',p_source,'reason',nullif(btrim(coalesce(p_reason,'')),''))::text,'sha256'),'hex');
+  v_replay := public.patient_communication_operation_replay(p_tenant_id,p_operation_key,'consent_set',v_fingerprint);
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  INSERT INTO public.patient_communication_preferences(tenant_id,patient_id,updated_by)
+  VALUES(p_tenant_id,p_patient_id,auth.uid()) ON CONFLICT (tenant_id,patient_id) DO NOTHING;
+  SELECT * INTO v_before FROM public.patient_communication_preferences
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id FOR UPDATE;
+  v_previous := CASE p_channel WHEN 'sms' THEN v_before.sms_consent_state WHEN 'whatsapp' THEN v_before.whatsapp_consent_state ELSE v_before.email_consent_state END;
+  IF v_previous IS DISTINCT FROM p_new_state THEN
+    UPDATE public.patient_communication_preferences
+    SET sms_consent_state=CASE WHEN p_channel='sms' THEN p_new_state ELSE sms_consent_state END,
+        whatsapp_consent_state=CASE WHEN p_channel='whatsapp' THEN p_new_state ELSE whatsapp_consent_state END,
+        email_consent_state=CASE WHEN p_channel='email' THEN p_new_state ELSE email_consent_state END,
+        updated_by=auth.uid()
+    WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id RETURNING * INTO v_after;
+    INSERT INTO public.patient_communication_consent_events(
+      tenant_id,patient_id,channel,previous_state,new_state,source,actor_user_id,reason,metadata,operation_key,fingerprint
+    ) VALUES (
+      p_tenant_id,p_patient_id,p_channel,v_previous,p_new_state,p_source,auth.uid(),nullif(btrim(coalesce(p_reason,'')),''),
+      jsonb_build_object('representativeSource',p_source LIKE 'representative_%'),btrim(p_operation_key),v_fingerprint
+    ) RETURNING * INTO v_event;
+    PERFORM public.record_patient_communication_audit_internal(
+      p_tenant_id,p_patient_id,'patient_communication_consent_changed','patient_communication_consent_event',v_event.id::text,
+      jsonb_build_object('channel',p_channel,'state',v_previous),jsonb_build_object('channel',p_channel,'state',p_new_state),
+      p_reason,jsonb_build_object('source',p_source,'consentEventId',v_event.id)
+    );
+  ELSE
+    v_after := v_before;
+  END IF;
+  v_result := jsonb_build_object(
+    'preferences',public.patient_communication_preferences_json(v_after),
+    'consentEventId',v_event.id,'changed',v_previous IS DISTINCT FROM p_new_state,'replayed',false
+  );
+  PERFORM public.patient_communication_store_operation(p_tenant_id,p_patient_id,p_operation_key,'consent_set',v_fingerprint,v_result);
+  RETURN v_result;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.set_patient_communication_suppression(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_channel text,
+  p_suppressed boolean,
+  p_reason text,
+  p_operation_key text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_before public.patient_communication_preferences%ROWTYPE;
+  v_after public.patient_communication_preferences%ROWTYPE;
+  v_fingerprint text;
+  v_replay jsonb;
+  v_result jsonb;
+  v_reason text := nullif(btrim(coalesce(p_reason,'')),'');
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  IF p_channel NOT IN ('global','phone','sms','whatsapp','email') THEN
+    RAISE EXCEPTION 'Не удалось сохранить настройки связи.' USING ERRCODE='22023';
+  END IF;
+  IF p_suppressed AND v_reason NOT IN ('patient_request','representative_request','invalid_contact','wrong_number','duplicate_contact','legal_restriction','staff_decision','other') THEN
+    RAISE EXCEPTION 'Укажите причину.' USING ERRCODE='22023';
+  END IF;
+  IF v_role='registrar' AND p_suppressed AND v_reason NOT IN ('invalid_contact','wrong_number','duplicate_contact','staff_decision') THEN
+    RAISE EXCEPTION 'Недостаточно прав для изменения настроек связи.' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.patient_communication_assert_patient(p_tenant_id,p_patient_id);
+  v_fingerprint := encode(extensions.digest(jsonb_build_object('patientId',p_patient_id,'channel',p_channel,'suppressed',p_suppressed,'reason',v_reason)::text,'sha256'),'hex');
+  v_replay := public.patient_communication_operation_replay(p_tenant_id,p_operation_key,'suppression_set',v_fingerprint);
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  INSERT INTO public.patient_communication_preferences(tenant_id,patient_id,updated_by)
+  VALUES(p_tenant_id,p_patient_id,auth.uid()) ON CONFLICT (tenant_id,patient_id) DO NOTHING;
+  SELECT * INTO v_before FROM public.patient_communication_preferences
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id FOR UPDATE;
+  UPDATE public.patient_communication_preferences
+  SET phone_suppressed=CASE WHEN p_channel='phone' THEN p_suppressed ELSE phone_suppressed END,
+      phone_suppression_reason=CASE WHEN p_channel='phone' THEN CASE WHEN p_suppressed THEN v_reason END ELSE phone_suppression_reason END,
+      phone_suppressed_at=CASE WHEN p_channel='phone' THEN CASE WHEN p_suppressed THEN transaction_timestamp() END ELSE phone_suppressed_at END,
+      phone_suppressed_by=CASE WHEN p_channel='phone' THEN CASE WHEN p_suppressed THEN auth.uid() END ELSE phone_suppressed_by END,
+      sms_suppressed=CASE WHEN p_channel='sms' THEN p_suppressed ELSE sms_suppressed END,
+      sms_suppression_reason=CASE WHEN p_channel='sms' THEN CASE WHEN p_suppressed THEN v_reason END ELSE sms_suppression_reason END,
+      sms_suppressed_at=CASE WHEN p_channel='sms' THEN CASE WHEN p_suppressed THEN transaction_timestamp() END ELSE sms_suppressed_at END,
+      sms_suppressed_by=CASE WHEN p_channel='sms' THEN CASE WHEN p_suppressed THEN auth.uid() END ELSE sms_suppressed_by END,
+      whatsapp_suppressed=CASE WHEN p_channel='whatsapp' THEN p_suppressed ELSE whatsapp_suppressed END,
+      whatsapp_suppression_reason=CASE WHEN p_channel='whatsapp' THEN CASE WHEN p_suppressed THEN v_reason END ELSE whatsapp_suppression_reason END,
+      whatsapp_suppressed_at=CASE WHEN p_channel='whatsapp' THEN CASE WHEN p_suppressed THEN transaction_timestamp() END ELSE whatsapp_suppressed_at END,
+      whatsapp_suppressed_by=CASE WHEN p_channel='whatsapp' THEN CASE WHEN p_suppressed THEN auth.uid() END ELSE whatsapp_suppressed_by END,
+      email_suppressed=CASE WHEN p_channel='email' THEN p_suppressed ELSE email_suppressed END,
+      email_suppression_reason=CASE WHEN p_channel='email' THEN CASE WHEN p_suppressed THEN v_reason END ELSE email_suppression_reason END,
+      email_suppressed_at=CASE WHEN p_channel='email' THEN CASE WHEN p_suppressed THEN transaction_timestamp() END ELSE email_suppressed_at END,
+      email_suppressed_by=CASE WHEN p_channel='email' THEN CASE WHEN p_suppressed THEN auth.uid() END ELSE email_suppressed_by END,
+      global_suppression=CASE WHEN p_channel='global' THEN p_suppressed ELSE global_suppression END,
+      global_suppression_reason=CASE WHEN p_channel='global' THEN CASE WHEN p_suppressed THEN v_reason END ELSE global_suppression_reason END,
+      global_suppressed_at=CASE WHEN p_channel='global' THEN CASE WHEN p_suppressed THEN transaction_timestamp() END ELSE global_suppressed_at END,
+      global_suppressed_by=CASE WHEN p_channel='global' THEN CASE WHEN p_suppressed THEN auth.uid() END ELSE global_suppressed_by END,
+      updated_by=auth.uid()
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id RETURNING * INTO v_after;
+  PERFORM public.record_patient_communication_audit_internal(
+    p_tenant_id,p_patient_id,'patient_communication_suppression_changed','patient_communication_preferences',p_patient_id::text,
+    jsonb_build_object('channel',p_channel,'suppressed',CASE p_channel WHEN 'global' THEN v_before.global_suppression WHEN 'phone' THEN v_before.phone_suppressed WHEN 'sms' THEN v_before.sms_suppressed WHEN 'whatsapp' THEN v_before.whatsapp_suppressed ELSE v_before.email_suppressed END),
+    jsonb_build_object('channel',p_channel,'suppressed',p_suppressed),v_reason,jsonb_build_object('channel',p_channel)
+  );
+  v_result := jsonb_build_object('preferences',public.patient_communication_preferences_json(v_after),'replayed',false);
+  PERFORM public.patient_communication_store_operation(p_tenant_id,p_patient_id,p_operation_key,'suppression_set',v_fingerprint,v_result);
+  RETURN v_result;
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.get_patient_communication_eligibility(
+  p_tenant_id uuid,
+  p_patient_id uuid,
+  p_channel text
+) RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_role text := public.patient_communication_role(p_tenant_id);
+  v_preferences public.patient_communication_preferences%ROWTYPE;
+  v_contact public.patient_communication_contacts%ROWTYPE;
+  v_contact_type text;
+  v_consent text := 'unknown';
+  v_channel_suppressed boolean := false;
+  v_global_suppressed boolean := false;
+  v_manual_eligible boolean := false;
+  v_automated_eligible boolean := false;
+  v_blocked text[] := ARRAY[]::text[];
+  v_status text := 'blocked';
+  v_requires_review boolean := false;
+BEGIN
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar','doctor') THEN
+    RAISE EXCEPTION 'Недостаточно прав для просмотра настроек связи.' USING ERRCODE='42501';
+  END IF;
+  IF p_channel NOT IN ('phone','sms','whatsapp','email') THEN
+    RAISE EXCEPTION 'Не удалось проверить возможность связи.' USING ERRCODE='22023';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.patients p WHERE p.tenant_id=p_tenant_id AND p.id=p_patient_id) THEN
+    RAISE EXCEPTION 'Недостаточно прав для просмотра настроек связи.' USING ERRCODE='42501';
+  END IF;
+  SELECT * INTO v_preferences FROM public.patient_communication_preferences
+  WHERE tenant_id=p_tenant_id AND patient_id=p_patient_id;
+  IF NOT FOUND THEN
+    v_preferences.tenant_id := p_tenant_id;
+    v_preferences.patient_id := p_patient_id;
+    v_preferences.preferred_language := 'ru';
+    v_preferences.preferred_channel := 'none';
+    v_preferences.allow_manual_phone := true;
+    v_preferences.sms_consent_state := 'unknown';
+    v_preferences.whatsapp_consent_state := 'unknown';
+    v_preferences.email_consent_state := 'unknown';
+    v_preferences.phone_suppressed := false;
+    v_preferences.sms_suppressed := false;
+    v_preferences.whatsapp_suppressed := false;
+    v_preferences.email_suppressed := false;
+    v_preferences.global_suppression := false;
+  END IF;
+  v_contact_type := CASE WHEN p_channel='email' THEN 'email' ELSE 'phone' END;
+  SELECT * INTO v_contact FROM public.patient_communication_contacts c
+  WHERE c.tenant_id=p_tenant_id AND c.patient_id=p_patient_id AND c.contact_type=v_contact_type
+    AND c.archived_at IS NULL
+  ORDER BY c.is_primary DESC, c.created_at ASC, c.id ASC
+  LIMIT 1;
+
+  v_global_suppressed := coalesce(v_preferences.global_suppression,false);
+  v_channel_suppressed := CASE p_channel
+    WHEN 'phone' THEN coalesce(v_preferences.phone_suppressed,false)
+    WHEN 'sms' THEN coalesce(v_preferences.sms_suppressed,false)
+    WHEN 'whatsapp' THEN coalesce(v_preferences.whatsapp_suppressed,false)
+    ELSE coalesce(v_preferences.email_suppressed,false)
+  END;
+  v_consent := CASE p_channel
+    WHEN 'sms' THEN coalesce(v_preferences.sms_consent_state,'unknown')
+    WHEN 'whatsapp' THEN coalesce(v_preferences.whatsapp_consent_state,'unknown')
+    WHEN 'email' THEN coalesce(v_preferences.email_consent_state,'unknown')
+    ELSE 'not_required'
+  END;
+
+  IF p_channel='phone' THEN
+    IF v_contact.id IS NULL THEN v_blocked := array_append(v_blocked,'no_contact'); END IF;
+    IF v_contact.id IS NOT NULL AND v_contact.contact_value_normalized IS NULL THEN v_blocked := array_append(v_blocked,'invalid_contact'); END IF;
+    IF v_contact.id IS NOT NULL AND NOT v_contact.is_verified THEN v_requires_review := true; END IF;
+    IF v_contact.owner_type='representative' THEN v_requires_review := true; END IF;
+    IF v_channel_suppressed OR NOT coalesce(v_preferences.allow_manual_phone,true) THEN v_blocked := array_append(v_blocked,'channel_suppressed'); END IF;
+    IF v_global_suppressed AND v_preferences.global_suppression_reason='legal_restriction' THEN v_blocked := array_append(v_blocked,'global_suppression'); END IF;
+    v_manual_eligible := v_contact.id IS NOT NULL AND NOT ('channel_suppressed'=ANY(v_blocked)) AND NOT ('global_suppression'=ANY(v_blocked));
+    v_status := CASE WHEN v_manual_eligible THEN 'manual_only' ELSE 'blocked' END;
+  ELSE
+    IF v_global_suppressed THEN v_blocked := array_append(v_blocked,'global_suppression'); END IF;
+    IF v_channel_suppressed THEN v_blocked := array_append(v_blocked,'channel_suppressed'); END IF;
+    IF v_consent='unknown' THEN v_blocked := array_append(v_blocked,'consent_unknown'); END IF;
+    IF v_consent='denied' THEN v_blocked := array_append(v_blocked,'consent_denied'); END IF;
+    IF v_consent='withdrawn' THEN v_blocked := array_append(v_blocked,'consent_withdrawn'); END IF;
+    IF v_preferences.preferred_channel='none' THEN v_blocked := array_append(v_blocked,'no_preferred_channel'); END IF;
+    IF v_contact.id IS NULL THEN v_blocked := array_append(v_blocked,'no_contact'); END IF;
+    IF v_contact.id IS NOT NULL AND v_contact.contact_value_normalized IS NULL THEN v_blocked := array_append(v_blocked,'invalid_contact'); END IF;
+    IF v_contact.id IS NOT NULL AND NOT v_contact.is_verified THEN v_blocked := array_append(v_blocked,'unverified_contact'); END IF;
+    IF v_contact.owner_type='representative' THEN
+      v_blocked := array_append(v_blocked,'representative_review_required');
+      v_requires_review := true;
+    END IF;
+    v_automated_eligible := cardinality(v_blocked)=0 AND v_consent='granted';
+    v_status := CASE
+      WHEN v_automated_eligible THEN 'available'
+      WHEN 'global_suppression'=ANY(v_blocked) OR 'channel_suppressed'=ANY(v_blocked) THEN 'suppressed'
+      WHEN 'consent_unknown'=ANY(v_blocked) THEN 'consent_unknown'
+      WHEN 'invalid_contact'=ANY(v_blocked) OR 'unverified_contact'=ANY(v_blocked) THEN 'invalid_contact'
+      ELSE 'blocked'
+    END;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible', CASE WHEN p_channel='phone' THEN v_manual_eligible ELSE v_automated_eligible END,
+    'automatedEligible', v_automated_eligible,
+    'manualEligible', v_manual_eligible,
+    'status', v_status,
+    'channel', p_channel,
+    'selectedContactId', v_contact.id,
+    'normalizedDestination', v_contact.contact_value_normalized,
+    'language', coalesce(v_contact.language,v_preferences.preferred_language,'ru'),
+    'blockedReasons', to_jsonb(v_blocked),
+    'consentState', v_consent,
+    'suppressionState', jsonb_build_object('global',v_global_suppressed,'channel',v_channel_suppressed),
+    'representative', coalesce(v_contact.owner_type='representative',false),
+    'requiresManualReview', v_requires_review
+  );
+END;
+$fn$;
+
+-- Legacy compatibility: preserve patients.phone and import/synchronize only an unverified import_legacy contact.
+CREATE OR REPLACE FUNCTION public.sync_patient_communication_legacy_phone()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  v_existing uuid;
+  v_normalized text;
+BEGIN
+  INSERT INTO public.patient_communication_preferences(tenant_id,patient_id,preferred_language,preferred_channel,allow_manual_phone)
+  VALUES(NEW.tenant_id,NEW.id,'ru','none',true)
+  ON CONFLICT (tenant_id,patient_id) DO NOTHING;
+
+  IF nullif(btrim(coalesce(NEW.phone,'')),'') IS NULL THEN
+    RETURN NEW;
+  END IF;
+  v_normalized := public.normalize_patient_phone_e164(NEW.phone);
+  SELECT c.id INTO v_existing
+  FROM public.patient_communication_contacts c
+  WHERE c.tenant_id=NEW.tenant_id AND c.patient_id=NEW.id AND c.contact_type='phone'
+    AND c.owner_type='patient' AND c.verification_source='import_legacy'
+    AND NOT c.is_verified AND c.archived_at IS NULL
+  ORDER BY c.is_primary DESC,c.created_at,c.id
+  LIMIT 1
+  FOR UPDATE;
+
+  IF v_existing IS NOT NULL THEN
+    UPDATE public.patient_communication_contacts
+    SET contact_value_raw=btrim(NEW.phone),
+        contact_value_normalized=v_normalized,
+        country_code=CASE WHEN v_normalized LIKE '+7%' THEN '7' END,
+        updated_by=NULL
+    WHERE id=v_existing;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM public.patient_communication_contacts c
+    WHERE c.tenant_id=NEW.tenant_id AND c.patient_id=NEW.id
+      AND c.contact_type='phone' AND c.archived_at IS NULL
+  ) THEN
+    INSERT INTO public.patient_communication_contacts(
+      tenant_id,patient_id,contact_type,contact_value_raw,contact_value_normalized,country_code,
+      is_primary,is_verified,verification_source,owner_type,created_by,updated_by
+    ) VALUES(
+      NEW.tenant_id,NEW.id,'phone',btrim(NEW.phone),v_normalized,
+      CASE WHEN v_normalized LIKE '+7%' THEN '7' END,
+      true,false,'import_legacy','patient',NULL,NULL
+    );
+  END IF;
+  RETURN NEW;
+END;
+$fn$;
+
+CREATE TRIGGER patient_communication_legacy_phone_insert
+AFTER INSERT ON public.patients
+FOR EACH ROW EXECUTE FUNCTION public.sync_patient_communication_legacy_phone();
+CREATE TRIGGER patient_communication_legacy_phone_update
+AFTER UPDATE OF phone ON public.patients
+FOR EACH ROW WHEN (OLD.phone IS DISTINCT FROM NEW.phone)
+EXECUTE FUNCTION public.sync_patient_communication_legacy_phone();
+
+INSERT INTO public.patient_communication_preferences(tenant_id,patient_id,preferred_language,preferred_channel,allow_manual_phone)
+SELECT p.tenant_id,p.id,'ru','none',true FROM public.patients p
+ON CONFLICT (tenant_id,patient_id) DO NOTHING;
+
+INSERT INTO public.patient_communication_contacts(
+  tenant_id,patient_id,contact_type,contact_value_raw,contact_value_normalized,country_code,
+  is_primary,is_verified,verification_source,owner_type,created_by,updated_by
+)
+SELECT p.tenant_id,p.id,'phone',btrim(p.phone),public.normalize_patient_phone_e164(p.phone),
+       CASE WHEN public.normalize_patient_phone_e164(p.phone) LIKE '+7%' THEN '7' END,
+       true,false,'import_legacy','patient',NULL,NULL
+FROM public.patients p
+WHERE nullif(btrim(coalesce(p.phone,'')),'') IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.patient_communication_contacts c
+    WHERE c.tenant_id=p.tenant_id AND c.patient_id=p.id AND c.contact_type='phone' AND c.archived_at IS NULL
+  );
+
+ALTER TABLE public.patient_communication_contacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.patient_communication_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.patient_communication_consent_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.patient_communication_operations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY patient_communication_contacts_select
+ON public.patient_communication_contacts FOR SELECT TO authenticated
+USING (public.patient_communication_role(tenant_id) IN ('clinic_owner','clinic_admin','registrar','doctor'));
+CREATE POLICY patient_communication_preferences_select
+ON public.patient_communication_preferences FOR SELECT TO authenticated
+USING (public.patient_communication_role(tenant_id) IN ('clinic_owner','clinic_admin','registrar','doctor'));
+CREATE POLICY patient_communication_consent_events_select
+ON public.patient_communication_consent_events FOR SELECT TO authenticated
+USING (public.patient_communication_role(tenant_id) IN ('clinic_owner','clinic_admin','registrar'));
+
+REVOKE ALL ON public.patient_communication_contacts FROM anon, authenticated;
+REVOKE ALL ON public.patient_communication_preferences FROM anon, authenticated;
+REVOKE ALL ON public.patient_communication_consent_events FROM anon, authenticated;
+REVOKE ALL ON public.patient_communication_operations FROM anon, authenticated;
+GRANT SELECT ON public.patient_communication_contacts TO authenticated;
+GRANT SELECT ON public.patient_communication_preferences TO authenticated;
+GRANT SELECT ON public.patient_communication_consent_events TO authenticated;
+
+REVOKE ALL ON FUNCTION public.normalize_patient_phone_e164(text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.normalize_patient_email(text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_communication_role(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.patient_communication_role(uuid) TO authenticated;
+REVOKE ALL ON FUNCTION public.sync_patient_communication_legacy_phone() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_communication_assert_patient(uuid,uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_communication_operation_replay(uuid,text,text,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_communication_store_operation(uuid,uuid,text,text,text,jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.record_patient_communication_audit_internal(uuid,uuid,text,text,text,jsonb,jsonb,text,jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_communication_contact_json(public.patient_communication_contacts) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.patient_communication_preferences_json(public.patient_communication_preferences) FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.upsert_patient_communication_contact(uuid,uuid,uuid,text,text,boolean,boolean,text,text,text,text,text,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.archive_patient_communication_contact(uuid,uuid,uuid,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.set_primary_patient_communication_contact(uuid,uuid,uuid,timestamptz,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.set_patient_communication_preferences(uuid,uuid,text,text,boolean,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.set_patient_communication_consent(uuid,uuid,text,text,text,text,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.set_patient_communication_suppression(uuid,uuid,text,boolean,text,text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_patient_communication_eligibility(uuid,uuid,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.upsert_patient_communication_contact(uuid,uuid,uuid,text,text,boolean,boolean,text,text,text,text,text,timestamptz,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.archive_patient_communication_contact(uuid,uuid,uuid,timestamptz,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_primary_patient_communication_contact(uuid,uuid,uuid,timestamptz,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_patient_communication_preferences(uuid,uuid,text,text,boolean,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_patient_communication_consent(uuid,uuid,text,text,text,text,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.set_patient_communication_suppression(uuid,uuid,text,boolean,text,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_patient_communication_eligibility(uuid,uuid,text) TO authenticated;
+
+COMMENT ON TABLE public.patient_communication_contacts IS 'Tenant-scoped raw and normalized patient/representative contacts. Contact existence is not consent.';
+COMMENT ON TABLE public.patient_communication_preferences IS 'Provider-neutral language, channel, consent and suppression facts. Unknown consent is never treated as granted.';
+COMMENT ON TABLE public.patient_communication_consent_events IS 'Append-only evidence for channel-specific consent transitions.';
+COMMENT ON FUNCTION public.get_patient_communication_eligibility(uuid,uuid,text) IS 'Read-only provider-neutral eligibility. It never sends or mutates reminder jobs.';
+
+COMMIT;

--- a/supabase/tests/0031_patient_communication_contact_consent_foundation_test.sql
+++ b/supabase/tests/0031_patient_communication_contact_consent_foundation_test.sql
@@ -1,0 +1,293 @@
+\set ON_ERROR_STOP on
+\echo 'APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001 SQL validation'
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $assert$
+BEGIN
+  IF NOT coalesce(p_condition,false) THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$assert$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $expect$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_message = MESSAGE_TEXT;
+    IF v_message LIKE 'expected error containing%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message))=0 THEN
+      RAISE EXCEPTION 'expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$expect$;
+
+\set tenant_a 'c3110000-0000-4000-8000-000000000001'
+\set tenant_b 'c3110000-0000-4000-8000-000000000002'
+\set owner_a 'c3120000-0000-4000-8000-000000000001'
+\set admin_a 'c3120000-0000-4000-8000-000000000002'
+\set registrar_a 'c3120000-0000-4000-8000-000000000003'
+\set doctor_a 'c3120000-0000-4000-8000-000000000004'
+\set cashier_a 'c3120000-0000-4000-8000-000000000005'
+\set unknown_user 'c3120000-0000-4000-8000-000000000006'
+\set owner_b 'c3120000-0000-4000-8000-000000000007'
+\set patient_legacy 'c3130000-0000-4000-8000-000000000001'
+\set patient_a 'c3130000-0000-4000-8000-000000000002'
+\set patient_family 'c3130000-0000-4000-8000-000000000003'
+\set patient_b 'c3130000-0000-4000-8000-000000000004'
+
+DELETE FROM public.tenants WHERE id IN (:'tenant_a'::uuid,:'tenant_b'::uuid);
+DELETE FROM auth.users WHERE id IN (
+  :'owner_a'::uuid,:'admin_a'::uuid,:'registrar_a'::uuid,:'doctor_a'::uuid,
+  :'cashier_a'::uuid,:'unknown_user'::uuid,:'owner_b'::uuid
+);
+
+INSERT INTO public.tenants(id,name,timezone) VALUES
+(:'tenant_a','Communication Test A','Asia/Almaty'),(:'tenant_b','Communication Test B','Europe/Berlin');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+(:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-owner-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-admin-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-registrar-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'doctor_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-doctor-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-cashier-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'unknown_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-unknown@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'owner_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','comm-owner-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES
+(:'owner_a'),(:'admin_a'),(:'registrar_a'),(:'doctor_a'),(:'cashier_a'),(:'unknown_user'),(:'owner_b');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+(:'tenant_a',:'owner_a','clinic_owner'),(:'tenant_a',:'admin_a','clinic_admin'),
+(:'tenant_a',:'registrar_a','registrar'),(:'tenant_a',:'doctor_a','doctor'),
+(:'tenant_a',:'cashier_a','cashier'),(:'tenant_b',:'owner_b','clinic_owner');
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+(:'patient_legacy',:'tenant_a','Legacy Patient','+7 (700) 111-22-33','phone','active',123.45),
+(:'patient_a',:'tenant_a','Patient A',NULL,'phone','active',50),
+(:'patient_family',:'tenant_a','Family Patient',NULL,'phone','active',0),
+(:'patient_b',:'tenant_b','Patient B','+4915112345678','phone','active',0);
+
+SELECT balance::text AS patient_balance_before FROM public.patients WHERE id=:'patient_a' \gset
+SELECT count(*)::text AS reminders_before FROM public.appointment_reminder_jobs \gset
+SELECT count(*)::text AS confirmations_before FROM public.appointment_confirmation_attempts \gset
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+
+-- 1-10 Role and tenant isolation matrix.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_legacy'),'owner reads contacts');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_legacy'),'admin reads contacts');
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_legacy'),'registrar reads contacts');
+SELECT set_config('request.jwt.claim.sub',:'doctor_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_legacy'),'doctor read-only contact visibility');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.patient_communication_consent_events),'doctor cannot view consent history');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.patient_communication_contacts),'cashier has no communication contact access');
+SELECT set_config('request.jwt.claim.sub',:'unknown_user',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.patient_communication_contacts),'unknown user blocked');
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_b'),'tenant B sees own legacy contact');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.patient_communication_contacts WHERE patient_id=:'patient_legacy'),'cross-tenant read blocked');
+SELECT pg_temp.expect_error(format(
+  'select public.set_patient_communication_preferences(%L::uuid,%L::uuid,%L,%L,true,%L)',
+  :'tenant_a',:'patient_a','ru','phone','cross-tenant-preferences-001'
+),'Недостаточно прав');
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error('select count(*) from public.patient_communication_contacts','permission denied');
+RESET ROLE;
+
+-- 11-19 Normalization and legacy behavior.
+SELECT pg_temp.assert_true(public.normalize_patient_phone_e164('+7 (700) 123-45-67')='+77001234567','Kazakhstan E.164 normalization');
+SELECT pg_temp.assert_true(public.normalize_patient_phone_e164('+49 151 12345678')='+4915112345678','international E.164 normalization');
+SELECT pg_temp.assert_true(public.normalize_patient_phone_e164('87001234567') IS NULL,'no silent country guess');
+SELECT pg_temp.assert_true(public.normalize_patient_phone_e164('+77001234567 ext 4') IS NULL,'extensions rejected');
+SELECT pg_temp.assert_true(public.normalize_patient_email(' Patient+tag@Example.COM ')='patient+tag@example.com','email trim lower and plus preserved');
+SELECT pg_temp.assert_true(public.normalize_patient_email('bad@') IS NULL,'invalid email rejected');
+SELECT pg_temp.assert_true((SELECT contact_value_raw='+7 (700) 111-22-33' AND contact_value_normalized='+77001112233' AND NOT is_verified AND verification_source='import_legacy' FROM public.patient_communication_contacts WHERE patient_id=:'patient_legacy'),'legacy raw preserved and imported unverified');
+SELECT pg_temp.assert_true((SELECT sms_consent_state='unknown' AND whatsapp_consent_state='unknown' AND email_consent_state='unknown' FROM public.patient_communication_preferences WHERE patient_id=:'patient_legacy'),'legacy consent unknown');
+SELECT pg_temp.assert_true((SELECT phone='+7 (700) 111-22-33' FROM public.patients WHERE id=:'patient_legacy'),'patients.phone unchanged');
+
+-- 20-26 Contacts, primary rules, representative and preferences.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.upsert_patient_communication_contact(
+  :'tenant_a',:'patient_a',NULL,'phone','+7 700 222 33 44',true,true,'patient_confirmed','patient',NULL,NULL,'ru',NULL,'contact-phone-a-001'
+) AS phone_a_result \gset
+SELECT (:'phone_a_result'::jsonb->'contact'->>'id') AS phone_a_id \gset
+SELECT pg_temp.assert_true(:'phone_a_result'::jsonb->'contact'->>'contactValueNormalized'='+77002223344','normalized phone stored');
+SELECT pg_temp.assert_true(:'phone_a_result'::jsonb->'contact'->>'contactValueRaw'='+7 700 222 33 44','raw phone preserved');
+SELECT pg_temp.expect_error(format(
+  'select public.upsert_patient_communication_contact(%L::uuid,%L::uuid,NULL,%L,%L,false,false,%L,%L,NULL,NULL,%L,NULL,%L)',
+  :'tenant_a',:'patient_a','phone','8700','staff_entered','patient','ru','invalid-phone-001'
+),'корректный номер телефона');
+SELECT public.upsert_patient_communication_contact(
+  :'tenant_a',:'patient_a',NULL,'phone','+77009990000',true,true,'patient_confirmed','patient',NULL,NULL,'kk',NULL,'contact-second-phone-001'
+) AS second_phone_result \gset
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_a' AND contact_type='phone' AND is_primary AND archived_at IS NULL),'one primary phone');
+SELECT public.upsert_patient_communication_contact(
+  :'tenant_a',:'patient_a',NULL,'email',' Patient+tag@Example.COM ',true,false,'staff_entered','patient',NULL,NULL,'en',NULL,'contact-email-a-001'
+) AS email_a_result \gset
+SELECT (:'email_a_result'::jsonb->'contact'->>'id') AS email_a_id \gset
+SELECT pg_temp.assert_true(:'email_a_result'::jsonb->'contact'->>'contactValueNormalized'='patient+tag@example.com','email lowercased without plus collapse');
+SELECT pg_temp.expect_error(format(
+  'select public.upsert_patient_communication_contact(%L::uuid,%L::uuid,NULL,%L,%L,false,false,%L,%L,NULL,NULL,%L,NULL,%L)',
+  :'tenant_a',:'patient_a','email','bad@','staff_entered','patient','ru','invalid-email-001'
+),'корректный адрес электронной почты');
+SELECT public.upsert_patient_communication_contact(
+  :'tenant_a',:'patient_a',NULL,'email','second@example.com',true,false,'staff_entered','patient',NULL,NULL,'ru',NULL,'contact-second-email-001'
+);
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_contacts WHERE patient_id=:'patient_a' AND contact_type='email' AND is_primary AND archived_at IS NULL),'one primary email');
+SELECT pg_temp.expect_error(format(
+  'select public.upsert_patient_communication_contact(%L::uuid,%L::uuid,NULL,%L,%L,false,false,%L,%L,%L,NULL,%L,NULL,%L)',
+  :'tenant_a',:'patient_family','phone','+77005556677','staff_entered','representative','Мама','ru','representative-missing-relation-001'
+),'представителя');
+SELECT public.upsert_patient_communication_contact(
+  :'tenant_a',:'patient_family',NULL,'phone','+77005556677',true,true,'representative_confirmed','representative','Мама пациента','parent','kk',NULL,'representative-valid-001'
+) AS representative_result \gset
+SELECT pg_temp.assert_true(:'representative_result'::jsonb->'contact'->>'ownerType'='representative' AND :'representative_result'::jsonb->'contact'->>'representativeRelation'='parent','representative explicit');
+SELECT pg_temp.expect_error(format(
+  'select public.set_patient_communication_preferences(%L::uuid,%L::uuid,%L,%L,true,%L)',
+  :'tenant_a',:'patient_a','de','sms','bad-language-001'
+),'Не удалось сохранить');
+SELECT pg_temp.expect_error(format(
+  'select public.set_patient_communication_preferences(%L::uuid,%L::uuid,%L,%L,true,%L)',
+  :'tenant_a',:'patient_a','ru','telegram','bad-channel-001'
+),'Не удалось сохранить');
+SELECT public.set_patient_communication_preferences(:'tenant_a',:'patient_a','kk','sms',true,'preferences-valid-001');
+SELECT pg_temp.assert_true((SELECT preferred_language='kk' AND preferred_channel='sms' FROM public.patient_communication_preferences WHERE patient_id=:'patient_a'),'preferences validated and saved');
+
+-- 27-34 Consent states and idempotency.
+SELECT pg_temp.assert_true((SELECT sms_consent_state='unknown' FROM public.patient_communication_preferences WHERE patient_id=:'patient_a'),'consent unknown by default');
+SELECT count(*)::text AS audit_before_consent FROM public.audit_events WHERE patient_id=:'patient_a' AND action='patient_communication_consent_changed' \gset
+SELECT public.set_patient_communication_consent(:'tenant_a',:'patient_a','sms','granted','patient_verbal','Пациент согласился','consent-sms-grant-001') AS sms_grant_result \gset
+SELECT pg_temp.assert_true((SELECT sms_consent_state='granted' FROM public.patient_communication_preferences WHERE patient_id=:'patient_a'),'grant SMS consent');
+SELECT public.set_patient_communication_consent(:'tenant_a',:'patient_a','whatsapp','granted','patient_written','Письменно','consent-whatsapp-grant-001');
+SELECT pg_temp.assert_true((SELECT whatsapp_consent_state='granted' FROM public.patient_communication_preferences WHERE patient_id=:'patient_a'),'grant WhatsApp separately');
+SELECT public.set_patient_communication_consent(:'tenant_a',:'patient_a','email','denied','patient_verbal','Не желает email','consent-email-deny-001');
+SELECT pg_temp.assert_true((SELECT email_consent_state='denied' FROM public.patient_communication_preferences WHERE patient_id=:'patient_a'),'deny email consent');
+SELECT public.set_patient_communication_consent(:'tenant_a',:'patient_a','sms','withdrawn','patient_verbal','Отозвал','consent-sms-withdraw-001');
+SELECT pg_temp.assert_true((SELECT sms_consent_state='withdrawn' FROM public.patient_communication_preferences WHERE patient_id=:'patient_a'),'withdraw consent');
+SELECT public.set_patient_communication_consent(:'tenant_a',:'patient_a','sms','granted','patient_verbal','Пациент согласился снова','consent-sms-regrant-001');
+SELECT public.set_patient_communication_consent(:'tenant_a',:'patient_a','sms','granted','patient_verbal','Пациент согласился снова','consent-sms-regrant-001') AS sms_replay \gset
+SELECT pg_temp.assert_true((:'sms_replay'::jsonb->>'replayed')::boolean,'same-key replay safe');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.patient_communication_consent_events WHERE operation_key='consent-sms-regrant-001'),'one consent event on replay');
+SELECT pg_temp.expect_error(format(
+  'select public.set_patient_communication_consent(%L::uuid,%L::uuid,%L,%L,%L,%L,%L)',
+  :'tenant_a',:'patient_a','sms','denied','patient_verbal','changed','consent-sms-regrant-001'
+),'другими параметрами');
+SELECT pg_temp.assert_true((SELECT count(*)=5 FROM public.patient_communication_consent_events WHERE patient_id=:'patient_a'),'consent transition history count');
+SELECT pg_temp.assert_true((SELECT count(*)::int=(:'audit_before_consent')::int+5 FROM public.audit_events WHERE patient_id=:'patient_a' AND action='patient_communication_consent_changed'),'audit exactly once per changed consent');
+
+-- 35-45 Suppression, eligibility, representative and duplicate behavior.
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','sms') AS sms_eligible \gset
+SELECT pg_temp.assert_true((:'sms_eligible'::jsonb->>'automatedEligible')::boolean,'granted valid verified phone eligible for SMS');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','whatsapp') AS whatsapp_eligible \gset
+SELECT pg_temp.assert_true((:'whatsapp_eligible'::jsonb->>'automatedEligible')::boolean,'WhatsApp consent independent and eligible');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','email') AS email_blocked \gset
+SELECT pg_temp.assert_true(NOT (:'email_blocked'::jsonb->>'automatedEligible')::boolean AND :'email_blocked'::jsonb->'blockedReasons' ? 'consent_denied','denied email blocked');
+SELECT public.set_patient_communication_suppression(:'tenant_a',:'patient_a','whatsapp',true,'patient_request','suppress-whatsapp-001');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','whatsapp') AS whatsapp_suppressed \gset
+SELECT pg_temp.assert_true(:'whatsapp_suppressed'::jsonb->'blockedReasons' ? 'channel_suppressed','channel suppression precedence');
+SELECT public.set_patient_communication_suppression(:'tenant_a',:'patient_a','whatsapp',false,NULL,'unsuppress-whatsapp-001');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','whatsapp') AS whatsapp_restored \gset
+SELECT pg_temp.assert_true((:'whatsapp_restored'::jsonb->>'automatedEligible')::boolean,'unsuppress restores when consent permits');
+SELECT public.set_patient_communication_suppression(:'tenant_a',:'patient_a','global',true,'patient_request','global-suppress-001');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','sms') AS globally_blocked_sms \gset
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','whatsapp') AS globally_blocked_whatsapp \gset
+SELECT pg_temp.assert_true(:'globally_blocked_sms'::jsonb->'blockedReasons' ? 'global_suppression' AND :'globally_blocked_whatsapp'::jsonb->'blockedReasons' ? 'global_suppression','global suppression blocks automated channels');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','phone') AS manual_phone_during_global \gset
+SELECT pg_temp.assert_true((:'manual_phone_during_global'::jsonb->>'manualEligible')::boolean,'manual phone remains distinct for non-legal global suppression');
+SELECT public.set_patient_communication_suppression(:'tenant_a',:'patient_a','global',false,NULL,'global-unsuppress-001');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_legacy','sms') AS legacy_sms \gset
+SELECT pg_temp.assert_true(:'legacy_sms'::jsonb->'blockedReasons' ? 'consent_unknown' AND :'legacy_sms'::jsonb->'blockedReasons' ? 'unverified_contact','legacy unknown/unverified blocks automation');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_family','whatsapp') AS representative_review \gset
+SELECT pg_temp.assert_true(:'representative_review'::jsonb->'blockedReasons' ? 'representative_review_required','representative requires review');
+SELECT public.upsert_patient_communication_contact(
+  :'tenant_a',:'patient_a',NULL,'phone','+77005556677',false,true,'patient_confirmed','patient',NULL,NULL,'ru',NULL,'duplicate-family-001'
+) AS duplicate_result \gset
+SELECT pg_temp.assert_true((:'duplicate_result'::jsonb->>'duplicateWarning')::boolean,'duplicate warning detected');
+SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.patient_communication_contacts WHERE tenant_id=:'tenant_a' AND contact_value_normalized='+77005556677' AND archived_at IS NULL),'shared family number not hard blocked');
+
+-- Missing contact and invalid/unverified eligibility.
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_a','email') AS email_existing \gset
+SELECT pg_temp.assert_true(:'email_existing'::jsonb->'blockedReasons' ? 'consent_denied','email existing but denied blocked');
+SELECT public.get_patient_communication_eligibility(:'tenant_a',:'patient_family','email') AS missing_email \gset
+SELECT pg_temp.assert_true(:'missing_email'::jsonb->'blockedReasons' ? 'no_contact','missing contact blocked');
+
+-- Archive and primary rules.
+SELECT updated_at::text AS email_updated FROM public.patient_communication_contacts WHERE id=:'email_a_id'::uuid \gset
+SELECT public.archive_patient_communication_contact(:'tenant_a',:'patient_a',:'email_a_id',:'email_updated'::timestamptz,'archive-email-001');
+SELECT updated_at::text AS archived_email_updated FROM public.patient_communication_contacts WHERE id=:'email_a_id'::uuid \gset
+SELECT pg_temp.expect_error(format(
+  'select public.set_primary_patient_communication_contact(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L)',
+  :'tenant_a',:'patient_a',:'email_a_id',:'archived_email_updated','archived-primary-001'
+),'Архивный контакт');
+
+-- 46-49 Direct writes, append-only and RLS.
+SELECT pg_temp.expect_error(format(
+  'insert into public.patient_communication_contacts(tenant_id,patient_id,contact_type,contact_value_raw,owner_type) values(%L::uuid,%L::uuid,%L,%L,%L)',
+  :'tenant_a',:'patient_a','phone','+77000000000','patient'
+),'permission denied');
+SELECT pg_temp.expect_error(format(
+  'update public.patient_communication_preferences set preferred_language=%L where tenant_id=%L::uuid and patient_id=%L::uuid',
+  'en',:'tenant_a',:'patient_a'
+),'permission denied');
+SELECT pg_temp.expect_error('update public.patient_communication_consent_events set reason=''changed''','permission denied');
+SELECT pg_temp.expect_error('delete from public.patient_communication_consent_events','permission denied');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.patient_communication_contacts'::regclass),'contacts RLS enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.patient_communication_preferences'::regclass),'preferences RLS enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.patient_communication_consent_events'::regclass),'consent RLS enabled');
+
+-- 50 Audit/activity parity and 51-55 side-effect invariants.
+SELECT pg_temp.assert_true((
+  SELECT count(*) FROM public.audit_events WHERE tenant_id=:'tenant_a' AND action LIKE 'patient_communication_%'
+)=(
+  SELECT count(*) FROM public.activity_events WHERE tenant_id=:'tenant_a' AND type LIKE 'patient_communication_%'
+),'audit/activity parity');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'reminders_before')::int FROM public.appointment_reminder_jobs),'no reminder job mutation');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'confirmations_before')::int FROM public.appointment_confirmation_attempts),'no confirmation mutation');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'visits_before')::int FROM public.patient_visits),'no visits created');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'encounters_before')::int FROM public.clinical_encounters),'no encounters created');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'services_before')::int FROM public.completed_services),'no services created');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'invoices_before')::int FROM public.invoices),'no invoices created');
+SELECT pg_temp.assert_true((SELECT count(*)=(:'payments_before')::int FROM public.payments),'no payments created');
+SELECT pg_temp.assert_true((SELECT balance::text=:'patient_balance_before' FROM public.patients WHERE id=:'patient_a'),'patient balance unchanged');
+SELECT pg_temp.assert_true(NOT EXISTS(
+  SELECT 1 FROM public.patient_communication_consent_events GROUP BY tenant_id,operation_key HAVING count(*)>1
+),'duplicate consent events zero');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.patient_communication_contacts c JOIN public.patients p ON p.id=c.patient_id WHERE c.tenant_id<>p.tenant_id),'cross-tenant contact leaks zero');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.patient_communication_contacts WHERE contact_value_normalized IS NOT NULL AND ((contact_type='phone' AND contact_value_normalized !~ '^\+[1-9][0-9]{7,14}$') OR (contact_type='email' AND contact_value_normalized<>lower(contact_value_normalized)))),'invalid normalized contacts zero');
+SELECT pg_temp.assert_true(NOT EXISTS(
+  SELECT 1
+  FROM (VALUES
+    (:'patient_legacy'::uuid,'sms'),(:'patient_legacy'::uuid,'whatsapp'),(:'patient_legacy'::uuid,'email'),
+    (:'patient_a'::uuid,'sms'),(:'patient_a'::uuid,'whatsapp'),(:'patient_a'::uuid,'email'),
+    (:'patient_family'::uuid,'sms'),(:'patient_family'::uuid,'whatsapp'),(:'patient_family'::uuid,'email')
+  ) AS candidate(patient_id,channel)
+  CROSS JOIN LATERAL public.get_patient_communication_eligibility(:'tenant_a',candidate.patient_id,candidate.channel) result
+  WHERE (result->>'automatedEligible')::boolean
+    AND result->>'consentState'<>'granted'
+),'automated eligibility without consent zero');
+
+SELECT
+  (SELECT count(*) FROM public.patient_communication_contacts WHERE tenant_id='c3110000-0000-4000-8000-000000000001') AS contacts,
+  (SELECT count(*) FROM public.patient_communication_consent_events WHERE tenant_id='c3110000-0000-4000-8000-000000000001') AS consent_events,
+  (SELECT count(*) FROM public.patient_communication_operations WHERE tenant_id='c3110000-0000-4000-8000-000000000001') AS operations,
+  (SELECT count(*) FROM public.audit_events WHERE tenant_id='c3110000-0000-4000-8000-000000000001' AND action LIKE 'patient_communication_%') AS audit,
+  (SELECT count(*) FROM public.activity_events WHERE tenant_id='c3110000-0000-4000-8000-000000000001' AND type LIKE 'patient_communication_%') AS activity,
+  (SELECT count(*) FROM public.appointment_reminder_jobs) AS reminder_jobs;
+
+ROLLBACK;
+\echo 'APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Implements a tenant-scoped patient communication contact and consent foundation on baseline `112f9990ed486201a3d86648521867c20ddd1aff`.

Adds normalized raw/canonical phone and email contacts, explicit patient/representative ownership, primary-contact rules, preferred language/channel, channel-specific consent, per-channel/global suppression, append-only consent evidence, tenant-scoped idempotency, controlled RPC mutations, RLS/audit and provider-neutral eligibility.

Adds a minimal `Связь` section to the patient card and communication eligibility badges to the manual reminder queue. Legacy `patients.phone` remains unchanged and is imported/synchronized only as an unverified `import_legacy` contact with unknown consent.

No SMS, WhatsApp, email, provider SDK, delivery attempt, worker, cron, webhook, template engine, cloud migration or clinical/financial mutation is included. The pull request is left open for review and is not merged by this task.

Full evidence is in `_ai_work/REPORTS/APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001_foundation.md`.

## Checks

- Schema assertions 45/45 passed
- SQL regression 0024-0031 passed
- Concurrency suites 0025/0026/0027/0029/0030 passed
- Targeted communication/reminder tests 54/54 passed
- Full Vitest 96 files / 1070 tests passed
- ESLint passed
- Production build passed
- Browser role/tenant/legacy/consent/suppression/representative/reminder smoke passed
- Network: RPC mutations only; direct table writes 0; provider requests 0
- Cleanup: QA users/patients/jobs/operations/events 0

## Limitations

- No provider delivery or verification OTP is implemented
- Legacy patients.phone remains for compatibility
- Reminder eligibility currently performs four eligibility RPCs per unique patient and should be batched before high-volume provider work
- HeadlessChrome was used because a separate Chrome DevTools MCP executable was unavailable
