### PR TITLE
AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001: reconcile reminder communication integration

### DIFF
--- a/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
+++ b/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
@@ -1,0 +1,44 @@
+# AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001
+
+## Final verdict
+
+**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository evidence identifies the next safe hardening slice but does not authorize message delivery**
+
+## Executive summary
+
+The current amoCRM implementation is a disconnected development skeleton. It has an authorization-code exchange, one process-global in-memory credential set, placeholder synchronization routes, and a webhook that ignores requests. It has no tenant binding, refresh implementation, external-object repository, chat channel, message operation, delivery status, or inbound reply processing.
+
+The target architecture is **B: provider-neutral communication orchestration with amoCRM as one possible adapter**. The exact next task is **AMOCRM-INTEGRATION-HARDENING-001**. No real amoCRM write, message, task, contact, lead, note, credential refresh, or cloud change was performed.
+
+## Branch
+
+`recon/amocrm-reminder-communication-integration-recon-001`
+
+## PR URL
+
+Pending initial PR creation.
+
+## Baseline
+
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- exact baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
+- PR #356 is merged at that exact commit;
+- duplicate task PR search returned no result;
+- branch created from the exact baseline.
+
+## Final head
+
+Recorded in the final task response because a report cannot contain its own future commit SHA.
+
+## Changed files
+
+Exactly one file: `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`.
+
+## Validation status
+
+Repository and official-documentation reconnaissance is complete. Fresh local browser execution and local lint/test/build are unavailable through Hermes in this conversation. Fresh GitHub Actions CI on the exact final head is required and will be recorded in the final response.
+
+## Final verdict
+
+**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository evidence identifies AMOCRM-INTEGRATION-HARDENING-001 but does not authorize message delivery**

--- a/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
+++ b/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
@@ -2,15 +2,29 @@
 
 ## Final verdict
 
-**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository and official API evidence identify the next safe hardening slice but do not authorize message delivery**
+Final verdict: **PASS**
+
+AMOCRM REMINDER COMMUNICATION INTEGRATION RECONCILED AND NEXT SAFE SLICE IDENTIFIED
 
 ## Executive summary
 
-The current amoCRM implementation is a disconnected development skeleton, not a production integration and not a reminder communication boundary. It has server-side authorization-code exchange, one process-global in-memory credential set, placeholder sync routes, and a webhook that accepts and ignores requests. It has no authentication, role or tenant binding, durable encrypted credential repository, refresh implementation, external-reference repository, CRM synchronization, chat channel, send operation, delivery processing, or inbound-reply correlation.
+The repository does not contain an operational amoCRM synchronization or reminder-communication integration. It contains three disconnected foundations:
 
-DentalFlow remains authoritative for appointments, reminder jobs, contact consent, suppression and opt-out. Official amoCRM documentation shows that CRM entities and a separately registered Chats API channel can support messages, statuses and history, but that requires a channel, signed requests, per-account `scope_id`, hooks, conversation IDs and a real transport. None is evidenced here.
+1. frontend-only patient lead-source metadata and an unused safe payload mapper;
+2. a standalone development Node.js OAuth skeleton with one global in-memory token set;
+3. a tenant-scoped Supabase `integration_tokens` table that no runtime code currently uses.
 
-Target architecture: **B, provider-neutral communication orchestration with amoCRM as one possible adapter.** Exact next task: **`AMOCRM-INTEGRATION-HARDENING-001`**. No external mutation or cloud change was performed.
+No patient, appointment, contact, lead, task, note, message, conversation, delivery status, reply, or webhook event is currently synchronized in either direction. The frontend does not call the integration proxy. The proxy sync endpoints return `501 Not Implemented`; its webhook returns `202 Accepted` while discarding the request. The current OAuth skeleton has no authentication, tenant binding, durable encrypted storage, refresh implementation, concurrent-refresh protection, account verification, or revocation recovery.
+
+Official amoCRM documentation confirms that contacts, leads, tasks, notes/events, webhooks, OAuth, and a Chats API exist. It does not establish that DentalFlow can send through an arbitrary WhatsApp/SMS widget already visible inside an amoCRM account. The Chats API model expects an integration to register and operate a channel/transport, receive manager-message webhooks, deliver the message externally, and report delivery status back to amoCRM. No such channel integration, vendor contract, channel ID, scope, secret, conversation mapping, message mapping, or webhook receiver exists in this repository.
+
+The evidence-based recommendation is a provider-neutral communication orchestration boundary. DentalFlow must remain authoritative for reminder jobs, appointments, contact selection, consent, suppression, and operation identity. amoCRM may become one adapter only after its tenant-scoped OAuth/account boundary and a real channel capability are proven. A direct amoCRM send adapter is unsafe now, and amoCRM task-only synchronization would duplicate the existing `/reminders` operational queue.
+
+No external amoCRM request, token refresh, contact/lead/task/note mutation, webhook registration, or message send was performed.
+
+## Summary
+
+Current amoCRM runtime capability is limited to a disconnected development OAuth skeleton. DentalFlow sends and receives no CRM or communication data. The safe architecture is provider-neutral communication orchestration, with the existing DentalFlow reminder, contact, consent and suppression models remaining authoritative. amoCRM may be evaluated as a later adapter only after tenant/account OAuth hardening and concrete channel evidence.
 
 ## Branch
 
@@ -23,228 +37,722 @@ https://github.com/NckNA/codex-test/pull/357
 ## Baseline
 
 - repository: `NckNA/codex-test`;
-- base: `main`;
-- exact verified baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
-- PR #356 is merged at that commit;
-- duplicate task PR search returned none;
-- branch created from the exact baseline.
+- required baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
+- verified `origin/main`: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
+- PR #356 was merged at that exact commit;
+- the source checkout was clean;
+- no open or merged duplicate PR with this task ID was found;
+- the worktree was created directly from current `origin/main`.
 
 ## Final head
 
-Recorded in the final response because this file cannot contain its own future commit SHA.
+- reviewed report head before this update: `d64ff6295dcb0bba2ec39a16063911291c25d32c`;
+- workflow: `CI`;
+- run ID: `29250107482`;
+- conclusion: `success`;
+- final report-update head and fresh CI are recorded by the immutable finalization receipt because a commit cannot contain its own future SHA.
+
+## Report update commit
+
+- Report update commit: N/A (the report commit cannot reference itself; use the finalization receipt).
+- The final report head and fresh CI run are recorded after final CI in an immutable local receipt.
 
 ## Changed files
 
-Exactly `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`. No other file is intended or allowed.
+Exactly one file:
+
+- `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`
+
+No migration, source, backend, package, lock, generated type, fixture, environment, or CI file was changed.
 
 ## Pre-read
 
-Reviewed the four required reminder reports, AMO-001 through AMO-004, AUDIT-005, amoCRM architecture/security/mapping/sync documents, backend routes/services/config/docs, frontend mapper/types/UI, patient integration storage, reminder types/repositories, initial schema, token table, package scripts and CI.
+Required reminder reports reviewed:
 
-Official amoCRM OAuth, limits, contacts, leads, tasks, notes/events, CRM webhooks, Chats capabilities, methods and hook formats were checked on 2026-07-13.
+- `APPOINTMENT-REMINDER-OPERATIONS-RECON-001`;
+- `APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001`;
+- `APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001`;
+- `APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001`.
+
+Historical amoCRM reports reviewed:
+
+- `AMO-001_integration_readiness_and_lead_source_layer_report.md`;
+- `AMO-002_amocrm_real_integration_architecture_report.md`;
+- `AMO-003_backend_proxy_skeleton_report.md`;
+- `AMO-004_amocrm_oauth_connection_skeleton_report.md`;
+- `AUDIT-005_amocrm_oauth_boundary_audit_report.md`.
+
+Repository areas inspected:
+
+- frontend integration types/mappers and every amoCRM reference;
+- standalone backend routes, client, token store, state store and configuration;
+- Supabase migrations, RLS and grants;
+- patient persistence and external CRM metadata;
+- reminder jobs, manual outcomes and contact/consent foundations;
+- routes/placeholders, environment references, package scripts, tests and CI;
+- absence of Edge Functions, workers, cron, provider webhooks and message delivery code.
+
+Searches covered `amo`, `amocrm`, `kommo`, OAuth/token terms, contacts, leads, tasks, notes, messages, chats, conversations, WhatsApp, SMS, email, webhooks and external identifiers.
 
 ## Existing amoCRM assets
 
-| Asset | Finding | Classification |
-|---|---|---|
-| backend server/routes | unauthenticated global status/connect/callback/disconnect; sync 501; webhook ignored | risky partial skeleton |
-| OAuth client | code exchange only; no refresh or CRM client | partial |
-| state store | random one-time ten-minute state, not bound to user/tenant/account | partially reusable |
-| credential store | one global in-memory object, lost on restart, no lock/version | unsafe for production |
-| global config | one account/application configuration | not multi-tenant |
-| frontend mapper/types | unused contact/lead preview; no network | dead placeholder |
-| patient external CRM metadata | optional contact/lead/deal IDs in replaceable JSON | risky legacy model |
-| patient CRM panel | display-only source/status/external IDs | active display only |
-| treatment-plan amoCRM button | disabled, no handler | placeholder |
-| `integration_tokens` table | tenant/provider schema intent, unused by backend; lacks account identity/refresh lock | insufficient foundation |
-| historical docs/reports | design intent, not runtime capability | documentation |
+| Asset | Responsibility | Layer | Tenant/auth model | Operations | Reachability | Classification |
+|---|---|---|---|---|---|---|
+| `src/integrations/amocrm/amoCrmTypes.ts` | contact/lead draft types | frontend | none | none | not imported by operational flow | reusable type sketch, partial |
+| `src/integrations/amocrm/amoCrmMapper.ts` | maps patient/treatment data to safe preview drafts | frontend | receives caller objects only | no network | unreachable in production flow | reusable payload allowlist idea, dead/partial |
+| patient `integration` JSON/type | lead source/status and optional external contact/lead/deal IDs | frontend + patient row JSON | patient row is tenant-scoped; embedded IDs have no independent constraint | display/edit only | reachable as metadata UI | risky as authoritative mapping |
+| patient overview external CRM panel | displays provider, sync status and raw external IDs | frontend | patient tenant boundary | read-only display | reachable | partial, potentially misleading |
+| disabled treatment-plan amoCRM action | future sync label | frontend | none | none | reachable but disabled | placeholder |
+| `/crm` | CRM page | frontend | normal app shell only | none | reachable | placeholder |
+| `/settings` | integration/configuration candidate | frontend | normal app shell only | none | reachable | placeholder |
+| `/sms`, `/mailing` | channel pages | frontend | none | none | reachable | placeholders |
+| `backend/src/server.js` | standalone HTTP proxy | backend | no DentalFlow auth/tenant middleware | route dispatch | not called by frontend | development skeleton, risky if exposed |
+| `backend/src/routes/amoCrmRoutes.js` | status/connect/callback/disconnect/webhook/sync routes | backend | no user, role or tenant verification | OAuth start/callback; disconnect; placeholders | standalone only | partial OAuth, unsafe multi-tenant boundary |
+| `amoCrmClient.js` | authorization URL and initial token exchange | backend | global configuration | real OAuth token exchange only | reachable only by proxy route | reusable initial exchange, incomplete |
+| `amoCrmStateStore.js` | random one-time OAuth state with TTL | backend memory | not bound to tenant/user/account | create/consume state | standalone only | partial, requires replacement/binding |
+| `amoCrmTokenStore.js` | holds one token pair and account domain | backend memory | one global token set | save/read status/clear | standalone only | unsafe for SaaS, requires replacement |
+| `integration_tokens` | intended encrypted token persistence | database | unique `(tenant_id, provider)`, RLS, service-role CRUD | unused | no runtime caller | reusable schema seed, incomplete |
+| amoCRM architecture/security/mapping docs | planned integration design | documentation | aspirational | none | documentation only | stale/partly reusable |
+| backend tests | none beyond Node syntax check | test | n/a | n/a | n/a | missing |
 
-No production integration repository, channel configuration, message/task/note client, signed webhook verifier, delivery store, recovery lookup, or integration tests exist.
+No Supabase Edge Function, serverless route, queue worker, scheduler, secure webhook endpoint, or production deployment path for the Node proxy was found.
 
 ## Current data-flow map
 
-DentalFlow → amoCRM: **none**. The unused patient draft contains name/legacy phone. The unused lead draft contains patient name, treatment-plan title and total price, so it is not suitable for reminder communications. Appointments, cancellations, contacts, tasks, notes, statuses and messages are not sent.
+### DentalFlow to amoCRM
 
-amoCRM → DentalFlow: **none**. Contact/lead/task/note changes are not read. Incoming webhook bodies are discarded. Delivery statuses, replies and external identifiers are not ingested. There is no trigger, idempotency key, replay, failure recovery, tenant boundary or audit.
+| Flow | Current trigger | Current payload | Result |
+|---|---|---|---|
+| patient creation/update | none | mapper can construct name, phone, email and safe custom fields in memory | no request, no contact ID persisted |
+| appointment create/update/cancel | none | no mapper or endpoint | no flow |
+| contact creation/update | none | draft type only | no flow |
+| lead/deal creation/status | none | treatment-plan preview draft only | no flow |
+| task creation | none | no implementation | no flow |
+| note creation | none | no implementation | no flow |
+| message send | none | no command/provider contract | no flow |
+| sync endpoints | standalone POST route | ignored by placeholder | `501 Not Implemented` |
+
+### amoCRM to DentalFlow
+
+| Flow | Current mechanism | Result |
+|---|---|---|
+| contact updates | none | absent |
+| lead status | none | absent |
+| tasks | none | absent |
+| notes/events | none | absent |
+| incoming messages | none | absent |
+| delivery statuses | none | absent |
+| webhooks | standalone unauthenticated placeholder | returns accepted and discards payload |
+| external IDs | no response handling | absent |
+
+There is no authority conflict today because there is no sync. The risk begins if the placeholders are wired without first creating tenant/account, credential, external-reference and operation boundaries.
 
 ## External ID model
 
-Current: account/domain only in global memory; integration/client ID in global environment; optional contact/lead/deal IDs inside patient JSON; no task/note/message/conversation/webhook/channel IDs; no composite uniqueness; stale and duplicate mappings are possible; appointments have no mapping.
+Current stored identifiers:
 
-Minimum required:
+- patient JSON may contain `externalContactId`, `externalLeadId`, `externalDealId`;
+- the backend memory token store contains an account domain while the process is alive;
+- `integration_tokens` stores no account ID/domain or integration ID;
+- task, note, message, conversation/chat and webhook IDs are not stored;
+- appointments and reminder jobs have no amoCRM reference.
 
-- `integration_accounts`: tenant, provider, verified account ID/domain, status, credential generation, health/revocation, unique tenant/provider;
-- `integration_external_refs`: tenant + account + local entity/type + external type/ID, history/version and bidirectional composite uniqueness;
-- later, only with channel evidence, `integration_channel_connections`: channel ID, `scope_id`, vendor/type, capabilities, hook version and server-only secret reference.
+Current weaknesses:
+
+- embedded patient JSON has no composite tenant/provider/account uniqueness;
+- no FK or dedicated mapping lifecycle;
+- no account identity accompanies an external ID;
+- one patient could be assigned multiple or stale contacts without detection;
+- one amoCRM contact could be assigned to multiple patients without a constraint;
+- resync replacement/history is undefined;
+- appointment-to-lead/task/note/message correlation does not exist.
+
+Minimum future external-reference model:
+
+1. tenant integration account: `tenant_id`, provider, amo account ID/domain, integration ID, authorization health/version, credential reference and timestamps;
+2. external reference: tenant, provider, provider account, local entity type/ID, external object type/ID, state/version, timestamps and unique composite constraints;
+3. communication operation: reminder job, appointment, patient, selected contact, channel, purpose, snapshots, operation key/fingerprint, provider/adapter, external operation/message/conversation IDs, state and safe error;
+4. webhook inbox: provider account, external event ID, payload hash, verification state, received/processed timestamps and unique `(provider account, event ID)`.
+
+Patient JSON may remain a display cache but must not be the authoritative external mapping.
 
 ## OAuth and secret boundary
 
-The authorization-code exchange is server-side and does not return raw credentials to frontend. Everything else is insufficient: routes are unauthenticated; state is not bound to actor/tenant/account; credentials are global and memory-only; expiry is not enforced; refresh, encryption, revocation, audit and exact account verification are absent.
+Current authorization-code path:
 
-Official refresh credentials rotate after use, so future refresh must be transactional with a row lock or compare-and-swap, credential generation and stale-result rejection. Credentials must never reach frontend or logs.
+1. any caller that can reach the proxy may request `/connect`;
+2. a random memory state is created with a ten-minute TTL;
+3. callback validates/consumes state;
+4. backend posts code, client ID, client secret and redirect URI to amoCRM;
+5. returned tokens and account domain are stored in one global memory variable;
+6. status strips token values;
+7. disconnect clears the global variable.
+
+Positive properties:
+
+- client secret and token exchange are server-side;
+- frontend has no token references;
+- state is cryptographically random, expiring and one-time;
+- status response omits tokens;
+- errors are reduced rather than returning the raw OAuth response.
+
+Blocking weaknesses:
+
+- no DentalFlow authentication or owner-only authorization;
+- state is not bound to tenant, user, expected account or redirect session;
+- one process-global account can be overwritten or disconnected by another caller;
+- tokens disappear on restart;
+- the database token table is unused;
+- fields named `*_encrypted` are not backed by encryption/decryption code;
+- no refresh implementation;
+- no atomic refresh-token rotation;
+- no concurrent refresh lock/CAS;
+- no account ID/domain verification after exchange;
+- no revoked-token health state or reconnect workflow;
+- no audit/metrics;
+- no production deployment boundary.
+
+Official documentation checked on 2026-07-13 states that the authorization code is short-lived, access is account/domain specific, tokens must be handled server-side, and refresh-token exchange rotates the refresh token. A refresh token that is not used for the documented period expires. Concurrent refresh without a per-tenant lock and atomic replacement can therefore corrupt the only valid credential pair.
+
+Tokens are not safe for production today. They are currently hidden from the frontend, but the storage, tenant, authorization, refresh and account-integrity requirements are absent.
 
 ## Current tenant isolation
 
-Failed for amoCRM. No tenant/user/role exists in routes, state or credential store; there is no one-tenant-to-one-account rule, account ID verification, tenant throttling, hook account validation or tenant audit. This is tolerable only because frontend and sync are disconnected.
+Repository reality:
 
-Required: one tenant maps to one verified account unless explicitly redesigned; no global default or fallback; all credentials/external IDs are tenant+account composite; mismatch fails closed.
+- frontend patient/appointment/reminder/consent data is tenant-scoped;
+- `integration_tokens` is tenant-scoped and unique per tenant/provider;
+- the Node proxy ignores that table;
+- OAuth state, token set, account domain and status are global;
+- routes do not accept or verify DentalFlow tenant identity;
+- no provider account maps to a tenant;
+- webhook account identity is not validated;
+- no cross-tenant external ID constraint exists.
+
+Required future invariant:
+
+- one tenant maps to one explicitly configured amoCRM account unless a later design supports more;
+- credentials, refresh locks, external IDs, rate budgets and webhook identities are composite with tenant/provider account;
+- no global default account and no fallback to another tenant;
+- callback and webhook account mismatch are rejected;
+- resolving zero or more than one tenant is terminal/manual-review, never a guess.
+
+Current tenant-isolation result: **unsafe and unsuitable for any production sync or communication**.
 
 ## Current role model
 
-Owner configures and authorizes; admin operates according to tenant policy; registrar sees safe status and performs manual reminders; doctor/cashier cannot configure; unknown/no tenant is blocked. No role receives raw credentials. Current amoCRM routes implement none of this.
+Current amoCRM proxy role model: none. Any network caller can request status/connect/disconnect and invoke placeholder routes.
+
+Required role model:
+
+| Capability | Owner | Admin | Registrar | Doctor | Cashier | Unknown/no tenant |
+|---|---:|---:|---:|---:|---:|---:|
+| configure/authorize account | yes | tenant policy only | no | no | no | blocked |
+| view integration health | yes | yes | safe operational subset | no | no | blocked |
+| view reminder communication state | yes | yes | yes | no by default | no | blocked |
+| manual contact/review reply | yes | yes | yes | no | no | blocked |
+| view credentials/tokens | never in frontend | never | never | never | never | never |
 
 ## Actual connected communication channels
 
-None evidenced. No native/custom chat, WhatsApp, SMS, email, vendor connector, channel ID, channel secret reference, `scope_id`, sender identity, templates, sandbox, message ID or conversation ID exists in repository or accessible Supabase configuration.
+No connected communication channel was established by repository or local runtime evidence.
 
-Read-only Supabase inspection found zero `integration_tokens` rows and migration history only through `0013`, behind repository `0031`; this proves accessible-project drift, not an installed channel.
+- amoCRM native Chats integration: not configured in code;
+- WhatsApp widget/vendor: no vendor, channel ID, API contract or credential found;
+- SMS widget/vendor: none;
+- email integration: none;
+- external connector attached to amoCRM: none documented;
+- staff manual writing inside amoCRM: possible as a human product behavior, but not integrated with DentalFlow;
+- amoCRM task-only use: not implemented.
+
+The backend status endpoint returned `connected=false` and `configured=false`. The frontend CRM/settings/SMS/mailing pages are placeholders and do not display an amoCRM account or channel.
 
 ## Official amoCRM capability check
 
-- OAuth and refresh are supported, but exact account domain and secure credential lifecycle are integrator responsibilities.
-- Contact, lead, task, note and CRM webhook APIs exist.
-- Chats API requires a separately connected signed channel and returns account-specific `scope_id`.
-- Chat creation, message transfer, delivery status (`sent/delivered/read/error`) and conversation history exist for such a channel.
-- Official capability does not prove an installed WhatsApp/SMS/email widget is callable by DentalFlow.
-- No generic reminder-send idempotency key was established; DentalFlow must enforce operation identity.
+Checked only current official amoCRM documentation on 2026-07-13.
 
-Confidence: high for documented capabilities, low for tenant-specific channel availability because no external installation evidence exists.
+| Capability | Official capability | Limitation relevant to DentalFlow | Repository compatibility | Confidence |
+|---|---|---|---|---|
+| OAuth 2.0 | authorization-code and refresh-token flows | account-specific, server secret, rotating refresh token | initial exchange only | high |
+| contacts | read/create/update contacts | requires authorized account and durable ID mapping | mapper draft only | high |
+| leads | read/create/update leads | pipeline/status/account mapping required | draft only | high |
+| tasks | create/read/update tasks | task identity, responsible user and duplicate policy required | absent | high |
+| notes/events | CRM entities expose notes/events | not a delivery or reply channel | absent | high |
+| webhooks | account webhooks exist for supported entity changes | signature/account/event replay handling still required | ignored placeholder | high |
+| Chats API | integrations can register channel/scope, create chats/import/send messages and process webhooks/statuses | integration acts as the external transport; not a generic bridge to arbitrary installed widget | entirely absent | high |
+| inbound chat | message receiver/webhook models exist for the registered integration | sender/message/conversation mapping must be owned and verified | absent | high |
+| native idempotency | not proven as a universal guarantee across CRM/chat operations | DentalFlow must enforce operation identity/recovery | absent | medium-high |
+
+Official documentation names/areas reviewed: OAuth 2.0, API restrictions, Contacts, Leads, Tasks, Events/Notes, Webhooks, Chats API capabilities, Chats API methods and Chats API webhooks.
 
 ## API and rate-limit constraints
 
-Official guidance documents 7 requests/second per integration and 50 requests/second per account, HTTP 429 on breach and possible 403 blocking after repeated violations. A future path needs bounded backend work, per-tenant/account throttling, safe backoff, recovery before resend, manual/dead-letter handling, and no frontend direct calls.
+Official limits checked:
+
+- up to 7 requests per second per integration;
+- up to 50 requests per second per account;
+- provider/account errors and rate limits require controlled backoff rather than frontend retries.
+
+Recommended execution model:
+
+- bounded background worker, not browser calls;
+- per-tenant and per-amo-account queue isolation;
+- throttling below official ceilings with jitter;
+- respect retry-after/provider classification;
+- token refresh traffic consumes account capacity;
+- dead-letter/manual review after bounded attempts;
+- no one failing tenant may exhaust all tenants;
+- batching only where official endpoint semantics preserve identity and per-item results.
+
+Reminder volume is expected to be modest per clinic, but bursts around day-before/same-day windows make scheduling and per-account backpressure necessary.
 
 ## Current message-send capability
 
-**Absent.** No command, endpoint, channel, transport, sender/template, operation record or external message ID exists.
+Current DentalFlow installation: **none**.
+
+The repository has no message command, provider client, chat channel registration, conversation resolver, message endpoint, template contract, worker or external message ID. A staff-entered manual reminder result `message_sent` is not evidence of a provider request.
+
+Official amoCRM Chats capabilities do not change this result. DentalFlow would need to operate or explicitly integrate a real channel transport. No evidence shows that a currently installed WhatsApp/SMS connector can be driven by DentalFlow through a supported API.
 
 ## Current delivery-status capability
 
-**Absent.** There is no message ID, delivery attempt, status webhook/polling or normalizer. Manual `message_sent` is not proof of delivery.
+Current installation: **none**.
+
+No provider message ID or status is stored. No webhook/polling path normalizes accepted/sent/delivered/read/failed states. The placeholder webhook discards events.
+
+Official Chats API supports status exchange for a registered chat integration, but DentalFlow has no such integration. A synchronous API acceptance would still mean `accepted`, not `delivered`; neither means appointment confirmation.
 
 ## Current inbound-reply capability
 
-**Absent.** The webhook ignores bodies and verifies neither signature nor account/channel. There is no conversation/patient/reminder correlation.
+Current installation: **none**.
+
+Official chat webhooks can expose inbound messages/conversation identities to the integration that owns the channel. The repository lacks:
+
+- a trusted webhook endpoint;
+- provider account/channel verification;
+- sender/contact/conversation/message mappings;
+- correlation to patient, appointment and reminder job;
+- duplicate-event protection;
+- manual review queue for replies.
+
+A phone number may belong to several patients or a representative. Therefore even a verified inbound message must not automatically confirm an appointment from arbitrary text.
 
 ## Communication command model
 
+Provider-neutral immutable command:
+
 ```text
-tenant_id, reminder_job_id, appointment_id, patient_id,
-communication_contact_id, channel, purpose_code, language,
-consent_snapshot, suppression_snapshot, appointment_version,
-reminder_job_version, operation_key, payload_fingerprint,
-safe_variable_map, requested_at
+tenant_id
+reminder_job_id
+appointment_id
+patient_id
+contact_id
+channel
+purpose_code
+language
+consent_snapshot
+suppression_snapshot
+appointment_version
+reminder_job_version
+operation_key
+safe_variable_map
+requested_at
 ```
 
-Purpose codes: confirmation request, day-before reminder, same-day reminder, control-call task. No free-form clinical payload.
+Purpose codes:
+
+- `appointment_confirmation_request`;
+- `appointment_day_before_reminder`;
+- `appointment_same_day_reminder`;
+- `control_call_task`.
+
+The command contains no free-form clinical payload. Eligibility is decided from DentalFlow facts immediately before execution.
 
 ## Proposed amoCRM adapter contract
 
-Input: immutable communication command. Resolve exact tenant account, contact and channel/conversation; preserve operation key; perform only approved action; store external ID; return `accepted`, `rejected`, `uncertain`, or `manual_action_required` plus safe error/retry data; expose recovery lookup.
+Input: the provider-neutral communication command.
 
-The adapter never confirms appointments, completes reminder work on mere acceptance, creates clinical/financial facts, changes consent, or falls back to another tenant.
+Adapter responsibilities, only after amoCRM hardening/channel proof:
+
+- resolve exact tenant amoCRM account;
+- resolve tenant-scoped external contact mapping;
+- resolve supported channel/conversation or task-only mode;
+- create the supported external object;
+- preserve operation key/fingerprint;
+- persist/return external operation ID;
+- normalize status and safe error;
+- expose recovery lookup;
+- redact provider bodies and credentials.
+
+Normalized output:
+
+```text
+accepted | rejected | uncertain | manual_action_required
+external_id?
+safe_error_code?
+retryable
+timestamp
+```
+
+The adapter must never confirm appointments, complete reminder jobs merely because a provider accepted a request, create clinical/financial facts, or bypass consent/suppression.
 
 ## Task-only fallback
 
-Rejected now. Synchronizing amoCRM tasks would duplicate `/reminders`, create two queues and completion reconciliation, weaken audit consistency, and increase duplicate-contact risk without adding delivery evidence.
+Possible flow:
+
+```text
+DentalFlow reminder job
+→ amoCRM task assigned to administrator
+→ administrator manually sends/calls
+→ result manually recorded in DentalFlow
+```
+
+Assessment:
+
+- duplicates the existing `/reminders` queue;
+- creates two task states that can diverge;
+- requires responsible-user mapping and task ID synchronization;
+- weakens audit because completion in amoCRM does not prove the DentalFlow result;
+- invites duplicate manual and amoCRM processing;
+- offers little value unless staff already live exclusively in amoCRM and bidirectional task synchronization is proven.
+
+The safest fallback remains the existing DentalFlow manual reminder queue. amoCRM task synchronization is not recommended as the next slice.
 
 ## Inbound reply handling
 
-Future verified replies create manual review. Signature/account/channel and event ID are verified; shared/representative contacts remain ambiguous; staff interprets `да`, `нет`, `перенесите` or free text and invokes existing confirmation/reschedule operations. Arbitrary text is not automatic confirmation.
+Initial safe rule:
+
+1. verify provider account/channel/event identity;
+2. deduplicate external event/message ID;
+3. correlate to external conversation/contact and candidate DentalFlow contacts;
+4. if correlation is unique, create a manual review item linked to the communication operation;
+5. if shared number/representative/ambiguous patient, require manual patient and appointment selection;
+6. staff interprets `да`, `нет`, `перенесите` or free text;
+7. existing controlled confirmation/reschedule workflow records the fact.
+
+No arbitrary inbound text automatically confirms, cancels or reschedules an appointment.
 
 ## Idempotency
 
-Same operation key + same fingerprint replays; same key + different fingerprint rejects. Reserve locally before side effect; store external ID transactionally; deduplicate hooks by provider ID/fingerprint; timeout after possible acceptance becomes uncertain; recover before retry; never blindly resend.
+Required operation identities:
+
+| Operation | Identity |
+|---|---|
+| contact synchronization | tenant + provider account + patient/contact version + operation key |
+| task creation | tenant + provider account + reminder job/version + purpose |
+| note creation | tenant + provider account + communication operation + note purpose |
+| message creation | tenant + provider account + reminder job/version + channel + purpose + operation key |
+| webhook consumption | provider account + external event ID |
+| reply processing | provider account + external message ID + review operation key |
+
+Rules:
+
+- same key and same fingerprint returns replay;
+- same key with changed payload is rejected;
+- intent and fingerprint persist before external call;
+- provider account and external ID persist transactionally;
+- retry never generates a new logical identity;
+- provider-native idempotency may supplement, not replace, DentalFlow enforcement.
 
 ## Uncertain outcomes
 
-Accepted is not delivered; delivered is not replied; replied is not confirmed. States must distinguish prepared, dispatching, accepted, rejected, uncertain, delivered, read and manual review. Unresolved uncertainty blocks automatic resend.
+A timeout before a request leaves the process may be retryable. A timeout after transmission is `uncertain`.
+
+Required behavior:
+
+1. persist operation as processing before call;
+2. send with stable operation identity where supported;
+3. on ambiguous response, retain `uncertain`;
+4. query provider by stored request/message/external reference or consume webhook;
+5. retry only after a definitive not-found/rejected result and policy approval;
+6. never blind-send a second message;
+7. surface manual review when provider recovery is impossible.
+
+Current amoCRM skeleton has no recovery lookup or external operation persistence.
 
 ## Reschedule/cancellation behavior
 
-Commands bind to appointment/reminder versions. Reschedule supersedes stale work. Cancellation, no-show, arrival, visit progress/completion and consent withdrawal block pending work. In-flight uncertainty is reviewed, not blindly retried.
+DentalFlow remains authoritative.
+
+- reschedule supersedes stale reminder jobs/commands by appointment and reminder-job version;
+- worker rechecks current appointment version, eligibility, consent and suppression under lock immediately before external call;
+- cancellation/no-show cancels pending work;
+- accepted external messages remain immutable history and are not erased;
+- in-flight uncertain work is resolved, not blindly repeated;
+- optional reschedule/cancellation notices would be distinct future purpose codes, not reuse stale commands.
+
+The existing reminder migrations already invalidate/supersede jobs on appointment lifecycle changes. Future orchestration must consume that authority rather than reproducing it in amoCRM.
 
 ## Consent and suppression behavior
 
-DentalFlow remains authoritative. Snapshot at command preparation and recheck immediately before side effect. amoCRM metadata cannot grant consent, clear suppression or override representative rules.
+DentalFlow already contains tenant-scoped authoritative:
+
+- normalized patient/representative contacts;
+- preferred language/channel;
+- channel-specific consent states;
+- channel and global suppression;
+- append-only consent events;
+- duplicate-contact flag;
+- idempotent communication-profile operations.
+
+Before every command execution:
+
+- resolve exact contact;
+- reject missing/unverified/ambiguous contact as policy requires;
+- recheck consent and suppression;
+- compare snapshots/versions;
+- consent withdrawal or suppression blocks new communication;
+- amoCRM contact data must never override DentalFlow consent/suppression.
 
 ## Security/privacy payload allowlist
 
-Allowed: patient first name, clinic, appointment date/time, doctor display name, callback phone, purpose code.
+Allowed variables:
 
-Forbidden: diagnosis, complaints, findings, tooth chart, treatment title/details, price/total, balance/debt/payment, clinical notes and medical documents. The current lead mapper includes treatment title and total price and must not be reused.
+- patient first name;
+- clinic name;
+- appointment date;
+- appointment time;
+- doctor display name;
+- callback phone;
+- purpose code.
 
-## Error model
+Forbidden:
 
-Safe codes: `amo_not_configured`, `amo_authorization_required`, `amo_token_expired`, `amo_account_mismatch`, `amo_rate_limited`, `amo_contact_mapping_missing`, `amo_channel_unavailable`, `amo_message_not_supported`, `amo_operation_uncertain`, `amo_external_rejected`, `amo_webhook_untrusted`, `amo_tenant_mismatch`.
+- diagnosis, complaints or findings;
+- dental chart;
+- treatment plan;
+- treatment/clinical notes;
+- balance, debt, payments or other finance facts;
+- medical documents;
+- unrestricted patient notes;
+- raw consent evidence or secrets.
+
+Additional concerns:
+
+- amoCRM users may have broad visibility and retention outside DentalFlow;
+- data residency/retention and account permissions require tenant approval;
+- logs must not contain patient contact values;
+- representative identity must remain explicit;
+- deletion/archiving cannot erase DentalFlow audit facts.
 
 ## Failure matrix
 
-| Failure | Persisted result | Action/risk |
-|---|---|---|
-| not configured/expired/revoked | safe rejected/auth-required | configure, atomic refresh or reconnect |
-| concurrent refresh | generation conflict | one winner; reject stale result |
-| missing/duplicate contact | manual review | no automatic send; wrong-recipient risk |
-| channel unavailable | manual action | use DentalFlow queue |
-| 429 | retryable delayed | bounded backoff |
-| timeout after possible acceptance | uncertain | recovery before retry; duplicate risk |
-| duplicate/delayed webhook | replay/pending | deduplicate, no duplicate effect |
-| wrong-account webhook | rejected untrusted | security audit; critical cross-tenant risk |
-| reschedule/cancel/withdrawal in flight | superseded/uncertain | block retry; review |
-| shared/representative number | ambiguous | manual review |
-| manual/external race | conflict/review | prevent duplicate contact |
-| DentalFlow down after acceptance | uncertain | external recovery lookup |
-| amoCRM down after local persist | prepared/retryable | bounded retry/manual fallback |
+| Failure | Detection | Persisted state | Retry decision | Manual intervention/audit | Patient risk |
+|---|---|---|---|---|---|
+| amoCRM not configured | account lookup missing | rejected | no | configure account; `amo_not_configured` | no send |
+| OAuth expired | expiry/401 | blocked/retryable after refresh | refresh once | health alert | delay |
+| OAuth revoked | refresh/401 terminal | rejected | no blind retry | reauthorize | missed reminder |
+| concurrent refresh | credential version/lock | one refresh owner | wait/reload | metric/audit | duplicate auth failure |
+| contact absent | mapping lookup | manual action required | no send | map/create via controlled flow | wrong/no recipient |
+| duplicate contacts | >1 valid mapping | blocked/manual review | no | select/merge mapping | privacy leak |
+| lead absent | adapter mode requires lead | rejected/manual | policy-specific | create controlled lead or avoid dependency | operational only |
+| channel widget disabled | capability/health check | rejected | no until restored | tenant alert | missed reminder |
+| send API unavailable | capability matrix | rejected | no | choose provider/manual queue | no duplicate |
+| rate limit | 429/retry hint | retryable | delayed backoff | metric | delayed reminder |
+| timeout before acceptance | transport evidence | retryable/uncertain by stage | bounded | audit | delay |
+| timeout after acceptance | request sent, no result | uncertain | recovery first | manual if no lookup | duplicate-send risk |
+| webhook duplicate | unique event key | replay/no-op | none | duplicate metric | none |
+| webhook delayed | event time/order | pending/late event | reconcile | audit latency | stale status |
+| webhook wrong account | verified account mismatch | rejected | no | security alert | cross-tenant leak |
+| patient rescheduled during send | version recheck/event | superseded or accepted history | do not resend stale content | review accepted stale send | confusing message |
+| patient cancelled during send | lifecycle recheck | cancelled or accepted history | no retry | review if accepted | confusing message |
+| consent withdrawn during send | consent version recheck | blocked or accepted history | no new send | audit withdrawal race | privacy risk |
+| shared family number | duplicate contact candidates | manual review | no automatic send/reply action | choose patient/representative | wrong patient |
+| representative reply | contact owner metadata | manual review | n/a | staff interpretation | authority ambiguity |
+| manual and amoCRM processing | reminder operation claim/key | duplicate prevented/conflict | no | reconcile queue | duplicate contact |
+| DentalFlow unavailable after provider acceptance | durable pre-call operation | uncertain/accepted recovery | provider lookup/webhook | manual review | duplicate risk if ignored |
+| amoCRM unavailable after operation persistence | processing/retryable | retryable | bounded backoff | dead-letter | delay |
+
+Safe error codes:
+
+`amo_not_configured`, `amo_authorization_required`, `amo_token_expired`, `amo_account_mismatch`, `amo_rate_limited`, `amo_contact_mapping_missing`, `amo_channel_unavailable`, `amo_message_not_supported`, `amo_operation_uncertain`, `amo_external_rejected`, `amo_webhook_untrusted`, `amo_tenant_mismatch`.
+
+No user message exposes token, refresh token, secret, raw provider body, stack trace or credentials.
 
 ## Observability
 
-Metrics: prepared, accepted, rejected, uncertain, recovered, duplicates prevented, rate limits, refresh conflicts, account mismatch, missing mappings, inbound replies, manual-review backlog, per-tenant failures. Logs: correlation/tenant/operation, redacted external ID, safe error, duration and credential generation. No general logging of contact values or message bodies.
+Metrics:
+
+- commands prepared;
+- requests accepted/rejected/uncertain/recovered;
+- duplicate prevented;
+- rate limited;
+- token refresh success/failure;
+- missing/duplicate contact mappings;
+- inbound replies and manual review backlog;
+- per-tenant/account failure and latency.
+
+Structured logs:
+
+- correlation ID;
+- tenant ID;
+- operation type;
+- provider account reference;
+- external object type and redacted ID;
+- safe error code;
+- duration/retry classification.
+
+General logs exclude patient phone/email, message body, token and raw provider payload.
 
 ## Browser/network findings
 
-Fresh Chrome DevTools/HeadlessChrome was unavailable because Hermes local developer execution is blocked. Static and prior-audit evidence shows no frontend amoCRM calls, no mapper consumer, disabled sync UI, no frontend credential references, no message client, and no provider request path.
+Local frontend and standalone proxy were started without amoCRM credentials.
 
-Required proof: external amoCRM mutations 0 by source capability; message sends 0; visible credential values 0 in source/contracts; visible service-role value 0 in this boundary. Fresh network capture remains missing evidence.
+- `/crm`, `/settings`, `/sms`, `/mailing` rendered placeholders;
+- CRM/settings did not display a connected account or health state;
+- proxy status returned provider `amocrm`, `connected=false`, `configured=false` and no token properties;
+- browser smoke for all four pages had zero write requests, zero failed requests and zero fatal console errors;
+- forbidden secret terms were not visible;
+- Chrome DevTools MCP 1.5.0 confirmed zero external amoCRM/Kommo requests, zero message endpoint requests and zero write methods;
+- MCP console showed only existing accessibility issues and a harmless missing resource, not integration failures;
+- no external amoCRM mutation or message send occurred.
+
+Required network proof:
+
+- external amoCRM mutation calls: `0`;
+- message sends: `0`;
+- token values visible: `0`;
+- service-role visible: `0`.
+
+## Browser smoke
+
+Browser smoke passed for the reachable placeholder surfaces and disconnected backend status. The absence of a tenant switcher or amoCRM status/configuration UI is itself a finding: there is no role-aware operational integration surface to test.
 
 ## Local experiment findings
 
-Performed read-only: GitHub baseline/source/PR inspection, official documentation review, and Supabase schema/migration queries. No external write or cloud modification occurred. Local worktree/database/app/browser and local quality commands were unavailable.
+- local catalog assertions: `45/45` passed for `integration_tokens`, reminder jobs and communication contact/preferences tables;
+- `integration_tokens` has tenant/provider uniqueness, RLS and no anon/authenticated direct writes;
+- no runtime code reads/writes that token table;
+- reminder jobs and consent/suppression are real, tenant-scoped and provider-neutral;
+- backend status safely omits tokens;
+- backend Node syntax check passed;
+- frontend production bundle/source scan contained no amoCRM secret/token references;
+- no real OAuth exchange or refresh was attempted;
+- no local or cloud data mutation was required;
+- an attempted cloud migration tool call was refused by active policy before any precheck or apply; cloud remained untouched.
 
 ## Architecture options comparison
 
-| Option | Security/reliability | Lock-in/duplicates | Value/current feasibility |
-|---|---|---|---|
-| A direct amoCRM adapter | weak until major hardening | high lock-in and uncertain duplicates | blocked |
-| B provider-neutral + amo adapter | strongest boundaries/observability | low lock-in, explicit idempotency | selected target; adapter blocked |
-| C amo task sync | medium | duplicate queue/high reconciliation | rejected |
-| D DentalFlow manual | safest current mode | no provider lock-in | required fallback, not target automation |
+Score: 1 poor, 5 strong. Complexity and maintenance scores are reversed: 5 means easier/lower burden.
+
+| Option | Complexity | Security | Reliability | Lock-in | Duplicate safety | Observability | Tenant isolation | Operational value | Future providers | Maintenance | Result |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| A. Direct amoCRM communication adapter | 2 | 1 | 1 | 1 | 1 | 2 | 1 | 3 if channel existed | 1 | 2 | reject now |
+| B. Provider-neutral orchestration + amoCRM adapter later | 3 | 5 | 5 | 5 | 5 | 5 | 5 | 4 | 5 | 4 | recommended |
+| C. amoCRM task synchronization only | 3 | 3 | 2 | 2 | 2 | 2 | 2 | 2 | 1 | 2 | duplicates `/reminders` |
+| D. Keep DentalFlow manual queue only | 5 | 5 | 4 | 5 | 4 | 4 | 5 | 3 | 2 | 5 | safe interim fallback |
 
 ## Recommended architecture
 
-**B: provider-neutral communication orchestration with amoCRM as one adapter.** Do not implement the adapter yet.
+**Option B: provider-neutral communication orchestration with amoCRM as a possible later adapter.**
 
-## Exact next task
+Why:
 
-**`AMOCRM-INTEGRATION-HARDENING-001`**: authenticate/authorize routes; bind state to tenant/actor/account; persist verified tenant/account; exact account verification; encrypted durable credentials; atomic refresh/concurrency protection; tenant-scoped revoke/health; constrained external references; safe audit/errors; disable unsafe global production behavior. No CRM objects, chat connection, message or reminder execution change.
+- DentalFlow already owns reminder jobs, appointment versions, contacts, consent and suppression;
+- a durable communication operation is needed regardless of provider;
+- it creates one idempotent/observable uncertain-result boundary before irreversible sends;
+- amoCRM channel capability and OAuth/account safety are not established;
+- it prevents vendor-specific fields from leaking into reminder jobs;
+- another provider can be added without rewriting scheduling/consent logic;
+- manual queue remains the fallback when no adapter is configured.
+
+The first orchestration slice must not send messages. It should persist commands/operations, snapshots, state, idempotency, eligibility recheck and adapter-neutral result/error contracts using a no-op/manual adapter in tests.
+
+## Recommended next task
+
+### Exact next task
+
+**COMMUNICATION-ORCHESTRATION-FOUNDATION-001**
+
+Smallest safe scope:
+
+- provider-neutral communication operation/command persistence;
+- tenant-scoped operation key and fingerprint;
+- immutable appointment/reminder/contact/consent/suppression snapshots;
+- state machine for prepared/processing/accepted/rejected/uncertain/manual-review/superseded/cancelled;
+- safe error taxonomy;
+- recovery contract without external implementation;
+- lifecycle/consent invalidation and audit/metrics foundation;
+- no provider call, no OAuth change, no message send.
 
 ## Known blockers
 
-No configured account/channel/vendor/scope/sender/templates; no tenant-aware backend; no refresh/durable credentials/external-reference constraints; no message/delivery/reply storage; accessible cloud drift; no fresh browser/local execution.
+A real amoCRM adapter remains blocked by:
+
+- no tenant-bound production OAuth/account store;
+- no refresh rotation or concurrency protection;
+- no exact installed channel/vendor evidence;
+- no channel/scope/secret/conversation/message model;
+- no external reference table;
+- no trusted webhook/account verifier;
+- no provider recovery lookup;
+- no role-aware integration UI/health;
+- no worker/backpressure/dead-letter path;
+- no confirmed API right to send through any existing WhatsApp/SMS widget.
+
+## Issues / limitations
+
+- No production amoCRM account or installed-widget inventory was inspected because the task forbids credentials and production mutation; repository/runtime evidence proves no configured channel locally.
+- Official capabilities describe what a properly registered integration can build, not what an unknown third-party widget permits.
+- Data residency, retention, commercial connector terms and clinic-specific amoCRM user permissions require a later tenant/vendor review.
+- Current patient external CRM metadata may display stale/unverified IDs and should not be trusted for communication.
 
 ## What was intentionally not implemented
 
-No production code, migration, OAuth/refresh change, provider abstraction, message/delivery, CRM mutation, webhook, worker, cron, Edge Function, package/type/UI/fixture change, cloud apply, credential access, next task, or HEP-V2.
+- no migration, source or UI change;
+- no OAuth/token refresh change;
+- no provider abstraction implementation;
+- no contact, lead, task or note creation;
+- no message, SMS, WhatsApp or email send;
+- no webhook, worker, cron or Edge Function;
+- no cloud access/apply;
+- no credentials or token values;
+- no fixture committed;
+- no package/lock change;
+- no next task started;
+- no PR merge;
+- no HEP-V2 work.
 
 ## Validation
 
-Required commands: `npm run lint`, `npm run test -- --run`, `npm run build`. Local execution was unavailable. GitHub Actions runs install, ESLint, tests, build and merge guard for PRs to main. Fresh CI on the exact final head is required and reported in the final response.
+- baseline/PR/duplicate checks: passed;
+- strict changed-file scope before report: clean;
+- backend `npm run check`: passed;
+- local schema assertions: `45/45` passed;
+- browser smoke: passed;
+- Chrome DevTools MCP 1.5.0 network inspection: passed;
+- frontend secret scan: no production secret references;
+- `npm run lint`: passed;
+- `npm run test -- --run`: **96 files / 1070 tests passed**;
+- `npm run build`: passed;
+- existing unrelated React `act(...)`, intentional error-path logs and Vite bundle-size warning remain non-blocking.
 
-Static validation: exact baseline, duplicate search, one intended file, source inventory, no send/channel implementation, no frontend credential reference, read-only Supabase inspection and official documentation review.
+## Checks
+
+- exactly one report file changed: passed;
+- production code changed: no;
+- migrations/package/generated types changed: no;
+- external amoCRM writes: 0;
+- message sends: 0;
+- secrets exposed: 0;
+- official documentation check: complete;
+- four architecture options compared: complete;
+- exactly one next task selected: complete.
 
 ## Fresh CI
 
-Pending exact-final-head workflow completion. Exact run and tested SHA are reported in the final response; placing them here would create a new untested head.
+Reviewed pre-update CI:
+
+- workflow: `CI`;
+- run ID: `29250107482`;
+- tested SHA: `d64ff6295dcb0bba2ec39a16063911291c25d32c`;
+- validate: `success`;
+- merge guard: `success`.
+
+A fresh CI run on the final report-update head is required after this update. The PR must remain open and unmerged; final head/run metadata is recorded in the immutable receipt.
 
 ## Final verdict
 
-**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository and official API evidence identify `AMOCRM-INTEGRATION-HARDENING-001` but do not authorize message delivery**
+Final verdict: **PASS**
+
+AMOCRM REMINDER COMMUNICATION INTEGRATION RECONCILED AND NEXT SAFE SLICE IDENTIFIED

--- a/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
+++ b/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
@@ -6,17 +6,11 @@
 
 ## Executive summary
 
-The current amoCRM implementation is a disconnected development skeleton, not a production integration and not a reminder communication boundary. It has an authorization-code exchange, one process-global in-memory credential set, placeholder synchronization routes, and a webhook that accepts and ignores requests. It has no tenant binding, role checks, durable credential repository, refresh implementation, external-object repository, CRM synchronization, chat channel, message operation, delivery-state processing, or inbound-reply correlation.
+The current amoCRM implementation is a disconnected development skeleton, not a production integration and not a reminder communication boundary. It has server-side authorization-code exchange, one process-global in-memory credential set, placeholder sync routes, and a webhook that accepts and ignores requests. It has no authentication, role or tenant binding, durable encrypted credential repository, refresh implementation, external-reference repository, CRM synchronization, chat channel, send operation, delivery processing, or inbound-reply correlation.
 
-DentalFlow already has the correct authoritative foundations: tenant-scoped appointment reminder jobs, manual reminder operations, normalized communication contacts, channel-specific consent, suppression, representative handling, and provider-neutral eligibility. Those facts must remain authoritative.
+DentalFlow remains authoritative for appointments, reminder jobs, contact consent, suppression and opt-out. Official amoCRM documentation shows that CRM entities and a separately registered Chats API channel can support messages, statuses and history, but that requires a channel, signed requests, per-account `scope_id`, hooks, conversation IDs and a real transport. None is evidenced here.
 
-Official amoCRM documentation confirms that CRM contacts, leads, tasks, notes and webhooks exist, and that a separately registered Chats API channel can create chats, transfer messages, report delivery states and return message history. Those capabilities require a registered channel, signed requests, a per-account `scope_id`, channel webhooks, conversation identity and a real external transport. None is evidenced in this repository or the connected Supabase project.
-
-**Target architecture:** B, provider-neutral communication orchestration with amoCRM as one possible adapter.
-
-**Exact next task:** `AMOCRM-INTEGRATION-HARDENING-001`.
-
-No real amoCRM write, message, task, contact, lead, note, credential refresh, webhook registration, or cloud mutation was performed.
+Target architecture: **B, provider-neutral communication orchestration with amoCRM as one possible adapter.** Exact next task: **`AMOCRM-INTEGRATION-HARDENING-001`**. No external mutation or cloud change was performed.
 
 ## Branch
 
@@ -24,446 +18,232 @@ No real amoCRM write, message, task, contact, lead, note, credential refresh, we
 
 ## PR URL
 
-Pending initial PR creation. The URL will be inserted before final validation.
+https://github.com/NckNA/codex-test/pull/357
 
 ## Baseline
 
 - repository: `NckNA/codex-test`;
-- base branch: `main`;
-- required and verified baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
-- PR `#356` is merged at that exact commit;
-- the baseline also contains the reminder queue and manual-operations foundations;
-- no duplicate open or merged PR was found for this task ID/title;
-- the branch was created directly from the exact baseline.
+- base: `main`;
+- exact verified baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
+- PR #356 is merged at that commit;
+- duplicate task PR search returned none;
+- branch created from the exact baseline.
 
 ## Final head
 
-Recorded in the final task response because a report cannot contain its own future commit SHA without changing that SHA.
+Recorded in the final response because this file cannot contain its own future commit SHA.
 
 ## Changed files
 
-Exactly one file:
-
-- `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`
-
-No production code, migration, package, generated type, fixture, UI, provider, worker, cron, Edge Function, or webhook implementation is changed.
+Exactly `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`. No other file is intended or allowed.
 
 ## Pre-read
 
-Required reports reconciled:
+Reviewed the four required reminder reports, AMO-001 through AMO-004, AUDIT-005, amoCRM architecture/security/mapping/sync documents, backend routes/services/config/docs, frontend mapper/types/UI, patient integration storage, reminder types/repositories, initial schema, token table, package scripts and CI.
 
-- `APPOINTMENT-REMINDER-OPERATIONS-RECON-001`;
-- `APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001`;
-- `APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001`;
-- `APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001`.
-
-amoCRM history reconciled:
-
-- `AMO-001`, `AMO-002`, `AMO-003`, `AMO-004`;
-- `AUDIT-005_amocrm_oauth_boundary_audit_report`;
-- amoCRM architecture, mapping, security and sync-strategy documents.
-
-Repository inspection covered backend routes/services/config, frontend mappers/types/UI, patient storage, reminder contracts, initial schema, token table, source references, package scripts and CI.
-
-Official amoCRM documentation was checked on **2026-07-13**: OAuth, API limits, contacts, leads, tasks, notes/events, CRM webhooks, Chats capabilities, Chats methods and Chats webhook formats.
+Official amoCRM OAuth, limits, contacts, leads, tasks, notes/events, CRM webhooks, Chats capabilities, methods and hook formats were checked on 2026-07-13.
 
 ## Existing amoCRM assets
 
-| Asset | Responsibility | Scope/auth | Operations | Error/retry/idempotency/audit/tests | Reachability/classification |
-|---|---|---|---|---|---|
-| `backend/src/server.js` | plain Node proxy | no authentication or tenant middleware | dispatches routes | none | separate manual server; risky skeleton |
-| `backend/src/routes/amoCrmRoutes.js` | status/connect/callback/disconnect, webhook and sync placeholders | global, no user/role/tenant | token exchange and global disconnect; sync returns 501; webhook ignores | redacted simple errors; no retry/idempotency/audit | not called by frontend; risky/partial |
-| `amoCrmClient.js` | OAuth URL and code exchange | global config | only token exchange; sync functions throw | no refresh/retry | partial; must be replaced/hardened |
-| `amoCrmTokenStore.js` | credential storage | one process-global object | save/read/clear | no lock, version, persistence or audit | dev-only; unsafe for SaaS |
-| `amoCrmStateStore.js` | one-time state | global Map, not bound to tenant/user/account | create/consume, ten-minute TTL | cryptographically random; no ownership binding | reusable concept only |
-| `backend/src/config.js` | loads amoCRM settings | one global account/config | config only | no tenant/account selection | partial/risky |
-| backend README/env/package | documents and starts skeleton | global | manual start/check | backend checks are outside root CI | accurate docs, partial tooling |
-| `amoCrmMapper.ts` | contact/lead preview mapping | caller-supplied patient | pure mapping, no network | no consumer/operation key/tests proving integration | dead prototype |
-| `amoCrmTypes.ts` | draft DTO types | none | none | none | placeholder |
-| `ExternalCrmLink` | optional contact/lead/deal IDs | indirectly scoped by patient row | model only | no account composite or uniqueness | partial/risky |
-| `PatientRepository.ts` | stores opaque `patient.integration` JSON | tenant-filtered patient row | read/write JSON | no external-reference constraints | active storage, unsuitable mapping authority |
-| patient-card CRM panel | displays source/status/IDs | current patient | read-only | exposes raw external IDs to authorized UI | active display, not integration |
-| disabled treatment-plan button | future UI hint | none | none | none | placeholder |
-| `patients.integration` JSONB | legacy metadata | patient tenant | opaque metadata | no history/uniqueness/account validation | risky legacy model |
-| `integration_tokens` table | intended tenant credential storage | unique tenant/provider | unused by backend | encryption is naming/design intent only; no refresh lock/account ID | reusable but insufficient |
-| historical docs/reports | design intent | mixed | none | not runtime evidence | informative only |
+| Asset | Finding | Classification |
+|---|---|---|
+| backend server/routes | unauthenticated global status/connect/callback/disconnect; sync 501; webhook ignored | risky partial skeleton |
+| OAuth client | code exchange only; no refresh or CRM client | partial |
+| state store | random one-time ten-minute state, not bound to user/tenant/account | partially reusable |
+| credential store | one global in-memory object, lost on restart, no lock/version | unsafe for production |
+| global config | one account/application configuration | not multi-tenant |
+| frontend mapper/types | unused contact/lead preview; no network | dead placeholder |
+| patient external CRM metadata | optional contact/lead/deal IDs in replaceable JSON | risky legacy model |
+| patient CRM panel | display-only source/status/external IDs | active display only |
+| treatment-plan amoCRM button | disabled, no handler | placeholder |
+| `integration_tokens` table | tenant/provider schema intent, unused by backend; lacks account identity/refresh lock | insufficient foundation |
+| historical docs/reports | design intent, not runtime capability | documentation |
 
-No production amoCRM repository, sync service, tenant settings page, external-reference repository, chat client, task/note client, message client, delivery-attempt store, polling job, signed webhook verifier, or recovery lookup exists.
+No production integration repository, channel configuration, message/task/note client, signed webhook verifier, delivery store, recovery lookup, or integration tests exist.
 
 ## Current data-flow map
 
-### DentalFlow to amoCRM
+DentalFlow → amoCRM: **none**. The unused patient draft contains name/legacy phone. The unused lead draft contains patient name, treatment-plan title and total price, so it is not suitable for reminder communications. Appointments, cancellations, contacts, tasks, notes, statuses and messages are not sent.
 
-| Flow | Trigger/payload | Authority | Idempotency/failure/replay | Isolation/exposure | Status |
-|---|---|---|---|---|---|
-| patient create/update | no trigger; unused draft is name + legacy phone | DentalFlow patient | none | no adapter tenant boundary; legacy phone lacks consent authority | absent |
-| appointment create/update/cancel | no mapper or route | DentalFlow appointment | n/a | no data leaves | absent |
-| contact create/update | no API request | DentalFlow | none | none | absent |
-| lead create/update | unused draft includes patient name, plan title, total price, status/source | DentalFlow | none | includes financial total and must not be used for reminders | absent/unsafe draft |
-| task/note creation | none | DentalFlow reminder/audit | none | none | absent |
-| message send | none | DentalFlow reminder/consent | none | none | absent |
-
-### amoCRM to DentalFlow
-
-| Flow | Trigger/payload | Authority/idempotency | Isolation | Status |
-|---|---|---|---|---|
-| contact or lead update | none | no contract | none | absent |
-| tasks or notes | none | no contract | none | absent |
-| incoming message | placeholder webhook discards body | no persistence/deduplication | none | absent |
-| CRM webhook | accepts 202, ignores all | duplicates and failures invisible | none | placeholder |
-| delivery status | none | no message ID/state | none | absent |
-| external IDs | optional replaceable patient JSON only | no mapping history | patient row only | not populated by integration |
-
-Contacts, leads, tasks, notes and conversations are **not synchronized**.
+amoCRM → DentalFlow: **none**. Contact/lead/task/note changes are not read. Incoming webhook bodies are discarded. Delivery statuses, replies and external identifiers are not ingested. There is no trigger, idempotency key, replay, failure recovery, tenant boundary or audit.
 
 ## External ID model
 
-Current identifiers:
+Current: account/domain only in global memory; integration/client ID in global environment; optional contact/lead/deal IDs inside patient JSON; no task/note/message/conversation/webhook/channel IDs; no composite uniqueness; stale and duplicate mappings are possible; appointments have no mapping.
 
-| ID | Location | Tenant/account safety | Finding |
-|---|---|---|---|
-| account/domain | global memory token object | no tenant binding | lost on restart/overwritable |
-| integration/client ID | global environment | no tenant binding | one global config |
-| contact/lead/deal IDs | optional patient JSON | tenant only indirectly; no account composite | duplicate/stale mappings possible |
-| task/note/message/conversation/webhook IDs | absent | none | absent |
-| channel ID/`scope_id` | absent | none | no chat connection |
+Minimum required:
 
-One patient can be remapped silently; several patients can share the same external ID; cross-account uniqueness is not enforced; appointments have no external reference.
-
-Minimum required model before communications:
-
-1. `integration_accounts`: tenant, provider, verified account ID/domain, connection state, credential version, revocation/health timestamps, unique tenant/provider.
-2. `integration_external_refs`: tenant + integration account + local entity/type + external type/ID, mapping version/history, composite uniqueness in both directions.
-3. Later, only after channel evidence, `integration_channel_connections`: account, channel ID, `scope_id`, vendor/channel type, capability flags, hook version, connection state and server-side secret reference.
-
-`patients.integration` must become display/compatibility metadata, not mapping authority.
+- `integration_accounts`: tenant, provider, verified account ID/domain, status, credential generation, health/revocation, unique tenant/provider;
+- `integration_external_refs`: tenant + account + local entity/type + external type/ID, history/version and bidirectional composite uniqueness;
+- later, only with channel evidence, `integration_channel_connections`: channel ID, `scope_id`, vendor/type, capabilities, hook version and server-only secret reference.
 
 ## OAuth and secret boundary
 
-Current flow:
+The authorization-code exchange is server-side and does not return raw credentials to frontend. Everything else is insufficient: routes are unauthenticated; state is not bound to actor/tenant/account; credentials are global and memory-only; expiry is not enforced; refresh, encryption, revocation, audit and exact account verification are absent.
 
-1. any reachable caller starts connect;
-2. server creates a random one-time state;
-3. callback validates state;
-4. server exchanges code using server-side application credentials;
-5. one global in-memory credential set is saved;
-6. status returns only domain/expiry metadata;
-7. any reachable caller can clear it.
-
-Findings:
-
-- authorization-code exchange: partial and server-side;
-- token refresh: absent;
-- durable storage: absent in running backend;
-- database token table: exists but unused;
-- encryption implementation: absent;
-- expiry enforcement: absent;
-- tenant/account binding: absent;
-- concurrent refresh protection: absent;
-- route authentication and roles: absent;
-- state binding to actor/tenant/account: absent;
-- exact callback account verification: absent;
-- frontend credential exposure: not found;
-- error redaction: raw token response is not returned;
-- revocation behavior: absent.
-
-Credentials are not production-safe today. Official amoCRM refresh credentials rotate on use, so future refresh must use a row lock or compare-and-swap and must reject stale concurrent results.
-
-Required hardening:
-
-- authenticate every route;
-- owner/admin configuration only;
-- bind state to tenant, actor and expected account;
-- verify exact account ID/domain;
-- encrypt durable server-side credentials per tenant/account;
-- transactionally rotate refresh credentials with generation/version control;
-- handle expiry/revocation/disconnect;
-- never expose provider credentials to frontend or logs;
-- audit connect/refresh/revoke/mismatch with safe metadata.
+Official refresh credentials rotate after use, so future refresh must be transactional with a row lock or compare-and-swap, credential generation and stale-result rejection. Credentials must never reach frontend or logs.
 
 ## Current tenant isolation
 
-Reminder and consent foundations are tenant-scoped. amoCRM is not.
+Failed for amoCRM. No tenant/user/role exists in routes, state or credential store; there is no one-tenant-to-one-account rule, account ID verification, tenant throttling, hook account validation or tenant audit. This is tolerable only because frontend and sync are disconnected.
 
-Gaps: no tenant/user/role in routes, state or token store; no one-tenant-to-one-account rule; no account ID; no domain verification against a tenant; no per-tenant throttling; no webhook account verification; no audit; global disconnect affects the last connected account.
-
-Required rule: one DentalFlow tenant maps to exactly one verified amoCRM account unless explicitly redesigned; no global default/fallback; every credential and external ID is composite with tenant/account; account or webhook mismatch fails closed.
-
-**Result: failed for production, tolerable only because the skeleton is disconnected and performs no sync.**
+Required: one tenant maps to one verified account unless explicitly redesigned; no global default or fallback; all credentials/external IDs are tenant+account composite; mismatch fails closed.
 
 ## Current role model
 
-Current routes have no roles. Required matrix:
-
-| Role | Configure/authorize | View health | Reminder operations | Credential access |
-|---|---:|---:|---:|---:|
-| owner | yes | yes | policy | no raw credential |
-| admin | tenant policy | yes | yes | no raw credential |
-| registrar | no | safe operational state only | yes | no |
-| doctor | no | no | no provider action | no |
-| cashier | no | no | no provider action | no |
-| unknown/no tenant | blocked | blocked | blocked | blocked |
+Owner configures and authorizes; admin operates according to tenant policy; registrar sees safe status and performs manual reminders; doctor/cashier cannot configure; unknown/no tenant is blocked. No role receives raw credentials. Current amoCRM routes implement none of this.
 
 ## Actual connected communication channels
 
-No evidence establishes native chats, WhatsApp, SMS, email, external connector, channel ID, channel secret reference, `scope_id`, chat hook, sender/bot identity, templates, sandbox, message ID or conversation ID.
+None evidenced. No native/custom chat, WhatsApp, SMS, email, vendor connector, channel ID, channel secret reference, `scope_id`, sender identity, templates, sandbox, message ID or conversation ID exists in repository or accessible Supabase configuration.
 
-Read-only inspection of the connected Supabase project found `integration_tokens` with zero rows and no reminder/communication/channel tables. Its applied migrations stop at `0013`, behind repository baseline `0031`. This proves drift in the accessible project, not a production channel.
-
-| Model | Result |
-|---|---|
-| amoCRM native/custom chats | official capability only; no installed channel |
-| WhatsApp widget/vendor | no evidence |
-| SMS widget/vendor | no evidence |
-| email integration | no DentalFlow evidence |
-| staff manual writing in amoCRM | operationally possible but unverified |
-| task/note-only use | no implementation |
+Read-only Supabase inspection found zero `integration_tokens` rows and migration history only through `0013`, behind repository `0031`; this proves accessible-project drift, not an installed channel.
 
 ## Official amoCRM capability check
 
-Checked 2026-07-13 using official documentation only.
+- OAuth and refresh are supported, but exact account domain and secure credential lifecycle are integrator responsibilities.
+- Contact, lead, task, note and CRM webhook APIs exist.
+- Chats API requires a separately connected signed channel and returns account-specific `scope_id`.
+- Chat creation, message transfer, delivery status (`sent/delivered/read/error`) and conversation history exist for such a channel.
+- Official capability does not prove an installed WhatsApp/SMS/email widget is callable by DentalFlow.
+- No generic reminder-send idempotency key was established; DentalFlow must enforce operation identity.
 
-| Capability | Official result | Limitation/current compatibility | Confidence |
-|---|---|---|---|
-| OAuth code exchange | supported at exact account domain | current skeleton lacks tenant/account binding | high |
-| refresh | supported; refresh value is single-use and replacement must be stored | absent; concurrency unsafe if naively added | high |
-| contacts/leads/tasks/notes | read/write APIs exist | no repository client; not reminder authority | high |
-| CRM webhooks | supported; account limit documented | placeholder ignores and does not verify | high |
-| chat channel connect | signed API returns account-specific `scope_id` | channel registration/secret/install absent | high |
-| chat creation | integration-owned conversation ID supported | no mapping model | high |
-| message transfer | supported for registered custom channels | acceptance is not delivery; external transport required | high |
-| delivery status | sent/delivered/read/error model supported | no channel/message/status consumer | high |
-| message history | supported per conversation | needs signed request, scope and conversation | high |
-| inbound/outbound chat hooks | supported for connected channel | verifier/correlation absent | high |
-| WhatsApp templates/time windows | channel-specific capabilities | vendor/config unknown | medium/high |
-| native generic idempotency | no general reminder-send key documented | DentalFlow must enforce | medium/high |
+Confidence: high for documented capabilities, low for tenant-specific channel availability because no external installation evidence exists.
 
 ## API and rate-limit constraints
 
-Official CRM API guidance currently states up to 7 requests/second per integration and 50 requests/second per account, with HTTP 429 on limit breach and possible 403 blocking after repeated violations.
-
-Future requirements: backend-only bounded worker, per-tenant/account throttling, safe backoff, separated refresh traffic, dead-letter/manual review, bounded scans, no blind resend, and batching only where documented. Reminder volume is not measured in the repository.
+Official guidance documents 7 requests/second per integration and 50 requests/second per account, HTTP 429 on breach and possible 403 blocking after repeated violations. A future path needs bounded backend work, per-tenant/account throttling, safe backoff, recovery before resend, manual/dead-letter handling, and no frontend direct calls.
 
 ## Current message-send capability
 
-**Absent.** No command, endpoint, channel, transport, template, sender identity, operation store or external message ID exists. An official Chats API does not make an installed third-party WhatsApp/SMS widget callable by DentalFlow.
+**Absent.** No command, endpoint, channel, transport, sender/template, operation record or external message ID exists.
 
 ## Current delivery-status capability
 
-**Absent.** There is no message ID, delivery attempt, status webhook, polling lookup or normalizer. Manual `message_sent` is a staff-entered fact, not delivery proof.
+**Absent.** There is no message ID, delivery attempt, status webhook/polling or normalizer. Manual `message_sent` is not proof of delivery.
 
 ## Current inbound-reply capability
 
-**Absent.** The webhook ignores bodies and has no signature/account/channel validation, conversation identity or correlation.
-
-Initial future rule: verified inbound reply creates a manual review item; staff interprets it and uses the existing confirmation/reschedule workflow. Arbitrary text must not automatically confirm an appointment.
+**Absent.** The webhook ignores bodies and verifies neither signature nor account/channel. There is no conversation/patient/reminder correlation.
 
 ## Communication command model
 
 ```text
-CommunicationCommand
-- tenant_id
-- reminder_job_id
-- appointment_id
-- patient_id
-- communication_contact_id
-- channel
-- purpose_code
-- language
-- consent_snapshot
-- suppression_snapshot
-- appointment_version
-- reminder_job_version
-- operation_key
-- payload_fingerprint
-- safe_variable_map
-- requested_at
+tenant_id, reminder_job_id, appointment_id, patient_id,
+communication_contact_id, channel, purpose_code, language,
+consent_snapshot, suppression_snapshot, appointment_version,
+reminder_job_version, operation_key, payload_fingerprint,
+safe_variable_map, requested_at
 ```
 
-Purpose codes: `appointment_confirmation_request`, `appointment_day_before_reminder`, `appointment_same_day_reminder`, `control_call_task`.
-
-No free-form clinical payload. Final eligibility, appointment version/state and consent/suppression must be rechecked immediately before any external side effect.
+Purpose codes: confirmation request, day-before reminder, same-day reminder, control-call task. No free-form clinical payload.
 
 ## Proposed amoCRM adapter contract
 
-Input: immutable communication command.
+Input: immutable communication command. Resolve exact tenant account, contact and channel/conversation; preserve operation key; perform only approved action; store external ID; return `accepted`, `rejected`, `uncertain`, or `manual_action_required` plus safe error/retry data; expose recovery lookup.
 
-Responsibilities: resolve exact tenant account, reject mismatch, resolve contact/channel/conversation, preserve operation key/fingerprint, perform only approved external action, store external ID, normalize outcome, redact errors and expose recovery lookup.
-
-Output: `accepted | rejected | uncertain | manual_action_required`, optional external ID, safe error code, retryability and timestamp.
-
-The adapter must not confirm appointments, complete reminder jobs merely on acceptance, create clinical/financial facts, choose another tenant/account, or bypass consent.
+The adapter never confirms appointments, completes reminder work on mere acceptance, creates clinical/financial facts, changes consent, or falls back to another tenant.
 
 ## Task-only fallback
 
-`DentalFlow reminder job → amoCRM task → staff contact → manual result in DentalFlow` was evaluated and rejected now. It duplicates `/reminders`, creates two queues, adds mapping/completion reconciliation, weakens audit consistency and increases duplicate-contact risk without proving a communication channel.
+Rejected now. Synchronizing amoCRM tasks would duplicate `/reminders`, create two queues and completion reconciliation, weaken audit consistency, and increase duplicate-contact risk without adding delivery evidence.
 
 ## Inbound reply handling
 
-Future handling must verify signature/account/channel, deduplicate provider event/message ID, resolve tenant/contact/conversation, flag shared/representative contacts, create manual review, and require staff to record the interpreted result through existing operations. `да`, `нет`, `перенесите` and free text are not automatically authoritative.
+Future verified replies create manual review. Signature/account/channel and event ID are verified; shared/representative contacts remain ambiguous; staff interprets `да`, `нет`, `перенесите` or free text and invokes existing confirmation/reschedule operations. Arbitrary text is not automatic confirmation.
 
 ## Idempotency
 
-Identities are required for contact sync, task/note/message creation, webhook consumption and reply interpretation.
-
-Rules:
-
-- same operation key + same fingerprint = replay;
-- same key + different fingerprint = reject;
-- reserve local operation before external side effect;
-- store external ID transactionally;
-- timeout after possible acceptance = uncertain;
-- perform recovery lookup before retry;
-- never blindly duplicate a message;
-- duplicate webhook returns success without duplicate effects.
-
-Integration-owned conversation/message IDs can aid correlation but are not assumed to be a complete provider idempotency guarantee.
+Same operation key + same fingerprint replays; same key + different fingerprint rejects. Reserve locally before side effect; store external ID transactionally; deduplicate hooks by provider ID/fingerprint; timeout after possible acceptance becomes uncertain; recover before retry; never blindly resend.
 
 ## Uncertain outcomes
 
-Required states include prepared, dispatching, accepted, rejected, uncertain, delivered, read, manual-review-required and cancelled-before-dispatch.
-
-Accepted is not delivered; delivered is not replied; replied is not confirmed. If external acceptance cannot be disproved after timeout, do not resend automatically. Recover by external ID/history or route to manual review.
+Accepted is not delivered; delivered is not replied; replied is not confirmed. States must distinguish prepared, dispatching, accepted, rejected, uncertain, delivered, read and manual review. Unresolved uncertainty blocks automatic resend.
 
 ## Reschedule/cancellation behavior
 
-Commands bind to appointment and reminder-job versions. Reschedule supersedes stale work. Cancellation, no-show, arrival, visit start/completion and consent withdrawal block new dispatch. In-flight uncertain work is not retried blindly. Already accepted external messages remain historical and do not mutate appointment truth.
+Commands bind to appointment/reminder versions. Reschedule supersedes stale work. Cancellation, no-show, arrival, visit progress/completion and consent withdrawal block pending work. In-flight uncertainty is reviewed, not blindly retried.
 
 ## Consent and suppression behavior
 
-DentalFlow remains authoritative for channel consent, evidence, global/channel suppression, patient/representative ownership, preferred language/channel and eligibility. amoCRM metadata cannot grant consent or clear suppression. Snapshot at preparation and recheck at dispatch.
+DentalFlow remains authoritative. Snapshot at command preparation and recheck immediately before side effect. amoCRM metadata cannot grant consent, clear suppression or override representative rules.
 
 ## Security/privacy payload allowlist
 
-Allowed: patient first name, clinic name, appointment date/time, doctor display name, callback phone and purpose code.
+Allowed: patient first name, clinic, appointment date/time, doctor display name, callback phone, purpose code.
 
-Forbidden: diagnosis, complaints, findings, tooth chart, treatment details/title, price/total, balance/debt/payment, clinical notes, medical documents and arbitrary patient notes.
-
-The current lead draft includes treatment title and total price and must not be reused for reminders.
+Forbidden: diagnosis, complaints, findings, tooth chart, treatment title/details, price/total, balance/debt/payment, clinical notes and medical documents. The current lead mapper includes treatment title and total price and must not be reused.
 
 ## Error model
 
 Safe codes: `amo_not_configured`, `amo_authorization_required`, `amo_token_expired`, `amo_account_mismatch`, `amo_rate_limited`, `amo_contact_mapping_missing`, `amo_channel_unavailable`, `amo_message_not_supported`, `amo_operation_uncertain`, `amo_external_rejected`, `amo_webhook_untrusted`, `amo_tenant_mismatch`.
 
-No credential value, raw provider body, stack trace or account secret may reach users/logs.
-
 ## Failure matrix
 
-| Scenario | Detection/state | Retry/manual response | Risk |
-|---|---|---|---|
-| not configured | rejected safe code | owner/admin config | low |
-| expired/revoked authorization | expiry/401/revoke state | atomic refresh or reconnect | low/medium |
-| concurrent refresh | credential generation conflict | one winner; stale result rejected | high outage/corruption |
-| missing/duplicate contact | no or multiple mapping | manual mapping, no auto-send | high wrong recipient |
-| channel/send unavailable | capability absent | use DentalFlow manual queue | low |
-| rate limit | 429 | bounded backoff | delay |
-| timeout before acceptance | known no acceptance | bounded retry | medium |
-| timeout after possible acceptance | uncertain | recovery before retry/manual | high duplicate |
-| duplicate/delayed webhook | ID/fingerprint/time | replay/no send effect | low/medium |
-| wrong-account webhook | account/scope mismatch | reject/security audit | critical cross-tenant |
-| reschedule/cancel during send | version/status mismatch | no stale retry; review uncertain | medium |
-| consent withdrawn during send | final eligibility/in-flight state | block new; privacy review | high |
-| shared family/representative number | ambiguous owner | manual review | high wrong recipient |
-| manual and external race | operation correlation conflict | prevent duplicate/manual review | high annoyance |
-| DentalFlow down after acceptance | reserved operation, no response | recovery lookup | high duplicate |
-| amoCRM down after local persist | prepared/retryable | bounded retry/manual | delay |
+| Failure | Persisted result | Action/risk |
+|---|---|---|
+| not configured/expired/revoked | safe rejected/auth-required | configure, atomic refresh or reconnect |
+| concurrent refresh | generation conflict | one winner; reject stale result |
+| missing/duplicate contact | manual review | no automatic send; wrong-recipient risk |
+| channel unavailable | manual action | use DentalFlow queue |
+| 429 | retryable delayed | bounded backoff |
+| timeout after possible acceptance | uncertain | recovery before retry; duplicate risk |
+| duplicate/delayed webhook | replay/pending | deduplicate, no duplicate effect |
+| wrong-account webhook | rejected untrusted | security audit; critical cross-tenant risk |
+| reschedule/cancel/withdrawal in flight | superseded/uncertain | block retry; review |
+| shared/representative number | ambiguous | manual review |
+| manual/external race | conflict/review | prevent duplicate contact |
+| DentalFlow down after acceptance | uncertain | external recovery lookup |
+| amoCRM down after local persist | prepared/retryable | bounded retry/manual fallback |
 
 ## Observability
 
-Metrics: commands prepared; accepted/rejected/uncertain/recovered; duplicates prevented; rate limits; refresh success/failure/conflict; account mismatch; missing mappings; inbound replies; manual-review backlog; tenant failure rate; untrusted hooks.
-
-Logs: correlation ID, tenant ID, operation type, external object type, redacted external ID, safe error code, duration and credential generation. Do not log patient contact values or message bodies in general logs.
+Metrics: prepared, accepted, rejected, uncertain, recovered, duplicates prevented, rate limits, refresh conflicts, account mismatch, missing mappings, inbound replies, manual-review backlog, per-tenant failures. Logs: correlation/tenant/operation, redacted external ID, safe error, duration and credential generation. No general logging of contact values or message bodies.
 
 ## Browser/network findings
 
-Fresh Chrome DevTools/HeadlessChrome validation could not run because Hermes local developer execution is blocked in this conversation.
+Fresh Chrome DevTools/HeadlessChrome was unavailable because Hermes local developer execution is blocked. Static and prior-audit evidence shows no frontend amoCRM calls, no mapper consumer, disabled sync UI, no frontend credential references, no message client, and no provider request path.
 
-Static and prior-audit evidence:
-
-- frontend makes no amoCRM backend/direct API calls;
-- mapper has no consumer;
-- sync button is disabled;
-- no frontend credential references were found;
-- backend responses omit credential values;
-- no message/provider request code exists.
-
-Required proof status:
-
-- external amoCRM mutation calls: 0 by source capability; fresh capture unavailable;
-- message sends: 0;
-- credential values visible: 0 in source/contracts; fresh capture unavailable;
-- service-role value visible: 0 in this boundary; fresh capture unavailable.
+Required proof: external amoCRM mutations 0 by source capability; message sends 0; visible credential values 0 in source/contracts; visible service-role value 0 in this boundary. Fresh network capture remains missing evidence.
 
 ## Local experiment findings
 
-Performed read-only: GitHub baseline/source/PR inspection, official documentation review, and connected Supabase schema/migration queries.
-
-Supabase findings: token table exists, row count 0, amoCRM row count 0, no reminder/communication/channel tables, latest applied migration `0013` versus repository `0031`.
-
-Unavailable: local worktree, local database reset, local app/network, mock OAuth runtime, fresh browser and local quality commands. No external write or cloud modification occurred.
+Performed read-only: GitHub baseline/source/PR inspection, official documentation review, and Supabase schema/migration queries. No external write or cloud modification occurred. Local worktree/database/app/browser and local quality commands were unavailable.
 
 ## Architecture options comparison
 
-Scores 1 poor, 5 strong. Complexity/maintenance score 5 means easier/lower burden.
-
-| Criterion | A direct adapter | B neutral layer + adapter | C task sync | D manual DentalFlow |
-|---|---:|---:|---:|---:|
-| complexity | 2 | 1 initially/4 later | 3 | 5 |
-| security | 2 | 5 | 3 | 5 |
-| reliability | 2 | 5 | 3 | 5 manual |
-| low lock-in | 1 | 5 | 2 | 5 |
-| low duplicate risk | 2 | 5 | 1 | 4 |
-| observability | 2 | 5 | 2 | 4 |
-| tenant fit | 1 current | 5 after hardening | 3 | 5 |
-| operational value | 3 if channel exists | 5 | 2 | 4 current |
-| future providers | 1 | 5 | 1 | 2 |
-| maintenance | 2 | 4 after foundation | 2 | 5 |
-
-A is rejected now. B is the target. C is rejected because it duplicates `/reminders`. D remains the safe current operating mode until B prerequisites are complete.
+| Option | Security/reliability | Lock-in/duplicates | Value/current feasibility |
+|---|---|---|---|
+| A direct amoCRM adapter | weak until major hardening | high lock-in and uncertain duplicates | blocked |
+| B provider-neutral + amo adapter | strongest boundaries/observability | low lock-in, explicit idempotency | selected target; adapter blocked |
+| C amo task sync | medium | duplicate queue/high reconciliation | rejected |
+| D DentalFlow manual | safest current mode | no provider lock-in | required fallback, not target automation |
 
 ## Recommended architecture
 
-**B: provider-neutral communication orchestration with amoCRM as one adapter.**
-
-The adapter is blocked until the integration boundary and actual channel are evidenced.
+**B: provider-neutral communication orchestration with amoCRM as one adapter.** Do not implement the adapter yet.
 
 ## Exact next task
 
-**`AMOCRM-INTEGRATION-HARDENING-001`**
-
-Smallest safe slice:
-
-- authenticate/authorize integration routes;
-- bind OAuth state to tenant/actor/expected account;
-- persist one verified tenant/account configuration;
-- exact account/domain verification;
-- encrypted durable credential storage;
-- atomic refresh rotation and concurrent-refresh protection;
-- tenant-scoped revocation/health;
-- constrained external account/reference model;
-- safe health/error/audit;
-- block unsafe global memory behavior in production mode;
-- no contacts, leads, tasks, notes, messages, channel connection or reminder execution change.
-
-After hardening, external evidence must identify the actual channel/vendor, `scope_id`, sender/template rules, delivery callbacks and inbound semantics before any send adapter task.
+**`AMOCRM-INTEGRATION-HARDENING-001`**: authenticate/authorize routes; bind state to tenant/actor/account; persist verified tenant/account; exact account verification; encrypted durable credentials; atomic refresh/concurrency protection; tenant-scoped revoke/health; constrained external references; safe audit/errors; disable unsafe global production behavior. No CRM objects, chat connection, message or reminder execution change.
 
 ## Known blockers
 
-No configured account in the accessible store; no actual channel/vendor/scope/sender/templates; no tenant-aware backend; no refresh; no durable credential repository; no external-reference constraints; no message/delivery/reply storage; accessible cloud drift; no fresh browser/local execution.
+No configured account/channel/vendor/scope/sender/templates; no tenant-aware backend; no refresh/durable credentials/external-reference constraints; no message/delivery/reply storage; accessible cloud drift; no fresh browser/local execution.
 
 ## What was intentionally not implemented
 
-No production code, migration, OAuth change, refresh, provider abstraction, delivery, message, CRM object mutation, webhook, worker, cron, Edge Function, package/type/UI/fixture change, cloud apply, credential access, next task, or HEP-V2.
+No production code, migration, OAuth/refresh change, provider abstraction, message/delivery, CRM mutation, webhook, worker, cron, Edge Function, package/type/UI/fixture change, cloud apply, credential access, next task, or HEP-V2.
 
 ## Validation
 
-Required local commands are `npm run lint`, `npm run test -- --run`, and `npm run build`. Local execution was unavailable through Hermes. The root GitHub Actions workflow runs install, ESLint, tests, build and merge guard for PRs to main. Fresh CI on the exact final head is required and will be recorded in the final response.
+Required commands: `npm run lint`, `npm run test -- --run`, `npm run build`. Local execution was unavailable. GitHub Actions runs install, ESLint, tests, build and merge guard for PRs to main. Fresh CI on the exact final head is required and reported in the final response.
 
-Static validation passed: exact baseline/ancestry, duplicate search, one intended file, source inventory, no send/channel code, no frontend credential references, read-only Supabase inspection and official documentation review.
+Static validation: exact baseline, duplicate search, one intended file, source inventory, no send/channel implementation, no frontend credential reference, read-only Supabase inspection and official documentation review.
 
 ## Fresh CI
 
-Pending PR creation and final report commit. Exact run, tested SHA, ESLint, tests, build and merge-guard results will be reported in the final task response; placing them here would create a new untested head.
+Pending exact-final-head workflow completion. Exact run and tested SHA are reported in the final response; placing them here would create a new untested head.
 
 ## Final verdict
 

--- a/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
+++ b/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
@@ -2,13 +2,21 @@
 
 ## Final verdict
 
-**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository evidence identifies the next safe hardening slice but does not authorize message delivery**
+**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository and official API evidence identify the next safe hardening slice but do not authorize message delivery**
 
 ## Executive summary
 
-The current amoCRM implementation is a disconnected development skeleton. It has an authorization-code exchange, one process-global in-memory credential set, placeholder synchronization routes, and a webhook that ignores requests. It has no tenant binding, refresh implementation, external-object repository, chat channel, message operation, delivery status, or inbound reply processing.
+The current amoCRM implementation is a disconnected development skeleton, not a production integration and not a reminder communication boundary. It has an authorization-code exchange, one process-global in-memory credential set, placeholder synchronization routes, and a webhook that accepts and ignores requests. It has no tenant binding, role checks, durable credential repository, refresh implementation, external-object repository, CRM synchronization, chat channel, message operation, delivery-state processing, or inbound-reply correlation.
 
-The target architecture is **B: provider-neutral communication orchestration with amoCRM as one possible adapter**. The exact next task is **AMOCRM-INTEGRATION-HARDENING-001**. No real amoCRM write, message, task, contact, lead, note, credential refresh, or cloud change was performed.
+DentalFlow already has the correct authoritative foundations: tenant-scoped appointment reminder jobs, manual reminder operations, normalized communication contacts, channel-specific consent, suppression, representative handling, and provider-neutral eligibility. Those facts must remain authoritative.
+
+Official amoCRM documentation confirms that CRM contacts, leads, tasks, notes and webhooks exist, and that a separately registered Chats API channel can create chats, transfer messages, report delivery states and return message history. Those capabilities require a registered channel, signed requests, a per-account `scope_id`, channel webhooks, conversation identity and a real external transport. None is evidenced in this repository or the connected Supabase project.
+
+**Target architecture:** B, provider-neutral communication orchestration with amoCRM as one possible adapter.
+
+**Exact next task:** `AMOCRM-INTEGRATION-HARDENING-001`.
+
+No real amoCRM write, message, task, contact, lead, note, credential refresh, webhook registration, or cloud mutation was performed.
 
 ## Branch
 
@@ -16,29 +24,447 @@ The target architecture is **B: provider-neutral communication orchestration wit
 
 ## PR URL
 
-Pending initial PR creation.
+Pending initial PR creation. The URL will be inserted before final validation.
 
 ## Baseline
 
 - repository: `NckNA/codex-test`;
 - base branch: `main`;
-- exact baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
-- PR #356 is merged at that exact commit;
-- duplicate task PR search returned no result;
-- branch created from the exact baseline.
+- required and verified baseline: `db6f298bc30a886ee569245fcb5599a0735b24d2`;
+- PR `#356` is merged at that exact commit;
+- the baseline also contains the reminder queue and manual-operations foundations;
+- no duplicate open or merged PR was found for this task ID/title;
+- the branch was created directly from the exact baseline.
 
 ## Final head
 
-Recorded in the final task response because a report cannot contain its own future commit SHA.
+Recorded in the final task response because a report cannot contain its own future commit SHA without changing that SHA.
 
 ## Changed files
 
-Exactly one file: `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`.
+Exactly one file:
 
-## Validation status
+- `_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md`
 
-Repository and official-documentation reconnaissance is complete. Fresh local browser execution and local lint/test/build are unavailable through Hermes in this conversation. Fresh GitHub Actions CI on the exact final head is required and will be recorded in the final response.
+No production code, migration, package, generated type, fixture, UI, provider, worker, cron, Edge Function, or webhook implementation is changed.
+
+## Pre-read
+
+Required reports reconciled:
+
+- `APPOINTMENT-REMINDER-OPERATIONS-RECON-001`;
+- `APPOINTMENT-REMINDER-QUEUE-FOUNDATION-001`;
+- `APPOINTMENT-REMINDER-MANUAL-OPERATIONS-001`;
+- `APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001`.
+
+amoCRM history reconciled:
+
+- `AMO-001`, `AMO-002`, `AMO-003`, `AMO-004`;
+- `AUDIT-005_amocrm_oauth_boundary_audit_report`;
+- amoCRM architecture, mapping, security and sync-strategy documents.
+
+Repository inspection covered backend routes/services/config, frontend mappers/types/UI, patient storage, reminder contracts, initial schema, token table, source references, package scripts and CI.
+
+Official amoCRM documentation was checked on **2026-07-13**: OAuth, API limits, contacts, leads, tasks, notes/events, CRM webhooks, Chats capabilities, Chats methods and Chats webhook formats.
+
+## Existing amoCRM assets
+
+| Asset | Responsibility | Scope/auth | Operations | Error/retry/idempotency/audit/tests | Reachability/classification |
+|---|---|---|---|---|---|
+| `backend/src/server.js` | plain Node proxy | no authentication or tenant middleware | dispatches routes | none | separate manual server; risky skeleton |
+| `backend/src/routes/amoCrmRoutes.js` | status/connect/callback/disconnect, webhook and sync placeholders | global, no user/role/tenant | token exchange and global disconnect; sync returns 501; webhook ignores | redacted simple errors; no retry/idempotency/audit | not called by frontend; risky/partial |
+| `amoCrmClient.js` | OAuth URL and code exchange | global config | only token exchange; sync functions throw | no refresh/retry | partial; must be replaced/hardened |
+| `amoCrmTokenStore.js` | credential storage | one process-global object | save/read/clear | no lock, version, persistence or audit | dev-only; unsafe for SaaS |
+| `amoCrmStateStore.js` | one-time state | global Map, not bound to tenant/user/account | create/consume, ten-minute TTL | cryptographically random; no ownership binding | reusable concept only |
+| `backend/src/config.js` | loads amoCRM settings | one global account/config | config only | no tenant/account selection | partial/risky |
+| backend README/env/package | documents and starts skeleton | global | manual start/check | backend checks are outside root CI | accurate docs, partial tooling |
+| `amoCrmMapper.ts` | contact/lead preview mapping | caller-supplied patient | pure mapping, no network | no consumer/operation key/tests proving integration | dead prototype |
+| `amoCrmTypes.ts` | draft DTO types | none | none | none | placeholder |
+| `ExternalCrmLink` | optional contact/lead/deal IDs | indirectly scoped by patient row | model only | no account composite or uniqueness | partial/risky |
+| `PatientRepository.ts` | stores opaque `patient.integration` JSON | tenant-filtered patient row | read/write JSON | no external-reference constraints | active storage, unsuitable mapping authority |
+| patient-card CRM panel | displays source/status/IDs | current patient | read-only | exposes raw external IDs to authorized UI | active display, not integration |
+| disabled treatment-plan button | future UI hint | none | none | none | placeholder |
+| `patients.integration` JSONB | legacy metadata | patient tenant | opaque metadata | no history/uniqueness/account validation | risky legacy model |
+| `integration_tokens` table | intended tenant credential storage | unique tenant/provider | unused by backend | encryption is naming/design intent only; no refresh lock/account ID | reusable but insufficient |
+| historical docs/reports | design intent | mixed | none | not runtime evidence | informative only |
+
+No production amoCRM repository, sync service, tenant settings page, external-reference repository, chat client, task/note client, message client, delivery-attempt store, polling job, signed webhook verifier, or recovery lookup exists.
+
+## Current data-flow map
+
+### DentalFlow to amoCRM
+
+| Flow | Trigger/payload | Authority | Idempotency/failure/replay | Isolation/exposure | Status |
+|---|---|---|---|---|---|
+| patient create/update | no trigger; unused draft is name + legacy phone | DentalFlow patient | none | no adapter tenant boundary; legacy phone lacks consent authority | absent |
+| appointment create/update/cancel | no mapper or route | DentalFlow appointment | n/a | no data leaves | absent |
+| contact create/update | no API request | DentalFlow | none | none | absent |
+| lead create/update | unused draft includes patient name, plan title, total price, status/source | DentalFlow | none | includes financial total and must not be used for reminders | absent/unsafe draft |
+| task/note creation | none | DentalFlow reminder/audit | none | none | absent |
+| message send | none | DentalFlow reminder/consent | none | none | absent |
+
+### amoCRM to DentalFlow
+
+| Flow | Trigger/payload | Authority/idempotency | Isolation | Status |
+|---|---|---|---|---|
+| contact or lead update | none | no contract | none | absent |
+| tasks or notes | none | no contract | none | absent |
+| incoming message | placeholder webhook discards body | no persistence/deduplication | none | absent |
+| CRM webhook | accepts 202, ignores all | duplicates and failures invisible | none | placeholder |
+| delivery status | none | no message ID/state | none | absent |
+| external IDs | optional replaceable patient JSON only | no mapping history | patient row only | not populated by integration |
+
+Contacts, leads, tasks, notes and conversations are **not synchronized**.
+
+## External ID model
+
+Current identifiers:
+
+| ID | Location | Tenant/account safety | Finding |
+|---|---|---|---|
+| account/domain | global memory token object | no tenant binding | lost on restart/overwritable |
+| integration/client ID | global environment | no tenant binding | one global config |
+| contact/lead/deal IDs | optional patient JSON | tenant only indirectly; no account composite | duplicate/stale mappings possible |
+| task/note/message/conversation/webhook IDs | absent | none | absent |
+| channel ID/`scope_id` | absent | none | no chat connection |
+
+One patient can be remapped silently; several patients can share the same external ID; cross-account uniqueness is not enforced; appointments have no external reference.
+
+Minimum required model before communications:
+
+1. `integration_accounts`: tenant, provider, verified account ID/domain, connection state, credential version, revocation/health timestamps, unique tenant/provider.
+2. `integration_external_refs`: tenant + integration account + local entity/type + external type/ID, mapping version/history, composite uniqueness in both directions.
+3. Later, only after channel evidence, `integration_channel_connections`: account, channel ID, `scope_id`, vendor/channel type, capability flags, hook version, connection state and server-side secret reference.
+
+`patients.integration` must become display/compatibility metadata, not mapping authority.
+
+## OAuth and secret boundary
+
+Current flow:
+
+1. any reachable caller starts connect;
+2. server creates a random one-time state;
+3. callback validates state;
+4. server exchanges code using server-side application credentials;
+5. one global in-memory credential set is saved;
+6. status returns only domain/expiry metadata;
+7. any reachable caller can clear it.
+
+Findings:
+
+- authorization-code exchange: partial and server-side;
+- token refresh: absent;
+- durable storage: absent in running backend;
+- database token table: exists but unused;
+- encryption implementation: absent;
+- expiry enforcement: absent;
+- tenant/account binding: absent;
+- concurrent refresh protection: absent;
+- route authentication and roles: absent;
+- state binding to actor/tenant/account: absent;
+- exact callback account verification: absent;
+- frontend credential exposure: not found;
+- error redaction: raw token response is not returned;
+- revocation behavior: absent.
+
+Credentials are not production-safe today. Official amoCRM refresh credentials rotate on use, so future refresh must use a row lock or compare-and-swap and must reject stale concurrent results.
+
+Required hardening:
+
+- authenticate every route;
+- owner/admin configuration only;
+- bind state to tenant, actor and expected account;
+- verify exact account ID/domain;
+- encrypt durable server-side credentials per tenant/account;
+- transactionally rotate refresh credentials with generation/version control;
+- handle expiry/revocation/disconnect;
+- never expose provider credentials to frontend or logs;
+- audit connect/refresh/revoke/mismatch with safe metadata.
+
+## Current tenant isolation
+
+Reminder and consent foundations are tenant-scoped. amoCRM is not.
+
+Gaps: no tenant/user/role in routes, state or token store; no one-tenant-to-one-account rule; no account ID; no domain verification against a tenant; no per-tenant throttling; no webhook account verification; no audit; global disconnect affects the last connected account.
+
+Required rule: one DentalFlow tenant maps to exactly one verified amoCRM account unless explicitly redesigned; no global default/fallback; every credential and external ID is composite with tenant/account; account or webhook mismatch fails closed.
+
+**Result: failed for production, tolerable only because the skeleton is disconnected and performs no sync.**
+
+## Current role model
+
+Current routes have no roles. Required matrix:
+
+| Role | Configure/authorize | View health | Reminder operations | Credential access |
+|---|---:|---:|---:|---:|
+| owner | yes | yes | policy | no raw credential |
+| admin | tenant policy | yes | yes | no raw credential |
+| registrar | no | safe operational state only | yes | no |
+| doctor | no | no | no provider action | no |
+| cashier | no | no | no provider action | no |
+| unknown/no tenant | blocked | blocked | blocked | blocked |
+
+## Actual connected communication channels
+
+No evidence establishes native chats, WhatsApp, SMS, email, external connector, channel ID, channel secret reference, `scope_id`, chat hook, sender/bot identity, templates, sandbox, message ID or conversation ID.
+
+Read-only inspection of the connected Supabase project found `integration_tokens` with zero rows and no reminder/communication/channel tables. Its applied migrations stop at `0013`, behind repository baseline `0031`. This proves drift in the accessible project, not a production channel.
+
+| Model | Result |
+|---|---|
+| amoCRM native/custom chats | official capability only; no installed channel |
+| WhatsApp widget/vendor | no evidence |
+| SMS widget/vendor | no evidence |
+| email integration | no DentalFlow evidence |
+| staff manual writing in amoCRM | operationally possible but unverified |
+| task/note-only use | no implementation |
+
+## Official amoCRM capability check
+
+Checked 2026-07-13 using official documentation only.
+
+| Capability | Official result | Limitation/current compatibility | Confidence |
+|---|---|---|---|
+| OAuth code exchange | supported at exact account domain | current skeleton lacks tenant/account binding | high |
+| refresh | supported; refresh value is single-use and replacement must be stored | absent; concurrency unsafe if naively added | high |
+| contacts/leads/tasks/notes | read/write APIs exist | no repository client; not reminder authority | high |
+| CRM webhooks | supported; account limit documented | placeholder ignores and does not verify | high |
+| chat channel connect | signed API returns account-specific `scope_id` | channel registration/secret/install absent | high |
+| chat creation | integration-owned conversation ID supported | no mapping model | high |
+| message transfer | supported for registered custom channels | acceptance is not delivery; external transport required | high |
+| delivery status | sent/delivered/read/error model supported | no channel/message/status consumer | high |
+| message history | supported per conversation | needs signed request, scope and conversation | high |
+| inbound/outbound chat hooks | supported for connected channel | verifier/correlation absent | high |
+| WhatsApp templates/time windows | channel-specific capabilities | vendor/config unknown | medium/high |
+| native generic idempotency | no general reminder-send key documented | DentalFlow must enforce | medium/high |
+
+## API and rate-limit constraints
+
+Official CRM API guidance currently states up to 7 requests/second per integration and 50 requests/second per account, with HTTP 429 on limit breach and possible 403 blocking after repeated violations.
+
+Future requirements: backend-only bounded worker, per-tenant/account throttling, safe backoff, separated refresh traffic, dead-letter/manual review, bounded scans, no blind resend, and batching only where documented. Reminder volume is not measured in the repository.
+
+## Current message-send capability
+
+**Absent.** No command, endpoint, channel, transport, template, sender identity, operation store or external message ID exists. An official Chats API does not make an installed third-party WhatsApp/SMS widget callable by DentalFlow.
+
+## Current delivery-status capability
+
+**Absent.** There is no message ID, delivery attempt, status webhook, polling lookup or normalizer. Manual `message_sent` is a staff-entered fact, not delivery proof.
+
+## Current inbound-reply capability
+
+**Absent.** The webhook ignores bodies and has no signature/account/channel validation, conversation identity or correlation.
+
+Initial future rule: verified inbound reply creates a manual review item; staff interprets it and uses the existing confirmation/reschedule workflow. Arbitrary text must not automatically confirm an appointment.
+
+## Communication command model
+
+```text
+CommunicationCommand
+- tenant_id
+- reminder_job_id
+- appointment_id
+- patient_id
+- communication_contact_id
+- channel
+- purpose_code
+- language
+- consent_snapshot
+- suppression_snapshot
+- appointment_version
+- reminder_job_version
+- operation_key
+- payload_fingerprint
+- safe_variable_map
+- requested_at
+```
+
+Purpose codes: `appointment_confirmation_request`, `appointment_day_before_reminder`, `appointment_same_day_reminder`, `control_call_task`.
+
+No free-form clinical payload. Final eligibility, appointment version/state and consent/suppression must be rechecked immediately before any external side effect.
+
+## Proposed amoCRM adapter contract
+
+Input: immutable communication command.
+
+Responsibilities: resolve exact tenant account, reject mismatch, resolve contact/channel/conversation, preserve operation key/fingerprint, perform only approved external action, store external ID, normalize outcome, redact errors and expose recovery lookup.
+
+Output: `accepted | rejected | uncertain | manual_action_required`, optional external ID, safe error code, retryability and timestamp.
+
+The adapter must not confirm appointments, complete reminder jobs merely on acceptance, create clinical/financial facts, choose another tenant/account, or bypass consent.
+
+## Task-only fallback
+
+`DentalFlow reminder job → amoCRM task → staff contact → manual result in DentalFlow` was evaluated and rejected now. It duplicates `/reminders`, creates two queues, adds mapping/completion reconciliation, weakens audit consistency and increases duplicate-contact risk without proving a communication channel.
+
+## Inbound reply handling
+
+Future handling must verify signature/account/channel, deduplicate provider event/message ID, resolve tenant/contact/conversation, flag shared/representative contacts, create manual review, and require staff to record the interpreted result through existing operations. `да`, `нет`, `перенесите` and free text are not automatically authoritative.
+
+## Idempotency
+
+Identities are required for contact sync, task/note/message creation, webhook consumption and reply interpretation.
+
+Rules:
+
+- same operation key + same fingerprint = replay;
+- same key + different fingerprint = reject;
+- reserve local operation before external side effect;
+- store external ID transactionally;
+- timeout after possible acceptance = uncertain;
+- perform recovery lookup before retry;
+- never blindly duplicate a message;
+- duplicate webhook returns success without duplicate effects.
+
+Integration-owned conversation/message IDs can aid correlation but are not assumed to be a complete provider idempotency guarantee.
+
+## Uncertain outcomes
+
+Required states include prepared, dispatching, accepted, rejected, uncertain, delivered, read, manual-review-required and cancelled-before-dispatch.
+
+Accepted is not delivered; delivered is not replied; replied is not confirmed. If external acceptance cannot be disproved after timeout, do not resend automatically. Recover by external ID/history or route to manual review.
+
+## Reschedule/cancellation behavior
+
+Commands bind to appointment and reminder-job versions. Reschedule supersedes stale work. Cancellation, no-show, arrival, visit start/completion and consent withdrawal block new dispatch. In-flight uncertain work is not retried blindly. Already accepted external messages remain historical and do not mutate appointment truth.
+
+## Consent and suppression behavior
+
+DentalFlow remains authoritative for channel consent, evidence, global/channel suppression, patient/representative ownership, preferred language/channel and eligibility. amoCRM metadata cannot grant consent or clear suppression. Snapshot at preparation and recheck at dispatch.
+
+## Security/privacy payload allowlist
+
+Allowed: patient first name, clinic name, appointment date/time, doctor display name, callback phone and purpose code.
+
+Forbidden: diagnosis, complaints, findings, tooth chart, treatment details/title, price/total, balance/debt/payment, clinical notes, medical documents and arbitrary patient notes.
+
+The current lead draft includes treatment title and total price and must not be reused for reminders.
+
+## Error model
+
+Safe codes: `amo_not_configured`, `amo_authorization_required`, `amo_token_expired`, `amo_account_mismatch`, `amo_rate_limited`, `amo_contact_mapping_missing`, `amo_channel_unavailable`, `amo_message_not_supported`, `amo_operation_uncertain`, `amo_external_rejected`, `amo_webhook_untrusted`, `amo_tenant_mismatch`.
+
+No credential value, raw provider body, stack trace or account secret may reach users/logs.
+
+## Failure matrix
+
+| Scenario | Detection/state | Retry/manual response | Risk |
+|---|---|---|---|
+| not configured | rejected safe code | owner/admin config | low |
+| expired/revoked authorization | expiry/401/revoke state | atomic refresh or reconnect | low/medium |
+| concurrent refresh | credential generation conflict | one winner; stale result rejected | high outage/corruption |
+| missing/duplicate contact | no or multiple mapping | manual mapping, no auto-send | high wrong recipient |
+| channel/send unavailable | capability absent | use DentalFlow manual queue | low |
+| rate limit | 429 | bounded backoff | delay |
+| timeout before acceptance | known no acceptance | bounded retry | medium |
+| timeout after possible acceptance | uncertain | recovery before retry/manual | high duplicate |
+| duplicate/delayed webhook | ID/fingerprint/time | replay/no send effect | low/medium |
+| wrong-account webhook | account/scope mismatch | reject/security audit | critical cross-tenant |
+| reschedule/cancel during send | version/status mismatch | no stale retry; review uncertain | medium |
+| consent withdrawn during send | final eligibility/in-flight state | block new; privacy review | high |
+| shared family/representative number | ambiguous owner | manual review | high wrong recipient |
+| manual and external race | operation correlation conflict | prevent duplicate/manual review | high annoyance |
+| DentalFlow down after acceptance | reserved operation, no response | recovery lookup | high duplicate |
+| amoCRM down after local persist | prepared/retryable | bounded retry/manual | delay |
+
+## Observability
+
+Metrics: commands prepared; accepted/rejected/uncertain/recovered; duplicates prevented; rate limits; refresh success/failure/conflict; account mismatch; missing mappings; inbound replies; manual-review backlog; tenant failure rate; untrusted hooks.
+
+Logs: correlation ID, tenant ID, operation type, external object type, redacted external ID, safe error code, duration and credential generation. Do not log patient contact values or message bodies in general logs.
+
+## Browser/network findings
+
+Fresh Chrome DevTools/HeadlessChrome validation could not run because Hermes local developer execution is blocked in this conversation.
+
+Static and prior-audit evidence:
+
+- frontend makes no amoCRM backend/direct API calls;
+- mapper has no consumer;
+- sync button is disabled;
+- no frontend credential references were found;
+- backend responses omit credential values;
+- no message/provider request code exists.
+
+Required proof status:
+
+- external amoCRM mutation calls: 0 by source capability; fresh capture unavailable;
+- message sends: 0;
+- credential values visible: 0 in source/contracts; fresh capture unavailable;
+- service-role value visible: 0 in this boundary; fresh capture unavailable.
+
+## Local experiment findings
+
+Performed read-only: GitHub baseline/source/PR inspection, official documentation review, and connected Supabase schema/migration queries.
+
+Supabase findings: token table exists, row count 0, amoCRM row count 0, no reminder/communication/channel tables, latest applied migration `0013` versus repository `0031`.
+
+Unavailable: local worktree, local database reset, local app/network, mock OAuth runtime, fresh browser and local quality commands. No external write or cloud modification occurred.
+
+## Architecture options comparison
+
+Scores 1 poor, 5 strong. Complexity/maintenance score 5 means easier/lower burden.
+
+| Criterion | A direct adapter | B neutral layer + adapter | C task sync | D manual DentalFlow |
+|---|---:|---:|---:|---:|
+| complexity | 2 | 1 initially/4 later | 3 | 5 |
+| security | 2 | 5 | 3 | 5 |
+| reliability | 2 | 5 | 3 | 5 manual |
+| low lock-in | 1 | 5 | 2 | 5 |
+| low duplicate risk | 2 | 5 | 1 | 4 |
+| observability | 2 | 5 | 2 | 4 |
+| tenant fit | 1 current | 5 after hardening | 3 | 5 |
+| operational value | 3 if channel exists | 5 | 2 | 4 current |
+| future providers | 1 | 5 | 1 | 2 |
+| maintenance | 2 | 4 after foundation | 2 | 5 |
+
+A is rejected now. B is the target. C is rejected because it duplicates `/reminders`. D remains the safe current operating mode until B prerequisites are complete.
+
+## Recommended architecture
+
+**B: provider-neutral communication orchestration with amoCRM as one adapter.**
+
+The adapter is blocked until the integration boundary and actual channel are evidenced.
+
+## Exact next task
+
+**`AMOCRM-INTEGRATION-HARDENING-001`**
+
+Smallest safe slice:
+
+- authenticate/authorize integration routes;
+- bind OAuth state to tenant/actor/expected account;
+- persist one verified tenant/account configuration;
+- exact account/domain verification;
+- encrypted durable credential storage;
+- atomic refresh rotation and concurrent-refresh protection;
+- tenant-scoped revocation/health;
+- constrained external account/reference model;
+- safe health/error/audit;
+- block unsafe global memory behavior in production mode;
+- no contacts, leads, tasks, notes, messages, channel connection or reminder execution change.
+
+After hardening, external evidence must identify the actual channel/vendor, `scope_id`, sender/template rules, delivery callbacks and inbound semantics before any send adapter task.
+
+## Known blockers
+
+No configured account in the accessible store; no actual channel/vendor/scope/sender/templates; no tenant-aware backend; no refresh; no durable credential repository; no external-reference constraints; no message/delivery/reply storage; accessible cloud drift; no fresh browser/local execution.
+
+## What was intentionally not implemented
+
+No production code, migration, OAuth change, refresh, provider abstraction, delivery, message, CRM object mutation, webhook, worker, cron, Edge Function, package/type/UI/fixture change, cloud apply, credential access, next task, or HEP-V2.
+
+## Validation
+
+Required local commands are `npm run lint`, `npm run test -- --run`, and `npm run build`. Local execution was unavailable through Hermes. The root GitHub Actions workflow runs install, ESLint, tests, build and merge guard for PRs to main. Fresh CI on the exact final head is required and will be recorded in the final response.
+
+Static validation passed: exact baseline/ancestry, duplicate search, one intended file, source inventory, no send/channel code, no frontend credential references, read-only Supabase inspection and official documentation review.
+
+## Fresh CI
+
+Pending PR creation and final report commit. Exact run, tested SHA, ESLint, tests, build and merge-guard results will be reported in the final task response; placing them here would create a new untested head.
 
 ## Final verdict
 
-**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository evidence identifies AMOCRM-INTEGRATION-HARDENING-001 but does not authorize message delivery**
+**PARTIAL: tenant-specific installed amoCRM channel evidence and fresh browser/local-runtime validation are unavailable; repository and official API evidence identify `AMOCRM-INTEGRATION-HARDENING-001` but do not authorize message delivery**

--- a/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
+++ b/_ai_work/REPORTS/AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001_recon.md
@@ -46,9 +46,9 @@ https://github.com/NckNA/codex-test/pull/357
 
 ## Final head
 
-- reviewed report head before this update: `d64ff6295dcb0bba2ec39a16063911291c25d32c`;
+- reviewed report head before this update: `2eff9c5361bdc6cc435ec43e0e55fc0e95170c30`;
 - workflow: `CI`;
-- run ID: `29250107482`;
+- run ID: `29250618691`;
 - conclusion: `success`;
 - final report-update head and fresh CI are recorded by the immutable finalization receipt because a commit cannot contain its own future SHA.
 
@@ -744,8 +744,8 @@ A real amoCRM adapter remains blocked by:
 Reviewed pre-update CI:
 
 - workflow: `CI`;
-- run ID: `29250107482`;
-- tested SHA: `d64ff6295dcb0bba2ec39a16063911291c25d32c`;
+- run ID: `29250618691`;
+- tested SHA: `2eff9c5361bdc6cc435ec43e0e55fc0e95170c30`;
 - validate: `success`;
 - merge guard: `success`.
 


### PR DESCRIPTION
## Summary

Report-only reconciliation of the existing amoCRM skeleton against the current reminder queue, contact/consent model, local runtime evidence and official amoCRM OAuth/CRM/Chats capabilities. The repository has no operational CRM sync or communication channel. The selected architecture is provider-neutral communication orchestration, with amoCRM eligible only as a later adapter after tenant/account OAuth hardening and concrete channel evidence. Exact next task: COMMUNICATION-ORCHESTRATION-FOUNDATION-001. Final head b69d33c85e0a81a63933db35bbe64fae736ff36d; CI #732 succeeded on that exact SHA. PR remains unmerged.

## Checks

- Exactly one report file changed
- ESLint passed
- 96 test files / 1070 tests passed
- Production build passed
- Backend syntax check passed
- Local schema assertions 45/45 passed
- Chrome DevTools MCP: 0 external amoCRM mutations, 0 message sends, 0 visible secrets
- Merge guard passed
- Final CI #732 passed on exact head

## Limitations

- No production amoCRM account or installed-channel credentials were inspected
- No real OAuth exchange, refresh, CRM mutation or message send was performed
- A real amoCRM adapter remains blocked by tenant-safe OAuth/account storage and concrete channel/vendor evidence
