### PR TITLE
COMMUNICATION-TEMPLATE-FOUNDATION-001: add versioned communication templates

### DIFF
--- a/_ai_work/REPORTS/COMMUNICATION-TEMPLATE-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/COMMUNICATION-TEMPLATE-FOUNDATION-001_foundation.md
@@ -1,0 +1,626 @@
+# COMMUNICATION-TEMPLATE-FOUNDATION-001
+
+## 1. Final verdict
+
+**COMMUNICATION TEMPLATE FOUNDATION IMPLEMENTED AND VERIFIED**
+
+Tenant-scoped versioned templates, deterministic plain-text rendering, immutable publishing, exact operation snapshots, RLS, controlled RPC mutations, audit/activity, repository/hook/UI integration and all required local validation are complete. No provider was called and no message was sent.
+
+## 2. Summary
+
+This task adds a tenant-owned template foundation for the existing noop/mock communication orchestration. Templates are keyed by tenant, appointment-reminder purpose, channel and explicit language. Content is versioned through draft, published, superseded and archived states. Published content is immutable.
+
+Operation preparation now resolves one exact active template only after eligibility, consent, suppression, contact and route checks. It renders an allowlisted variable map and stores the exact template version, content fingerprint, rendered fingerprint and rendered plain text in the communication operation. Later template publishing does not alter historical operations.
+
+## 3. Branch
+
+`feature/communication-template-foundation-001`
+
+## 4. PR URL
+
+The PR URL is added to the task final response after the branch is pushed and the pull request is opened. The PR must remain open and unmerged.
+
+## 5. Baseline
+
+- repository: `NckNA/codex-test`;
+- base branch: `main`;
+- exact baseline: `38e221ed2e7ce2b2599f7f948ce1bd2431af5ab8`;
+- baseline is merge commit for PR #358;
+- `origin/main` was fetched and confirmed at the exact baseline;
+- no open or merged duplicate task PR was found;
+- isolated worktree was created from the exact baseline;
+- starting worktree was clean.
+
+## 6. Final head
+
+The exact final head is recorded in the final task response and PR metadata. A commit cannot contain its own future SHA.
+
+## 7. Changed files
+
+Expected final scope:
+
+- `_ai_work/REPORTS/COMMUNICATION-TEMPLATE-FOUNDATION-001_foundation.md`;
+- `supabase/migrations/0033_communication_template_foundation.sql`;
+- `supabase/tests/0033_communication_template_foundation_test.sql`;
+- `supabase/tests/0033_communication_template_concurrency.ps1`;
+- `supabase/tests/0032_communication_orchestration_foundation_test.sql`;
+- `supabase/tests/0032_communication_orchestration_concurrency.ps1`;
+- `src/domain/communications/CommunicationTemplate.ts` and test;
+- `src/domain/communications/CommunicationTemplateRenderer.ts` and test;
+- `src/domain/communications/CommunicationCommand.ts` and test;
+- `src/data/repositories/CommunicationTemplateRepository.ts` and test;
+- `src/data/repositories/CommunicationOrchestrationRepository.ts`;
+- `src/data/hooks/useCommunicationTemplates.ts` and test;
+- `src/components/communications/CommunicationTemplateManager.tsx` and test;
+- `src/components/communications/CommunicationOperationsPanel.tsx`;
+- `src/pages/CommunicationTemplatesPage.tsx`;
+- `src/App.tsx`;
+- `src/components/layout/Sidebar.tsx`.
+
+No historical migration, dependency, lockfile, generated type, workflow, provider SDK, cloud configuration or environment file is changed.
+
+## 8. Pre-read
+
+Reviewed:
+
+- `APPOINTMENT-REMINDER-CONTACT-CONSENT-FOUNDATION-001` report and migration 0031;
+- `AMOCRM-REMINDER-COMMUNICATION-INTEGRATION-RECON-001` report;
+- `COMMUNICATION-ORCHESTRATION-FOUNDATION-001` report, migration 0032, SQL and concurrency suites;
+- communication routes and operations;
+- `prepare_communication_operation`;
+- structured communication command;
+- noop/mock adapter contract;
+- patient contacts, preferences, consent and suppression;
+- appointment reminder jobs and tenant timezone logic;
+- audit/activity helpers;
+- role/RLS model;
+- current SMS, mailing, reminder and confirmation pages;
+- tenant display name and communication language sources.
+
+## 9. Existing message/template inventory
+
+| Path / area | Classification | Finding |
+|---|---|---|
+| `src/pages/SmsPage.tsx` | placeholder | UI placeholder; no durable template model and no provider send path. |
+| `src/pages/MailingPage.tsx` | placeholder/unrelated | Mailing placeholder; marketing remains outside this task. |
+| `src/pages/ReminderOperationsPage.tsx` | reusable operations UI | Displays durable reminder tasks and statuses, not message bodies. |
+| `src/components/schedule/AppointmentConfirmationPanel.tsx` | manual workflow | Manual appointment confirmation controls; not a provider template. |
+| `src/pages/CommunicationDiagnosticsPage.tsx` | reusable | Existing noop/mock orchestration diagnostics reused for exact rendered snapshots. |
+| `src/components/communications/CommunicationOperationsPanel.tsx` | reusable | Existing route/preparation/simulation UI extended with template version and rendered content. |
+| `src/components/patients/patient-card/PatientCommunicationSection.tsx` | reusable authoritative profile | Provides language, contacts, consent and suppression facts; not content. |
+| `public.tenants.name` | authoritative reusable variable | Used for `clinic_name`. |
+| appointment/doctor/patient records | authoritative reusable variables | Used only for the six allowlisted values. |
+| callback phone | missing authoritative source | Variable remains allowed, but rendering fails safely when a selected template requires it. No value is invented. |
+| hardcoded UI notifications | unrelated | User-interface labels and safe errors are not provider message templates. |
+
+No reachable real SMS, WhatsApp, email or amoCRM delivery implementation was found or added.
+
+## 10. Purpose model
+
+Supported purposes remain exactly:
+
+- `appointment_confirmation_request`;
+- `appointment_day_before_reminder`;
+- `appointment_same_day_reminder`;
+- `appointment_control_call_task`.
+
+Both historical reminder code `control_call_task` and the actual queue code `callback_task` map to the one stable purpose `appointment_control_call_task`. No marketing, recall, billing, debt, clinical result, treatment offer or document purpose was added.
+
+## 11. Channel model
+
+Supported channels:
+
+- `sms`;
+- `whatsapp`;
+- `email`.
+
+All are plain text in this foundation. Email supports a plain-text subject and body. SMS/WhatsApp subjects are rejected. There is no channel fallback, provider routing or delivery state.
+
+## 12. Language model
+
+Supported explicit languages:
+
+- `ru`;
+- `kk`;
+- `en`.
+
+Language derives from the selected authoritative contact/profile. No automatic translation or mixed-language generation exists. Selection is exact tenant + purpose + channel + language. No silent default-language fallback was enabled.
+
+## 13. Template schema
+
+`public.communication_templates` is the stable identity and contains:
+
+- tenant;
+- exact purpose/channel/language;
+- display name;
+- active/inactive/archived status;
+- active version reference;
+- actor timestamps;
+- empty validated metadata.
+
+A partial unique index permits at most one non-archived stable identity per tenant/purpose/channel/language.
+
+## 14. Version schema
+
+`public.communication_template_versions` contains:
+
+- tenant/template composite ownership;
+- monotonically increasing version number;
+- draft/published/superseded/archived status;
+- optional email subject;
+- required plain-text body;
+- deterministic ordered variable keys;
+- SHA-256 content fingerprint;
+- created/updated/published/archive actors and times;
+- superseded version reference;
+- empty validated metadata.
+
+Unique indexes enforce one draft and one published version per template.
+
+## 15. Placeholder syntax
+
+Minimal syntax:
+
+`{{patient_first_name}}`
+
+The parser accepts exact lowercase ASCII identifiers only. It rejects:
+
+- malformed or unbalanced braces;
+- spaces inside placeholders;
+- nesting;
+- property access;
+- filters;
+- functions;
+- loops;
+- conditionals;
+- expressions;
+- remote includes;
+- arbitrary code.
+
+Variable keys are returned in deterministic alphabetical order.
+
+## 16. Variable allowlist
+
+Allowed only:
+
+- `patient_first_name`;
+- `clinic_name`;
+- `appointment_date`;
+- `appointment_time`;
+- `doctor_display_name`;
+- `clinic_callback_phone`.
+
+Explicitly rejected examples include diagnosis, complaint, finding, tooth, treatment, treatment plan, procedure, balance, debt, invoice, payment, discount, document, medical result, raw phone and raw email. Unknown variables also fail.
+
+## 17. Content safety
+
+Validation rejects:
+
+- empty body;
+- control characters and null bytes;
+- HTML-like markup;
+- malformed braces;
+- unknown, clinical and financial placeholders;
+- missing email subject;
+- SMS/WhatsApp subject;
+- excessive body/subject length;
+- non-object render variables;
+- extra render variables;
+- missing or blank required variables;
+- unsafe variable values.
+
+Unicode is preserved. No HTML execution, JavaScript evaluation or database expression interpolation exists.
+
+## 18. Length policy
+
+Foundation safety limits:
+
+- SMS body: 1000 characters;
+- WhatsApp body: 4000 characters;
+- email subject: 200 characters;
+- email body: 10000 characters;
+- individual rendered variable value: 500 characters.
+
+Rendered SMS over 160 characters receives `sms_practical_single_message_length`. No segmentation or provider-limit claim is implemented.
+
+## 19. Draft lifecycle
+
+Creating a stable template creates version 1 as a draft. A published template can receive one new draft copied from the current active version. Draft updates use expected `updated_at` optimistic concurrency and recompute ordered variables and content fingerprint.
+
+## 20. Publishing lifecycle
+
+Publishing is transactional:
+
+1. manager role verified;
+2. template-level advisory lock acquired;
+3. template and draft locked;
+4. idempotency checked;
+5. exact draft version and expected timestamp checked;
+6. content revalidated;
+7. previous published version marked superseded;
+8. draft marked published;
+9. stable template points to the new active version;
+10. audit/activity written once;
+11. result stored for replay.
+
+## 21. Immutability
+
+Published, superseded and archived version content cannot be changed. The write guard blocks subject, body, variable keys, fingerprint, version number, template ID or tenant changes. Direct authenticated mutations are revoked. Editing requires a new draft/version.
+
+## 22. Rendering contract
+
+Input:
+
+- exact version content;
+- exact channel;
+- exact variable map.
+
+Output:
+
+- optional email subject;
+- rendered plain-text body;
+- character count;
+- rendered SHA-256 fingerprint;
+- variable keys used;
+- warnings.
+
+Rendering is deterministic and requires exact variables: every required key must be present and no extra key is accepted.
+
+## 23. Fingerprints
+
+Template content fingerprint covers channel, normalized subject, body and ordered variable keys. Rendered fingerprint covers channel, rendered subject, rendered body and variable keys. Operation payload fingerprint additionally covers template/version identities and rendered fingerprint, preventing replay with changed content.
+
+## 24. Active-template resolution
+
+`get_active_communication_template` resolves only one active, non-archived stable template with its exact published active version. Database uniqueness and transactional publishing prevent ambiguity.
+
+## 25. Fallback policy
+
+Implemented policy:
+
+1. exact tenant;
+2. exact purpose;
+3. exact channel;
+4. exact explicit language;
+5. otherwise blocked.
+
+No tenant-default-language fallback and no cross-channel fallback are silently applied.
+
+## 26. Orchestration integration
+
+`prepare_communication_operation` now performs:
+
+1. manager authentication;
+2. reminder/appointment/version validation;
+3. purpose derivation;
+4. eligibility recomputation;
+5. verified patient-owned contact selection;
+6. granted consent and suppression checks;
+7. noop/mock simulation route selection;
+8. explicit language resolution;
+9. exact active template/version resolution;
+10. safe variable-map construction;
+11. deterministic rendering;
+12. exact template/render snapshots;
+13. operation persistence and paired audit/activity.
+
+No adapter executes during preparation.
+
+## 27. Operation template snapshot
+
+New operation fields:
+
+- `template_id`;
+- `template_version_id`;
+- `template_version_number`;
+- `template_content_fingerprint`;
+- `rendered_content_fingerprint`;
+- `rendered_subject`;
+- `rendered_body`;
+- `rendered_character_count`;
+- `template_snapshot`.
+
+The structured command also contains safe template identity/fingerprints and rendered plain text. Raw contact destination remains absent.
+
+Legacy operations created before migration 0033 may retain all-null template fields. Every new preparation requires a complete snapshot.
+
+## 28. Stale-version handling
+
+Template and version rows are locked during preparation. Publishing uses the same template lock. Preparation versus publishing therefore snapshots one coherent version, never a mixed template ID/body/fingerprint. A newer published version does not mutate or cancel existing prepared operations.
+
+## 29. Role matrix
+
+| Role | Read | Preview | Create/edit/publish/archive |
+|---|---:|---:|---:|
+| clinic owner | yes | yes | yes |
+| clinic admin | yes | yes | yes |
+| registrar | yes | yes | no |
+| doctor | no | no | no |
+| cashier | no | no | no |
+| unknown/no tenant | no | no | no |
+| anonymous | no | no | no |
+
+## 30. RLS
+
+RLS is enabled on templates, versions and template-operation idempotency storage. Owner/admin/registrar have tenant-scoped SELECT through policies/RPCs. Anonymous access is revoked. Authenticated INSERT/UPDATE/DELETE is revoked. All mutations use controlled SECURITY DEFINER RPCs with explicit NULL-safe membership checks.
+
+A real defect was found and fixed: `NULL NOT IN (...)` in a SECURITY DEFINER role check could fail to reject a no-membership user. All template read RPCs and the manager helper now use `v_role IS NULL OR ...`.
+
+## 31. Audit/activity
+
+Paired events:
+
+- `communication_template_created`;
+- `communication_template_draft_created`;
+- `communication_template_draft_updated`;
+- `communication_template_published`;
+- `communication_template_superseded`;
+- `communication_template_archived`.
+
+Metadata contains IDs, purpose, channel, language, version number and fingerprints. It excludes contact destination, patient-specific rendered body, secrets and clinical/financial data.
+
+## 32. Repository integration
+
+`CommunicationTemplateRepository` provides:
+
+- list/get/get-active;
+- create stable template;
+- create/update draft;
+- publish;
+- archive;
+- preview.
+
+Writes are RPC-only, tenant ID is injected into every call, ordering is database-defined and errors are mapped to safe domain messages. No localStorage fallback or direct table mutation exists.
+
+The orchestration repository maps the new template/render snapshot fields and exposes the safe no-active-template error.
+
+## 33. Hook integration
+
+`useCommunicationTemplates` exposes templates, selection, draft, preview, loading/saving/publishing/archiving/error and role capabilities. It:
+
+- performs no fetch without tenant/user/Supabase access;
+- clears state on tenant change;
+- ignores stale responses;
+- blocks duplicate publish;
+- preserves optimistic timestamps;
+- keeps editor state available after safe errors;
+- refreshes once after a successful mutation.
+
+## 34. Template UI
+
+`/communication-templates` provides:
+
+- exact purpose/channel/language selection;
+- plain textarea editor;
+- allowed-variable insertion helpers;
+- live placeholder validation;
+- safe sample preview;
+- rendered length/fingerprint;
+- create draft, save, publish, new version and archive actions;
+- read-only published content;
+- registrar read-only view.
+
+Warnings state that published versions are immutable, templates do not send messages and only allowlisted variables may be used. No send button, WYSIWYG or HTML editor exists.
+
+Communication diagnostics now displays exact template version, rendered fingerprint and rendered snapshot for prepared operations.
+
+## 35. SQL tests
+
+Full local SQL regression result:
+
+- suites: `10` (`0024` through `0033`);
+- explicit `pg_temp.assert_true` assertions counted by runner: `552`;
+- result: PASS.
+
+Template suite 0033: `85` explicit assertions plus expected-error scenarios. It covers roles/RLS, identity validation, draft/publish/archive, replay/conflict, immutable published content, Unicode RU/KK, deterministic preview, exact resolution, operation v1/v2 snapshots, no raw destination, no clinical/financial variables and side-effect counters.
+
+Updated 0032 orchestration regression creates exact active tenant templates and validates the real `callback_task` mapping.
+
+## 36. Concurrency tests
+
+Required suites passed:
+
+- 0025 appointment conflicts;
+- 0026 cancellation/no-show;
+- 0027 confirmation workflow;
+- 0029 reminder queue;
+- 0030 manual reminder operations;
+- 0032 communication orchestration;
+- 0033 communication templates.
+
+0033 final counters:
+
+- templates: `5`;
+- versions: `10`;
+- drafts: `0`;
+- published: `3`;
+- superseded: `2`;
+- active templates: `3`;
+- replays: `2`;
+- expected conflicts: `5`;
+- operations by template version: one operation on v1 and two on v2;
+- multiple active versions: `0`;
+- duplicate version numbers: `0`;
+- operations without template snapshot: `0`;
+- audit/activity: `29/29`;
+- deadlocks: `0`.
+
+Scenarios A-K passed, including same-key replay, competing drafts, competing publishes, update/publish, publish/archive, preparation/publish and cross-tenant keys.
+
+## 37. TypeScript tests
+
+Targeted template suite:
+
+- files: `5`;
+- tests: `40`;
+- result: PASS.
+
+Full repository suite:
+
+- files: `107`;
+- tests: `1143`;
+- result: PASS.
+
+Coverage includes parser, clinical/financial rejection, malformed braces, deterministic fingerprints/rendering, Unicode, limits, repository RPC mapping, safe errors, no direct writes, hook tenant switching, duplicate publish, owner/admin controls, registrar read-only UI, live validation and absence of send action.
+
+## 38. Browser smoke
+
+Authenticated local Chromium/Playwright smoke passed with real Supabase Auth and RLS:
+
+- owner manages templates;
+- admin manages templates;
+- registrar reads active templates with no mutation controls;
+- doctor blocked;
+- cashier blocked;
+- tenant B cannot see tenant A templates;
+- RU SMS draft saved and previewed;
+- version 1 published and read-only;
+- invalid `{{diagnosis}}` blocks publish;
+- corrected version 2 published and prior version retained;
+- KK Cyrillic preview/publish preserved;
+- callback preparation without exact active template blocked safely;
+- operation v1 rendered snapshot visible;
+- after v2 publish old operation remains v1;
+- new operation uses v2.
+
+## 39. Network proof
+
+Authenticated browser counters:
+
+- total requests: `2050`;
+- external calls: `0`;
+- provider calls: `0`;
+- amoCRM calls: `0`;
+- SMS calls: `0`;
+- WhatsApp calls: `0`;
+- email sends: `0`;
+- direct template writes: `0`;
+- direct version writes: `0`;
+- controlled RPC mutations: `10`;
+- service role exposed: `false`;
+- secrets in URL/body: `false`;
+- hosts: `127.0.0.1:5186`, `127.0.0.1:54321` only.
+
+## 40. Database counters
+
+After browser smoke:
+
+- templates: `2`;
+- versions: `3`;
+- published: `2`;
+- superseded: `1`;
+- multiple active versions: `0`;
+- duplicate version numbers: `0`;
+- published versions mutated: `0`;
+- communication operations: `2`;
+- operation version sequence: `1,2`;
+- operations without template snapshot: `0`;
+- operations with invalid variables: `0`;
+- operations with clinical/financial content: `0`;
+- cross-tenant template links: `0`;
+- raw destination exposure: `0`;
+- reminder jobs changed: `0`;
+- appointments changed: `0`;
+- confirmation attempts created: `0`;
+- template audit/activity: `10/10`;
+- mismatch: `0`;
+- concurrency deadlocks: `0`.
+
+## 41. Side-effect validation
+
+Tenant-specific counters remained zero for:
+
+- visits;
+- encounters;
+- findings;
+- treatment plans;
+- completed services;
+- invoices;
+- payments;
+- refunds;
+- write-offs/financial adjustments;
+- patient balance changes;
+- patient files/documents.
+
+No stock, dental chart, amoCRM, provider credential or external message path was touched.
+
+## 42. Cleanup
+
+Removed:
+
+- temporary QA users;
+- browser patients/doctors/appointments/jobs/contacts;
+- temporary routes;
+- templates and versions;
+- communication operations;
+- temporary scripts, SQL files, logs and screenshots;
+- Vite/browser process.
+
+Final `npx supabase db reset --no-seed` passed and applied migrations `0001` through `0033`. Post-reset counts:
+
+- QA auth users: `0`;
+- browser fixture patients/doctors/appointments/jobs/contacts/routes: `0`;
+- templates: `0`;
+- versions: `0`;
+- communication operations: `0`;
+- Vite port 5186: not listening.
+
+The two Demo Clinic tenant rows are baseline rows created by historical migration 0001, not remaining task fixtures.
+
+## 43. Lint/test/build
+
+- ESLint: PASS;
+- targeted template tests: `40/40` PASS;
+- full Vitest: `107 files / 1143 tests` PASS;
+- TypeScript + Vite production build: PASS;
+- transformed modules: `1970`;
+- no dependency or lockfile change.
+
+Existing non-blocking React `act(...)` warnings and the existing Vite chunk-size warning remain unrelated to this task.
+
+## 44. Fresh CI
+
+Fresh GitHub Actions CI must run on the exact final pushed head. Run ID, tested SHA and step conclusions are recorded in the final task response because this report commit cannot contain evidence from its own future CI run.
+
+Required expected steps:
+
+- ESLint;
+- full tests;
+- build;
+- merge guard.
+
+## 45. Known limitations
+
+- no authoritative clinic callback phone source currently exists; templates requiring it fail safely;
+- no default-language fallback is enabled;
+- no auto-translation;
+- no default-template auto-seeding;
+- email remains subject + plain text only;
+- no provider delivery, worker, webhook or retry engine;
+- no inbound reply handling;
+- template body is visible only to authorized communication roles.
+
+## 46. What was intentionally not implemented
+
+- no real message send;
+- no SMS/WhatsApp/email provider SDK;
+- no amoCRM adapter;
+- no amoCRM OAuth change;
+- no HTML email engine;
+- no WYSIWYG;
+- no Liquid/Mustache/Handlebars;
+- no expressions, loops, conditions or custom code;
+- no attachments or document links;
+- no marketing, bulk campaigns, payment reminders or clinical-result messages;
+- no worker, cron, webhook or retry engine;
+- no cloud migration apply;
+- no generated types;
+- no package addition;
+- no HEP-V2;
+- no PR merge.
+
+## 47. Recommended next task
+
+`AMOCRM-INTEGRATION-HARDENING-001`
+
+After provider-neutral orchestration and exact versioned content exist, the next safe slice is tenant-safe OAuth/account hardening. Real message delivery must still wait until amoCRM channel capability and adapter contracts are proven.

--- a/_ai_work/REPORTS/COMMUNICATION-TEMPLATE-FOUNDATION-001_foundation.md
+++ b/_ai_work/REPORTS/COMMUNICATION-TEMPLATE-FOUNDATION-001_foundation.md
@@ -18,7 +18,9 @@ Operation preparation now resolves one exact active template only after eligibil
 
 ## 4. PR URL
 
-The PR URL is added to the task final response after the branch is pushed and the pull request is opened. The PR must remain open and unmerged.
+https://github.com/NckNA/codex-test/pull/360
+
+PR #360 remains open, must not be merged, and is moved from draft to ready only after fresh CI succeeds on the exact final head.
 
 ## 5. Baseline
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Layout } from './components/layout/Layout';
 import { SchedulePage } from './pages/SchedulePage';
 import { ReminderOperationsPage } from './pages/ReminderOperationsPage';
 import { CommunicationDiagnosticsPage } from './pages/CommunicationDiagnosticsPage';
+import { CommunicationTemplatesPage } from './pages/CommunicationTemplatesPage';
 import { CrmPage } from './pages/CrmPage';
 import { AppointmentsPage } from './pages/AppointmentsPage';
 import { DocumentsPage } from './pages/DocumentsPage';
@@ -102,6 +103,7 @@ function AppContent() {
           <Route index element={<SchedulePage />} />
           <Route path="reminders" element={<ReminderOperationsPage />} />
           <Route path="communications" element={<CommunicationDiagnosticsPage />} />
+          <Route path="communication-templates" element={<CommunicationTemplatesPage />} />
           <Route path="crm" element={<CrmPage />} />
           <Route path="appointments" element={<AppointmentsPage />} />
           <Route path="documents" element={<DocumentsPage />} />

--- a/src/components/communications/CommunicationOperationsPanel.tsx
+++ b/src/components/communications/CommunicationOperationsPanel.tsx
@@ -279,8 +279,17 @@ export function CommunicationOperationsPanel({
                       <span>Назначение: {operation.purposeCode}</span>
                       <span>Адресат: {operation.contactSnapshot.maskedDestination ?? '***'}</span>
                       <span>Маршрут: v{operation.routeVersion}</span>
+                      <span>Шаблон: {operation.templateVersionNumber ? `v${operation.templateVersionNumber}` : 'legacy'}</span>
                       <span>Результат: {operation.adapterResultCode ?? 'не запускался'}</span>
+                      <span>Fingerprint: {operation.renderedContentFingerprint?.slice(0, 12) ?? '—'}</span>
                     </div>
+                    {operation.renderedBody && (
+                      <div className="mt-3 rounded-lg border border-slate-200 bg-white/70 p-3" data-testid={`rendered-template-${operation.id}`}>
+                        {operation.renderedSubject && <div className="text-sm font-medium text-slate-900">{operation.renderedSubject}</div>}
+                        <p className="mt-1 whitespace-pre-wrap text-sm text-slate-700">{operation.renderedBody}</p>
+                        <p className="mt-2 text-xs text-slate-500">Символов: {operation.renderedCharacterCount ?? 0}</p>
+                      </div>
+                    )}
                     {operation.uncertain && (
                       <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-100 px-3 py-2 text-xs text-amber-900">
                         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />

--- a/src/components/communications/CommunicationTemplateManager.test.tsx
+++ b/src/components/communications/CommunicationTemplateManager.test.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCommunicationTemplates } from '../../data/hooks/useCommunicationTemplates';
+import { CommunicationTemplateManager } from './CommunicationTemplateManager';
+
+vi.mock('../../data/hooks/useCommunicationTemplates', () => ({ useCommunicationTemplates: vi.fn() }));
+
+const version = {
+  id: 'version-a', tenantId: 'tenant-a', templateId: 'template-a', versionNumber: 2, status: 'draft',
+  subject: undefined, body: 'Здравствуйте, {{patient_first_name}}', variableKeys: ['patient_first_name'],
+  contentFingerprint: 'a'.repeat(64), createdAt: 'now', updatedAt: 'version-time',
+};
+const template = {
+  id: 'template-a', tenantId: 'tenant-a', purposeCode: 'appointment_confirmation_request', channel: 'sms', language: 'ru',
+  displayName: 'RU SMS', status: 'active', activeVersionId: 'version-old',
+  activeVersion: { ...version, id: 'version-old', versionNumber: 1, status: 'published', publishedAt: 'now' },
+  draftVersion: version, createdAt: 'now', updatedAt: 'template-time',
+};
+const preview = {
+  templateId: 'template-a', versionId: 'version-a', versionNumber: 2,
+  purposeCode: 'appointment_confirmation_request', channel: 'sms', language: 'ru', contentFingerprint: 'a'.repeat(64),
+  rendered: { body: 'Здравствуйте, Айгүл', renderedCharacterCount: 19, renderedFingerprint: 'b'.repeat(64), variableKeys: ['patient_first_name'], warnings: [] },
+};
+const makeHook = (overrides: Record<string, unknown> = {}) => ({
+  templates: [template], selectedTemplate: template, draft: version, preview: null,
+  loading: false, saving: false, publishing: false, archiving: false, error: null,
+  canRead: true, canManage: true,
+  refresh: vi.fn(), selectTemplate: vi.fn(), createTemplate: vi.fn(), createDraft: vi.fn(),
+  updateDraft: vi.fn().mockResolvedValue({ template, version, replayed: false }),
+  publishDraft: vi.fn().mockResolvedValue({ template, version, replayed: false }),
+  archiveTemplate: vi.fn().mockResolvedValue({ template, replayed: false }),
+  previewDraft: vi.fn().mockResolvedValue(preview), clearError: vi.fn(), ...overrides,
+});
+const mount = async () => {
+  const container = document.createElement('div'); document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(<CommunicationTemplateManager />); });
+  return { container, root };
+};
+
+describe('CommunicationTemplateManager', () => {
+  beforeEach(() => { vi.clearAllMocks(); vi.mocked(useCommunicationTemplates).mockReturnValue(makeHook() as any); });
+
+  it('shows foundation warnings and no send action', async () => {
+    const { container, root } = await mount();
+    expect(container.textContent).toContain('Опубликованная версия неизменяема');
+    expect(container.textContent).toContain('Шаблон не отправляет сообщения сам по себе');
+    expect(container.textContent).toContain('Используйте только разрешённые переменные');
+    expect(container.textContent).not.toContain('Отправить сообщение');
+    await act(async () => root.unmount()); container.remove();
+  });
+
+  it('shows allowed variables and writable owner/admin editor', async () => {
+    const { container, root } = await mount();
+    expect(container.textContent).toContain('{{patient_first_name}}');
+    expect(container.textContent).toContain('{{appointment_time}}');
+    expect((container.querySelector('[data-testid="template-body-editor"]') as HTMLTextAreaElement).readOnly).toBe(false);
+    expect(container.querySelector('[data-testid="publish-template"]')).not.toBeNull();
+    await act(async () => root.unmount()); container.remove();
+  });
+
+  it('shows live invalid-placeholder warning and disables publish', async () => {
+    const invalidVersion = { ...version, body: 'Диагноз {{diagnosis}}' };
+    const invalidTemplate = { ...template, draftVersion: invalidVersion };
+    vi.mocked(useCommunicationTemplates).mockReturnValue(makeHook({
+      templates: [invalidTemplate], selectedTemplate: invalidTemplate, draft: invalidVersion,
+    }) as any);
+    const { container, root } = await mount();
+    expect(container.querySelector('[data-testid="template-validation-error"]')?.textContent).toContain('запрещённую');
+    expect((container.querySelector('[data-testid="publish-template"]') as HTMLButtonElement).disabled).toBe(true);
+    await act(async () => root.unmount()); container.remove();
+  });
+
+  it('keeps registrar read-only with no mutation controls', async () => {
+    vi.mocked(useCommunicationTemplates).mockReturnValue(makeHook({ canManage: false }) as any);
+    const { container, root } = await mount();
+    expect(container.querySelector('[data-testid="template-create-panel"]')).toBeNull();
+    expect(container.querySelector('[data-testid="save-template-draft"]')).toBeNull();
+    expect(container.querySelector('[data-testid="publish-template"]')).toBeNull();
+    expect(container.querySelector('[data-testid="archive-template"]')).toBeNull();
+    expect((container.querySelector('[data-testid="template-body-editor"]') as HTMLTextAreaElement).readOnly).toBe(true);
+    expect(container.querySelector('[data-testid="preview-template"]')).not.toBeNull();
+    await act(async () => root.unmount()); container.remove();
+  });
+
+  it('shows preview and exact rendered text', async () => {
+    vi.mocked(useCommunicationTemplates).mockReturnValue(makeHook({ preview }) as any);
+    const { container, root } = await mount();
+    expect(container.querySelector('[data-testid="template-preview"]')?.textContent).toContain('Здравствуйте, Айгүл');
+    expect(container.textContent).toContain('fingerprint');
+    await act(async () => root.unmount()); container.remove();
+  });
+});

--- a/src/components/communications/CommunicationTemplateManager.tsx
+++ b/src/components/communications/CommunicationTemplateManager.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Archive, Eye, FilePlus2, Plus, Save, ShieldAlert, Upload } from 'lucide-react';
+import type { CommunicationChannel, CommunicationLanguage, CommunicationPurpose } from '../../domain/communications/CommunicationCommand';
+import {
+  COMMUNICATION_TEMPLATE_CHANNELS,
+  COMMUNICATION_TEMPLATE_LANGUAGES,
+  COMMUNICATION_TEMPLATE_PURPOSES,
+  COMMUNICATION_TEMPLATE_VARIABLES,
+  type CommunicationTemplate,
+  validateCommunicationTemplateContent,
+} from '../../domain/communications/CommunicationTemplate';
+import { useCommunicationTemplates } from '../../data/hooks/useCommunicationTemplates';
+
+const PURPOSE_LABELS: Record<CommunicationPurpose, string> = {
+  appointment_confirmation_request: 'Запрос подтверждения записи',
+  appointment_day_before_reminder: 'Напоминание за день',
+  appointment_same_day_reminder: 'Напоминание в день записи',
+  appointment_control_call_task: 'Контрольный звонок',
+};
+const CHANNEL_LABELS: Record<CommunicationChannel, string> = { sms: 'SMS', whatsapp: 'WhatsApp', email: 'Email' };
+const LANGUAGE_LABELS: Record<CommunicationLanguage, string> = { ru: 'RU', kk: 'KK', en: 'EN' };
+const SAMPLE_VALUES: Record<string, string> = {
+  patient_first_name: 'Айгүл',
+  clinic_name: 'Демо-клиника',
+  appointment_date: '14.07.2026',
+  appointment_time: '10:30',
+  doctor_display_name: 'Доктор Тестов',
+  clinic_callback_phone: '+7 700 000 00 00',
+};
+
+const makeDraftState = (template: CommunicationTemplate | null) => ({
+  subject: template?.draftVersion?.subject ?? '',
+  body: template?.draftVersion?.body ?? '',
+});
+
+export function CommunicationTemplateManager() {
+  const {
+    templates,
+    selectedTemplate,
+    draft,
+    preview,
+    loading,
+    saving,
+    publishing,
+    archiving,
+    error,
+    canRead,
+    canManage,
+    selectTemplate,
+    createTemplate,
+    createDraft,
+    updateDraft,
+    publishDraft,
+    archiveTemplate,
+    previewDraft,
+  } = useCommunicationTemplates();
+
+  const [purposeCode, setPurposeCode] = useState<CommunicationPurpose>('appointment_confirmation_request');
+  const [channel, setChannel] = useState<CommunicationChannel>('sms');
+  const [language, setLanguage] = useState<CommunicationLanguage>('ru');
+  const [displayName, setDisplayName] = useState('');
+  const [createSubject, setCreateSubject] = useState('');
+  const [createBody, setCreateBody] = useState('');
+  const [editor, setEditor] = useState(() => makeDraftState(null));
+  const [localNotice, setLocalNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void Promise.resolve().then(() => {
+      if (active) setEditor(makeDraftState(selectedTemplate));
+    });
+    return () => { active = false; };
+  }, [selectedTemplate]);
+
+  const validation = useMemo(() => {
+    if (!selectedTemplate || !draft) return { message: null, variableKeys: [] as string[] };
+    try {
+      const result = validateCommunicationTemplateContent({
+        channel: selectedTemplate.channel,
+        subject: editor.subject || null,
+        body: editor.body,
+      });
+      return { message: null, variableKeys: result.variableKeys as string[] };
+    } catch (cause) {
+      return { message: cause instanceof Error ? cause.message : 'Шаблон содержит ошибку.', variableKeys: [] as string[] };
+    }
+  }, [draft, editor.body, editor.subject, selectedTemplate]);
+
+  if (!canRead) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-8 text-center" data-testid="template-access-blocked">
+        <ShieldAlert className="mx-auto h-10 w-10 text-amber-600" />
+        <h2 className="mt-3 text-lg font-semibold text-slate-900">Управление шаблонами недоступно</h2>
+        <p className="mt-2 text-sm text-slate-600">Недостаточно прав для управления шаблонами.</p>
+      </div>
+    );
+  }
+
+  const run = async (action: () => Promise<unknown>, notice: string) => {
+    setLocalNotice(null);
+    try {
+      await action();
+      setLocalNotice(notice);
+    } catch {
+      // Hook exposes a redacted safe error and keeps the editor open.
+    }
+  };
+
+  const insertVariable = (key: string) => {
+    setEditor((current) => ({ ...current, body: `${current.body}{{${key}}}` }));
+  };
+
+  const submitCreate = async () => {
+    await run(async () => {
+      const result = await createTemplate({
+        purposeCode,
+        channel,
+        language,
+        displayName,
+        subject: channel === 'email' ? createSubject : undefined,
+        body: createBody,
+      });
+      setDisplayName('');
+      setCreateSubject('');
+      setCreateBody('');
+      selectTemplate(result.template.id);
+    }, 'Черновик шаблона создан.');
+  };
+
+  const previewVariables = Object.fromEntries(
+    (draft?.variableKeys ?? []).map((key) => [key, SAMPLE_VALUES[key]]),
+  );
+
+  return (
+    <section className="space-y-5" data-testid="communication-template-manager">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-xl border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+          <strong className="block">Опубликованная версия неизменяема.</strong>
+          Для правки создайте новую версию.
+        </div>
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+          <strong className="block">Шаблон не отправляет сообщения сам по себе.</strong>
+          Предпросмотр не является доставкой.
+        </div>
+        <div className="rounded-xl border border-violet-200 bg-violet-50 p-4 text-sm text-violet-900">
+          <strong className="block">Используйте только разрешённые переменные.</strong>
+          Произвольные выражения, HTML и клинические данные запрещены.
+        </div>
+      </div>
+
+      {(error || localNotice) && (
+        <div className="space-y-2">
+          {error && <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
+          {localNotice && <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{localNotice}</div>}
+        </div>
+      )}
+
+      {canManage && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm" data-testid="template-create-panel">
+          <div className="flex items-center gap-2 font-semibold text-slate-900"><Plus className="h-4 w-4" />Новый шаблон</div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-4">
+            <select value={purposeCode} onChange={(event) => setPurposeCode(event.target.value as CommunicationPurpose)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm" aria-label="Назначение шаблона">
+              {COMMUNICATION_TEMPLATE_PURPOSES.map((item) => <option key={item} value={item}>{PURPOSE_LABELS[item]}</option>)}
+            </select>
+            <select value={channel} onChange={(event) => setChannel(event.target.value as CommunicationChannel)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm" aria-label="Канал шаблона">
+              {COMMUNICATION_TEMPLATE_CHANNELS.map((item) => <option key={item} value={item}>{CHANNEL_LABELS[item]}</option>)}
+            </select>
+            <select value={language} onChange={(event) => setLanguage(event.target.value as CommunicationLanguage)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm" aria-label="Язык шаблона">
+              {COMMUNICATION_TEMPLATE_LANGUAGES.map((item) => <option key={item} value={item}>{LANGUAGE_LABELS[item]}</option>)}
+            </select>
+            <input value={displayName} onChange={(event) => setDisplayName(event.target.value)} className="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="Название" aria-label="Название шаблона" />
+          </div>
+          {channel === 'email' && <input value={createSubject} onChange={(event) => setCreateSubject(event.target.value)} className="mt-3 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="Тема email" aria-label="Тема нового шаблона" />}
+          <textarea value={createBody} onChange={(event) => setCreateBody(event.target.value)} className="mt-3 min-h-28 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="Текст шаблона" aria-label="Текст нового шаблона" />
+          <button type="button" data-testid="create-template" disabled={saving || !displayName.trim() || !createBody.trim()} onClick={() => void submitCreate()} className="mt-3 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"><FilePlus2 className="h-4 w-4" />Создать черновик</button>
+        </div>
+      )}
+
+      <div className="grid gap-5 xl:grid-cols-[0.8fr_1.2fr]">
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <h2 className="font-semibold text-slate-900">Шаблоны</h2>
+          {loading ? <p className="mt-4 text-sm text-slate-500">Загрузка шаблонов…</p> : templates.length === 0 ? (
+            <p className="mt-4 rounded-lg border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">Шаблоны ещё не созданы.</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {templates.map((template) => (
+                <button key={template.id} type="button" onClick={() => selectTemplate(template.id)} data-testid={`template-row-${template.id}`} className={`w-full rounded-xl border p-3 text-left text-sm ${selectedTemplate?.id === template.id ? 'border-indigo-400 bg-indigo-50' : 'border-slate-200 hover:bg-slate-50'}`}>
+                  <div className="font-semibold text-slate-900">{template.displayName}</div>
+                  <div className="mt-1 text-xs text-slate-500">{PURPOSE_LABELS[template.purposeCode]} · {CHANNEL_LABELS[template.channel]} · {LANGUAGE_LABELS[template.language]}</div>
+                  <div className="mt-2 flex gap-2 text-xs"><span className="rounded bg-slate-100 px-2 py-1">{template.status}</span><span>active v{template.activeVersion?.versionNumber ?? '—'}</span><span>draft v{template.draftVersion?.versionNumber ?? '—'}</span></div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          {!selectedTemplate ? <p className="text-sm text-slate-500">Выберите шаблон.</p> : (
+            <div data-testid="template-editor">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">{selectedTemplate.displayName}</h2>
+                  <p className="mt-1 text-xs text-slate-500">{PURPOSE_LABELS[selectedTemplate.purposeCode]} · {CHANNEL_LABELS[selectedTemplate.channel]} · {LANGUAGE_LABELS[selectedTemplate.language]}</p>
+                </div>
+                {canManage && selectedTemplate.status !== 'archived' && (
+                  <div className="flex flex-wrap gap-2">
+                    {!draft && <button type="button" data-testid="create-template-draft" disabled={saving} onClick={() => void run(() => createDraft(selectedTemplate), 'Новый черновик создан.')} className="rounded-lg border border-slate-300 px-3 py-2 text-sm"><FilePlus2 className="mr-1 inline h-4 w-4" />Новая версия</button>}
+                    <button type="button" data-testid="archive-template" disabled={archiving} onClick={() => void run(() => archiveTemplate(selectedTemplate), 'Шаблон архивирован.')} className="rounded-lg border border-red-200 px-3 py-2 text-sm text-red-700"><Archive className="mr-1 inline h-4 w-4" />Архивировать</button>
+                  </div>
+                )}
+              </div>
+
+              {draft ? (
+                <div className="mt-5 space-y-3">
+                  {selectedTemplate.channel === 'email' && <input value={editor.subject} readOnly={!canManage} onChange={(event) => setEditor((current) => ({ ...current, subject: event.target.value }))} className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm read-only:bg-slate-50" aria-label="Тема черновика" />}
+                  <textarea value={editor.body} readOnly={!canManage} onChange={(event) => setEditor((current) => ({ ...current, body: event.target.value }))} className="min-h-48 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm read-only:bg-slate-50" aria-label="Текст черновика" data-testid="template-body-editor" />
+                  <div className="flex flex-wrap gap-2" aria-label="Разрешённые переменные">
+                    {COMMUNICATION_TEMPLATE_VARIABLES.map((key) => <button key={key} type="button" disabled={!canManage} onClick={() => insertVariable(key)} className="rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs disabled:opacity-60">{`{{${key}}}`}</button>)}
+                  </div>
+                  {validation.message ? <p className="text-sm text-red-700" data-testid="template-validation-error">{validation.message}</p> : <p className="text-xs text-slate-500">Переменные: {validation.variableKeys.join(', ') || 'нет'}</p>}
+                  <div className="flex flex-wrap gap-2">
+                    {canManage && <button type="button" data-testid="save-template-draft" disabled={saving || Boolean(validation.message)} onClick={() => void run(() => updateDraft(selectedTemplate, editor.subject || undefined, editor.body), 'Черновик сохранён.')} className="rounded-lg bg-slate-800 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"><Save className="mr-1 inline h-4 w-4" />Сохранить</button>}
+                    <button type="button" data-testid="preview-template" disabled={Boolean(validation.message)} onClick={() => void run(() => previewDraft(draft, previewVariables), 'Предпросмотр сформирован.')} className="rounded-lg border border-indigo-200 px-3 py-2 text-sm text-indigo-700 disabled:opacity-50"><Eye className="mr-1 inline h-4 w-4" />Предпросмотр</button>
+                    {canManage && <button type="button" data-testid="publish-template" disabled={publishing || Boolean(validation.message)} onClick={() => void run(() => publishDraft(selectedTemplate), 'Версия опубликована.')} className="rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"><Upload className="mr-1 inline h-4 w-4" />Опубликовать</button>}
+                  </div>
+                </div>
+              ) : selectedTemplate.activeVersion ? (
+                <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4" data-testid="published-template-readonly">
+                  {selectedTemplate.activeVersion.subject && <div className="font-medium text-slate-800">{selectedTemplate.activeVersion.subject}</div>}
+                  <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-slate-700">{selectedTemplate.activeVersion.body}</pre>
+                  <p className="mt-3 text-xs text-slate-500">Опубликована версия {selectedTemplate.activeVersion.versionNumber}; редактирование на месте запрещено.</p>
+                </div>
+              ) : <p className="mt-5 text-sm text-slate-500">У шаблона нет черновика или активной версии.</p>}
+
+              {preview && (
+                <div className="mt-5 rounded-xl border border-emerald-200 bg-emerald-50 p-4" data-testid="template-preview">
+                  <h3 className="font-semibold text-emerald-900">Безопасный предпросмотр</h3>
+                  {preview.rendered.subject && <div className="mt-2 text-sm font-medium text-emerald-950">{preview.rendered.subject}</div>}
+                  <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-emerald-900">{preview.rendered.body}</pre>
+                  <div className="mt-2 text-xs text-emerald-700">Символов: {preview.rendered.renderedCharacterCount} · fingerprint: {preview.rendered.renderedFingerprint.slice(0, 12)}…</div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -55,6 +55,7 @@ export function Sidebar() {
     ? [
         { to: '/reminders', icon: BellRing, label: 'Напоминания' },
         { to: '/communications', icon: FlaskConical, label: 'Коммуникации' },
+        { to: '/communication-templates', icon: FileText, label: 'Шаблоны сообщений' },
       ]
     : [];
   const operationalItems = [navItems[0], ...reminderItems, ...navItems.slice(1)];

--- a/src/data/hooks/useCommunicationTemplates.test.tsx
+++ b/src/data/hooks/useCommunicationTemplates.test.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// @vitest-environment jsdom
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { createCommunicationTemplateRepository } from '../repositories/CommunicationTemplateRepository';
+import { useCommunicationTemplates } from './useCommunicationTemplates';
+
+vi.mock('../../lib/supabaseClient', () => ({ isSupabaseConfigured: true, supabase: {} }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('../../contexts/TenantContext', () => ({ useTenant: vi.fn() }));
+vi.mock('../repositories/CommunicationTemplateRepository', async () => {
+  const actual = await vi.importActual('../repositories/CommunicationTemplateRepository');
+  return { ...actual as object, createCommunicationTemplateRepository: vi.fn() };
+});
+
+const tenantA = '11111111-1111-4111-8111-111111111111';
+const tenantB = '22222222-2222-4222-8222-222222222222';
+const version = {
+  id: 'version-a', tenantId: tenantA, templateId: 'template-a', versionNumber: 1, status: 'draft' as const,
+  body: 'Привет, {{patient_first_name}}', variableKeys: ['patient_first_name' as const],
+  contentFingerprint: 'a'.repeat(64), createdAt: 'now', updatedAt: 'version-time',
+};
+const template = {
+  id: 'template-a', tenantId: tenantA, purposeCode: 'appointment_confirmation_request' as const,
+  channel: 'sms' as const, language: 'ru' as const, displayName: 'RU SMS', status: 'inactive' as const,
+  draftVersion: version, createdAt: 'now', updatedAt: 'template-time',
+};
+const makeRepository = () => ({
+  listTemplates: vi.fn().mockResolvedValue([template]),
+  getTemplate: vi.fn().mockResolvedValue(template),
+  getActiveTemplate: vi.fn().mockResolvedValue(null),
+  createTemplate: vi.fn().mockResolvedValue({ template, version, replayed: false }),
+  createDraft: vi.fn().mockResolvedValue({ template, version, replayed: false }),
+  updateDraft: vi.fn().mockResolvedValue({ template, version, replayed: false }),
+  publishVersion: vi.fn().mockResolvedValue({ template: { ...template, status: 'active' }, version: { ...version, status: 'published' }, replayed: false }),
+  archiveTemplate: vi.fn().mockResolvedValue({ template: { ...template, status: 'archived' }, replayed: false }),
+  previewTemplate: vi.fn().mockResolvedValue({
+    templateId: template.id, versionId: version.id, versionNumber: 1,
+    purposeCode: template.purposeCode, channel: template.channel, language: template.language,
+    contentFingerprint: version.contentFingerprint,
+    rendered: { body: 'Привет, Айгүл', renderedCharacterCount: 13, renderedFingerprint: 'b'.repeat(64), variableKeys: ['patient_first_name'], warnings: [] },
+  }),
+});
+
+describe('useCommunicationTemplates', () => {
+  let authState: any;
+  let tenantState: any;
+  let repository: ReturnType<typeof makeRepository>;
+  let current: ReturnType<typeof useCommunicationTemplates> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = { authMode: 'supabase-active', user: { id: 'user-a' } };
+    tenantState = { activeTenant: { tenantId: tenantA, role: 'clinic_admin' } };
+    repository = makeRepository();
+    vi.mocked(useAuth).mockImplementation(() => authState);
+    vi.mocked(useTenant).mockImplementation(() => tenantState);
+    vi.mocked(createCommunicationTemplateRepository).mockReturnValue(repository as any);
+  });
+
+  const mount = async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const Harness = ({ tick = 0 }: { tick?: number }) => { void tick; current = useCommunicationTemplates(); return null; };
+    await act(async () => { root.render(<Harness />); });
+    return { root, Harness };
+  };
+
+  it('does not fetch without a tenant', async () => {
+    tenantState = { activeTenant: null };
+    const { root } = await mount();
+    expect(createCommunicationTemplateRepository).not.toHaveBeenCalled();
+    expect(current?.templates).toEqual([]);
+    await act(async () => root.unmount());
+  });
+
+  it('loads templates and keeps registrar read-only', async () => {
+    tenantState.activeTenant.role = 'registrar';
+    const { root } = await mount();
+    expect(repository.listTemplates).toHaveBeenCalledTimes(1);
+    expect(current).toMatchObject({ canRead: true, canManage: false });
+    await expect(current!.createDraft(template)).rejects.toMatchObject({ code: 'permission' });
+    await act(async () => root.unmount());
+  });
+
+  it('updates, previews and publishes a draft', async () => {
+    const { root } = await mount();
+    await act(async () => { await current!.updateDraft(template, undefined, 'Новый текст'); });
+    expect(repository.updateDraft).toHaveBeenCalledWith(expect.objectContaining({ versionId: version.id, expectedUpdatedAt: 'version-time' }));
+    await act(async () => { await current!.previewDraft(version, { patient_first_name: 'Айгүл' }); });
+    expect(current?.preview?.rendered.body).toBe('Привет, Айгүл');
+    await act(async () => { await current!.publishDraft(template); });
+    expect(repository.publishVersion).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('blocks duplicate publish while request is active', async () => {
+    let resolve!: (value: any) => void;
+    repository.publishVersion.mockReturnValueOnce(new Promise((res) => { resolve = res; }));
+    const { root } = await mount();
+    let first!: Promise<any>;
+    await act(async () => { first = current!.publishDraft(template); });
+    await expect(current!.publishDraft(template)).rejects.toMatchObject({ code: 'conflict' });
+    await act(async () => { resolve({ template, version, replayed: false }); await first; });
+    expect(repository.publishVersion).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
+  });
+
+  it('clears tenant A state and ignores its late response after tenant switch', async () => {
+    let resolveA!: (value: any) => void;
+    const repoA = { ...makeRepository(), listTemplates: vi.fn(() => new Promise((res) => { resolveA = res; })) };
+    const templateB = { ...template, id: 'template-b', tenantId: tenantB };
+    const repoB = { ...makeRepository(), listTemplates: vi.fn().mockResolvedValue([templateB]) };
+    vi.mocked(createCommunicationTemplateRepository).mockImplementation(({ tenantId }) => (tenantId === tenantA ? repoA : repoB) as any);
+    const { root, Harness } = await mount();
+    tenantState = { activeTenant: { tenantId: tenantB, role: 'clinic_admin' } };
+    await act(async () => { root.render(<Harness tick={1} />); await Promise.resolve(); });
+    expect(current?.templates[0]?.id).toBe('template-b');
+    await act(async () => { resolveA([template]); });
+    expect(current?.templates[0]?.id).toBe('template-b');
+    await act(async () => root.unmount());
+  });
+});

--- a/src/data/hooks/useCommunicationTemplates.ts
+++ b/src/data/hooks/useCommunicationTemplates.ts
@@ -1,0 +1,286 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTenant } from '../../contexts/TenantContext';
+import { isSupabaseConfigured } from '../../lib/supabaseClient';
+import type { CommunicationChannel, CommunicationLanguage, CommunicationPurpose } from '../../domain/communications/CommunicationCommand';
+import type { CommunicationTemplate, CommunicationTemplateVersion } from '../../domain/communications/CommunicationTemplate';
+import {
+  CommunicationTemplateRepositoryError,
+  createCommunicationTemplateRepository,
+  type CommunicationTemplateFilters,
+  type CommunicationTemplateMutationResult,
+  type CommunicationTemplatePreview,
+  type CommunicationTemplateRepository,
+} from '../repositories/CommunicationTemplateRepository';
+
+const READ_ROLES = new Set(['clinic_owner', 'clinic_admin', 'registrar']);
+const MANAGE_ROLES = new Set(['clinic_owner', 'clinic_admin']);
+
+const operationKey = (kind: string, id: string): string => {
+  const random = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `communication-template-${kind}-${id}-${random}`;
+};
+
+export interface CreateTemplateDraftInput {
+  purposeCode: CommunicationPurpose;
+  channel: CommunicationChannel;
+  language: CommunicationLanguage;
+  displayName: string;
+  subject?: string;
+  body: string;
+}
+
+export interface UseCommunicationTemplatesResult {
+  templates: CommunicationTemplate[];
+  selectedTemplate: CommunicationTemplate | null;
+  draft: CommunicationTemplateVersion | null;
+  preview: CommunicationTemplatePreview | null;
+  loading: boolean;
+  saving: boolean;
+  publishing: boolean;
+  archiving: boolean;
+  error: string | null;
+  canRead: boolean;
+  canManage: boolean;
+  refresh: (filters?: CommunicationTemplateFilters) => Promise<void>;
+  selectTemplate: (templateId: string | null) => void;
+  createTemplate: (input: CreateTemplateDraftInput) => Promise<CommunicationTemplateMutationResult>;
+  createDraft: (template: CommunicationTemplate) => Promise<CommunicationTemplateMutationResult>;
+  updateDraft: (template: CommunicationTemplate, subject: string | undefined, body: string) => Promise<CommunicationTemplateMutationResult>;
+  publishDraft: (template: CommunicationTemplate) => Promise<CommunicationTemplateMutationResult>;
+  archiveTemplate: (template: CommunicationTemplate) => Promise<CommunicationTemplateMutationResult>;
+  previewDraft: (version: CommunicationTemplateVersion, variables: Record<string, string>) => Promise<CommunicationTemplatePreview>;
+  clearError: () => void;
+}
+
+export function useCommunicationTemplates(): UseCommunicationTemplatesResult {
+  const { authMode, user } = useAuth();
+  const { activeTenant } = useTenant();
+  const tenantId = activeTenant?.tenantId;
+  const role = activeTenant?.role;
+  const canRead = authMode === 'dev' || READ_ROLES.has(role ?? '');
+  const canManage = authMode === 'dev' || MANAGE_ROLES.has(role ?? '');
+  const isSupabaseMode = authMode === 'supabase-active' && isSupabaseConfigured;
+
+  const repository = useMemo<CommunicationTemplateRepository | null>(() => {
+    if (!tenantId || !user?.id || !isSupabaseMode || !canRead) return null;
+    return createCommunicationTemplateRepository({ tenantId });
+  }, [canRead, isSupabaseMode, tenantId, user?.id]);
+
+  const [templates, setTemplates] = useState<CommunicationTemplate[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [preview, setPreview] = useState<CommunicationTemplatePreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [archiving, setArchiving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sequence = useRef(0);
+  const busy = useRef(new Set<string>());
+
+  const selectedTemplate = useMemo(
+    () => templates.find((item) => item.id === selectedId) ?? null,
+    [selectedId, templates],
+  );
+  const draft = selectedTemplate?.draftVersion ?? null;
+
+  const refresh = useCallback(async (filters: CommunicationTemplateFilters = {}): Promise<void> => {
+    const request = ++sequence.current;
+    if (!repository || !tenantId || !canRead) {
+      setTemplates([]);
+      setSelectedId(null);
+      setPreview(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await repository.listTemplates(filters);
+      if (request !== sequence.current) return;
+      setTemplates(next);
+      setSelectedId((current) => current && next.some((item) => item.id === current)
+        ? current : next[0]?.id ?? null);
+    } catch (cause) {
+      if (request !== sequence.current) return;
+      setError(cause instanceof Error ? cause.message : 'Не удалось загрузить шаблоны.');
+      setTemplates([]);
+      setSelectedId(null);
+    } finally {
+      if (request === sequence.current) setLoading(false);
+    }
+  }, [canRead, repository, tenantId]);
+
+  useEffect(() => {
+    const request = ++sequence.current;
+    busy.current.clear();
+    void Promise.resolve().then(() => {
+      if (request !== sequence.current) return;
+      setTemplates([]);
+      setSelectedId(null);
+      setPreview(null);
+      setError(null);
+      return refresh();
+    });
+  }, [refresh, tenantId]);
+
+  const applyResult = useCallback(async (result: CommunicationTemplateMutationResult) => {
+    await refresh();
+    setSelectedId(result.template.id);
+    return result;
+  }, [refresh]);
+
+  const assertManage = useCallback(() => {
+    if (!repository || !tenantId || !canManage) throw new CommunicationTemplateRepositoryError('permission');
+  }, [canManage, repository, tenantId]);
+
+  const createTemplate = useCallback(async (input: CreateTemplateDraftInput) => {
+    assertManage();
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await repository!.createTemplate({
+        ...input,
+        operationKey: operationKey('create', `${input.purposeCode}-${input.channel}-${input.language}`),
+      });
+      return await applyResult(result);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить шаблон.');
+      throw cause;
+    } finally {
+      setSaving(false);
+    }
+  }, [applyResult, assertManage, repository]);
+
+  const createDraft = useCallback(async (template: CommunicationTemplate) => {
+    assertManage();
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await repository!.createDraft(template.id, operationKey('draft', template.id));
+      return await applyResult(result);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить шаблон.');
+      throw cause;
+    } finally {
+      setSaving(false);
+    }
+  }, [applyResult, assertManage, repository]);
+
+  const updateDraft = useCallback(async (
+    template: CommunicationTemplate,
+    subject: string | undefined,
+    body: string,
+  ) => {
+    assertManage();
+    const currentDraft = template.draftVersion;
+    if (!currentDraft) throw new CommunicationTemplateRepositoryError('not_found');
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await repository!.updateDraft({
+        versionId: currentDraft.id,
+        subject,
+        body,
+        expectedUpdatedAt: currentDraft.updatedAt,
+        operationKey: operationKey('update', currentDraft.id),
+      });
+      return await applyResult(result);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить шаблон.');
+      throw cause;
+    } finally {
+      setSaving(false);
+    }
+  }, [applyResult, assertManage, repository]);
+
+  const publishDraft = useCallback(async (template: CommunicationTemplate) => {
+    assertManage();
+    const currentDraft = template.draftVersion;
+    if (!currentDraft) throw new CommunicationTemplateRepositoryError('not_found');
+    const slot = `publish:${template.id}`;
+    if (busy.current.has(slot)) throw new CommunicationTemplateRepositoryError('conflict');
+    busy.current.add(slot);
+    setPublishing(true);
+    setError(null);
+    try {
+      const result = await repository!.publishVersion(
+        template.id,
+        currentDraft.id,
+        currentDraft.updatedAt,
+        operationKey('publish', currentDraft.id),
+      );
+      return await applyResult(result);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить шаблон.');
+      throw cause;
+    } finally {
+      busy.current.delete(slot);
+      setPublishing(false);
+    }
+  }, [applyResult, assertManage, repository]);
+
+  const archiveTemplate = useCallback(async (template: CommunicationTemplate) => {
+    assertManage();
+    setArchiving(true);
+    setError(null);
+    try {
+      const result = await repository!.archiveTemplate(
+        template.id,
+        template.updatedAt,
+        operationKey('archive', template.id),
+      );
+      setPreview(null);
+      return await applyResult(result);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить шаблон.');
+      throw cause;
+    } finally {
+      setArchiving(false);
+    }
+  }, [applyResult, assertManage, repository]);
+
+  const previewDraft = useCallback(async (
+    version: CommunicationTemplateVersion,
+    variables: Record<string, string>,
+  ) => {
+    if (!repository || !tenantId || !canRead) throw new CommunicationTemplateRepositoryError('permission');
+    setError(null);
+    try {
+      const result = await repository.previewTemplate(version.id, variables);
+      setPreview(result);
+      return result;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Не удалось сохранить шаблон.');
+      throw cause;
+    }
+  }, [canRead, repository, tenantId]);
+
+  return {
+    templates,
+    selectedTemplate,
+    draft,
+    preview,
+    loading,
+    saving,
+    publishing,
+    archiving,
+    error,
+    canRead,
+    canManage,
+    refresh,
+    selectTemplate: (templateId) => {
+      setSelectedId(templateId);
+      setPreview(null);
+    },
+    createTemplate,
+    createDraft,
+    updateDraft,
+    publishDraft,
+    archiveTemplate,
+    previewDraft,
+    clearError: () => setError(null),
+  };
+}

--- a/src/data/repositories/CommunicationOrchestrationRepository.ts
+++ b/src/data/repositories/CommunicationOrchestrationRepository.ts
@@ -48,6 +48,15 @@ export interface CommunicationOperation {
   routeId: string;
   routeVersion: number;
   adapterCode: CommunicationAdapterCode;
+  templateId?: string;
+  templateVersionId?: string;
+  templateVersionNumber?: number;
+  templateContentFingerprint?: string;
+  renderedContentFingerprint?: string;
+  renderedSubject?: string;
+  renderedBody?: string;
+  renderedCharacterCount?: number;
+  templateSnapshot?: Record<string, unknown>;
   externalOperationId?: string;
   adapterResultCode?: CommunicationAdapterResultCode;
   retryable?: boolean;
@@ -112,6 +121,7 @@ export interface SimulateCommunicationOperationInput {
 export type CommunicationRepositoryErrorCode =
   | 'permission'
   | 'no_route'
+  | 'no_template'
   | 'not_eligible'
   | 'stale'
   | 'conflict'
@@ -123,6 +133,7 @@ export type CommunicationRepositoryErrorCode =
 const SAFE_MESSAGES: Record<CommunicationRepositoryErrorCode, string> = {
   permission: 'Недостаточно прав для работы с коммуникациями.',
   no_route: 'Для этого канала не настроен тестовый маршрут.',
+  no_template: 'Для выбранного канала и языка нет активного шаблона.',
   not_eligible: 'Контакт или согласие больше не позволяют подготовить коммуникацию.',
   stale: 'Данные записи или контакта изменились. Обновите задачу.',
   conflict: 'Операция уже выполнена с другими параметрами.',
@@ -164,6 +175,9 @@ export const toSafeCommunicationRepositoryError = (
   }
   if (normalized.includes('не настроен тестовый маршрут')) {
     return new CommunicationOrchestrationRepositoryError('no_route');
+  }
+  if (normalized.includes('нет активного шаблона')) {
+    return new CommunicationOrchestrationRepositoryError('no_template');
   }
   if (normalized.includes('контакт или согласие')) {
     return new CommunicationOrchestrationRepositoryError('not_eligible');
@@ -218,6 +232,17 @@ export const mapCommunicationOperation = (row: Row): CommunicationOperation => (
   routeId: String(value(row, 'routeId', 'route_id')),
   routeVersion: Number(value(row, 'routeVersion', 'route_version')),
   adapterCode: value(row, 'adapterCode', 'adapter_code') as CommunicationAdapterCode,
+  templateId: optionalString(value(row, 'templateId', 'template_id')),
+  templateVersionId: optionalString(value(row, 'templateVersionId', 'template_version_id')),
+  templateVersionNumber: value(row, 'templateVersionNumber', 'template_version_number') == null
+    ? undefined : Number(value(row, 'templateVersionNumber', 'template_version_number')),
+  templateContentFingerprint: optionalString(value(row, 'templateContentFingerprint', 'template_content_fingerprint')),
+  renderedContentFingerprint: optionalString(value(row, 'renderedContentFingerprint', 'rendered_content_fingerprint')),
+  renderedSubject: optionalString(value(row, 'renderedSubject', 'rendered_subject')),
+  renderedBody: optionalString(value(row, 'renderedBody', 'rendered_body')),
+  renderedCharacterCount: value(row, 'renderedCharacterCount', 'rendered_character_count') == null
+    ? undefined : Number(value(row, 'renderedCharacterCount', 'rendered_character_count')),
+  templateSnapshot: (value(row, 'templateSnapshot', 'template_snapshot') ?? undefined) as Record<string, unknown> | undefined,
   externalOperationId: optionalString(value(row, 'externalOperationId', 'external_operation_id')),
   adapterResultCode: optionalString(value(row, 'adapterResultCode', 'adapter_result_code')) as CommunicationAdapterResultCode | undefined,
   retryable: value(row, 'retryable', 'retryable') == null ? undefined : Boolean(value(row, 'retryable', 'retryable')),

--- a/src/data/repositories/CommunicationTemplateRepository.test.ts
+++ b/src/data/repositories/CommunicationTemplateRepository.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import repositorySource from './CommunicationTemplateRepository.ts?raw';
+import {
+  CommunicationTemplateRepositoryError,
+  SupabaseCommunicationTemplateRepository,
+  mapCommunicationTemplate,
+  mapCommunicationTemplateVersion,
+  toSafeCommunicationTemplateError,
+} from './CommunicationTemplateRepository';
+
+vi.mock('../../lib/supabaseClient', () => ({ supabase: { rpc: vi.fn(), from: vi.fn() } }));
+
+const tenantId = '11111111-1111-4111-8111-111111111111';
+const versionRow = {
+  id: 'version-a', tenantId, templateId: 'template-a', versionNumber: 2, status: 'draft',
+  subject: null, body: 'Здравствуйте, {{patient_first_name}}', variableKeys: ['patient_first_name'],
+  contentFingerprint: 'a'.repeat(64), createdAt: '2026-07-13T00:00:00Z', updatedAt: '2026-07-13T01:00:00Z',
+};
+const templateRow = {
+  id: 'template-a', tenantId, purposeCode: 'appointment_confirmation_request', channel: 'sms', language: 'ru',
+  displayName: 'Подтверждение RU', status: 'inactive', activeVersionId: null,
+  activeVersion: null, draftVersion: versionRow, createdAt: '2026-07-13T00:00:00Z', updatedAt: '2026-07-13T01:00:00Z',
+};
+
+describe('CommunicationTemplateRepository', () => {
+  it('maps templates and versions', () => {
+    expect(mapCommunicationTemplateVersion(versionRow)).toMatchObject({ versionNumber: 2, variableKeys: ['patient_first_name'] });
+    expect(mapCommunicationTemplate(templateRow)).toMatchObject({
+      tenantId, channel: 'sms', language: 'ru', draftVersion: { id: 'version-a' },
+    });
+  });
+
+  it('lists templates tenant-scoped with deterministic filters', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [templateRow], error: null });
+    const repository = new SupabaseCommunicationTemplateRepository(tenantId, { rpc } as unknown as SupabaseClient);
+    await expect(repository.listTemplates({ channel: 'sms', language: 'ru' })).resolves.toHaveLength(1);
+    expect(rpc).toHaveBeenCalledWith('list_communication_templates', {
+      p_tenant_id: tenantId, p_purpose_code: null, p_channel: 'sms', p_language: 'ru',
+    });
+  });
+
+  it('calls every controlled mutation and preview RPC', async () => {
+    const result = { template: templateRow, version: versionRow, replayed: false };
+    const rpc = vi.fn()
+      .mockResolvedValueOnce({ data: result, error: null })
+      .mockResolvedValueOnce({ data: result, error: null })
+      .mockResolvedValueOnce({ data: result, error: null })
+      .mockResolvedValueOnce({ data: result, error: null })
+      .mockResolvedValueOnce({ data: { template: templateRow, replayed: false }, error: null })
+      .mockResolvedValueOnce({ data: {
+        templateId: 'template-a', versionId: 'version-a', versionNumber: 2,
+        purposeCode: 'appointment_confirmation_request', channel: 'sms', language: 'ru',
+        contentFingerprint: 'a'.repeat(64), rendered: {
+          body: 'Здравствуйте, Айгүл', renderedCharacterCount: 19,
+          renderedFingerprint: 'b'.repeat(64), variableKeys: ['patient_first_name'], warnings: [],
+        },
+      }, error: null });
+    const repository = new SupabaseCommunicationTemplateRepository(tenantId, { rpc } as unknown as SupabaseClient);
+
+    await repository.createTemplate({
+      purposeCode: 'appointment_confirmation_request', channel: 'sms', language: 'ru',
+      displayName: 'RU', body: 'Привет', operationKey: 'template-create-a',
+    });
+    await repository.createDraft('template-a', 'template-draft-a');
+    await repository.updateDraft({ versionId: 'version-a', body: 'Текст', expectedUpdatedAt: 'v1', operationKey: 'template-update-a' });
+    await repository.publishVersion('template-a', 'version-a', 'v1', 'template-publish-a');
+    await repository.archiveTemplate('template-a', 't1', 'template-archive-a');
+    await repository.previewTemplate('version-a', { patient_first_name: 'Айгүл' });
+
+    expect(rpc.mock.calls.map(([name]) => name)).toEqual([
+      'create_communication_template', 'create_communication_template_draft',
+      'update_communication_template_draft', 'publish_communication_template_version',
+      'archive_communication_template', 'preview_communication_template',
+    ]);
+    expect(rpc.mock.calls.every(([, params]) => params.p_tenant_id === tenantId)).toBe(true);
+  });
+
+  it('maps database failures to safe messages', () => {
+    expect(toSafeCommunicationTemplateError({ message: 'permission denied 42501' })).toMatchObject({ code: 'permission' });
+    expect(toSafeCommunicationTemplateError({ message: 'Шаблон содержит неизвестную или некорректную переменную.' })).toMatchObject({ code: 'invalid_template' });
+    expect(toSafeCommunicationTemplateError({ message: 'Для формирования сообщения не хватает обязательных данных.' })).toMatchObject({ code: 'missing_variable' });
+    expect(toSafeCommunicationTemplateError({ message: 'Опубликованную версию нельзя изменить.' })).toMatchObject({ code: 'published_immutable' });
+    expect(toSafeCommunicationTemplateError({ message: '40001' })).toMatchObject({ code: 'stale' });
+    expect(toSafeCommunicationTemplateError({ message: '23505' })).toMatchObject({ code: 'conflict' });
+    expect(toSafeCommunicationTemplateError({ message: 'internal SQL stack trace' }))
+      .toEqual(new CommunicationTemplateRepositoryError('save_failed'));
+  });
+
+  it('has no direct table writes or provider path', () => {
+    expect(repositorySource).not.toMatch(/\.insert\s*\(|\.update\s*\(|\.delete\s*\(/);
+    expect(repositorySource).not.toMatch(/fetch\s*\(|axios|twilio|smtp|amocrm|whatsapp.*api|service[_-]?role/i);
+  });
+});

--- a/src/data/repositories/CommunicationTemplateRepository.ts
+++ b/src/data/repositories/CommunicationTemplateRepository.ts
@@ -1,0 +1,354 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '../../lib/supabaseClient';
+import type { CommunicationChannel, CommunicationLanguage, CommunicationPurpose } from '../../domain/communications/CommunicationCommand';
+import type {
+  CommunicationTemplate,
+  CommunicationTemplateVersion,
+  CommunicationTemplateVariable,
+} from '../../domain/communications/CommunicationTemplate';
+
+type Row = Record<string, unknown>;
+
+export interface CommunicationTemplateFilters {
+  purposeCode?: CommunicationPurpose;
+  channel?: CommunicationChannel;
+  language?: CommunicationLanguage;
+}
+
+export interface CreateCommunicationTemplateInput {
+  purposeCode: CommunicationPurpose;
+  channel: CommunicationChannel;
+  language: CommunicationLanguage;
+  displayName: string;
+  subject?: string;
+  body: string;
+  operationKey: string;
+}
+
+export interface UpdateCommunicationTemplateDraftInput {
+  versionId: string;
+  subject?: string;
+  body: string;
+  expectedUpdatedAt: string;
+  operationKey: string;
+}
+
+export interface CommunicationTemplateMutationResult {
+  template: CommunicationTemplate;
+  version?: CommunicationTemplateVersion;
+  supersededVersion?: CommunicationTemplateVersion;
+  replayed: boolean;
+}
+
+export interface CommunicationTemplatePreview {
+  templateId: string;
+  versionId: string;
+  versionNumber: number;
+  purposeCode: CommunicationPurpose;
+  channel: CommunicationChannel;
+  language: CommunicationLanguage;
+  contentFingerprint: string;
+  rendered: {
+    subject?: string;
+    body: string;
+    renderedCharacterCount: number;
+    renderedFingerprint: string;
+    variableKeys: CommunicationTemplateVariable[];
+    warnings: string[];
+  };
+}
+
+export type CommunicationTemplateRepositoryErrorCode =
+  | 'permission'
+  | 'invalid_template'
+  | 'missing_variable'
+  | 'published_immutable'
+  | 'stale'
+  | 'conflict'
+  | 'not_found'
+  | 'read_failed'
+  | 'save_failed';
+
+const SAFE_MESSAGES: Record<CommunicationTemplateRepositoryErrorCode, string> = {
+  permission: 'Недостаточно прав для управления шаблонами.',
+  invalid_template: 'Шаблон содержит неизвестную или некорректную переменную.',
+  missing_variable: 'Для формирования сообщения не хватает обязательных данных.',
+  published_immutable: 'Опубликованную версию нельзя изменить. Создайте новую версию.',
+  stale: 'Черновик был изменён другим пользователем. Обновите данные.',
+  conflict: 'Операция уже выполнена с другими параметрами.',
+  not_found: 'Шаблон не найден.',
+  read_failed: 'Не удалось загрузить шаблоны.',
+  save_failed: 'Не удалось сохранить шаблон.',
+};
+
+export class CommunicationTemplateRepositoryError extends Error {
+  readonly code: CommunicationTemplateRepositoryErrorCode;
+
+  constructor(code: CommunicationTemplateRepositoryErrorCode, message = SAFE_MESSAGES[code]) {
+    super(message);
+    this.name = 'CommunicationTemplateRepositoryError';
+    this.code = code;
+  }
+}
+
+const value = (row: Row, camel: string, snake: string): unknown => row[camel] ?? row[snake];
+const optionalString = (item: unknown): string | undefined => {
+  const normalized = String(item ?? '');
+  return normalized || undefined;
+};
+
+export function mapCommunicationTemplateVersion(row: Row): CommunicationTemplateVersion {
+  return {
+    id: String(value(row, 'id', 'id')),
+    tenantId: String(value(row, 'tenantId', 'tenant_id')),
+    templateId: String(value(row, 'templateId', 'template_id')),
+    versionNumber: Number(value(row, 'versionNumber', 'version_number')),
+    status: value(row, 'status', 'status') as CommunicationTemplateVersion['status'],
+    subject: optionalString(value(row, 'subject', 'subject')),
+    body: String(value(row, 'body', 'body') ?? ''),
+    variableKeys: (value(row, 'variableKeys', 'variable_keys') ?? []) as CommunicationTemplateVariable[],
+    contentFingerprint: String(value(row, 'contentFingerprint', 'content_fingerprint') ?? ''),
+    createdBy: optionalString(value(row, 'createdBy', 'created_by')),
+    createdAt: String(value(row, 'createdAt', 'created_at') ?? ''),
+    updatedAt: String(value(row, 'updatedAt', 'updated_at') ?? ''),
+    publishedBy: optionalString(value(row, 'publishedBy', 'published_by')),
+    publishedAt: optionalString(value(row, 'publishedAt', 'published_at')),
+    archivedAt: optionalString(value(row, 'archivedAt', 'archived_at')),
+    supersedesVersionId: optionalString(value(row, 'supersedesVersionId', 'supersedes_version_id')),
+  };
+}
+
+export function mapCommunicationTemplate(row: Row): CommunicationTemplate {
+  const active = value(row, 'activeVersion', 'active_version') as Row | null | undefined;
+  const draft = value(row, 'draftVersion', 'draft_version') as Row | null | undefined;
+  return {
+    id: String(value(row, 'id', 'id')),
+    tenantId: String(value(row, 'tenantId', 'tenant_id')),
+    purposeCode: value(row, 'purposeCode', 'purpose_code') as CommunicationPurpose,
+    channel: value(row, 'channel', 'channel') as CommunicationChannel,
+    language: value(row, 'language', 'language') as CommunicationLanguage,
+    displayName: String(value(row, 'displayName', 'display_name') ?? ''),
+    status: value(row, 'status', 'status') as CommunicationTemplate['status'],
+    activeVersionId: optionalString(value(row, 'activeVersionId', 'active_version_id')),
+    activeVersion: active ? mapCommunicationTemplateVersion(active) : undefined,
+    draftVersion: draft ? mapCommunicationTemplateVersion(draft) : undefined,
+    createdAt: String(value(row, 'createdAt', 'created_at') ?? ''),
+    updatedAt: String(value(row, 'updatedAt', 'updated_at') ?? ''),
+    archivedAt: optionalString(value(row, 'archivedAt', 'archived_at')),
+  };
+}
+
+const object = (data: unknown): Row => (
+  data && typeof data === 'object' && !Array.isArray(data) ? data as Row : {}
+);
+
+export function toSafeCommunicationTemplateError(
+  error: unknown,
+  context: 'read' | 'write' = 'write',
+): CommunicationTemplateRepositoryError {
+  if (error instanceof CommunicationTemplateRepositoryError) return error;
+  const row = error && typeof error === 'object' ? error as Row : {};
+  const normalized = [row.message, row.details, row.hint, row.code, error]
+    .map((item) => String(item ?? '')).join(' ').toLowerCase();
+  if (normalized.includes('недостаточно прав') || normalized.includes('42501') || normalized.includes('permission denied')) {
+    return new CommunicationTemplateRepositoryError('permission');
+  }
+  if (normalized.includes('неизвестную или некорректную') || normalized.includes('запрещённую клиническую')
+    || normalized.includes('тема разрешена') || normalized.includes('требуется тема') || normalized.includes('превышает допустимую')) {
+    return new CommunicationTemplateRepositoryError('invalid_template');
+  }
+  if (normalized.includes('не хватает обязательных данных')) return new CommunicationTemplateRepositoryError('missing_variable');
+  if (normalized.includes('опубликованную версию')) return new CommunicationTemplateRepositoryError('published_immutable');
+  if (normalized.includes('изменён другим пользователем') || normalized.includes('40001')) {
+    return new CommunicationTemplateRepositoryError('stale');
+  }
+  if (normalized.includes('другими параметрами') || normalized.includes('уже существует') || normalized.includes('23505')) {
+    return new CommunicationTemplateRepositoryError('conflict');
+  }
+  if (normalized.includes('не найден') || normalized.includes('p0002')) return new CommunicationTemplateRepositoryError('not_found');
+  return new CommunicationTemplateRepositoryError(context === 'read' ? 'read_failed' : 'save_failed');
+}
+
+export interface CommunicationTemplateRepository {
+  listTemplates(filters?: CommunicationTemplateFilters): Promise<CommunicationTemplate[]>;
+  getTemplate(templateId: string): Promise<CommunicationTemplate | null>;
+  getActiveTemplate(purpose: CommunicationPurpose, channel: CommunicationChannel, language: CommunicationLanguage): Promise<CommunicationTemplateMutationResult | null>;
+  createTemplate(input: CreateCommunicationTemplateInput): Promise<CommunicationTemplateMutationResult>;
+  createDraft(templateId: string, operationKey: string): Promise<CommunicationTemplateMutationResult>;
+  updateDraft(input: UpdateCommunicationTemplateDraftInput): Promise<CommunicationTemplateMutationResult>;
+  publishVersion(templateId: string, draftVersionId: string, expectedUpdatedAt: string, operationKey: string): Promise<CommunicationTemplateMutationResult>;
+  archiveTemplate(templateId: string, expectedUpdatedAt: string, operationKey: string): Promise<CommunicationTemplateMutationResult>;
+  previewTemplate(versionId: string, variables: Record<string, string>): Promise<CommunicationTemplatePreview>;
+}
+
+export class SupabaseCommunicationTemplateRepository implements CommunicationTemplateRepository {
+  private readonly tenantId: string;
+  private readonly client: SupabaseClient;
+
+  constructor(tenantId: string, client: SupabaseClient) {
+    this.tenantId = tenantId;
+    this.client = client;
+  }
+
+  async listTemplates(filters: CommunicationTemplateFilters = {}): Promise<CommunicationTemplate[]> {
+    try {
+      const { data, error } = await this.client.rpc('list_communication_templates', {
+        p_tenant_id: this.tenantId,
+        p_purpose_code: filters.purposeCode ?? null,
+        p_channel: filters.channel ?? null,
+        p_language: filters.language ?? null,
+      });
+      if (error) throw error;
+      return (Array.isArray(data) ? data : []).map((row) => mapCommunicationTemplate(row as Row));
+    } catch (error) {
+      throw toSafeCommunicationTemplateError(error, 'read');
+    }
+  }
+
+  async getTemplate(templateId: string): Promise<CommunicationTemplate | null> {
+    try {
+      const { data, error } = await this.client.rpc('get_communication_template', {
+        p_tenant_id: this.tenantId,
+        p_template_id: templateId,
+      });
+      if (error) throw error;
+      return data ? mapCommunicationTemplate(object(data)) : null;
+    } catch (error) {
+      throw toSafeCommunicationTemplateError(error, 'read');
+    }
+  }
+
+  async getActiveTemplate(
+    purpose: CommunicationPurpose,
+    channel: CommunicationChannel,
+    language: CommunicationLanguage,
+  ): Promise<CommunicationTemplateMutationResult | null> {
+    try {
+      const { data, error } = await this.client.rpc('get_active_communication_template', {
+        p_tenant_id: this.tenantId,
+        p_purpose_code: purpose,
+        p_channel: channel,
+        p_language: language,
+      });
+      if (error) throw error;
+      if (!data) return null;
+      const result = object(data);
+      return {
+        template: mapCommunicationTemplate(object(result.template)),
+        version: mapCommunicationTemplateVersion(object(result.version)),
+        replayed: false,
+      };
+    } catch (error) {
+      throw toSafeCommunicationTemplateError(error, 'read');
+    }
+  }
+
+  private async mutation(name: string, params: Row): Promise<CommunicationTemplateMutationResult> {
+    try {
+      const { data, error } = await this.client.rpc(name, params);
+      if (error) throw error;
+      const result = object(data);
+      return {
+        template: mapCommunicationTemplate(object(result.template)),
+        version: result.version ? mapCommunicationTemplateVersion(object(result.version)) : undefined,
+        supersededVersion: result.supersededVersion
+          ? mapCommunicationTemplateVersion(object(result.supersededVersion)) : undefined,
+        replayed: Boolean(result.replayed),
+      };
+    } catch (error) {
+      throw toSafeCommunicationTemplateError(error);
+    }
+  }
+
+  createTemplate(input: CreateCommunicationTemplateInput): Promise<CommunicationTemplateMutationResult> {
+    return this.mutation('create_communication_template', {
+      p_tenant_id: this.tenantId,
+      p_purpose_code: input.purposeCode,
+      p_channel: input.channel,
+      p_language: input.language,
+      p_display_name: input.displayName,
+      p_subject: input.subject ?? null,
+      p_body: input.body,
+      p_operation_key: input.operationKey,
+    });
+  }
+
+  createDraft(templateId: string, operationKey: string): Promise<CommunicationTemplateMutationResult> {
+    return this.mutation('create_communication_template_draft', {
+      p_tenant_id: this.tenantId,
+      p_template_id: templateId,
+      p_operation_key: operationKey,
+    });
+  }
+
+  updateDraft(input: UpdateCommunicationTemplateDraftInput): Promise<CommunicationTemplateMutationResult> {
+    return this.mutation('update_communication_template_draft', {
+      p_tenant_id: this.tenantId,
+      p_version_id: input.versionId,
+      p_subject: input.subject ?? null,
+      p_body: input.body,
+      p_expected_updated_at: input.expectedUpdatedAt,
+      p_operation_key: input.operationKey,
+    });
+  }
+
+  publishVersion(templateId: string, draftVersionId: string, expectedUpdatedAt: string, operationKey: string): Promise<CommunicationTemplateMutationResult> {
+    return this.mutation('publish_communication_template_version', {
+      p_tenant_id: this.tenantId,
+      p_template_id: templateId,
+      p_draft_version_id: draftVersionId,
+      p_expected_draft_updated_at: expectedUpdatedAt,
+      p_operation_key: operationKey,
+    });
+  }
+
+  archiveTemplate(templateId: string, expectedUpdatedAt: string, operationKey: string): Promise<CommunicationTemplateMutationResult> {
+    return this.mutation('archive_communication_template', {
+      p_tenant_id: this.tenantId,
+      p_template_id: templateId,
+      p_expected_updated_at: expectedUpdatedAt,
+      p_operation_key: operationKey,
+    });
+  }
+
+  async previewTemplate(versionId: string, variables: Record<string, string>): Promise<CommunicationTemplatePreview> {
+    try {
+      const { data, error } = await this.client.rpc('preview_communication_template', {
+        p_tenant_id: this.tenantId,
+        p_version_id: versionId,
+        p_variables: variables,
+      });
+      if (error) throw error;
+      const result = object(data);
+      const rendered = object(result.rendered);
+      return {
+        templateId: String(result.templateId ?? ''),
+        versionId: String(result.versionId ?? ''),
+        versionNumber: Number(result.versionNumber ?? 0),
+        purposeCode: result.purposeCode as CommunicationPurpose,
+        channel: result.channel as CommunicationChannel,
+        language: result.language as CommunicationLanguage,
+        contentFingerprint: String(result.contentFingerprint ?? ''),
+        rendered: {
+          subject: optionalString(rendered.subject),
+          body: String(rendered.body ?? ''),
+          renderedCharacterCount: Number(rendered.renderedCharacterCount ?? 0),
+          renderedFingerprint: String(rendered.renderedFingerprint ?? ''),
+          variableKeys: (rendered.variableKeys ?? []) as CommunicationTemplateVariable[],
+          warnings: (rendered.warnings ?? []) as string[],
+        },
+      };
+    } catch (error) {
+      throw toSafeCommunicationTemplateError(error);
+    }
+  }
+}
+
+export function createCommunicationTemplateRepository(options: {
+  tenantId: string;
+  client?: SupabaseClient | null;
+}): CommunicationTemplateRepository {
+  const client = options.client ?? supabase;
+  if (!client) throw new CommunicationTemplateRepositoryError('read_failed');
+  return new SupabaseCommunicationTemplateRepository(options.tenantId, client);
+}

--- a/src/domain/communications/CommunicationCommand.test.ts
+++ b/src/domain/communications/CommunicationCommand.test.ts
@@ -38,10 +38,11 @@ describe('CommunicationCommand', () => {
     expect(deriveCommunicationPurpose('day_before_reminder')).toBe('appointment_day_before_reminder');
     expect(deriveCommunicationPurpose('same_day_reminder')).toBe('appointment_same_day_reminder');
     expect(deriveCommunicationPurpose('control_call_task')).toBe('appointment_control_call_task');
+    expect(deriveCommunicationPurpose('callback_task')).toBe('appointment_control_call_task');
   });
 
   it('rejects unsupported reminder types', () => {
-    expect(() => deriveCommunicationPurpose('callback_task')).toThrow(/Unsupported/);
+    expect(() => deriveCommunicationPurpose('marketing_blast')).toThrow(/Unsupported/);
   });
 
   it('accepts only allowlisted variables', () => {

--- a/src/domain/communications/CommunicationCommand.ts
+++ b/src/domain/communications/CommunicationCommand.ts
@@ -61,6 +61,23 @@ export interface CommunicationCommand {
   operationKey: string;
   variables: CommunicationVariableMap;
   requestedAt: string;
+  template?: {
+    templateId: string;
+    templateVersionId: string;
+    versionNumber: number;
+    contentFingerprint: string;
+    renderedContentFingerprint: string;
+    language: CommunicationLanguage;
+    channel: CommunicationChannel;
+    purposeCode: CommunicationPurpose;
+    variableKeys: string[];
+  };
+  renderedContent?: {
+    subject?: string;
+    body: string;
+    renderedCharacterCount: number;
+    renderedFingerprint: string;
+  };
 }
 
 const PURPOSES: Record<string, CommunicationPurpose | undefined> = {
@@ -68,6 +85,7 @@ const PURPOSES: Record<string, CommunicationPurpose | undefined> = {
   day_before_reminder: 'appointment_day_before_reminder',
   same_day_reminder: 'appointment_same_day_reminder',
   control_call_task: 'appointment_control_call_task',
+  callback_task: 'appointment_control_call_task',
 };
 
 export function deriveCommunicationPurpose(reminderType: string): CommunicationPurpose {

--- a/src/domain/communications/CommunicationTemplate.test.ts
+++ b/src/domain/communications/CommunicationTemplate.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CommunicationTemplateValidationError,
+  parseCommunicationTemplateVariables,
+  validateCommunicationTemplateContent,
+} from './CommunicationTemplate';
+
+describe('CommunicationTemplate', () => {
+  it('parses allowed placeholders in deterministic order', () => {
+    expect(parseCommunicationTemplateVariables(
+      'Здравствуйте, {{patient_first_name}}',
+      '{{appointment_time}} {{clinic_name}} {{patient_first_name}}',
+    )).toEqual(['appointment_time', 'clinic_name', 'patient_first_name']);
+  });
+
+  it.each(['unknown_value', 'raw_phone', 'document'])(
+    'rejects unknown placeholder %s',
+    (key) => expect(() => parseCommunicationTemplateVariables(`{{${key}}}`))
+      .toThrow(CommunicationTemplateValidationError),
+  );
+
+  it.each(['diagnosis', 'complaint', 'finding', 'treatment_plan'])(
+    'rejects clinical placeholder %s',
+    (key) => expect(() => parseCommunicationTemplateVariables(`{{${key}}}`))
+      .toThrow(/клиническую или финансовую/),
+  );
+
+  it.each(['balance', 'debt', 'invoice', 'payment'])(
+    'rejects financial placeholder %s',
+    (key) => expect(() => parseCommunicationTemplateVariables(`{{${key}}}`))
+      .toThrow(/клиническую или финансовую/),
+  );
+
+  it.each(['{{patient_first_name}', '{patient_first_name}}', '{{ patient_first_name }}', '{{{{patient_first_name}}}}'])(
+    'rejects malformed braces %s',
+    (body) => {
+      expect(() => parseCommunicationTemplateVariables(body)).toThrow(/некорректную переменную/);
+    },
+  );
+
+  it('preserves RU and KK Unicode', () => {
+    expect(validateCommunicationTemplateContent({
+      channel: 'sms',
+      body: 'Здравствуйте, {{patient_first_name}}. Қабылдау уақыты {{appointment_time}}.',
+    }).variableKeys).toEqual(['appointment_time', 'patient_first_name']);
+  });
+
+  it('rejects subject for SMS and WhatsApp', () => {
+    expect(() => validateCommunicationTemplateContent({ channel: 'sms', subject: 'Тема', body: 'Текст' }))
+      .toThrow(/только для email/);
+    expect(() => validateCommunicationTemplateContent({ channel: 'whatsapp', subject: 'Тема', body: 'Текст' }))
+      .toThrow(/только для email/);
+  });
+
+  it('requires and accepts email subject', () => {
+    expect(() => validateCommunicationTemplateContent({ channel: 'email', body: 'Текст' }))
+      .toThrow(/требуется тема/);
+    expect(validateCommunicationTemplateContent({ channel: 'email', subject: 'Напоминание', body: 'Текст' }))
+      .toEqual({ variableKeys: [], warnings: [] });
+  });
+
+  it('enforces channel limits and plain text', () => {
+    expect(() => validateCommunicationTemplateContent({ channel: 'sms', body: 'x'.repeat(1001) }))
+      .toThrow(/превышает/);
+    expect(() => validateCommunicationTemplateContent({ channel: 'email', subject: 'Тема', body: '<script>x</script>' }))
+      .toThrow(/HTML/);
+  });
+});

--- a/src/domain/communications/CommunicationTemplate.ts
+++ b/src/domain/communications/CommunicationTemplate.ts
@@ -1,0 +1,179 @@
+import type { CommunicationChannel, CommunicationLanguage, CommunicationPurpose } from './CommunicationCommand';
+
+export const COMMUNICATION_TEMPLATE_PURPOSES = [
+  'appointment_confirmation_request',
+  'appointment_day_before_reminder',
+  'appointment_same_day_reminder',
+  'appointment_control_call_task',
+] as const satisfies readonly CommunicationPurpose[];
+
+export const COMMUNICATION_TEMPLATE_CHANNELS = ['sms', 'whatsapp', 'email'] as const satisfies readonly CommunicationChannel[];
+export const COMMUNICATION_TEMPLATE_LANGUAGES = ['ru', 'kk', 'en'] as const satisfies readonly CommunicationLanguage[];
+
+export const COMMUNICATION_TEMPLATE_VARIABLES = [
+  'appointment_date',
+  'appointment_time',
+  'clinic_callback_phone',
+  'clinic_name',
+  'doctor_display_name',
+  'patient_first_name',
+] as const;
+
+export type CommunicationTemplateVariable = typeof COMMUNICATION_TEMPLATE_VARIABLES[number];
+export type CommunicationTemplateStatus = 'active' | 'inactive' | 'archived';
+export type CommunicationTemplateVersionStatus = 'draft' | 'published' | 'superseded' | 'archived';
+
+export interface CommunicationTemplateVersion {
+  id: string;
+  tenantId: string;
+  templateId: string;
+  versionNumber: number;
+  status: CommunicationTemplateVersionStatus;
+  subject?: string;
+  body: string;
+  variableKeys: CommunicationTemplateVariable[];
+  contentFingerprint: string;
+  createdBy?: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedBy?: string;
+  publishedAt?: string;
+  archivedAt?: string;
+  supersedesVersionId?: string;
+}
+
+export interface CommunicationTemplate {
+  id: string;
+  tenantId: string;
+  purposeCode: CommunicationPurpose;
+  channel: CommunicationChannel;
+  language: CommunicationLanguage;
+  displayName: string;
+  status: CommunicationTemplateStatus;
+  activeVersionId?: string;
+  activeVersion?: CommunicationTemplateVersion;
+  draftVersion?: CommunicationTemplateVersion;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt?: string;
+}
+
+export interface CommunicationTemplateContent {
+  channel: CommunicationChannel;
+  subject?: string | null;
+  body: string;
+}
+
+export interface CommunicationTemplateValidation {
+  variableKeys: CommunicationTemplateVariable[];
+  warnings: string[];
+}
+
+export class CommunicationTemplateValidationError extends Error {
+  readonly code:
+    | 'invalid_placeholder'
+    | 'forbidden_variable'
+    | 'unknown_variable'
+    | 'invalid_content'
+    | 'missing_subject'
+    | 'subject_forbidden'
+    | 'length_exceeded';
+
+  constructor(code: CommunicationTemplateValidationError['code'], message: string) {
+    super(message);
+    this.name = 'CommunicationTemplateValidationError';
+    this.code = code;
+  }
+}
+
+const ALLOWED_SET = new Set<string>(COMMUNICATION_TEMPLATE_VARIABLES);
+const CLINICAL_VARIABLES = new Set([
+  'diagnosis', 'complaint', 'finding', 'tooth', 'treatment', 'treatment_plan',
+  'procedure', 'medical_result', 'clinical_result',
+]);
+const FINANCIAL_VARIABLES = new Set([
+  'balance', 'debt', 'invoice', 'payment', 'discount', 'refund', 'write_off',
+]);
+
+const PLACEHOLDER = /\{\{([a-z][a-z0-9_]*)\}\}/g;
+const HTML_LIKE_MARKUP = /<\/?[a-z][^>]*>/i;
+
+const hasForbiddenControlCharacter = (value: string): boolean => Array.from(value).some((character) => {
+  const code = character.charCodeAt(0);
+  return code === 127 || (code < 32 && code !== 9 && code !== 10 && code !== 13);
+});
+
+export function parseCommunicationTemplateVariables(...parts: Array<string | null | undefined>): CommunicationTemplateVariable[] {
+  const joined = parts.filter((part): part is string => typeof part === 'string').join('\n');
+  const variables = new Set<string>();
+  let match: RegExpExecArray | null;
+  PLACEHOLDER.lastIndex = 0;
+  while ((match = PLACEHOLDER.exec(joined)) !== null) variables.add(match[1]);
+
+  const residual = joined.replace(PLACEHOLDER, '');
+  PLACEHOLDER.lastIndex = 0;
+  if (/[{}]/.test(residual)) {
+    throw new CommunicationTemplateValidationError(
+      'invalid_placeholder',
+      'Шаблон содержит неизвестную или некорректную переменную.',
+    );
+  }
+
+  for (const variable of variables) {
+    if (CLINICAL_VARIABLES.has(variable) || FINANCIAL_VARIABLES.has(variable)) {
+      throw new CommunicationTemplateValidationError(
+        'forbidden_variable',
+        'Шаблон содержит запрещённую клиническую или финансовую переменную.',
+      );
+    }
+    if (!ALLOWED_SET.has(variable)) {
+      throw new CommunicationTemplateValidationError(
+        'unknown_variable',
+        'Шаблон содержит неизвестную или некорректную переменную.',
+      );
+    }
+  }
+
+  return [...variables].sort() as CommunicationTemplateVariable[];
+}
+
+export function validateCommunicationTemplateContent(
+  content: CommunicationTemplateContent,
+): CommunicationTemplateValidation {
+  const body = content.body ?? '';
+  const subject = content.subject?.trim() || null;
+  if (!body.trim()) {
+    throw new CommunicationTemplateValidationError('invalid_content', 'Текст шаблона не может быть пустым.');
+  }
+  if (hasForbiddenControlCharacter(body) || (subject && hasForbiddenControlCharacter(subject))) {
+    throw new CommunicationTemplateValidationError('invalid_content', 'Шаблон содержит недопустимые управляющие символы.');
+  }
+  if (HTML_LIKE_MARKUP.test(body) || (subject && HTML_LIKE_MARKUP.test(subject))) {
+    throw new CommunicationTemplateValidationError('invalid_content', 'HTML и исполняемая разметка в шаблонах запрещены.');
+  }
+
+  if (content.channel === 'email') {
+    if (!subject) {
+      throw new CommunicationTemplateValidationError('missing_subject', 'Для email-шаблона требуется тема.');
+    }
+    if (subject.length > 200) {
+      throw new CommunicationTemplateValidationError('length_exceeded', 'Тема email превышает допустимую длину.');
+    }
+  } else if (subject) {
+    throw new CommunicationTemplateValidationError('subject_forbidden', 'Тема разрешена только для email-шаблона.');
+  }
+
+  const limit = content.channel === 'sms' ? 1000 : content.channel === 'whatsapp' ? 4000 : 10000;
+  if (body.length > limit) {
+    throw new CommunicationTemplateValidationError('length_exceeded', 'Текст шаблона превышает допустимую длину.');
+  }
+
+  const variableKeys = parseCommunicationTemplateVariables(subject, body);
+  const warnings: string[] = [];
+  if (content.channel === 'sms' && body.length > 160) warnings.push('sms_practical_single_message_length');
+  return { variableKeys, warnings };
+}
+
+export function isCommunicationTemplateVariable(value: string): value is CommunicationTemplateVariable {
+  return ALLOWED_SET.has(value);
+}

--- a/src/domain/communications/CommunicationTemplateRenderer.test.ts
+++ b/src/domain/communications/CommunicationTemplateRenderer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fingerprintCommunicationTemplateContent,
+  renderCommunicationTemplate,
+} from './CommunicationTemplateRenderer';
+
+const content = {
+  channel: 'sms' as const,
+  body: 'Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+};
+
+const variables = {
+  patient_first_name: 'Айгүл',
+  clinic_name: 'Алтынсака',
+  appointment_date: '14.07.2026',
+  appointment_time: '10:30',
+};
+
+describe('CommunicationTemplateRenderer', () => {
+  it('renders deterministically and preserves Unicode', async () => {
+    const first = await renderCommunicationTemplate(content, variables);
+    const second = await renderCommunicationTemplate(content, variables);
+    expect(first).toEqual(second);
+    expect(first.body).toContain('Айгүл');
+    expect(first.renderedFingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('rejects missing variables', async () => {
+    await expect(renderCommunicationTemplate(content, {
+      patient_first_name: 'Айгүл',
+      clinic_name: 'Алтынсака',
+      appointment_date: '14.07.2026',
+    })).rejects.toThrow(/не хватает обязательных данных/);
+  });
+
+  it('rejects extra variables', async () => {
+    await expect(renderCommunicationTemplate(content, {
+      ...variables,
+      diagnosis: 'секрет',
+    })).rejects.toThrow(/лишние или неизвестные/);
+  });
+
+  it('creates deterministic content fingerprint and changes it with body', async () => {
+    const first = await fingerprintCommunicationTemplateContent(content);
+    const second = await fingerprintCommunicationTemplateContent(content);
+    const changed = await fingerprintCommunicationTemplateContent({ ...content, body: `${content.body}!` });
+    expect(first).toBe(second);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(changed).not.toBe(first);
+  });
+
+  it('returns practical SMS warning without segmenting or sending', async () => {
+    const result = await renderCommunicationTemplate({ channel: 'sms', body: 'x'.repeat(161) }, {});
+    expect(result.warnings).toContain('sms_practical_single_message_length');
+    expect(result.renderedCharacterCount).toBe(161);
+  });
+});

--- a/src/domain/communications/CommunicationTemplateRenderer.ts
+++ b/src/domain/communications/CommunicationTemplateRenderer.ts
@@ -1,0 +1,91 @@
+import {
+  type CommunicationTemplateContent,
+  type CommunicationTemplateVariable,
+  CommunicationTemplateValidationError,
+  parseCommunicationTemplateVariables,
+  validateCommunicationTemplateContent,
+} from './CommunicationTemplate';
+
+export interface CommunicationTemplateRenderResult {
+  subject?: string;
+  body: string;
+  renderedCharacterCount: number;
+  renderedFingerprint: string;
+  variableKeys: CommunicationTemplateVariable[];
+  warnings: string[];
+}
+
+const encoder = new TextEncoder();
+
+export async function sha256Hex(value: string): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('Web Crypto API is required for deterministic template fingerprints.');
+  }
+  const digest = await subtle.digest('SHA-256', encoder.encode(value));
+  return Array.from(new Uint8Array(digest), (item) => item.toString(16).padStart(2, '0')).join('');
+}
+
+export async function fingerprintCommunicationTemplateContent(
+  content: CommunicationTemplateContent,
+): Promise<string> {
+  const validation = validateCommunicationTemplateContent(content);
+  return sha256Hex(JSON.stringify({
+    channel: content.channel,
+    subject: content.subject?.trim() || null,
+    body: content.body,
+    variableKeys: validation.variableKeys,
+  }));
+}
+
+export async function renderCommunicationTemplate(
+  content: CommunicationTemplateContent,
+  variables: Record<string, string>,
+): Promise<CommunicationTemplateRenderResult> {
+  const validation = validateCommunicationTemplateContent(content);
+  const required = validation.variableKeys;
+  const provided = Object.keys(variables).sort();
+
+  for (const key of required) {
+    if (!Object.prototype.hasOwnProperty.call(variables, key) || !String(variables[key] ?? '').trim()) {
+      throw new CommunicationTemplateValidationError(
+        'invalid_content',
+        'Для формирования сообщения не хватает обязательных данных.',
+      );
+    }
+  }
+  const extra = provided.filter((key) => !required.includes(key as CommunicationTemplateVariable));
+  if (extra.length > 0) {
+    throw new CommunicationTemplateValidationError(
+      'unknown_variable',
+      'Переданы лишние или неизвестные переменные шаблона.',
+    );
+  }
+
+  const replace = (input: string): string => input.replace(
+    /\{\{([a-z][a-z0-9_]*)\}\}/g,
+    (_placeholder, key: string) => String(variables[key] ?? ''),
+  );
+  const subject = content.subject?.trim() ? replace(content.subject.trim()) : undefined;
+  const body = replace(content.body);
+  parseCommunicationTemplateVariables(subject, body);
+  const warnings = [...validation.warnings];
+  if (content.channel === 'sms' && body.length > 160 && !warnings.includes('sms_practical_single_message_length')) {
+    warnings.push('sms_practical_single_message_length');
+  }
+  const renderedFingerprint = await sha256Hex(JSON.stringify({
+    channel: content.channel,
+    subject: subject ?? null,
+    body,
+    variableKeys: required,
+  }));
+
+  return {
+    subject,
+    body,
+    renderedCharacterCount: body.length + (subject?.length ?? 0),
+    renderedFingerprint,
+    variableKeys: required,
+    warnings,
+  };
+}

--- a/src/pages/CommunicationTemplatesPage.tsx
+++ b/src/pages/CommunicationTemplatesPage.tsx
@@ -1,0 +1,20 @@
+import { FileText } from 'lucide-react';
+import { CommunicationTemplateManager } from '../components/communications/CommunicationTemplateManager';
+
+export function CommunicationTemplatesPage() {
+  return (
+    <div className="mx-auto max-w-[1600px] p-6">
+      <header className="mb-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center gap-2 text-indigo-700">
+          <FileText className="h-5 w-5" />
+          <span className="text-sm font-semibold uppercase tracking-wide">Versioned plain-text foundation</span>
+        </div>
+        <h1 className="mt-1 text-2xl font-bold text-slate-900">Шаблоны коммуникаций</h1>
+        <p className="mt-2 max-w-3xl text-sm text-slate-600">
+          Управление точными версиями шаблонов для напоминаний. Шаблон и предпросмотр не являются отправкой сообщения.
+        </p>
+      </header>
+      <CommunicationTemplateManager />
+    </div>
+  );
+}

--- a/supabase/migrations/0033_communication_template_foundation.sql
+++ b/supabase/migrations/0033_communication_template_foundation.sql
@@ -1,0 +1,1205 @@
+-- COMMUNICATION-TEMPLATE-FOUNDATION-001
+-- Tenant-scoped, versioned, plain-text communication templates.
+-- No provider, outbound HTTP, delivery worker or cloud operation is introduced.
+
+CREATE TABLE public.communication_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  purpose_code text NOT NULL CHECK (purpose_code IN (
+    'appointment_confirmation_request',
+    'appointment_day_before_reminder',
+    'appointment_same_day_reminder',
+    'appointment_control_call_task'
+  )),
+  channel text NOT NULL CHECK (channel IN ('sms','whatsapp','email')),
+  language text NOT NULL CHECK (language IN ('ru','kk','en')),
+  display_name text NOT NULL CHECK (length(btrim(display_name)) BETWEEN 1 AND 200),
+  status text NOT NULL DEFAULT 'inactive' CHECK (status IN ('active','inactive','archived')),
+  active_version_id uuid,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  archived_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata)='object' AND metadata='{}'::jsonb),
+  UNIQUE (tenant_id,id),
+  CHECK ((status='archived') = (archived_at IS NOT NULL)),
+  CHECK ((status='active') = (active_version_id IS NOT NULL))
+);
+CREATE UNIQUE INDEX communication_templates_current_identity_unique
+  ON public.communication_templates(tenant_id,purpose_code,channel,language)
+  WHERE archived_at IS NULL;
+CREATE INDEX communication_templates_tenant_status_idx
+  ON public.communication_templates(tenant_id,status,purpose_code,channel,language,id);
+
+CREATE TABLE public.communication_template_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  template_id uuid NOT NULL,
+  version_number integer NOT NULL CHECK (version_number >= 1),
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','published','superseded','archived')),
+  subject text,
+  body text NOT NULL,
+  variable_keys text[] NOT NULL DEFAULT '{}'::text[],
+  content_fingerprint text NOT NULL CHECK (content_fingerprint ~ '^[0-9a-f]{64}$'),
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  published_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  published_at timestamptz,
+  archived_at timestamptz,
+  supersedes_version_id uuid,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata)='object' AND metadata='{}'::jsonb),
+  UNIQUE (tenant_id,id),
+  UNIQUE (tenant_id,template_id,id),
+  UNIQUE (template_id,version_number),
+  FOREIGN KEY (tenant_id,template_id)
+    REFERENCES public.communication_templates(tenant_id,id) ON DELETE CASCADE,
+  FOREIGN KEY (tenant_id,supersedes_version_id)
+    REFERENCES public.communication_template_versions(tenant_id,id) ON DELETE RESTRICT,
+  CHECK (
+    (status='draft' AND published_at IS NULL AND published_by IS NULL AND archived_at IS NULL)
+    OR (status='published' AND published_at IS NOT NULL AND published_by IS NOT NULL AND archived_at IS NULL)
+    OR (status='superseded' AND published_at IS NOT NULL AND published_by IS NOT NULL AND archived_at IS NULL)
+    OR (status='archived' AND archived_at IS NOT NULL)
+  )
+);
+CREATE UNIQUE INDEX communication_template_versions_one_draft
+  ON public.communication_template_versions(template_id) WHERE status='draft';
+CREATE UNIQUE INDEX communication_template_versions_one_published
+  ON public.communication_template_versions(template_id) WHERE status='published';
+CREATE INDEX communication_template_versions_tenant_template_idx
+  ON public.communication_template_versions(tenant_id,template_id,version_number DESC,id);
+
+ALTER TABLE public.communication_templates
+  ADD CONSTRAINT communication_templates_active_version_fk
+  FOREIGN KEY (tenant_id,id,active_version_id)
+  REFERENCES public.communication_template_versions(tenant_id,template_id,id)
+  DEFERRABLE INITIALLY DEFERRED;
+
+CREATE TABLE public.communication_template_operations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  operation_key text NOT NULL CHECK (
+    length(operation_key) BETWEEN 8 AND 200
+    AND operation_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  operation_type text NOT NULL CHECK (operation_type IN (
+    'template_create','draft_create','draft_update','version_publish','template_archive'
+  )),
+  fingerprint text NOT NULL CHECK (fingerprint ~ '^[0-9a-f]{64}$'),
+  result jsonb NOT NULL CHECK (jsonb_typeof(result)='object'),
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  UNIQUE (tenant_id,operation_key)
+);
+
+ALTER TABLE public.communication_operations
+  ADD COLUMN template_id uuid,
+  ADD COLUMN template_version_id uuid,
+  ADD COLUMN template_version_number integer,
+  ADD COLUMN template_content_fingerprint text,
+  ADD COLUMN rendered_content_fingerprint text,
+  ADD COLUMN rendered_subject text,
+  ADD COLUMN rendered_body text,
+  ADD COLUMN rendered_character_count integer,
+  ADD COLUMN template_snapshot jsonb;
+
+ALTER TABLE public.communication_operations
+  ADD CONSTRAINT communication_operations_template_fk
+  FOREIGN KEY (tenant_id,template_id)
+  REFERENCES public.communication_templates(tenant_id,id) ON DELETE RESTRICT,
+  ADD CONSTRAINT communication_operations_template_version_fk
+  FOREIGN KEY (tenant_id,template_id,template_version_id)
+  REFERENCES public.communication_template_versions(tenant_id,template_id,id) ON DELETE RESTRICT,
+  ADD CONSTRAINT communication_operations_template_snapshot_check CHECK (
+    (template_id IS NULL AND template_version_id IS NULL AND template_version_number IS NULL
+      AND template_content_fingerprint IS NULL AND rendered_content_fingerprint IS NULL
+      AND rendered_subject IS NULL AND rendered_body IS NULL AND rendered_character_count IS NULL
+      AND template_snapshot IS NULL)
+    OR
+    (template_id IS NOT NULL AND template_version_id IS NOT NULL AND template_version_number >= 1
+      AND template_content_fingerprint ~ '^[0-9a-f]{64}$'
+      AND rendered_content_fingerprint ~ '^[0-9a-f]{64}$'
+      AND rendered_body IS NOT NULL AND rendered_character_count >= 0
+      AND jsonb_typeof(template_snapshot)='object'
+      AND ((channel='email' AND rendered_subject IS NOT NULL) OR (channel<>'email' AND rendered_subject IS NULL)))
+  );
+CREATE INDEX communication_operations_template_version_idx
+  ON public.communication_operations(tenant_id,template_version_id,prepared_at DESC,id)
+  WHERE template_version_id IS NOT NULL;
+
+ALTER TABLE public.communication_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.communication_template_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.communication_template_operations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY communication_templates_read_policy ON public.communication_templates
+FOR SELECT TO authenticated
+USING (public.communication_tenant_role(tenant_id) IN ('clinic_owner','clinic_admin','registrar'));
+CREATE POLICY communication_template_versions_read_policy ON public.communication_template_versions
+FOR SELECT TO authenticated
+USING (public.communication_tenant_role(tenant_id) IN ('clinic_owner','clinic_admin','registrar'));
+
+CREATE OR REPLACE FUNCTION public.communication_template_write_guard()
+RETURNS trigger LANGUAGE plpgsql SET search_path=public,pg_catalog
+AS $$
+BEGIN
+  IF current_setting('app.communication_template_internal',true)<>'on'
+     AND current_user<>'postgres' AND coalesce(auth.role(),'')<>'service_role' THEN
+    RAISE EXCEPTION 'Прямое изменение шаблонов запрещено.' USING ERRCODE='42501';
+  END IF;
+  IF TG_TABLE_NAME='communication_template_versions' THEN
+    IF TG_OP='UPDATE' AND OLD.status IN ('published','superseded','archived')
+       AND (
+         NEW.subject IS DISTINCT FROM OLD.subject OR NEW.body IS DISTINCT FROM OLD.body
+         OR NEW.variable_keys IS DISTINCT FROM OLD.variable_keys
+         OR NEW.content_fingerprint IS DISTINCT FROM OLD.content_fingerprint
+         OR NEW.version_number IS DISTINCT FROM OLD.version_number
+         OR NEW.template_id IS DISTINCT FROM OLD.template_id
+         OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       ) THEN
+      RAISE EXCEPTION 'Опубликованную версию нельзя изменить. Создайте новую версию.' USING ERRCODE='55000';
+    END IF;
+  END IF;
+  IF TG_OP='DELETE' AND current_user<>'postgres' AND coalesce(auth.role(),'')<>'service_role' THEN
+    RAISE EXCEPTION 'Удаление шаблонов запрещено.' USING ERRCODE='42501';
+  END IF;
+  RETURN coalesce(NEW,OLD);
+END;
+$$;
+CREATE TRIGGER communication_templates_write_guard
+BEFORE INSERT OR UPDATE OR DELETE ON public.communication_templates
+FOR EACH ROW EXECUTE FUNCTION public.communication_template_write_guard();
+CREATE TRIGGER communication_template_versions_write_guard
+BEFORE INSERT OR UPDATE OR DELETE ON public.communication_template_versions
+FOR EACH ROW EXECUTE FUNCTION public.communication_template_write_guard();
+
+CREATE OR REPLACE FUNCTION public.communication_template_validate_identity(
+  p_purpose text,p_channel text,p_language text
+) RETURNS void LANGUAGE plpgsql IMMUTABLE SET search_path=public,pg_catalog
+AS $$
+BEGIN
+  IF p_purpose NOT IN (
+    'appointment_confirmation_request','appointment_day_before_reminder',
+    'appointment_same_day_reminder','appointment_control_call_task'
+  ) THEN
+    RAISE EXCEPTION 'Назначение шаблона не поддерживается.' USING ERRCODE='22023';
+  END IF;
+  IF p_channel NOT IN ('sms','whatsapp','email') THEN
+    RAISE EXCEPTION 'Канал шаблона не поддерживается.' USING ERRCODE='22023';
+  END IF;
+  IF p_language NOT IN ('ru','kk','en') THEN
+    RAISE EXCEPTION 'Язык шаблона не поддерживается.' USING ERRCODE='22023';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_template_validate_content(
+  p_channel text,p_subject text,p_body text
+) RETURNS text[] LANGUAGE plpgsql IMMUTABLE SET search_path=public,pg_catalog
+AS $$
+DECLARE v_source text; v_residual text; v_match text[]; v_key text; v_keys text[]:='{}';
+  v_allowed constant text[]:=ARRAY[
+    'patient_first_name','clinic_name','appointment_date','appointment_time',
+    'doctor_display_name','clinic_callback_phone'
+  ];
+  v_forbidden constant text[]:=ARRAY[
+    'diagnosis','complaint','finding','tooth','treatment','treatment_plan','procedure',
+    'balance','debt','invoice','payment','discount','document','medical_result',
+    'raw_phone','raw_email'
+  ];
+BEGIN
+  IF p_channel NOT IN ('sms','whatsapp','email') THEN
+    RAISE EXCEPTION 'Канал шаблона не поддерживается.' USING ERRCODE='22023';
+  END IF;
+  IF p_body IS NULL OR btrim(p_body)='' THEN
+    RAISE EXCEPTION 'Текст шаблона не может быть пустым.' USING ERRCODE='22023';
+  END IF;
+  IF p_channel='email' AND (p_subject IS NULL OR btrim(p_subject)='') THEN
+    RAISE EXCEPTION 'Для email-шаблона требуется тема.' USING ERRCODE='22023';
+  END IF;
+  IF p_channel<>'email' AND p_subject IS NOT NULL AND btrim(p_subject)<>'' THEN
+    RAISE EXCEPTION 'Тема разрешена только для email-шаблона.' USING ERRCODE='22023';
+  END IF;
+  IF p_channel='sms' AND char_length(p_body)>1000
+     OR p_channel='whatsapp' AND char_length(p_body)>4000
+     OR p_channel='email' AND char_length(p_body)>10000
+     OR p_subject IS NOT NULL AND char_length(p_subject)>200 THEN
+    RAISE EXCEPTION 'Текст шаблона превышает допустимую длину.' USING ERRCODE='22023';
+  END IF;
+  IF regexp_replace(coalesce(p_subject,'')||p_body,E'[\n\r\t]','','g') ~ '[[:cntrl:]]' THEN
+    RAISE EXCEPTION 'Шаблон содержит недопустимые управляющие символы.' USING ERRCODE='22023';
+  END IF;
+  IF coalesce(p_subject,'') ~ '<\/?[A-Za-z][^>]*>' OR p_body ~ '<\/?[A-Za-z][^>]*>' THEN
+    RAISE EXCEPTION 'HTML и исполняемая разметка в шаблонах запрещены.' USING ERRCODE='22023';
+  END IF;
+  v_source:=coalesce(p_subject,'')||E'\n'||p_body;
+  FOR v_match IN SELECT regexp_matches(v_source,'\{\{([a-z][a-z0-9_]*)\}\}','g') LOOP
+    v_key:=v_match[1];
+    IF v_key=ANY(v_forbidden) THEN
+      RAISE EXCEPTION 'Шаблон содержит запрещённую клиническую или финансовую переменную.' USING ERRCODE='22023';
+    END IF;
+    IF NOT v_key=ANY(v_allowed) THEN
+      RAISE EXCEPTION 'Шаблон содержит неизвестную или некорректную переменную.' USING ERRCODE='22023';
+    END IF;
+    IF NOT v_key=ANY(v_keys) THEN v_keys:=array_append(v_keys,v_key); END IF;
+  END LOOP;
+  v_residual:=regexp_replace(v_source,'\{\{[a-z][a-z0-9_]*\}\}','','g');
+  IF v_residual ~ '[{}]' THEN
+    RAISE EXCEPTION 'Шаблон содержит неизвестную или некорректную переменную.' USING ERRCODE='22023';
+  END IF;
+  RETURN coalesce((SELECT array_agg(k ORDER BY k) FROM unnest(v_keys) k),'{}'::text[]);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_template_render_content(
+  p_channel text,p_subject text,p_body text,p_variables jsonb
+) RETURNS jsonb LANGUAGE plpgsql IMMUTABLE SET search_path=public,pg_catalog
+AS $$
+DECLARE v_required text[]; v_key text; v_subject text; v_body text; v_value text;
+  v_fingerprint text; v_warnings jsonb:='[]'::jsonb;
+BEGIN
+  IF jsonb_typeof(coalesce(p_variables,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'Переменные шаблона должны быть объектом.' USING ERRCODE='22023';
+  END IF;
+  v_required:=public.communication_template_validate_content(p_channel,p_subject,p_body);
+  IF EXISTS (SELECT 1 FROM jsonb_object_keys(coalesce(p_variables,'{}'::jsonb)) k WHERE NOT k=ANY(v_required)) THEN
+    RAISE EXCEPTION 'Переданы лишние или неизвестные переменные шаблона.' USING ERRCODE='22023';
+  END IF;
+  v_subject:=CASE WHEN p_subject IS NULL THEN NULL ELSE btrim(p_subject) END;
+  v_body:=p_body;
+  FOREACH v_key IN ARRAY v_required LOOP
+    IF NOT coalesce(p_variables,'{}'::jsonb) ? v_key
+       OR jsonb_typeof(p_variables->v_key)<>'string'
+       OR btrim(p_variables->>v_key)='' THEN
+      RAISE EXCEPTION 'Для формирования сообщения не хватает обязательных данных.' USING ERRCODE='P0002';
+    END IF;
+    v_value:=p_variables->>v_key;
+    IF regexp_replace(v_value,E'[\n\r\t]','','g') ~ '[[:cntrl:]]'
+       OR v_value ~ '<\/?[A-Za-z][^>]*>' OR char_length(v_value)>500 THEN
+      RAISE EXCEPTION 'Значение переменной шаблона недопустимо.' USING ERRCODE='22023';
+    END IF;
+    v_subject:=CASE WHEN v_subject IS NULL THEN NULL ELSE replace(v_subject,'{{'||v_key||'}}',v_value) END;
+    v_body:=replace(v_body,'{{'||v_key||'}}',v_value);
+  END LOOP;
+  IF p_channel='sms' AND char_length(v_body)>160 THEN
+    v_warnings:=jsonb_build_array('sms_practical_single_message_length');
+  END IF;
+  v_fingerprint:=public.communication_hash(jsonb_build_object(
+    'channel',p_channel,'subject',v_subject,'body',v_body,'variableKeys',v_required
+  )::text);
+  RETURN jsonb_build_object(
+    'subject',v_subject,'body',v_body,
+    'renderedCharacterCount',char_length(v_body)+coalesce(char_length(v_subject),0),
+    'renderedFingerprint',v_fingerprint,'variableKeys',to_jsonb(v_required),'warnings',v_warnings
+  );
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.communication_template_version_json(
+  p_version public.communication_template_versions
+) RETURNS jsonb LANGUAGE sql STABLE SET search_path=public,pg_catalog
+AS $$
+SELECT jsonb_build_object(
+  'id',p_version.id,'tenantId',p_version.tenant_id,'templateId',p_version.template_id,
+  'versionNumber',p_version.version_number,'status',p_version.status,
+  'subject',p_version.subject,'body',p_version.body,'variableKeys',to_jsonb(p_version.variable_keys),
+  'contentFingerprint',p_version.content_fingerprint,'createdBy',p_version.created_by,
+  'createdAt',p_version.created_at,'updatedAt',p_version.updated_at,
+  'publishedBy',p_version.published_by,'publishedAt',p_version.published_at,
+  'archivedAt',p_version.archived_at,'supersedesVersionId',p_version.supersedes_version_id
+)
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_template_json(
+  p_template public.communication_templates
+) RETURNS jsonb LANGUAGE plpgsql STABLE SET search_path=public,pg_catalog
+AS $$
+DECLARE v_active public.communication_template_versions%ROWTYPE;
+  v_draft public.communication_template_versions%ROWTYPE;
+BEGIN
+  IF p_template.active_version_id IS NOT NULL THEN
+    SELECT * INTO v_active FROM public.communication_template_versions
+    WHERE tenant_id=p_template.tenant_id AND template_id=p_template.id AND id=p_template.active_version_id;
+  END IF;
+  SELECT * INTO v_draft FROM public.communication_template_versions
+  WHERE tenant_id=p_template.tenant_id AND template_id=p_template.id AND status='draft'
+  ORDER BY version_number DESC,id DESC LIMIT 1;
+  RETURN jsonb_build_object(
+    'id',p_template.id,'tenantId',p_template.tenant_id,'purposeCode',p_template.purpose_code,
+    'channel',p_template.channel,'language',p_template.language,'displayName',p_template.display_name,
+    'status',p_template.status,'activeVersionId',p_template.active_version_id,
+    'activeVersion',CASE WHEN v_active.id IS NULL THEN NULL ELSE public.communication_template_version_json(v_active) END,
+    'draftVersion',CASE WHEN v_draft.id IS NULL THEN NULL ELSE public.communication_template_version_json(v_draft) END,
+    'createdAt',p_template.created_at,'updatedAt',p_template.updated_at,'archivedAt',p_template.archived_at
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_template_operation_replay(
+  p_tenant_id uuid,p_operation_key text,p_operation_type text,p_fingerprint text
+) RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_saved public.communication_template_operations%ROWTYPE;
+BEGIN
+  IF p_operation_key IS NULL OR length(p_operation_key) NOT BETWEEN 8 AND 200
+     OR p_operation_key !~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$' THEN
+    RAISE EXCEPTION 'Не удалось выполнить операцию с шаблоном.' USING ERRCODE='22023';
+  END IF;
+  SELECT * INTO v_saved FROM public.communication_template_operations
+  WHERE tenant_id=p_tenant_id AND operation_key=p_operation_key;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  IF v_saved.operation_type<>p_operation_type OR v_saved.fingerprint<>p_fingerprint THEN
+    RAISE EXCEPTION 'Операция уже выполнена с другими параметрами.' USING ERRCODE='23505';
+  END IF;
+  RETURN v_saved.result || jsonb_build_object('replayed',true);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_template_store_operation(
+  p_tenant_id uuid,p_operation_key text,p_operation_type text,p_fingerprint text,p_result jsonb
+) RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+BEGIN
+  INSERT INTO public.communication_template_operations(tenant_id,operation_key,operation_type,fingerprint,result)
+  VALUES(p_tenant_id,p_operation_key,p_operation_type,p_fingerprint,p_result);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_template_record_event(
+  p_template public.communication_templates,
+  p_version public.communication_template_versions,
+  p_action text
+) RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_audit uuid; v_role text; v_target text; v_target_id text; v_metadata jsonb;
+BEGIN
+  v_role:=public.communication_tenant_role(p_template.tenant_id);
+  v_target:=CASE WHEN p_version.id IS NULL THEN 'communication_template' ELSE 'communication_template_version' END;
+  v_target_id:=coalesce(p_version.id,p_template.id)::text;
+  v_metadata:=jsonb_strip_nulls(jsonb_build_object(
+    'templateId',p_template.id,'versionId',p_version.id,'purposeCode',p_template.purpose_code,
+    'channel',p_template.channel,'language',p_template.language,'versionNumber',p_version.version_number,
+    'contentFingerprint',p_version.content_fingerprint
+  ));
+  v_audit:=public.record_audit_event_internal(
+    p_tenant_id=>p_template.tenant_id,p_action=>p_action,p_category=>'tenant',
+    p_target_type=>v_target,p_target_id=>v_target_id,p_actor_user_id=>auth.uid(),
+    p_actor_tenant_role=>v_role,p_before_data=>'{}',p_after_data=>'{}',p_diff_data=>'{}',
+    p_redaction_level=>'standard',p_metadata=>v_metadata
+  );
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id=>p_template.tenant_id,p_category=>'system',p_type=>p_action,
+    p_title=>CASE p_action
+      WHEN 'communication_template_created' THEN 'Создан шаблон коммуникации'
+      WHEN 'communication_template_draft_created' THEN 'Создан черновик шаблона коммуникации'
+      WHEN 'communication_template_draft_updated' THEN 'Обновлён черновик шаблона коммуникации'
+      WHEN 'communication_template_published' THEN 'Опубликована версия шаблона коммуникации'
+      WHEN 'communication_template_superseded' THEN 'Предыдущая версия шаблона заменена'
+      WHEN 'communication_template_archived' THEN 'Шаблон коммуникации архивирован'
+      ELSE 'Изменён шаблон коммуникации' END,
+    p_source_type=>v_target,p_source_id=>v_target_id,p_audit_event_id=>v_audit,
+    p_actor_user_id=>auth.uid(),p_visibility=>'admin',p_metadata=>v_metadata
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_require_manager(p_tenant_id uuid)
+RETURNS text LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path=public,pg_catalog
+AS $manager$
+DECLARE v_role text;
+BEGIN
+  v_role:=public.communication_tenant_role(p_tenant_id);
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin') THEN
+    RAISE EXCEPTION 'Недостаточно прав для работы с коммуникациями.' USING ERRCODE='42501';
+  END IF;
+  RETURN v_role;
+END;
+$manager$;
+
+CREATE OR REPLACE FUNCTION public.list_communication_templates(
+  p_tenant_id uuid,p_purpose_code text DEFAULT NULL,p_channel text DEFAULT NULL,p_language text DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text;
+BEGIN
+  v_role:=public.communication_tenant_role(p_tenant_id);
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для управления шаблонами.' USING ERRCODE='42501';
+  END IF;
+  IF p_purpose_code IS NOT NULL OR p_channel IS NOT NULL OR p_language IS NOT NULL THEN
+    PERFORM public.communication_template_validate_identity(
+      coalesce(p_purpose_code,'appointment_confirmation_request'),
+      coalesce(p_channel,'sms'),coalesce(p_language,'ru')
+    );
+  END IF;
+  RETURN coalesce((
+    SELECT jsonb_agg(public.communication_template_json(t)
+      ORDER BY t.purpose_code,t.channel,t.language,t.created_at,t.id)
+    FROM public.communication_templates t
+    WHERE t.tenant_id=p_tenant_id
+      AND (p_purpose_code IS NULL OR t.purpose_code=p_purpose_code)
+      AND (p_channel IS NULL OR t.channel=p_channel)
+      AND (p_language IS NULL OR t.language=p_language)
+  ),'[]'::jsonb);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_communication_template(
+  p_tenant_id uuid,p_template_id uuid
+) RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_template public.communication_templates%ROWTYPE;
+BEGIN
+  v_role:=public.communication_tenant_role(p_tenant_id);
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для управления шаблонами.' USING ERRCODE='42501';
+  END IF;
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND id=p_template_id;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  RETURN public.communication_template_json(v_template);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_active_communication_template(
+  p_tenant_id uuid,p_purpose_code text,p_channel text,p_language text
+) RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_template public.communication_templates%ROWTYPE;
+  v_version public.communication_template_versions%ROWTYPE;
+BEGIN
+  v_role:=public.communication_tenant_role(p_tenant_id);
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для управления шаблонами.' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.communication_template_validate_identity(p_purpose_code,p_channel,p_language);
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND purpose_code=p_purpose_code
+    AND channel=p_channel AND language=p_language
+    AND status='active' AND archived_at IS NULL AND active_version_id IS NOT NULL;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO v_version FROM public.communication_template_versions
+  WHERE tenant_id=p_tenant_id AND template_id=v_template.id
+    AND id=v_template.active_version_id AND status='published';
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  RETURN jsonb_build_object(
+    'template',public.communication_template_json(v_template),
+    'version',public.communication_template_version_json(v_version)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.preview_communication_template(
+  p_tenant_id uuid,p_version_id uuid,p_variables jsonb
+) RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_version public.communication_template_versions%ROWTYPE;
+  v_template public.communication_templates%ROWTYPE; v_render jsonb;
+BEGIN
+  v_role:=public.communication_tenant_role(p_tenant_id);
+  IF v_role IS NULL OR v_role NOT IN ('clinic_owner','clinic_admin','registrar') THEN
+    RAISE EXCEPTION 'Недостаточно прав для управления шаблонами.' USING ERRCODE='42501';
+  END IF;
+  SELECT * INTO v_version FROM public.communication_template_versions
+  WHERE tenant_id=p_tenant_id AND id=p_version_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002'; END IF;
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND id=v_version.template_id;
+  v_render:=public.communication_template_render_content(
+    v_template.channel,v_version.subject,v_version.body,p_variables
+  );
+  RETURN jsonb_build_object(
+    'templateId',v_template.id,'versionId',v_version.id,'versionNumber',v_version.version_number,
+    'purposeCode',v_template.purpose_code,'channel',v_template.channel,'language',v_template.language,
+    'contentFingerprint',v_version.content_fingerprint,'rendered',v_render
+  );
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.create_communication_template(
+  p_tenant_id uuid,p_purpose_code text,p_channel text,p_language text,p_display_name text,
+  p_subject text,p_body text,p_operation_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_keys text[]; v_content_fingerprint text; v_fingerprint text;
+  v_replay jsonb; v_result jsonb; v_template public.communication_templates%ROWTYPE;
+  v_version public.communication_template_versions%ROWTYPE; v_empty public.communication_template_versions%ROWTYPE;
+BEGIN
+  v_role:=public.communication_require_manager(p_tenant_id);
+  PERFORM public.communication_template_validate_identity(p_purpose_code,p_channel,p_language);
+  IF p_display_name IS NULL OR length(btrim(p_display_name)) NOT BETWEEN 1 AND 200 THEN
+    RAISE EXCEPTION 'Название шаблона не указано.' USING ERRCODE='22023';
+  END IF;
+  v_keys:=public.communication_template_validate_content(p_channel,p_subject,p_body);
+  v_content_fingerprint:=public.communication_hash(jsonb_build_object(
+    'channel',p_channel,'subject',nullif(btrim(coalesce(p_subject,'')),''),
+    'body',p_body,'variableKeys',v_keys
+  )::text);
+  v_fingerprint:=public.communication_hash(jsonb_build_object(
+    'purposeCode',p_purpose_code,'channel',p_channel,'language',p_language,
+    'displayName',btrim(p_display_name),'contentFingerprint',v_content_fingerprint
+  )::text);
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template:'||p_tenant_id||':'||p_operation_key,0));
+  v_replay:=public.communication_template_operation_replay(
+    p_tenant_id,p_operation_key,'template_create',v_fingerprint
+  );
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.communication_templates
+    WHERE tenant_id=p_tenant_id AND purpose_code=p_purpose_code
+      AND channel=p_channel AND language=p_language AND archived_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Шаблон для выбранных цели, канала и языка уже существует.' USING ERRCODE='23505';
+  END IF;
+
+  PERFORM set_config('app.communication_template_internal','on',true);
+  INSERT INTO public.communication_templates(
+    tenant_id,purpose_code,channel,language,display_name,status,created_by,updated_by
+  ) VALUES(
+    p_tenant_id,p_purpose_code,p_channel,p_language,btrim(p_display_name),'inactive',auth.uid(),auth.uid()
+  ) RETURNING * INTO v_template;
+  INSERT INTO public.communication_template_versions(
+    tenant_id,template_id,version_number,status,subject,body,variable_keys,content_fingerprint,created_by
+  ) VALUES(
+    p_tenant_id,v_template.id,1,'draft',nullif(btrim(coalesce(p_subject,'')),''),p_body,v_keys,
+    v_content_fingerprint,auth.uid()
+  ) RETURNING * INTO v_version;
+  PERFORM set_config('app.communication_template_internal','off',true);
+
+  PERFORM public.communication_template_record_event(v_template,v_empty,'communication_template_created');
+  PERFORM public.communication_template_record_event(v_template,v_version,'communication_template_draft_created');
+  v_result:=jsonb_build_object(
+    'template',public.communication_template_json(v_template),
+    'version',public.communication_template_version_json(v_version)
+  );
+  PERFORM public.communication_template_store_operation(
+    p_tenant_id,p_operation_key,'template_create',v_fingerprint,v_result
+  );
+  RETURN v_result||jsonb_build_object('replayed',false);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_communication_template_draft(
+  p_tenant_id uuid,p_template_id uuid,p_operation_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_template public.communication_templates%ROWTYPE;
+  v_active public.communication_template_versions%ROWTYPE; v_version public.communication_template_versions%ROWTYPE;
+  v_number integer; v_fingerprint text; v_replay jsonb; v_result jsonb;
+BEGIN
+  v_role:=public.communication_require_manager(p_tenant_id);
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template:'||p_tenant_id||':'||p_operation_key,0));
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND id=p_template_id FOR UPDATE;
+  IF NOT FOUND OR v_template.status='archived' THEN
+    RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002';
+  END IF;
+  v_fingerprint:=public.communication_hash(jsonb_build_object(
+    'templateId',p_template_id,'activeVersionId',v_template.active_version_id,'action','draft_create'
+  )::text);
+  v_replay:=public.communication_template_operation_replay(
+    p_tenant_id,p_operation_key,'draft_create',v_fingerprint
+  );
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  IF EXISTS (SELECT 1 FROM public.communication_template_versions
+    WHERE tenant_id=p_tenant_id AND template_id=p_template_id AND status='draft') THEN
+    RAISE EXCEPTION 'У шаблона уже есть черновик.' USING ERRCODE='23505';
+  END IF;
+  IF v_template.active_version_id IS NOT NULL THEN
+    SELECT * INTO v_active FROM public.communication_template_versions
+    WHERE tenant_id=p_tenant_id AND template_id=p_template_id AND id=v_template.active_version_id FOR SHARE;
+  END IF;
+  SELECT coalesce(max(version_number),0)+1 INTO v_number
+  FROM public.communication_template_versions WHERE tenant_id=p_tenant_id AND template_id=p_template_id;
+  PERFORM set_config('app.communication_template_internal','on',true);
+  INSERT INTO public.communication_template_versions(
+    tenant_id,template_id,version_number,status,subject,body,variable_keys,content_fingerprint,
+    created_by,supersedes_version_id
+  ) VALUES(
+    p_tenant_id,p_template_id,v_number,'draft',v_active.subject,coalesce(v_active.body,''),
+    coalesce(v_active.variable_keys,'{}'::text[]),
+    coalesce(v_active.content_fingerprint,public.communication_hash(jsonb_build_object(
+      'channel',v_template.channel,'subject',NULL,'body','','variableKeys','[]'::jsonb
+    )::text)),auth.uid(),v_template.active_version_id
+  ) RETURNING * INTO v_version;
+  UPDATE public.communication_templates SET updated_by=auth.uid(),updated_at=transaction_timestamp()
+  WHERE tenant_id=p_tenant_id AND id=p_template_id RETURNING * INTO v_template;
+  PERFORM set_config('app.communication_template_internal','off',true);
+  PERFORM public.communication_template_record_event(v_template,v_version,'communication_template_draft_created');
+  v_result:=jsonb_build_object(
+    'template',public.communication_template_json(v_template),
+    'version',public.communication_template_version_json(v_version)
+  );
+  PERFORM public.communication_template_store_operation(
+    p_tenant_id,p_operation_key,'draft_create',v_fingerprint,v_result
+  );
+  RETURN v_result||jsonb_build_object('replayed',false);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_communication_template_draft(
+  p_tenant_id uuid,p_version_id uuid,p_subject text,p_body text,
+  p_expected_updated_at timestamptz,p_operation_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_template public.communication_templates%ROWTYPE;
+  v_version public.communication_template_versions%ROWTYPE; v_keys text[];
+  v_content_fingerprint text; v_fingerprint text; v_replay jsonb; v_result jsonb;
+BEGIN
+  v_role:=public.communication_require_manager(p_tenant_id);
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template:'||p_tenant_id||':'||p_operation_key,0));
+  SELECT * INTO v_version FROM public.communication_template_versions
+  WHERE tenant_id=p_tenant_id AND id=p_version_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002'; END IF;
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND id=v_version.template_id FOR UPDATE;
+  IF v_version.status<>'draft' THEN
+    RAISE EXCEPTION 'Опубликованную версию нельзя изменить. Создайте новую версию.' USING ERRCODE='55000';
+  END IF;
+  IF v_template.status='archived' THEN RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002'; END IF;
+  v_keys:=public.communication_template_validate_content(v_template.channel,p_subject,p_body);
+  v_content_fingerprint:=public.communication_hash(jsonb_build_object(
+    'channel',v_template.channel,'subject',nullif(btrim(coalesce(p_subject,'')),''),
+    'body',p_body,'variableKeys',v_keys
+  )::text);
+  v_fingerprint:=public.communication_hash(jsonb_build_object(
+    'versionId',p_version_id,'expectedUpdatedAt',p_expected_updated_at,
+    'contentFingerprint',v_content_fingerprint
+  )::text);
+  v_replay:=public.communication_template_operation_replay(
+    p_tenant_id,p_operation_key,'draft_update',v_fingerprint
+  );
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  IF p_expected_updated_at IS NULL OR v_version.updated_at<>p_expected_updated_at THEN
+    RAISE EXCEPTION 'Черновик был изменён другим пользователем. Обновите данные.' USING ERRCODE='40001';
+  END IF;
+  PERFORM set_config('app.communication_template_internal','on',true);
+  UPDATE public.communication_template_versions SET
+    subject=nullif(btrim(coalesce(p_subject,'')),''),body=p_body,variable_keys=v_keys,
+    content_fingerprint=v_content_fingerprint,updated_at=transaction_timestamp()
+  WHERE tenant_id=p_tenant_id AND id=p_version_id RETURNING * INTO v_version;
+  UPDATE public.communication_templates SET updated_by=auth.uid(),updated_at=transaction_timestamp()
+  WHERE tenant_id=p_tenant_id AND id=v_template.id RETURNING * INTO v_template;
+  PERFORM set_config('app.communication_template_internal','off',true);
+  PERFORM public.communication_template_record_event(v_template,v_version,'communication_template_draft_updated');
+  v_result:=jsonb_build_object(
+    'template',public.communication_template_json(v_template),
+    'version',public.communication_template_version_json(v_version)
+  );
+  PERFORM public.communication_template_store_operation(
+    p_tenant_id,p_operation_key,'draft_update',v_fingerprint,v_result
+  );
+  RETURN v_result||jsonb_build_object('replayed',false);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.publish_communication_template_version(
+  p_tenant_id uuid,p_template_id uuid,p_draft_version_id uuid,
+  p_expected_draft_updated_at timestamptz,p_operation_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_template public.communication_templates%ROWTYPE;
+  v_draft public.communication_template_versions%ROWTYPE; v_previous public.communication_template_versions%ROWTYPE;
+  v_fingerprint text; v_replay jsonb; v_result jsonb;
+BEGIN
+  v_role:=public.communication_require_manager(p_tenant_id);
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template-publish:'||p_tenant_id||':'||p_template_id,0));
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template:'||p_tenant_id||':'||p_operation_key,0));
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND id=p_template_id FOR UPDATE;
+  IF NOT FOUND OR v_template.status='archived' THEN RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002'; END IF;
+  SELECT * INTO v_draft FROM public.communication_template_versions
+  WHERE tenant_id=p_tenant_id AND template_id=p_template_id AND id=p_draft_version_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002'; END IF;
+  v_fingerprint:=public.communication_hash(jsonb_build_object(
+    'templateId',p_template_id,'draftVersionId',p_draft_version_id,
+    'expectedUpdatedAt',p_expected_draft_updated_at,'contentFingerprint',v_draft.content_fingerprint
+  )::text);
+  v_replay:=public.communication_template_operation_replay(
+    p_tenant_id,p_operation_key,'version_publish',v_fingerprint
+  );
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  IF v_draft.status<>'draft' THEN
+    RAISE EXCEPTION 'Опубликованную версию нельзя изменить. Создайте новую версию.' USING ERRCODE='55000';
+  END IF;
+  PERFORM public.communication_template_validate_content(v_template.channel,v_draft.subject,v_draft.body);
+  IF p_expected_draft_updated_at IS NULL OR v_draft.updated_at<>p_expected_draft_updated_at THEN
+    RAISE EXCEPTION 'Черновик был изменён другим пользователем. Обновите данные.' USING ERRCODE='40001';
+  END IF;
+  IF v_template.active_version_id IS NOT NULL THEN
+    SELECT * INTO v_previous FROM public.communication_template_versions
+    WHERE tenant_id=p_tenant_id AND template_id=p_template_id AND id=v_template.active_version_id FOR UPDATE;
+  END IF;
+  PERFORM set_config('app.communication_template_internal','on',true);
+  IF v_previous.id IS NOT NULL THEN
+    UPDATE public.communication_template_versions SET status='superseded',updated_at=transaction_timestamp()
+    WHERE tenant_id=p_tenant_id AND id=v_previous.id RETURNING * INTO v_previous;
+  END IF;
+  UPDATE public.communication_template_versions SET
+    status='published',published_by=auth.uid(),published_at=transaction_timestamp(),updated_at=transaction_timestamp()
+  WHERE tenant_id=p_tenant_id AND id=p_draft_version_id RETURNING * INTO v_draft;
+  UPDATE public.communication_templates SET
+    status='active',active_version_id=v_draft.id,updated_by=auth.uid(),updated_at=transaction_timestamp(),archived_at=NULL
+  WHERE tenant_id=p_tenant_id AND id=p_template_id RETURNING * INTO v_template;
+  PERFORM set_config('app.communication_template_internal','off',true);
+  IF v_previous.id IS NOT NULL THEN
+    PERFORM public.communication_template_record_event(v_template,v_previous,'communication_template_superseded');
+  END IF;
+  PERFORM public.communication_template_record_event(v_template,v_draft,'communication_template_published');
+  v_result:=jsonb_build_object(
+    'template',public.communication_template_json(v_template),
+    'version',public.communication_template_version_json(v_draft),
+    'supersededVersion',CASE WHEN v_previous.id IS NULL THEN NULL ELSE public.communication_template_version_json(v_previous) END
+  );
+  PERFORM public.communication_template_store_operation(
+    p_tenant_id,p_operation_key,'version_publish',v_fingerprint,v_result
+  );
+  RETURN v_result||jsonb_build_object('replayed',false);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.archive_communication_template(
+  p_tenant_id uuid,p_template_id uuid,p_expected_updated_at timestamptz,p_operation_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_template public.communication_templates%ROWTYPE;
+  v_active public.communication_template_versions%ROWTYPE; v_empty public.communication_template_versions%ROWTYPE;
+  v_fingerprint text; v_replay jsonb; v_result jsonb;
+BEGIN
+  v_role:=public.communication_require_manager(p_tenant_id);
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template-publish:'||p_tenant_id||':'||p_template_id,0));
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-template:'||p_tenant_id||':'||p_operation_key,0));
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND id=p_template_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Шаблон не найден.' USING ERRCODE='P0002'; END IF;
+  v_fingerprint:=public.communication_hash(jsonb_build_object(
+    'templateId',p_template_id,'expectedUpdatedAt',p_expected_updated_at,'action','archive'
+  )::text);
+  v_replay:=public.communication_template_operation_replay(
+    p_tenant_id,p_operation_key,'template_archive',v_fingerprint
+  );
+  IF v_replay IS NOT NULL THEN RETURN v_replay; END IF;
+  IF p_expected_updated_at IS NULL OR v_template.updated_at<>p_expected_updated_at THEN
+    RAISE EXCEPTION 'Шаблон был изменён другим пользователем. Обновите данные.' USING ERRCODE='40001';
+  END IF;
+  IF v_template.active_version_id IS NOT NULL THEN
+    SELECT * INTO v_active FROM public.communication_template_versions
+    WHERE tenant_id=p_tenant_id AND template_id=p_template_id AND id=v_template.active_version_id FOR UPDATE;
+  END IF;
+  PERFORM set_config('app.communication_template_internal','on',true);
+  IF v_active.id IS NOT NULL THEN
+    UPDATE public.communication_template_versions SET status='archived',archived_at=transaction_timestamp(),updated_at=transaction_timestamp()
+    WHERE tenant_id=p_tenant_id AND id=v_active.id RETURNING * INTO v_active;
+  END IF;
+  UPDATE public.communication_template_versions SET status='archived',archived_at=transaction_timestamp(),updated_at=transaction_timestamp()
+  WHERE tenant_id=p_tenant_id AND template_id=p_template_id AND status='draft';
+  UPDATE public.communication_templates SET
+    status='archived',active_version_id=NULL,archived_at=transaction_timestamp(),updated_by=auth.uid(),updated_at=transaction_timestamp()
+  WHERE tenant_id=p_tenant_id AND id=p_template_id RETURNING * INTO v_template;
+  PERFORM set_config('app.communication_template_internal','off',true);
+  IF v_active.id IS NULL THEN
+    PERFORM public.communication_template_record_event(v_template,v_empty,'communication_template_archived');
+  ELSE
+    PERFORM public.communication_template_record_event(v_template,v_active,'communication_template_archived');
+  END IF;
+  v_result:=jsonb_build_object('template',public.communication_template_json(v_template));
+  PERFORM public.communication_template_store_operation(
+    p_tenant_id,p_operation_key,'template_archive',v_fingerprint,v_result
+  );
+  RETURN v_result||jsonb_build_object('replayed',false);
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION public.communication_purpose(p_reminder_type text)
+RETURNS text LANGUAGE sql IMMUTABLE SET search_path=public,pg_catalog
+AS $purpose$
+SELECT CASE p_reminder_type
+  WHEN 'confirmation_request' THEN 'appointment_confirmation_request'
+  WHEN 'day_before_reminder' THEN 'appointment_day_before_reminder'
+  WHEN 'same_day_reminder' THEN 'appointment_same_day_reminder'
+  WHEN 'control_call_task' THEN 'appointment_control_call_task'
+  WHEN 'callback_task' THEN 'appointment_control_call_task'
+  ELSE NULL END
+$purpose$;
+
+CREATE OR REPLACE FUNCTION public.communication_operation_json(p_operation public.communication_operations)
+RETURNS jsonb LANGUAGE sql STABLE SET search_path=public,pg_catalog
+AS $$
+SELECT jsonb_build_object(
+  'id',p_operation.id,'tenantId',p_operation.tenant_id,
+  'reminderJobId',p_operation.reminder_job_id,'appointmentId',p_operation.appointment_id,
+  'patientId',p_operation.patient_id,'contactId',p_operation.contact_id,
+  'purposeCode',p_operation.purpose_code,'channel',p_operation.channel,
+  'language',p_operation.language,'state',p_operation.state,
+  'operationKey',p_operation.operation_key,'payloadFingerprint',p_operation.payload_fingerprint,
+  'appointmentUpdatedAt',p_operation.appointment_updated_at,
+  'reminderJobUpdatedAt',p_operation.reminder_job_updated_at,
+  'contactUpdatedAt',p_operation.contact_updated_at,'policyVersion',p_operation.policy_version,
+  'eligibilityVersion',p_operation.eligibility_version,'routeId',p_operation.route_id,
+  'routeVersion',p_operation.route_version,'adapterCode',p_operation.adapter_code,
+  'templateId',p_operation.template_id,'templateVersionId',p_operation.template_version_id,
+  'templateVersionNumber',p_operation.template_version_number,
+  'templateContentFingerprint',p_operation.template_content_fingerprint,
+  'renderedContentFingerprint',p_operation.rendered_content_fingerprint,
+  'renderedSubject',p_operation.rendered_subject,'renderedBody',p_operation.rendered_body,
+  'renderedCharacterCount',p_operation.rendered_character_count,
+  'templateSnapshot',p_operation.template_snapshot,
+  'externalOperationId',p_operation.external_operation_id,
+  'adapterResultCode',p_operation.adapter_result_code,'retryable',p_operation.retryable,
+  'uncertain',p_operation.uncertain,'safeErrorCode',p_operation.safe_error_code,
+  'preparedAt',p_operation.prepared_at,'executedAt',p_operation.executed_at,
+  'recoveredAt',p_operation.recovered_at,'cancelledAt',p_operation.cancelled_at,
+  'updatedAt',p_operation.updated_at,'eligibilitySnapshot',p_operation.eligibility_snapshot,
+  'consentSnapshot',p_operation.consent_snapshot,'suppressionSnapshot',p_operation.suppression_snapshot,
+  'contactSnapshot',p_operation.contact_snapshot,'appointmentSnapshot',p_operation.appointment_snapshot,
+  'routeSnapshot',p_operation.route_snapshot,'command',p_operation.command,'metadata',p_operation.metadata
+)
+$$;
+
+CREATE OR REPLACE FUNCTION public.communication_record_event(
+  p_operation public.communication_operations,p_action text,p_before jsonb,p_after jsonb,p_metadata jsonb DEFAULT '{}'
+) RETURNS void LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=public,pg_catalog
+AS $$
+DECLARE v_audit uuid; v_role text; v_safe jsonb;
+BEGIN
+  v_role:=public.communication_tenant_role(p_operation.tenant_id);
+  v_safe:=jsonb_strip_nulls(jsonb_build_object(
+    'id',p_operation.id,'state',p_operation.state,'reminderJobId',p_operation.reminder_job_id,
+    'appointmentId',p_operation.appointment_id,'purposeCode',p_operation.purpose_code,
+    'channel',p_operation.channel,'language',p_operation.language,'routeId',p_operation.route_id,
+    'routeVersion',p_operation.route_version,'adapterCode',p_operation.adapter_code,
+    'templateId',p_operation.template_id,'templateVersionId',p_operation.template_version_id,
+    'templateVersionNumber',p_operation.template_version_number,
+    'templateContentFingerprint',p_operation.template_content_fingerprint,
+    'renderedContentFingerprint',p_operation.rendered_content_fingerprint,
+    'adapterResultCode',p_operation.adapter_result_code,'safeErrorCode',p_operation.safe_error_code
+  ));
+  v_audit:=public.record_audit_event_internal(
+    p_tenant_id=>p_operation.tenant_id,p_action=>p_action,p_category=>'appointment',
+    p_target_type=>'communication_operation',p_target_id=>p_operation.id::text,
+    p_actor_user_id=>auth.uid(),p_actor_tenant_role=>v_role,
+    p_patient_id=>p_operation.patient_id,p_appointment_id=>p_operation.appointment_id::text,
+    p_before_data=>jsonb_build_object('state',coalesce(p_before->>'state',p_operation.state)),
+    p_after_data=>v_safe,
+    p_diff_data=>jsonb_build_object('state',jsonb_build_object('from',p_before->>'state','to',p_operation.state)),
+    p_redaction_level=>'standard',p_metadata=>coalesce(p_metadata,'{}')||jsonb_build_object(
+      'reminderJobId',p_operation.reminder_job_id,'purposeCode',p_operation.purpose_code,
+      'channel',p_operation.channel,'templateVersionId',p_operation.template_version_id,
+      'renderedContentFingerprint',p_operation.rendered_content_fingerprint
+    )
+  );
+  PERFORM public.record_activity_event_internal(
+    p_tenant_id=>p_operation.tenant_id,p_category=>'appointment',p_type=>p_action,
+    p_title=>CASE p_action
+      WHEN 'communication_operation_prepared' THEN 'Подготовлена тестовая коммуникационная операция'
+      WHEN 'communication_operation_simulation_started' THEN 'Запущена симуляция коммуникации'
+      WHEN 'communication_operation_simulation_succeeded' THEN 'Симуляция коммуникации принята'
+      WHEN 'communication_operation_simulation_uncertain' THEN 'Результат симуляции коммуникации не определён'
+      WHEN 'communication_operation_cancelled' THEN 'Коммуникационная операция отменена'
+      ELSE 'Симуляция коммуникации завершилась ошибкой' END,
+    p_source_type=>'communication_operation',p_source_id=>p_operation.id::text,
+    p_patient_id=>p_operation.patient_id,p_audit_event_id=>v_audit,p_actor_user_id=>auth.uid(),
+    p_visibility=>'admin',p_metadata=>jsonb_strip_nulls(jsonb_build_object(
+      'appointmentId',p_operation.appointment_id,'reminderJobId',p_operation.reminder_job_id,
+      'channel',p_operation.channel,'state',p_operation.state,'safeErrorCode',p_operation.safe_error_code,
+      'templateVersionId',p_operation.template_version_id,
+      'renderedContentFingerprint',p_operation.rendered_content_fingerprint
+    )||coalesce(p_metadata,'{}'))
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.prepare_communication_operation(
+  p_tenant_id uuid,p_reminder_job_id uuid,p_channel text,p_operation_key text,
+  p_expected_job_updated_at timestamptz,p_expected_appointment_updated_at timestamptz
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=public,pg_catalog
+AS $$
+DECLARE v_role text; v_existing public.communication_operations%ROWTYPE;
+  v_job public.appointment_reminder_jobs%ROWTYPE; v_appt public.appointments%ROWTYPE;
+  v_patient public.patients%ROWTYPE; v_contact public.patient_communication_contacts%ROWTYPE;
+  v_pref public.patient_communication_preferences%ROWTYPE; v_consent_event public.patient_communication_consent_events%ROWTYPE;
+  v_route public.communication_routes%ROWTYPE; v_template public.communication_templates%ROWTYPE;
+  v_template_version public.communication_template_versions%ROWTYPE;
+  v_doctor text; v_clinic text; v_timezone text; v_language text;
+  v_eligibility jsonb; v_purpose text; v_consent text; v_channel_suppressed boolean;
+  v_channel_reason text; v_channel_at timestamptz; v_available_variables jsonb; v_render_variables jsonb:='{}';
+  v_key text; v_render jsonb; v_template_snapshot jsonb;
+  v_eligibility_snapshot jsonb; v_consent_snapshot jsonb; v_suppression_snapshot jsonb;
+  v_contact_snapshot jsonb; v_appointment_snapshot jsonb; v_route_snapshot jsonb;
+  v_command jsonb; v_payload jsonb; v_fingerprint text; v_operation public.communication_operations%ROWTYPE;
+  v_operation_id uuid:=gen_random_uuid(); v_masked text; v_destination_fingerprint text;
+BEGIN
+  v_role:=public.communication_require_manager(p_tenant_id);
+  IF p_channel NOT IN ('sms','whatsapp','email') THEN
+    RAISE EXCEPTION 'Канал коммуникации не поддерживается.' USING ERRCODE='22023';
+  END IF;
+  IF p_operation_key IS NULL OR length(p_operation_key) NOT BETWEEN 8 AND 200
+     OR p_operation_key !~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$' THEN
+    RAISE EXCEPTION 'Не удалось выполнить тестовую операцию.' USING ERRCODE='22023';
+  END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended('communication-prepare:'||p_tenant_id||':'||p_operation_key,0));
+  SELECT * INTO v_existing FROM public.communication_operations
+  WHERE tenant_id=p_tenant_id AND operation_key=p_operation_key;
+  IF FOUND THEN
+    IF v_existing.reminder_job_id<>p_reminder_job_id OR v_existing.channel<>p_channel
+       OR v_existing.reminder_job_updated_at<>p_expected_job_updated_at
+       OR v_existing.appointment_updated_at<>p_expected_appointment_updated_at THEN
+      RAISE EXCEPTION 'Операция уже выполнена с другими параметрами.' USING ERRCODE='23505';
+    END IF;
+    RETURN jsonb_build_object('operation',public.communication_operation_json(v_existing),'replayed',true);
+  END IF;
+
+  SELECT * INTO v_job FROM public.appointment_reminder_jobs
+  WHERE tenant_id=p_tenant_id AND id=p_reminder_job_id FOR UPDATE;
+  IF NOT FOUND OR v_job.state NOT IN ('scheduled','ready') THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  IF v_job.updated_at<>p_expected_job_updated_at THEN
+    RAISE EXCEPTION 'Данные записи или контакта изменились. Обновите задачу.' USING ERRCODE='40001';
+  END IF;
+  SELECT * INTO v_appt FROM public.appointments
+  WHERE tenant_id=p_tenant_id AND id=v_job.appointment_id FOR UPDATE;
+  IF NOT FOUND OR v_appt.patient_id IS NULL OR v_appt.patient_id<>v_job.patient_id
+     OR v_appt.status IN ('cancelled','no_show','arrived','in_progress','completed','blocked')
+     OR v_appt.start_time<=transaction_timestamp() THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  IF v_appt.updated_at<>p_expected_appointment_updated_at OR v_job.appointment_updated_at<>v_appt.updated_at THEN
+    RAISE EXCEPTION 'Данные записи или контакта изменились. Обновите задачу.' USING ERRCODE='40001';
+  END IF;
+  v_purpose:=public.communication_purpose(v_job.reminder_type);
+  IF v_purpose IS NULL THEN
+    RAISE EXCEPTION 'Назначение шаблона не поддерживается.' USING ERRCODE='22023';
+  END IF;
+
+  SELECT * INTO v_pref FROM public.patient_communication_preferences
+  WHERE tenant_id=p_tenant_id AND patient_id=v_job.patient_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  v_eligibility:=public.get_patient_communication_eligibility(p_tenant_id,v_job.patient_id,p_channel);
+  IF NOT coalesce((v_eligibility->>'automatedEligible')::boolean,false)
+     OR coalesce((v_eligibility->>'requiresManualReview')::boolean,false) THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  SELECT * INTO v_contact FROM public.patient_communication_contacts
+  WHERE tenant_id=p_tenant_id AND id=(v_eligibility->>'selectedContactId')::uuid FOR UPDATE;
+  IF NOT FOUND OR v_contact.archived_at IS NOT NULL OR NOT v_contact.is_verified
+     OR v_contact.contact_value_normalized IS NULL OR v_contact.owner_type='representative' THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  v_consent:=CASE p_channel WHEN 'sms' THEN v_pref.sms_consent_state
+    WHEN 'whatsapp' THEN v_pref.whatsapp_consent_state ELSE v_pref.email_consent_state END;
+  v_channel_suppressed:=CASE p_channel WHEN 'sms' THEN v_pref.sms_suppressed
+    WHEN 'whatsapp' THEN v_pref.whatsapp_suppressed ELSE v_pref.email_suppressed END;
+  v_channel_reason:=CASE p_channel WHEN 'sms' THEN v_pref.sms_suppression_reason
+    WHEN 'whatsapp' THEN v_pref.whatsapp_suppression_reason ELSE v_pref.email_suppression_reason END;
+  v_channel_at:=CASE p_channel WHEN 'sms' THEN v_pref.sms_suppressed_at
+    WHEN 'whatsapp' THEN v_pref.whatsapp_suppressed_at ELSE v_pref.email_suppressed_at END;
+  IF v_consent<>'granted' OR v_pref.global_suppression OR v_channel_suppressed THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  SELECT * INTO v_consent_event FROM public.patient_communication_consent_events
+  WHERE tenant_id=p_tenant_id AND patient_id=v_job.patient_id AND channel=p_channel
+  ORDER BY occurred_at DESC,id DESC LIMIT 1;
+  IF NOT FOUND OR v_consent_event.new_state<>'granted' THEN
+    RAISE EXCEPTION 'Контакт или согласие больше не позволяют подготовить коммуникацию.' USING ERRCODE='P0002';
+  END IF;
+  SELECT * INTO v_route FROM public.communication_routes
+  WHERE tenant_id=p_tenant_id AND channel=p_channel AND enabled AND simulation_only AND archived_at IS NULL
+  ORDER BY priority,id LIMIT 1 FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Для этого канала не настроен тестовый маршрут.' USING ERRCODE='P0002';
+  END IF;
+  SELECT * INTO v_patient FROM public.patients WHERE tenant_id=p_tenant_id AND id=v_job.patient_id;
+  SELECT name,timezone INTO v_clinic,v_timezone FROM public.tenants WHERE id=p_tenant_id;
+  SELECT full_name INTO v_doctor FROM public.doctors WHERE tenant_id=p_tenant_id AND id=v_appt.doctor_id;
+  v_language:=coalesce(v_contact.language,v_pref.preferred_language);
+  IF v_language NOT IN ('ru','kk','en') THEN
+    RAISE EXCEPTION 'Язык шаблона не поддерживается.' USING ERRCODE='22023';
+  END IF;
+
+  SELECT * INTO v_template FROM public.communication_templates
+  WHERE tenant_id=p_tenant_id AND purpose_code=v_purpose AND channel=p_channel AND language=v_language
+    AND status='active' AND archived_at IS NULL AND active_version_id IS NOT NULL FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Для выбранного канала и языка нет активного шаблона.' USING ERRCODE='P0002';
+  END IF;
+  SELECT * INTO v_template_version FROM public.communication_template_versions
+  WHERE tenant_id=p_tenant_id AND template_id=v_template.id AND id=v_template.active_version_id
+    AND status='published' FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Для выбранного канала и языка нет активного шаблона.' USING ERRCODE='P0002';
+  END IF;
+  PERFORM public.communication_template_validate_content(
+    p_channel,v_template_version.subject,v_template_version.body
+  );
+
+  v_masked:=public.communication_mask_destination(v_contact.contact_value_normalized,p_channel);
+  v_destination_fingerprint:=public.communication_hash(v_contact.contact_value_normalized);
+  v_available_variables:=jsonb_strip_nulls(jsonb_build_object(
+    'patient_first_name',split_part(btrim(v_patient.full_name),' ',1),
+    'clinic_name',v_clinic,
+    'appointment_date',to_char(v_appt.start_time AT TIME ZONE v_timezone,'YYYY-MM-DD'),
+    'appointment_time',to_char(v_appt.start_time AT TIME ZONE v_timezone,'HH24:MI'),
+    'doctor_display_name',v_doctor,
+    'clinic_callback_phone',NULL
+  ));
+  FOREACH v_key IN ARRAY v_template_version.variable_keys LOOP
+    IF NOT v_available_variables ? v_key OR btrim(v_available_variables->>v_key)='' THEN
+      RAISE EXCEPTION 'Для формирования сообщения не хватает обязательных данных.' USING ERRCODE='P0002';
+    END IF;
+    v_render_variables:=v_render_variables||jsonb_build_object(v_key,v_available_variables->>v_key);
+  END LOOP;
+  v_render:=public.communication_template_render_content(
+    p_channel,v_template_version.subject,v_template_version.body,v_render_variables
+  );
+  v_template_snapshot:=jsonb_build_object(
+    'templateId',v_template.id,'templateVersionId',v_template_version.id,
+    'versionNumber',v_template_version.version_number,
+    'contentFingerprint',v_template_version.content_fingerprint,
+    'renderedContentFingerprint',v_render->>'renderedFingerprint',
+    'language',v_template.language,'channel',v_template.channel,'purposeCode',v_template.purpose_code,
+    'variableKeys',to_jsonb(v_template_version.variable_keys)
+  );
+
+  v_eligibility_snapshot:=jsonb_build_object(
+    'eligible',true,'channel',p_channel,'selectedContactId',v_contact.id,
+    'ownerType',v_contact.owner_type,'representative',false,'verified',v_contact.is_verified,
+    'blockedReasons','[]'::jsonb,'evaluationVersion',1
+  );
+  v_consent_snapshot:=jsonb_build_object(
+    'channel',p_channel,'state',v_consent,'source',v_consent_event.source,
+    'lastEventAt',v_consent_event.occurred_at,'eventId',v_consent_event.id
+  );
+  v_suppression_snapshot:=jsonb_build_object(
+    'global',v_pref.global_suppression,'globalReason',v_pref.global_suppression_reason,
+    'globalAt',v_pref.global_suppressed_at,'channel',v_channel_suppressed,
+    'channelReason',v_channel_reason,'channelAt',v_channel_at
+  );
+  v_contact_snapshot:=jsonb_build_object(
+    'destinationFingerprint',v_destination_fingerprint,'maskedDestination',v_masked,
+    'contactType',v_contact.contact_type,'primary',v_contact.is_primary,
+    'verified',v_contact.is_verified,'ownerType',v_contact.owner_type,
+    'representativeRelation',v_contact.representative_relation,'language',v_language
+  );
+  v_appointment_snapshot:=jsonb_build_object(
+    'startInstant',v_appt.start_time,
+    'tenantLocalDate',to_char(v_appt.start_time AT TIME ZONE v_timezone,'YYYY-MM-DD'),
+    'tenantLocalTime',to_char(v_appt.start_time AT TIME ZONE v_timezone,'HH24:MI'),
+    'doctorDisplayName',v_doctor,'clinicDisplayName',v_clinic,'callbackPhone',NULL
+  );
+  v_route_snapshot:=jsonb_build_object(
+    'routeId',v_route.id,'configurationVersion',v_route.configuration_version,
+    'adapterCode',v_route.adapter_code,'simulationOnly',true
+  );
+  v_command:=jsonb_build_object(
+    'tenantId',p_tenant_id,'operationId',v_operation_id,'reminderJobId',v_job.id,
+    'appointmentId',v_appt.id,'patientId',v_patient.id,'contactId',v_contact.id,
+    'purposeCode',v_purpose,'channel',p_channel,'language',v_language,
+    'maskedDestination',v_masked,'destinationFingerprint',v_destination_fingerprint,
+    'operationKey',p_operation_key,'variables',v_render_variables,'requestedAt',transaction_timestamp(),
+    'template',v_template_snapshot,
+    'renderedContent',jsonb_build_object(
+      'subject',v_render->'subject','body',v_render->>'body',
+      'renderedCharacterCount',(v_render->>'renderedCharacterCount')::integer,
+      'renderedFingerprint',v_render->>'renderedFingerprint'
+    )
+  );
+  v_payload:=jsonb_build_object(
+    'tenantId',p_tenant_id,'reminderJobId',v_job.id,'appointmentId',v_appt.id,
+    'patientId',v_patient.id,'contactId',v_contact.id,'purposeCode',v_purpose,
+    'channel',p_channel,'language',v_language,'appointmentUpdatedAt',v_appt.updated_at,
+    'reminderJobUpdatedAt',v_job.updated_at,'contactUpdatedAt',v_contact.updated_at,
+    'consentEventId',v_consent_event.id,'consentState',v_consent,
+    'globalSuppression',v_pref.global_suppression,'channelSuppression',v_channel_suppressed,
+    'routeId',v_route.id,'routeVersion',v_route.configuration_version,
+    'templateId',v_template.id,'templateVersionId',v_template_version.id,
+    'templateVersionNumber',v_template_version.version_number,
+    'templateContentFingerprint',v_template_version.content_fingerprint,
+    'renderedContentFingerprint',v_render->>'renderedFingerprint','variables',v_render_variables
+  );
+  v_fingerprint:=public.communication_hash(v_payload::text);
+
+  PERFORM set_config('app.communication_internal','on',true);
+  INSERT INTO public.communication_operations(
+    id,tenant_id,reminder_job_id,appointment_id,patient_id,contact_id,purpose_code,channel,language,
+    operation_key,payload_fingerprint,appointment_updated_at,reminder_job_updated_at,contact_updated_at,
+    policy_version,eligibility_version,route_id,route_version,adapter_code,created_by,
+    template_id,template_version_id,template_version_number,template_content_fingerprint,
+    rendered_content_fingerprint,rendered_subject,rendered_body,rendered_character_count,template_snapshot,
+    eligibility_snapshot,consent_snapshot,suppression_snapshot,contact_snapshot,appointment_snapshot,
+    route_snapshot,command,metadata
+  ) VALUES(
+    v_operation_id,p_tenant_id,v_job.id,v_appt.id,v_patient.id,v_contact.id,v_purpose,p_channel,v_language,
+    p_operation_key,v_fingerprint,v_appt.updated_at,v_job.updated_at,v_contact.updated_at,
+    v_job.policy_version,1,v_route.id,v_route.configuration_version,v_route.adapter_code,auth.uid(),
+    v_template.id,v_template_version.id,v_template_version.version_number,v_template_version.content_fingerprint,
+    v_render->>'renderedFingerprint',nullif(v_render->>'subject',''),v_render->>'body',
+    (v_render->>'renderedCharacterCount')::integer,v_template_snapshot,
+    v_eligibility_snapshot,v_consent_snapshot,v_suppression_snapshot,v_contact_snapshot,
+    v_appointment_snapshot,v_route_snapshot,v_command,jsonb_build_object('simulationOnly',true)
+  ) RETURNING * INTO v_operation;
+  PERFORM set_config('app.communication_internal','off',true);
+  PERFORM public.communication_record_event(
+    v_operation,'communication_operation_prepared','{}','{}',jsonb_build_object(
+      'templateId',v_template.id,'templateVersionId',v_template_version.id,
+      'templateVersionNumber',v_template_version.version_number,
+      'templateContentFingerprint',v_template_version.content_fingerprint,
+      'renderedContentFingerprint',v_render->>'renderedFingerprint'
+    )
+  );
+  RETURN jsonb_build_object('operation',public.communication_operation_json(v_operation),'replayed',false);
+END;
+$$;
+
+
+REVOKE ALL ON public.communication_templates FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON public.communication_template_versions FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON public.communication_template_operations FROM PUBLIC,anon,authenticated;
+GRANT SELECT ON public.communication_templates,public.communication_template_versions TO authenticated;
+GRANT ALL ON public.communication_templates,public.communication_template_versions,public.communication_template_operations TO service_role;
+
+REVOKE ALL ON FUNCTION public.communication_template_write_guard() FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_validate_identity(text,text,text) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_validate_content(text,text,text) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_render_content(text,text,text,jsonb) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_version_json(public.communication_template_versions) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_json(public.communication_templates) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_operation_replay(uuid,text,text,text) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_store_operation(uuid,text,text,text,jsonb) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_template_record_event(public.communication_templates,public.communication_template_versions,text) FROM PUBLIC,anon,authenticated;
+
+REVOKE ALL ON FUNCTION public.list_communication_templates(uuid,text,text,text) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.get_communication_template(uuid,uuid) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.get_active_communication_template(uuid,text,text,text) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.preview_communication_template(uuid,uuid,jsonb) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.create_communication_template(uuid,text,text,text,text,text,text,text) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.create_communication_template_draft(uuid,uuid,text) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.update_communication_template_draft(uuid,uuid,text,text,timestamptz,text) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.publish_communication_template_version(uuid,uuid,uuid,timestamptz,text) FROM PUBLIC,anon;
+REVOKE ALL ON FUNCTION public.archive_communication_template(uuid,uuid,timestamptz,text) FROM PUBLIC,anon;
+GRANT EXECUTE ON FUNCTION public.list_communication_templates(uuid,text,text,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_communication_template(uuid,uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_active_communication_template(uuid,text,text,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.preview_communication_template(uuid,uuid,jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_communication_template(uuid,text,text,text,text,text,text,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_communication_template_draft(uuid,uuid,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.update_communication_template_draft(uuid,uuid,text,text,timestamptz,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_communication_template_version(uuid,uuid,uuid,timestamptz,text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.archive_communication_template(uuid,uuid,timestamptz,text) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.communication_operation_json(public.communication_operations) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.communication_record_event(public.communication_operations,text,jsonb,jsonb,jsonb) FROM PUBLIC,anon,authenticated;
+REVOKE ALL ON FUNCTION public.prepare_communication_operation(uuid,uuid,text,text,timestamptz,timestamptz) FROM PUBLIC,anon;
+GRANT EXECUTE ON FUNCTION public.prepare_communication_operation(uuid,uuid,text,text,timestamptz,timestamptz) TO authenticated;
+
+COMMENT ON TABLE public.communication_templates IS 'Stable tenant/purpose/channel/language template identity. A template is not a message.';
+COMMENT ON TABLE public.communication_template_versions IS 'Versioned plain-text template content. Published content is immutable.';
+COMMENT ON TABLE public.communication_template_operations IS 'Idempotency records for controlled template mutations.';

--- a/supabase/tests/0032_communication_orchestration_concurrency.ps1
+++ b/supabase/tests/0032_communication_orchestration_concurrency.ps1
@@ -192,6 +192,36 @@ Invoke-Sql $setup | Out-Null
 Invoke-Sql ((AuthContext $adminA) + "SELECT public.create_or_update_communication_route('$tenantA',NULL,'sms','mock',true,100,NULL,'orch-conc-route-a'); COMMIT;") | Out-Null
 Invoke-Sql ((AuthContext $adminB) + "SELECT public.create_or_update_communication_route('$tenantB',NULL,'sms','mock',true,100,NULL,'orch-conc-route-b'); COMMIT;") | Out-Null
 
+# Publish exact tenant/language SMS templates required by the 0033 preparation contract.
+Invoke-Sql ((AuthContext $adminA) + @"
+WITH created AS (
+  SELECT public.create_communication_template(
+    '$tenantA','appointment_confirmation_request','sms','ru','Concurrency RU SMS',NULL,
+    'Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+    'orch-conc-template-a-create'
+  ) AS result
+)
+SELECT public.publish_communication_template_version(
+  '$tenantA',(result->'template'->>'id')::uuid,(result->'version'->>'id')::uuid,
+  (result->'version'->>'updatedAt')::timestamptz,'orch-conc-template-a-publish'
+) FROM created;
+COMMIT;
+"@) | Out-Null
+Invoke-Sql ((AuthContext $adminB) + @"
+WITH created AS (
+  SELECT public.create_communication_template(
+    '$tenantB','appointment_confirmation_request','sms','ru','Concurrency B RU SMS',NULL,
+    'Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+    'orch-conc-template-b-create'
+  ) AS result
+)
+SELECT public.publish_communication_template_version(
+  '$tenantB',(result->'template'->>'id')::uuid,(result->'version'->>'id')::uuid,
+  (result->'version'->>'updatedAt')::timestamptz,'orch-conc-template-b-publish'
+) FROM created;
+COMMIT;
+"@) | Out-Null
+
 $allResults = @()
 
 # A. Same preparation key: one insert and one replay.

--- a/supabase/tests/0032_communication_orchestration_foundation_test.sql
+++ b/supabase/tests/0032_communication_orchestration_foundation_test.sql
@@ -218,6 +218,34 @@ SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
 SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.communication_routes),'tenant A sees own historical disabled and active routes');
 SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_routes WHERE tenant_id=:'tenant_b'),'cross-tenant route read blocked');
 
+-- Template foundation prerequisite for orchestration regression.
+SELECT public.create_communication_template(
+  :'tenant_a','appointment_confirmation_request','sms','ru','Orchestration RU SMS',NULL,
+  'Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+  'orch-template-a-create'
+) AS template_a_result \gset
+SELECT (:'template_a_result'::jsonb->'template'->>'id') AS template_a_id,
+       (:'template_a_result'::jsonb->'version'->>'id') AS template_a_version_id,
+       (:'template_a_result'::jsonb->'version'->>'updatedAt') AS template_a_version_updated \gset
+SELECT public.publish_communication_template_version(
+  :'tenant_a',:'template_a_id',:'template_a_version_id',:'template_a_version_updated'::timestamptz,
+  'orch-template-a-publish'
+);
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT public.create_communication_template(
+  :'tenant_b','appointment_confirmation_request','sms','en','Orchestration EN SMS',NULL,
+  'Hello, {{patient_first_name}}. Appointment at {{clinic_name}} on {{appointment_date}} at {{appointment_time}}.',
+  'orch-template-b-create'
+) AS template_b_result \gset
+SELECT (:'template_b_result'::jsonb->'template'->>'id') AS template_b_id,
+       (:'template_b_result'::jsonb->'version'->>'id') AS template_b_version_id,
+       (:'template_b_result'::jsonb->'version'->>'updatedAt') AS template_b_version_updated \gset
+SELECT public.publish_communication_template_version(
+  :'tenant_b',:'template_b_id',:'template_b_version_id',:'template_b_version_updated'::timestamptz,
+  'orch-template-b-publish'
+);
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+
 -- No route safely blocks whatsapp.
 SELECT pg_temp.expect_error(format(
   'select public.prepare_communication_operation(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L::timestamptz)',
@@ -260,12 +288,12 @@ SELECT pg_temp.expect_error(format(
   :'job_version'::timestamptz,:'appointment_a_updated'::timestamptz
 ),'duplicate');
 
--- Unsupported callback purpose.
+-- Supported callback purpose remains blocked without an exact active template.
 SELECT pg_temp.expect_error(format(
   'select public.prepare_communication_operation(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L::timestamptz)',
-  :'tenant_a','d3270000-0000-4000-8000-000000000008','sms','orch-callback-unsupported',
+  :'tenant_a','d3270000-0000-4000-8000-000000000008','sms','orch-callback-no-template',
   :'job_version'::timestamptz,:'appointment_a_updated'::timestamptz
-),'не поддерживает');
+),'нет активного шаблона');
 
 -- Role and direct write protections.
 SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);

--- a/supabase/tests/0033_communication_template_concurrency.ps1
+++ b/supabase/tests/0033_communication_template_concurrency.ps1
@@ -1,0 +1,368 @@
+$ErrorActionPreference = 'Stop'
+
+# COMMUNICATION-TEMPLATE-FOUNDATION-001 local-only concurrency validation.
+# No external provider, amoCRM, SMS, WhatsApp or email request is made.
+$container = (docker ps --format '{{.Names}}' | Where-Object { $_ -like 'supabase_db_*' } | Select-Object -First 1)
+if (-not $container) { throw 'Local Supabase DB container is not running.' }
+
+$tenantA = 'f3310000-0000-4000-8000-000000000001'
+$tenantB = 'f3310000-0000-4000-8000-000000000002'
+$adminA = 'f3320000-0000-4000-8000-000000000001'
+$adminB = 'f3320000-0000-4000-8000-000000000002'
+$patientA = 'f3330000-0000-4000-8000-000000000001'
+$patientB = 'f3330000-0000-4000-8000-000000000002'
+$doctorA = 'f3340000-0000-4000-8000-000000000001'
+$doctorB = 'f3340000-0000-4000-8000-000000000002'
+$appointmentA1 = 'f3350000-0000-4000-8000-000000000001'
+$appointmentA2 = 'f3350000-0000-4000-8000-000000000002'
+$appointmentA3 = 'f3350000-0000-4000-8000-000000000003'
+$appointmentB1 = 'f3350000-0000-4000-8000-000000000101'
+$contactA = 'f3360000-0000-4000-8000-000000000001'
+$contactB = 'f3360000-0000-4000-8000-000000000002'
+$jobA1 = 'f3370000-0000-4000-8000-000000000001'
+$jobA2 = 'f3370000-0000-4000-8000-000000000002'
+$jobA3 = 'f3370000-0000-4000-8000-000000000003'
+$jobB1 = 'f3370000-0000-4000-8000-000000000101'
+
+function Invoke-Sql([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = $sql | & docker exec -i $container psql -U postgres -d postgres -v ON_ERROR_STOP=1 -q 2>&1
+  $code = [int]$LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "SQL failed:`n$($output -join "`n")" }
+  return $output
+}
+
+function Invoke-Scalar([string]$sql) {
+  $old = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  $output = & docker exec $container psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c $sql 2>&1
+  $code = [int]$LASTEXITCODE
+  $ErrorActionPreference = $old
+  if ($code -ne 0) { throw "Scalar SQL failed: $sql`n$($output -join "`n")" }
+  return (($output | Where-Object { $_ -ne $null -and $_.ToString().Trim() -ne '' } | Select-Object -Last 1).ToString().Trim())
+}
+
+function Invoke-ConcurrentPair([string]$sqlA, [string]$sqlB) {
+  $jobA = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlA
+  $jobB = Start-Job -ScriptBlock {
+    param($containerName, $sql)
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = $sql | & docker exec -i $containerName psql -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 2>&1
+    $code = [int]$LASTEXITCODE
+    $ErrorActionPreference = $old
+    [pscustomobject]@{ Code = $code; Text = ($output -join "`n") }
+  } -ArgumentList $container, $sqlB
+  Wait-Job $jobA, $jobB | Out-Null
+  $results = @((Receive-Job $jobA), (Receive-Job $jobB))
+  Remove-Job $jobA, $jobB
+  return $results
+}
+
+function AuthContext([string]$userId) {
+  return "BEGIN; SET LOCAL ROLE authenticated; SET LOCAL `"request.jwt.claim.sub`"='$userId'; "
+}
+
+function CreateTemplateSql(
+  [string]$tenantId,[string]$userId,[string]$purpose,[string]$channel,[string]$language,
+  [string]$displayName,[string]$subject,[string]$body,[string]$key
+) {
+  if ($key.Length -lt 8 -or $key.Length -gt 200 -or $key -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]*$') {
+    throw "Invalid template operation key before SQL: [$key]"
+  }
+  $subjectSql = if ([string]::IsNullOrWhiteSpace($subject)) { 'NULL' } else { "'$subject'" }
+  return (AuthContext $userId) + @"
+SELECT r->>'replayed' FROM (
+  SELECT public.create_communication_template(
+    '$tenantId','$purpose','$channel','$language','$displayName',$subjectSql,'$body','$key'
+  ) r
+) q;
+COMMIT;
+"@
+}
+function CreateDraftSql([string]$tenantId,[string]$userId,[string]$templateId,[string]$key) {
+  return (AuthContext $userId) + "SELECT r->>'replayed' FROM (SELECT public.create_communication_template_draft('$tenantId','$templateId','$key') r) q; COMMIT;"
+}
+
+function UpdateDraftSql(
+  [string]$tenantId,[string]$userId,[string]$versionId,[string]$body,[string]$expected,[string]$key
+) {
+  return (AuthContext $userId) + "SELECT r->>'replayed' FROM (SELECT public.update_communication_template_draft('$tenantId','$versionId',NULL,'$body','$expected','$key') r) q; COMMIT;"
+}
+
+function PublishSql(
+  [string]$tenantId,[string]$userId,[string]$templateId,[string]$versionId,[string]$expected,[string]$key
+) {
+  return (AuthContext $userId) + "SELECT r->>'replayed' FROM (SELECT public.publish_communication_template_version('$tenantId','$templateId','$versionId','$expected','$key') r) q; COMMIT;"
+}
+
+function ArchiveSql([string]$tenantId,[string]$userId,[string]$templateId,[string]$expected,[string]$key) {
+  return (AuthContext $userId) + "SELECT r->>'replayed' FROM (SELECT public.archive_communication_template('$tenantId','$templateId','$expected','$key') r) q; COMMIT;"
+}
+
+function PrepareSql([string]$tenantId,[string]$userId,[string]$jobId,[string]$key) {
+  return (AuthContext $userId) + @"
+SELECT r->>'replayed' FROM (
+  SELECT public.prepare_communication_operation(
+    '$tenantId','$jobId','sms','$key',
+    (SELECT updated_at FROM public.appointment_reminder_jobs WHERE tenant_id='$tenantId' AND id='$jobId'),
+    (SELECT a.updated_at FROM public.appointments a JOIN public.appointment_reminder_jobs j
+      ON j.tenant_id=a.tenant_id AND j.appointment_id=a.id
+      WHERE j.tenant_id='$tenantId' AND j.id='$jobId')
+  ) r
+) q;
+COMMIT;
+"@
+}
+
+function Count-Success([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 }).Count }
+function Count-Replay([object[]]$results) { return @($results | Where-Object { $_.Code -eq 0 -and $_.Text.Trim() -eq 'true' }).Count }
+function Count-Conflict([object[]]$results) { return @($results | Where-Object { $_.Code -ne 0 }).Count }
+function Count-Deadlocks([object[]]$results) { return @($results | Where-Object { $_.Text -match 'deadlock detected' }).Count }
+
+$cleanup = @"
+DELETE FROM public.tenants WHERE id IN ('$tenantA'::uuid,'$tenantB'::uuid);
+DELETE FROM auth.users WHERE id IN ('$adminA'::uuid,'$adminB'::uuid);
+"@
+
+$setup = @"
+BEGIN;
+$cleanup
+INSERT INTO public.tenants(id,name,timezone) VALUES
+ ('$tenantA','Template concurrency A','Asia/Almaty'),
+ ('$tenantB','Template concurrency B','Asia/Almaty');
+INSERT INTO auth.users(id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,raw_app_meta_data,raw_user_meta_data,created_at,updated_at) VALUES
+ ('$adminA','00000000-0000-0000-0000-000000000000','authenticated','authenticated','template-conc-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+ ('$adminB','00000000-0000-0000-0000-000000000000','authenticated','authenticated','template-conc-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+INSERT INTO public.profiles(id) VALUES ('$adminA'),('$adminB');
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+ ('$tenantA','$adminA','clinic_admin'),('$tenantB','$adminB','clinic_admin');
+INSERT INTO public.patients(id,tenant_id,full_name,source,status) VALUES
+ ('$patientA','$tenantA','Template Concurrent A','phone','active'),
+ ('$patientB','$tenantB','Template Concurrent B','phone','active');
+INSERT INTO public.doctors(id,tenant_id,full_name,specialization,cabinet,color,active) VALUES
+ ('$doctorA','$tenantA','Doctor A','General','A1','#111111',true),
+ ('$doctorB','$tenantB','Doctor B','General','B1','#222222',true);
+INSERT INTO public.appointments(id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time) VALUES
+ ('$appointmentA1','$tenantA','$patientA','$doctorA','A1','Template concurrency','new','2099-10-01 10:00+00','2099-10-01 11:00+00'),
+ ('$appointmentA2','$tenantA','$patientA','$doctorA','A1','Template concurrency','new','2099-10-02 10:00+00','2099-10-02 11:00+00'),
+ ('$appointmentA3','$tenantA','$patientA','$doctorA','A1','Template concurrency','new','2099-10-03 10:00+00','2099-10-03 11:00+00'),
+ ('$appointmentB1','$tenantB','$patientB','$doctorB','B1','Template concurrency B','new','2099-10-04 10:00+00','2099-10-04 11:00+00');
+INSERT INTO public.patient_communication_contacts(
+ id,tenant_id,patient_id,contact_type,contact_value_raw,contact_value_normalized,is_primary,is_verified,verification_source,owner_type,language
+) VALUES
+ ('$contactA','$tenantA','$patientA','phone','+77007778899','+77007778899',true,true,'patient_confirmed','patient','ru'),
+ ('$contactB','$tenantB','$patientB','phone','+77008889900','+77008889900',true,true,'patient_confirmed','patient','ru');
+UPDATE public.patient_communication_preferences
+ SET preferred_language='ru',preferred_channel='sms',sms_consent_state='granted',sms_suppressed=false,global_suppression=false
+ WHERE tenant_id='$tenantA' AND patient_id='$patientA';
+UPDATE public.patient_communication_preferences
+ SET preferred_language='ru',preferred_channel='sms',sms_consent_state='granted',sms_suppressed=false,global_suppression=false
+ WHERE tenant_id='$tenantB' AND patient_id='$patientB';
+INSERT INTO public.patient_communication_consent_events(
+ tenant_id,patient_id,channel,previous_state,new_state,source,actor_user_id,reason,operation_key,fingerprint
+) VALUES
+ ('$tenantA','$patientA','sms','unknown','granted','patient_written','$adminA','concurrency','template-conc-consent-a',repeat('a',64)),
+ ('$tenantB','$patientB','sms','unknown','granted','patient_written','$adminB','concurrency','template-conc-consent-b',repeat('b',64));
+INSERT INTO public.appointment_reminder_jobs(
+ id,tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,appointment_updated_at,
+ policy_version,plan_key,payload_fingerprint,priority,original_due_at,metadata
+) VALUES
+ ('$jobA1','$tenantA','$appointmentA1','$patientA','confirmation_request','manual','2099-09-30 08:00+00','scheduled',(SELECT updated_at FROM public.appointments WHERE id='$appointmentA1'),1,repeat('1',64),repeat('2',64),100,'2099-09-30 08:00+00','{}'),
+ ('$jobA2','$tenantA','$appointmentA2','$patientA','confirmation_request','manual','2099-10-01 08:00+00','scheduled',(SELECT updated_at FROM public.appointments WHERE id='$appointmentA2'),1,repeat('3',64),repeat('4',64),100,'2099-10-01 08:00+00','{}'),
+ ('$jobA3','$tenantA','$appointmentA3','$patientA','confirmation_request','manual','2099-10-02 08:00+00','scheduled',(SELECT updated_at FROM public.appointments WHERE id='$appointmentA3'),1,repeat('5',64),repeat('6',64),100,'2099-10-02 08:00+00','{}'),
+ ('$jobB1','$tenantB','$appointmentB1','$patientB','confirmation_request','manual','2099-10-03 08:00+00','scheduled',(SELECT updated_at FROM public.appointments WHERE id='$appointmentB1'),1,repeat('7',64),repeat('8',64),100,'2099-10-03 08:00+00','{}');
+COMMIT;
+"@
+Invoke-Sql $setup | Out-Null
+Invoke-Sql ((AuthContext $adminA) + "SELECT public.create_or_update_communication_route('$tenantA',NULL,'sms','mock',true,100,NULL,'template-conc-route-a'); COMMIT;") | Out-Null
+Invoke-Sql ((AuthContext $adminB) + "SELECT public.create_or_update_communication_route('$tenantB',NULL,'sms','mock',true,100,NULL,'template-conc-route-b'); COMMIT;") | Out-Null
+
+$allResults = @()
+
+# A. Same template creation key: one create and one replay.
+$resultsA = Invoke-ConcurrentPair `
+  (CreateTemplateSql $tenantA $adminA 'appointment_day_before_reminder' 'email' 'en' 'Day-before EN' 'Reminder' 'Hello, {{patient_first_name}}.' 'template-conc-create-same') `
+  (CreateTemplateSql $tenantA $adminA 'appointment_day_before_reminder' 'email' 'en' 'Day-before EN' 'Reminder' 'Hello, {{patient_first_name}}.' 'template-conc-create-same')
+$allResults += $resultsA
+$templateMain = Invoke-Scalar "SELECT id FROM public.communication_templates WHERE tenant_id='$tenantA' AND purpose_code='appointment_day_before_reminder' AND channel='email' AND language='en'"
+$version1 = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateMain' AND version_number=1"
+$version1Updated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$version1'"
+Invoke-Sql (PublishSql $tenantA $adminA $templateMain $version1 $version1Updated 'template-conc-initial-publish') | Out-Null
+Write-Host "A_SAME_CREATE success=$(Count-Success $resultsA) replay=$(Count-Replay $resultsA) templates=$(Invoke-Scalar "SELECT count(*) FROM public.communication_templates WHERE id='$templateMain'")"
+
+# B. Competing draft creation: one version 2 draft, one conflict.
+$resultsB = Invoke-ConcurrentPair `
+  (CreateDraftSql $tenantA $adminA $templateMain 'template-conc-draft-b1') `
+  (CreateDraftSql $tenantA $adminA $templateMain 'template-conc-draft-b2')
+$allResults += $resultsB
+$version2 = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateMain' AND version_number=2"
+$version2Updated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$version2'"
+Write-Host "B_COMPETING_DRAFT success=$(Count-Success $resultsB) conflict=$(Count-Conflict $resultsB) drafts=$(Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE template_id='$templateMain' AND status='draft'")"
+
+# C. Two publish operations: one winner, prior active superseded, no double active.
+$resultsC = Invoke-ConcurrentPair `
+  (PublishSql $tenantA $adminA $templateMain $version2 $version2Updated 'template-conc-publish-c1') `
+  (PublishSql $tenantA $adminA $templateMain $version2 $version2Updated 'template-conc-publish-c2')
+$allResults += $resultsC
+Write-Host "C_TWO_PUBLISH success=$(Count-Success $resultsC) conflict=$(Count-Conflict $resultsC) active=$(Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE template_id='$templateMain' AND status='published'") superseded=$(Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE template_id='$templateMain' AND status='superseded'")"
+
+# D. Same publish key: replay safe.
+Invoke-Sql (CreateDraftSql $tenantA $adminA $templateMain 'template-conc-draft-d') | Out-Null
+$version3 = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateMain' AND status='draft'"
+$version3Updated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$version3'"
+$resultsD = Invoke-ConcurrentPair `
+  (PublishSql $tenantA $adminA $templateMain $version3 $version3Updated 'template-conc-publish-same') `
+  (PublishSql $tenantA $adminA $templateMain $version3 $version3Updated 'template-conc-publish-same')
+$allResults += $resultsD
+Write-Host "D_SAME_PUBLISH success=$(Count-Success $resultsD) replay=$(Count-Replay $resultsD)"
+
+# E. Same operation key with changed payload: one winner and one idempotency conflict.
+$resultsE = Invoke-ConcurrentPair `
+  (CreateTemplateSql $tenantA $adminA 'appointment_same_day_reminder' 'whatsapp' 'en' 'Same-day A' '' 'Hello {{patient_first_name}}.' 'template-conc-changed-key') `
+  (CreateTemplateSql $tenantA $adminA 'appointment_control_call_task' 'whatsapp' 'en' 'Control B' '' 'Call {{patient_first_name}}.' 'template-conc-changed-key')
+$allResults += $resultsE
+Write-Host "E_CHANGED_PAYLOAD success=$(Count-Success $resultsE) conflict=$(Count-Conflict $resultsE)"
+
+# F. Draft update versus publish: one ordered success, the other stale or immutable.
+Invoke-Sql (CreateDraftSql $tenantA $adminA $templateMain 'template-conc-draft-f') | Out-Null
+$versionF = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateMain' AND status='draft'"
+$versionFUpdated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$versionF'"
+$resultsF = Invoke-ConcurrentPair `
+  (UpdateDraftSql $tenantA $adminA $versionF 'Updated concurrently for {{patient_first_name}}.' $versionFUpdated 'template-conc-update-f') `
+  (PublishSql $tenantA $adminA $templateMain $versionF $versionFUpdated 'template-conc-publish-f')
+$allResults += $resultsF
+$versionFStatus = Invoke-Scalar "SELECT status FROM public.communication_template_versions WHERE id='$versionF'"
+if ($versionFStatus -eq 'draft') {
+  $versionFUpdatedNow = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$versionF'"
+  Invoke-Sql (PublishSql $tenantA $adminA $templateMain $versionF $versionFUpdatedNow 'template-conc-publish-f-reconcile') | Out-Null
+}
+Write-Host "F_UPDATE_VS_PUBLISH success=$(Count-Success $resultsF) conflict=$(Count-Conflict $resultsF) final=$(Invoke-Scalar "SELECT status FROM public.communication_template_versions WHERE id='$versionF'")"
+
+# G. Publish versus archive: final template is deterministically archived.
+Invoke-Sql (CreateDraftSql $tenantA $adminA $templateMain 'template-conc-draft-g') | Out-Null
+$versionG = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateMain' AND status='draft'"
+$versionGUpdated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$versionG'"
+$templateGUpdated = Invoke-Scalar "SELECT updated_at FROM public.communication_templates WHERE id='$templateMain'"
+$resultsG = Invoke-ConcurrentPair `
+  (PublishSql $tenantA $adminA $templateMain $versionG $versionGUpdated 'template-conc-publish-g') `
+  (ArchiveSql $tenantA $adminA $templateMain $templateGUpdated 'template-conc-archive-g')
+$allResults += $resultsG
+$templateGFinal = Invoke-Scalar "SELECT status FROM public.communication_templates WHERE id='$templateMain'"
+if ($templateGFinal -ne 'archived') {
+  $templateGUpdatedNow = Invoke-Scalar "SELECT updated_at FROM public.communication_templates WHERE id='$templateMain'"
+  Invoke-Sql (ArchiveSql $tenantA $adminA $templateMain $templateGUpdatedNow 'template-conc-archive-g-reconcile') | Out-Null
+  $templateGFinal = Invoke-Scalar "SELECT status FROM public.communication_templates WHERE id='$templateMain'"
+}
+Write-Host "G_PUBLISH_VS_ARCHIVE success=$(Count-Success $resultsG) conflict=$(Count-Conflict $resultsG) final=$templateGFinal"
+
+# H. Preparation versus template publish: operation snapshots exactly one coherent version.
+$orchestrationCreateSql = CreateTemplateSql `
+  -tenantId $tenantA -userId $adminA -purpose 'appointment_confirmation_request' `
+  -channel 'sms' -language 'ru' -displayName 'Confirmation RU' -subject '' `
+  -body 'Version one: {{patient_first_name}} {{appointment_date}} {{appointment_time}} {{clinic_name}}.' `
+  -key 'template-conc-orch-create'
+Invoke-Sql $orchestrationCreateSql | Out-Null
+$templateOrch = Invoke-Scalar "SELECT id FROM public.communication_templates WHERE tenant_id='$tenantA' AND purpose_code='appointment_confirmation_request' AND channel='sms' AND language='ru'"
+$orchV1 = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateOrch' AND version_number=1"
+$orchV1Updated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$orchV1'"
+Invoke-Sql (PublishSql $tenantA $adminA $templateOrch $orchV1 $orchV1Updated 'template-conc-orch-publish-v1') | Out-Null
+Invoke-Sql (CreateDraftSql $tenantA $adminA $templateOrch 'template-conc-orch-draft-v2') | Out-Null
+$orchV2 = Invoke-Scalar "SELECT id FROM public.communication_template_versions WHERE template_id='$templateOrch' AND status='draft'"
+$orchV2Updated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$orchV2'"
+Invoke-Sql (UpdateDraftSql $tenantA $adminA $orchV2 'Version two: {{patient_first_name}} {{appointment_date}} {{appointment_time}} {{clinic_name}}.' $orchV2Updated 'template-conc-orch-update-v2') | Out-Null
+$orchV2Updated = Invoke-Scalar "SELECT updated_at FROM public.communication_template_versions WHERE id='$orchV2'"
+$resultsH = Invoke-ConcurrentPair `
+  (PrepareSql $tenantA $adminA $jobA1 'template-conc-prepare-h') `
+  (PublishSql $tenantA $adminA $templateOrch $orchV2 $orchV2Updated 'template-conc-orch-publish-v2')
+$allResults += $resultsH
+$operationHVersion = Invoke-Scalar "SELECT template_version_id FROM public.communication_operations WHERE tenant_id='$tenantA' AND reminder_job_id='$jobA1'"
+$operationHCoherent = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_operations o JOIN public.communication_template_versions v ON v.tenant_id=o.tenant_id AND v.template_id=o.template_id AND v.id=o.template_version_id WHERE o.tenant_id='$tenantA' AND o.reminder_job_id='$jobA1' AND o.template_content_fingerprint=v.content_fingerprint AND o.rendered_content_fingerprint=(o.template_snapshot->>'renderedContentFingerprint')")
+Write-Host "H_PREPARE_VS_PUBLISH success=$(Count-Success $resultsH) conflict=$(Count-Conflict $resultsH) snapshotVersion=$operationHVersion coherent=$operationHCoherent"
+
+# I. Concurrent preparations after publish use one active version.
+$activeOrchVersion = Invoke-Scalar "SELECT active_version_id FROM public.communication_templates WHERE id='$templateOrch'"
+$resultsI = Invoke-ConcurrentPair `
+  (PrepareSql $tenantA $adminA $jobA2 'template-conc-prepare-i2') `
+  (PrepareSql $tenantA $adminA $jobA3 'template-conc-prepare-i3')
+$allResults += $resultsI
+$operationsIWrong = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_operations WHERE reminder_job_id IN ('$jobA2','$jobA3') AND template_version_id<>'$activeOrchVersion'")
+Write-Host "I_PREPARE_AFTER_PUBLISH success=$(Count-Success $resultsI) wrongVersion=$operationsIWrong active=$activeOrchVersion"
+
+# J. Same operation key in different tenants remains independent.
+$crossTenantSqlA = CreateTemplateSql `
+  -tenantId $tenantA -userId $adminA -purpose 'appointment_control_call_task' `
+  -channel 'email' -language 'ru' -displayName 'Cross A' -subject 'Subject A' `
+  -body 'Body A' -key 'template-conc-cross-tenant-key'
+$crossTenantSqlB = CreateTemplateSql `
+  -tenantId $tenantB -userId $adminB -purpose 'appointment_control_call_task' `
+  -channel 'email' -language 'ru' -displayName 'Cross B' -subject 'Subject B' `
+  -body 'Body B' -key 'template-conc-cross-tenant-key'
+$resultsJ = Invoke-ConcurrentPair $crossTenantSqlA $crossTenantSqlB
+$allResults += $resultsJ
+Write-Host "J_CROSS_TENANT success=$(Count-Success $resultsJ) operationRows=$(Invoke-Scalar "SELECT count(*) FROM public.communication_template_operations WHERE operation_key='template-conc-cross-tenant-key'")"
+
+$templates = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_templates WHERE tenant_id IN ('$tenantA','$tenantB')")
+$versions = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE tenant_id IN ('$tenantA','$tenantB')")
+$drafts = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE tenant_id IN ('$tenantA','$tenantB') AND status='draft'")
+$published = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE tenant_id IN ('$tenantA','$tenantB') AND status='published'")
+$superseded = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_template_versions WHERE tenant_id IN ('$tenantA','$tenantB') AND status='superseded'")
+$activeVersions = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_templates WHERE tenant_id IN ('$tenantA','$tenantB') AND active_version_id IS NOT NULL")
+$replays = @($allResults | Where-Object { $_.Code -eq 0 -and $_.Text.Trim() -eq 'true' }).Count
+$conflicts = @($allResults | Where-Object { $_.Code -ne 0 }).Count
+$operationsByVersion = Invoke-Scalar "SELECT coalesce(string_agg(template_version_id::text||'='||count_value,',' ORDER BY template_version_id::text),'') FROM (SELECT template_version_id,count(*)::text count_value FROM public.communication_operations WHERE tenant_id IN ('$tenantA','$tenantB') GROUP BY template_version_id) s"
+$auditEvents = [int](Invoke-Scalar "SELECT count(*) FROM public.audit_events WHERE tenant_id IN ('$tenantA','$tenantB') AND action LIKE 'communication_template_%'")
+$activityEvents = [int](Invoke-Scalar "SELECT count(*) FROM public.activity_events WHERE tenant_id IN ('$tenantA','$tenantB') AND type LIKE 'communication_template_%'")
+$deadlocks = Count-Deadlocks $allResults
+$multipleActive = [int](Invoke-Scalar "SELECT count(*) FROM (SELECT template_id FROM public.communication_template_versions WHERE tenant_id IN ('$tenantA','$tenantB') AND status='published' GROUP BY template_id HAVING count(*)>1) d")
+$duplicateVersionNumbers = [int](Invoke-Scalar "SELECT count(*) FROM (SELECT template_id,version_number FROM public.communication_template_versions WHERE tenant_id IN ('$tenantA','$tenantB') GROUP BY template_id,version_number HAVING count(*)>1) d")
+$operationsWithoutSnapshot = [int](Invoke-Scalar "SELECT count(*) FROM public.communication_operations WHERE tenant_id IN ('$tenantA','$tenantB') AND (template_id IS NULL OR template_version_id IS NULL OR template_content_fingerprint IS NULL OR rendered_content_fingerprint IS NULL OR template_snapshot IS NULL)")
+$auditMismatch = [math]::Abs($auditEvents - $activityEvents)
+
+if ((Count-Success $resultsA) -ne 2 -or (Count-Replay $resultsA) -ne 1) { throw 'Scenario A replay invariant failed.' }
+if ((Count-Success $resultsB) -ne 1 -or (Count-Conflict $resultsB) -ne 1) { throw 'Scenario B competing draft invariant failed.' }
+if ((Count-Success $resultsC) -ne 1 -or (Count-Conflict $resultsC) -ne 1) { throw 'Scenario C competing publish invariant failed.' }
+if ((Count-Success $resultsD) -ne 2 -or (Count-Replay $resultsD) -ne 1) { throw 'Scenario D publish replay invariant failed.' }
+if ((Count-Success $resultsE) -ne 1 -or (Count-Conflict $resultsE) -ne 1) { throw 'Scenario E changed payload invariant failed.' }
+if ((Count-Success $resultsF) -ne 1 -or (Count-Conflict $resultsF) -ne 1) { throw 'Scenario F update/publish ordering invariant failed.' }
+if ((Invoke-Scalar "SELECT status FROM public.communication_templates WHERE id='$templateMain'") -ne 'archived') { throw 'Scenario G final template must be archived.' }
+if ($operationHCoherent -ne 1) { throw 'Scenario H operation snapshot is not coherent.' }
+if ((Count-Success $resultsI) -ne 2 -or $operationsIWrong -ne 0) { throw 'Scenario I active-version invariant failed.' }
+if ((Count-Success $resultsJ) -ne 2) { throw 'Scenario J cross-tenant independence failed.' }
+if ($multipleActive -ne 0) { throw "Multiple active versions: $multipleActive" }
+if ($duplicateVersionNumbers -ne 0) { throw "Duplicate version numbers: $duplicateVersionNumbers" }
+if ($operationsWithoutSnapshot -ne 0) { throw "Operations without template snapshot: $operationsWithoutSnapshot" }
+if ($auditMismatch -ne 0) { throw "Audit/activity mismatch: $auditEvents/$activityEvents" }
+if ($deadlocks -ne 0) { throw "Deadlocks detected: $deadlocks" }
+
+[pscustomobject]@{
+  templates = $templates
+  versions = $versions
+  drafts = $drafts
+  published = $published
+  superseded = $superseded
+  activeVersions = $activeVersions
+  replays = $replays
+  conflicts = $conflicts
+  operationsByTemplateVersion = $operationsByVersion
+  multipleActiveVersions = $multipleActive
+  duplicateVersionNumbers = $duplicateVersionNumbers
+  operationsWithoutTemplateSnapshot = $operationsWithoutSnapshot
+  auditEvents = $auditEvents
+  activityEvents = $activityEvents
+  auditActivityMismatch = $auditMismatch
+  deadlocks = $deadlocks
+} | Format-List
+
+Invoke-Sql $cleanup | Out-Null
+Write-Host 'COMMUNICATION-TEMPLATE-FOUNDATION-001 concurrency validation passed.'

--- a/supabase/tests/0033_communication_template_foundation_test.sql
+++ b/supabase/tests/0033_communication_template_foundation_test.sql
@@ -1,0 +1,493 @@
+\set ON_ERROR_STOP on
+\echo 'COMMUNICATION-TEMPLATE-FOUNDATION-001 SQL validation'
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_condition boolean, p_message text)
+RETURNS void LANGUAGE plpgsql AS $assert$
+BEGIN
+  IF NOT coalesce(p_condition, false) THEN
+    RAISE EXCEPTION 'ASSERTION FAILED: %', p_message;
+  END IF;
+END;
+$assert$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_expected text)
+RETURNS void LANGUAGE plpgsql AS $expect$
+DECLARE v_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'expected error containing "%"', p_expected;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_message = MESSAGE_TEXT;
+    IF v_message LIKE 'expected error containing%' THEN RAISE; END IF;
+    IF position(lower(p_expected) in lower(v_message)) = 0 THEN
+      RAISE EXCEPTION 'expected "%", got "%"', p_expected, v_message;
+    END IF;
+  END;
+END;
+$expect$;
+
+\set tenant_a 'd3210000-0000-4000-8000-000000000001'
+\set tenant_b 'd3210000-0000-4000-8000-000000000002'
+\set owner_a 'd3220000-0000-4000-8000-000000000001'
+\set admin_a 'd3220000-0000-4000-8000-000000000002'
+\set registrar_a 'd3220000-0000-4000-8000-000000000003'
+\set doctor_a 'd3220000-0000-4000-8000-000000000004'
+\set cashier_a 'd3220000-0000-4000-8000-000000000005'
+\set unknown_user 'd3220000-0000-4000-8000-000000000006'
+\set owner_b 'd3220000-0000-4000-8000-000000000007'
+\set patient_a 'd3230000-0000-4000-8000-000000000001'
+\set patient_b 'd3230000-0000-4000-8000-000000000002'
+\set representative_patient 'd3230000-0000-4000-8000-000000000003'
+\set doctor_entity_a 'd3240000-0000-4000-8000-000000000001'
+\set doctor_entity_b 'd3240000-0000-4000-8000-000000000002'
+\set appointment_a 'd3250000-0000-4000-8000-000000000001'
+\set appointment_b 'd3250000-0000-4000-8000-000000000002'
+\set contact_phone_a 'd3260000-0000-4000-8000-000000000001'
+\set contact_email_a 'd3260000-0000-4000-8000-000000000002'
+\set contact_rep 'd3260000-0000-4000-8000-000000000003'
+\set contact_phone_b 'd3260000-0000-4000-8000-000000000004'
+
+DELETE FROM public.tenants WHERE id IN (:'tenant_a'::uuid, :'tenant_b'::uuid);
+DELETE FROM auth.users WHERE id IN (
+  :'owner_a'::uuid, :'admin_a'::uuid, :'registrar_a'::uuid, :'doctor_a'::uuid,
+  :'cashier_a'::uuid, :'unknown_user'::uuid, :'owner_b'::uuid
+);
+
+INSERT INTO public.tenants(id, name, timezone) VALUES
+(:'tenant_a', 'Orchestration Test A', 'Asia/Almaty'),
+(:'tenant_b', 'Orchestration Test B', 'Europe/Berlin');
+
+INSERT INTO auth.users(
+  id,instance_id,aud,role,email,encrypted_password,email_confirmed_at,
+  raw_app_meta_data,raw_user_meta_data,created_at,updated_at
+) VALUES
+(:'owner_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-owner-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'admin_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-admin-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'registrar_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-registrar-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'doctor_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-doctor-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'cashier_a','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-cashier-a@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'unknown_user','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-unknown@example.local','x',now(),'{"provider":"email"}','{}',now(),now()),
+(:'owner_b','00000000-0000-0000-0000-000000000000','authenticated','authenticated','orch-owner-b@example.local','x',now(),'{"provider":"email"}','{}',now(),now());
+
+INSERT INTO public.profiles(id) VALUES
+(:'owner_a'),(:'admin_a'),(:'registrar_a'),(:'doctor_a'),(:'cashier_a'),(:'unknown_user'),(:'owner_b');
+
+INSERT INTO public.tenant_users(tenant_id,user_id,role) VALUES
+(:'tenant_a',:'owner_a','clinic_owner'),(:'tenant_a',:'admin_a','clinic_admin'),
+(:'tenant_a',:'registrar_a','registrar'),(:'tenant_a',:'doctor_a','doctor'),
+(:'tenant_a',:'cashier_a','cashier'),(:'tenant_b',:'owner_b','clinic_owner');
+
+INSERT INTO public.doctors(id,tenant_id,user_id,full_name,specialization,cabinet,color,active) VALUES
+(:'doctor_entity_a',:'tenant_a',:'doctor_a','Р’СЂР°С‡ РћСЂРєРµСЃС‚СЂР°С†РёРё','РўРµСЂР°РїРµРІС‚','1','#123456',true),
+(:'doctor_entity_b',:'tenant_b',NULL,'Р’СЂР°С‡ B','РўРµСЂР°РїРµРІС‚','1','#654321',true);
+
+INSERT INTO public.patients(id,tenant_id,full_name,phone,source,status,balance) VALUES
+(:'patient_a',:'tenant_a','РџР°С†РёРµРЅС‚ РћСЂРєРµСЃС‚СЂР°С†РёРё',NULL,'phone','active',123.45),
+(:'patient_b',:'tenant_b','РџР°С†РёРµРЅС‚ B',NULL,'phone','active',0),
+(:'representative_patient',:'tenant_a','РџР°С†РёРµРЅС‚ РџСЂРµРґСЃС‚Р°РІРёС‚РµР»СЏ',NULL,'phone','active',0);
+
+INSERT INTO public.appointments(
+  id,tenant_id,patient_id,doctor_id,cabinet,service,status,start_time,end_time,created_at,updated_at
+) VALUES
+(:'appointment_a',:'tenant_a',:'patient_a',:'doctor_entity_a','1','РћСЃРјРѕС‚СЂ','new','2099-07-20 10:00:00+00','2099-07-20 11:00:00+00',now(),'2099-07-13 08:00:00+00'),
+(:'appointment_b',:'tenant_b',:'patient_b',:'doctor_entity_b','1','РћСЃРјРѕС‚СЂ','new','2099-07-20 10:00:00+00','2099-07-20 11:00:00+00',now(),'2099-07-13 08:00:00+00');
+SELECT updated_at::text AS appointment_a_updated FROM public.appointments WHERE id=:'appointment_a' \gset
+SELECT updated_at::text AS appointment_b_updated FROM public.appointments WHERE id=:'appointment_b' \gset
+
+INSERT INTO public.patient_communication_contacts(
+  id,tenant_id,patient_id,contact_type,contact_value_raw,contact_value_normalized,
+  is_primary,is_verified,verification_source,owner_type,representative_name,representative_relation,language,updated_at
+) VALUES
+(:'contact_phone_a',:'tenant_a',:'patient_a','phone','+7 700 111 22 33','+77001112233',true,true,'patient_confirmed','patient',NULL,NULL,'ru','2099-07-13 08:00:00+00'),
+(:'contact_email_a',:'tenant_a',:'patient_a','email','patient@example.com','patient@example.com',true,true,'patient_confirmed','patient',NULL,NULL,'ru','2099-07-13 08:00:00+00'),
+(:'contact_rep',:'tenant_a',:'representative_patient','phone','+7 700 333 44 55','+77003334455',true,true,'representative_confirmed','representative','РњР°РјР° РїР°С†РёРµРЅС‚Р°','parent','ru','2099-07-13 08:00:00+00'),
+(:'contact_phone_b',:'tenant_b',:'patient_b','phone','+49 151 12345678','+4915112345678',true,true,'patient_confirmed','patient',NULL,NULL,'en','2099-07-13 08:00:00+00');
+
+UPDATE public.patient_communication_preferences
+SET preferred_language='ru',preferred_channel='sms',sms_consent_state='granted',
+    whatsapp_consent_state='granted',email_consent_state='granted',
+    sms_suppressed=false,whatsapp_suppressed=false,email_suppressed=false,global_suppression=false
+WHERE tenant_id=:'tenant_a' AND patient_id=:'patient_a';
+UPDATE public.patient_communication_preferences
+SET preferred_language='en',preferred_channel='sms',sms_consent_state='granted'
+WHERE tenant_id=:'tenant_b' AND patient_id=:'patient_b';
+UPDATE public.patient_communication_preferences
+SET preferred_language='ru',preferred_channel='sms',sms_consent_state='granted'
+WHERE tenant_id=:'tenant_a' AND patient_id=:'representative_patient';
+
+INSERT INTO public.patient_communication_consent_events(
+  tenant_id,patient_id,channel,previous_state,new_state,source,actor_user_id,reason,occurred_at,operation_key,fingerprint
+) VALUES
+(:'tenant_a',:'patient_a','sms','unknown','granted','patient_written',:'owner_a','test',now(),'orch-consent-sms-a',repeat('a',64)),
+(:'tenant_a',:'patient_a','whatsapp','unknown','granted','patient_written',:'owner_a','test',now(),'orch-consent-wa-a',repeat('b',64)),
+(:'tenant_a',:'patient_a','email','unknown','granted','patient_written',:'owner_a','test',now(),'orch-consent-email-a',repeat('c',64)),
+(:'tenant_b',:'patient_b','sms','unknown','granted','patient_written',:'owner_b','test',now(),'orch-consent-sms-b',repeat('d',64)),
+(:'tenant_a',:'representative_patient','sms','unknown','granted','representative_written',:'owner_a','test',now(),'orch-consent-rep',repeat('e',64));
+
+-- Scenario jobs. Each is a separate source operation so duplicate logical operations remain forbidden.
+INSERT INTO public.appointment_reminder_jobs(
+  id,tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,
+  appointment_updated_at,policy_version,plan_key,payload_fingerprint,priority,created_at,updated_at,original_due_at,metadata
+)
+SELECT
+  ('d3270000-0000-4000-8000-' || lpad(n::text,12,'0'))::uuid,
+  :'tenant_a'::uuid, :'appointment_a'::uuid, :'patient_a'::uuid,
+  CASE WHEN n=8 THEN 'callback_task' ELSE 'confirmation_request' END,
+  'manual','2099-07-19 08:00:00+00','scheduled',
+  :'appointment_a_updated'::timestamptz,1,
+  encode(extensions.digest('orch-plan-'||n::text,'sha256'),'hex'),
+  encode(extensions.digest('orch-payload-'||n::text,'sha256'),'hex'),
+  100,now(),('2099-07-13 08:00:00+00'::timestamptz + n * interval '1 microsecond'),
+  '2099-07-19 08:00:00+00','{}'::jsonb
+FROM generate_series(1,8) n;
+
+INSERT INTO public.appointment_reminder_jobs(
+  id,tenant_id,appointment_id,patient_id,reminder_type,execution_mode,due_at,state,
+  appointment_updated_at,policy_version,plan_key,payload_fingerprint,priority,created_at,updated_at,original_due_at,metadata
+) VALUES
+('d3270000-0000-4000-8000-000000000101',:'tenant_b',:'appointment_b',:'patient_b','confirmation_request','manual',
+ '2099-07-19 08:00:00+00','scheduled',:'appointment_b_updated'::timestamptz,1,
+ encode(extensions.digest('orch-plan-b','sha256'),'hex'),encode(extensions.digest('orch-payload-b','sha256'),'hex'),100,now(),
+ '2099-07-13 08:00:00+00','2099-07-19 08:00:00+00','{}');
+SELECT updated_at::text AS job_version FROM public.appointment_reminder_jobs WHERE id='d3270000-0000-4000-8000-000000000001' \gset
+
+SELECT count(*)::text AS visits_before FROM public.patient_visits \gset
+SELECT count(*)::text AS encounters_before FROM public.clinical_encounters \gset
+SELECT count(*)::text AS services_before FROM public.completed_services \gset
+SELECT count(*)::text AS invoices_before FROM public.invoices \gset
+SELECT count(*)::text AS payments_before FROM public.payments \gset
+SELECT count(*)::text AS confirmations_before FROM public.appointment_confirmation_attempts \gset
+SELECT balance::text AS balance_before FROM public.patients WHERE id=:'patient_a' \gset
+
+SELECT pg_temp.assert_true(has_function_privilege('authenticated','public.communication_tenant_role(uuid)','EXECUTE'),'authenticated can execute RLS role helper');
+
+
+-- Role/RLS and empty-state access.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates),'1 owner reads templates');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_template_versions),'2 owner reads versions');
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates),'3 admin reads templates');
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates),'4 registrar read-only templates');
+SELECT set_config('request.jwt.claim.sub',:'doctor_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates),'5 doctor blocked by RLS');
+SELECT set_config('request.jwt.claim.sub',:'cashier_a',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates),'6 cashier blocked by RLS');
+SELECT set_config('request.jwt.claim.sub',:'unknown_user',true);
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates),'7 unknown blocked by RLS');
+SELECT pg_temp.expect_error(format(
+  'select public.list_communication_templates(%L::uuid,NULL,NULL,NULL)',:'tenant_a'
+),'Недостаточно прав');
+RESET ROLE;
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error('select count(*) from public.communication_templates','permission denied');
+SELECT pg_temp.expect_error('select count(*) from public.communication_template_versions','permission denied');
+RESET ROLE;
+
+-- Simulation route exists, but preparation is blocked until an exact template is published.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT public.create_or_update_communication_route(
+  :'tenant_a',NULL,'sms','mock',true,100,NULL,'template-route-a'
+) AS route_a_result \gset
+SELECT pg_temp.expect_error(format(
+  'select public.prepare_communication_operation(%L::uuid,%L::uuid,%L,%L,%L::timestamptz,%L::timestamptz)',
+  :'tenant_a','d3270000-0000-4000-8000-000000000001','sms','template-no-active-prepare',
+  :'job_version'::timestamptz,:'appointment_a_updated'::timestamptz
+),'нет активного шаблона');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_operations),'8 no operation without active template');
+
+-- Owner creates the stable RU/SMS identity and first draft.
+SELECT public.create_communication_template(
+  :'tenant_a','appointment_confirmation_request','sms','ru','Подтверждение RU SMS',NULL,
+  'Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+  'template-create-ru-sms-001'
+) AS create_result \gset
+SELECT (:'create_result'::jsonb->'template'->>'id') AS template_id \gset
+SELECT (:'create_result'::jsonb->'version'->>'id') AS draft_v1_id \gset
+SELECT (:'create_result'::jsonb->'version'->>'updatedAt') AS draft_v1_updated \gset
+SELECT pg_temp.assert_true(:'create_result'::jsonb->>'replayed'='false','9 template create is new');
+SELECT pg_temp.assert_true(:'create_result'::jsonb->'template'->>'status'='inactive','10 new template inactive');
+SELECT pg_temp.assert_true(:'create_result'::jsonb->'version'->>'status'='draft','11 initial version draft');
+SELECT pg_temp.assert_true(:'create_result'::jsonb->'version'->>'versionNumber'='1','12 initial version number one');
+SELECT pg_temp.assert_true(:'create_result'::jsonb->'version'->'variableKeys'=to_jsonb(ARRAY['appointment_date','appointment_time','clinic_name','patient_first_name']::text[]),'13 ordered variables');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.communication_templates WHERE tenant_id=:'tenant_a'),'14 one stable template');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.communication_template_versions WHERE tenant_id=:'tenant_a'),'15 one draft version');
+SELECT pg_temp.assert_true((SELECT content_fingerprint ~ '^[0-9a-f]{64}$' FROM public.communication_template_versions WHERE id=:'draft_v1_id'),'16 content fingerprint');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT content_fingerprint=public.communication_hash(jsonb_build_object(
+  'channel','sms','subject',NULL,'body','Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+  'variableKeys',ARRAY['appointment_date','appointment_time','clinic_name','patient_first_name']::text[]
+)::text) FROM public.communication_template_versions WHERE id=:'draft_v1_id'),'17 deterministic content fingerprint');
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+
+-- Idempotency and changed-payload conflict.
+SELECT public.create_communication_template(
+  :'tenant_a','appointment_confirmation_request','sms','ru','Подтверждение RU SMS',NULL,
+  'Здравствуйте, {{patient_first_name}}. Запись в {{clinic_name}} на {{appointment_date}} в {{appointment_time}}.',
+  'template-create-ru-sms-001'
+) AS create_replay \gset
+SELECT pg_temp.assert_true(:'create_replay'::jsonb->>'replayed'='true','18 same create key replays');
+SELECT pg_temp.assert_true(:'create_replay'::jsonb->'template'->>'id'=:'template_id','19 create replay identity stable');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_confirmation_request','sms','ru','Changed','Другой текст','template-create-ru-sms-001'
+),'другими параметрами');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_confirmation_request','sms','ru','Duplicate','Текст','template-create-duplicate'
+),'уже существует');
+
+-- Admin creates a separate KK identity; registrar cannot mutate.
+SELECT set_config('request.jwt.claim.sub',:'admin_a',true);
+SELECT public.create_communication_template(
+  :'tenant_a','appointment_same_day_reminder','sms','kk','Сол күнгі еске салу',NULL,
+  'Сәлеметсіз бе, {{patient_first_name}}. {{appointment_time}} уақытында {{clinic_name}} клиникасында жазбаңыз бар.',
+  'template-create-kk-sms-001'
+) AS kk_create_result \gset
+SELECT pg_temp.assert_true(:'kk_create_result'::jsonb->'template'->>'language'='kk','20 admin creates KK template');
+SELECT pg_temp.assert_true(position('Сәлеметсіз' in :'kk_create_result')>0,'21 KK Unicode preserved');
+SELECT set_config('request.jwt.claim.sub',:'registrar_a',true);
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','ru','Registrar','Текст','template-registrar-create'
+),'Недостаточно прав');
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+
+-- Identity/content validation matrix.
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','marketing','sms','ru','Bad purpose','Текст','template-bad-purpose'
+),'Назначение');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','telegram','ru','Bad channel','Текст','template-bad-channel'
+),'Канал');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','de','Bad language','Текст','template-bad-language'
+),'Язык');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','ru','Unknown','{{unknown_value}}','template-bad-unknown'
+),'неизвестную');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','ru','Clinical','{{diagnosis}}','template-bad-clinical'
+),'клиническую');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','ru','Financial','{{balance}}','template-bad-financial'
+),'финансовую');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','ru','Malformed','{{patient_first_name}','template-bad-braces'
+),'некорректную');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','email','ru','No subject','Текст','template-email-no-subject'
+),'требуется тема');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,%L,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','en','SMS subject','Тема','Текст','template-sms-subject'
+),'только для email');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,%L,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','whatsapp','en','WA subject','Тема','Текст','template-wa-subject'
+),'только для email');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','whatsapp','ru','Empty','','template-empty-body'
+),'не может быть пустым');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,NULL,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','sms','en','Long',repeat('x',1001),'template-long-sms'
+),'превышает');
+SELECT pg_temp.expect_error(format(
+  'select public.create_communication_template(%L::uuid,%L,%L,%L,%L,%L,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','email','en','HTML','Subject','<script>alert(1)</script>','template-html'
+),'HTML');
+
+-- Draft update, stale protection, deterministic preview.
+SELECT public.update_communication_template_draft(
+  :'tenant_a',:'draft_v1_id',NULL,
+  'Здравствуйте, {{patient_first_name}}. Напоминаем о записи в {{clinic_name}} {{appointment_date}} в {{appointment_time}}.',
+  :'draft_v1_updated'::timestamptz,'template-update-v1'
+) AS update_v1_result \gset
+SELECT (:'update_v1_result'::jsonb->'version'->>'updatedAt') AS draft_v1_updated_2 \gset
+SELECT pg_temp.assert_true(:'update_v1_result'::jsonb->'version'->>'status'='draft','22 draft update succeeds');
+SELECT pg_temp.assert_true(position('Напоминаем' in :'update_v1_result')>0,'23 draft body updated');
+SELECT pg_temp.expect_error(format(
+  'select public.update_communication_template_draft(%L::uuid,%L::uuid,NULL,%L,%L::timestamptz,%L)',
+  :'tenant_a',:'draft_v1_id','Старое изменение',(:'draft_v1_updated'::timestamptz - interval '1 second'),'template-stale-update'
+),'изменён другим пользователем');
+SELECT pg_temp.expect_error(format(
+  'update public.communication_template_versions set body=%L where id=%L::uuid','Direct update',:'draft_v1_id'
+),'permission denied');
+
+SELECT public.preview_communication_template(
+  :'tenant_a',:'draft_v1_id',jsonb_build_object(
+    'patient_first_name','Айгүл','clinic_name','Клиника Тест','appointment_date','20.07.2099','appointment_time','16:00'
+  )
+) AS preview_one \gset
+SELECT public.preview_communication_template(
+  :'tenant_a',:'draft_v1_id',jsonb_build_object(
+    'patient_first_name','Айгүл','clinic_name','Клиника Тест','appointment_date','20.07.2099','appointment_time','16:00'
+  )
+) AS preview_two \gset
+SELECT pg_temp.assert_true(:'preview_one'::jsonb->'rendered'->>'body'=:'preview_two'::jsonb->'rendered'->>'body','24 preview deterministic body');
+SELECT pg_temp.assert_true(:'preview_one'::jsonb->'rendered'->>'renderedFingerprint'=:'preview_two'::jsonb->'rendered'->>'renderedFingerprint','25 preview deterministic fingerprint');
+SELECT pg_temp.assert_true(position('Айгүл' in :'preview_one')>0,'26 preview Unicode preserved');
+SELECT pg_temp.assert_true(:'preview_one'::jsonb->'rendered'->>'renderedCharacterCount'=(char_length(:'preview_one'::jsonb->'rendered'->>'body'))::text,'27 rendered count');
+SELECT pg_temp.expect_error(format(
+  'select public.preview_communication_template(%L::uuid,%L::uuid,%L::jsonb)',
+  :'tenant_a',:'draft_v1_id',jsonb_build_object('patient_first_name','Айгүл')::text
+),'не хватает обязательных данных');
+SELECT pg_temp.expect_error(format(
+  'select public.preview_communication_template(%L::uuid,%L::uuid,%L::jsonb)',
+  :'tenant_a',:'draft_v1_id',jsonb_build_object(
+    'patient_first_name','Айгүл','clinic_name','Клиника','appointment_date','20.07.2099','appointment_time','16:00','diagnosis','secret'
+  )::text
+),'лишние');
+
+-- Publish v1 transactionally and resolve exact identity only.
+SELECT public.publish_communication_template_version(
+  :'tenant_a',:'template_id',:'draft_v1_id',:'draft_v1_updated_2'::timestamptz,'template-publish-v1'
+) AS publish_v1_result \gset
+SELECT pg_temp.assert_true(:'publish_v1_result'::jsonb->'template'->>'status'='active','28 publish activates template');
+SELECT pg_temp.assert_true(:'publish_v1_result'::jsonb->'version'->>'status'='published','29 version published');
+SELECT pg_temp.assert_true(:'publish_v1_result'::jsonb->'template'->>'activeVersionId'=:'draft_v1_id','30 active version exact');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.communication_template_versions WHERE template_id=:'template_id' AND status='published'),'31 one published active version');
+SELECT public.publish_communication_template_version(
+  :'tenant_a',:'template_id',:'draft_v1_id',:'draft_v1_updated_2'::timestamptz,'template-publish-v1'
+) AS publish_v1_replay \gset
+SELECT pg_temp.assert_true(:'publish_v1_replay'::jsonb->>'replayed'='true','32 publish replay safe');
+SELECT pg_temp.expect_error(format(
+  'select public.publish_communication_template_version(%L::uuid,%L::uuid,%L::uuid,%L::timestamptz,%L)',
+  :'tenant_a',:'template_id',:'draft_v1_id',(:'draft_v1_updated_2'::timestamptz + interval '1 second'),'template-publish-v1'
+),'другими параметрами');
+SELECT pg_temp.expect_error(format(
+  'select public.update_communication_template_draft(%L::uuid,%L::uuid,NULL,%L,%L::timestamptz,%L)',
+  :'tenant_a',:'draft_v1_id','Cannot edit',:'draft_v1_updated_2'::timestamptz,'template-edit-published'
+),'Опубликованную версию');
+
+SELECT public.get_active_communication_template(
+  :'tenant_a','appointment_confirmation_request','sms','ru'
+) AS active_exact \gset
+SELECT pg_temp.assert_true(:'active_exact'::jsonb->'version'->>'id'=:'draft_v1_id','33 exact active resolution');
+SELECT pg_temp.assert_true(public.get_active_communication_template(
+  :'tenant_a','appointment_confirmation_request','sms','kk'
+) IS NULL,'34 no silent language fallback');
+SELECT pg_temp.assert_true(public.get_active_communication_template(
+  :'tenant_a','appointment_confirmation_request','whatsapp','ru'
+) IS NULL,'35 no silent channel fallback');
+SELECT set_config('request.jwt.claim.sub',:'owner_b',true);
+SELECT pg_temp.assert_true(public.get_active_communication_template(
+  :'tenant_b','appointment_confirmation_request','sms','ru'
+) IS NULL,'36 no silent tenant fallback');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_templates WHERE id=:'template_id'),'37 cross-tenant template read blocked');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_template_versions WHERE id=:'draft_v1_id'),'38 cross-tenant version read blocked');
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+
+-- Preparation snapshots exact v1 and changes no reminder/appointment/finance state.
+SELECT public.prepare_communication_operation(
+  :'tenant_a','d3270000-0000-4000-8000-000000000001','sms','template-operation-v1',
+  :'job_version'::timestamptz,:'appointment_a_updated'::timestamptz
+) AS operation_v1_result \gset
+SELECT (:'operation_v1_result'::jsonb->'operation'->>'id') AS operation_v1_id \gset
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->>'templateId'=:'template_id','39 operation template id');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->>'templateVersionId'=:'draft_v1_id','40 operation exact version id');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->>'templateVersionNumber'='1','41 operation v1 number');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->>'templateContentFingerprint' ~ '^[0-9a-f]{64}$','42 template fingerprint snapshot');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->>'renderedContentFingerprint' ~ '^[0-9a-f]{64}$','43 rendered fingerprint snapshot');
+SELECT pg_temp.assert_true(position('Здравствуйте' in (:'operation_v1_result'::jsonb->'operation'->>'renderedBody'))=1 AND position('{{' in (:'operation_v1_result'::jsonb->'operation'->>'renderedBody'))=0,'44 rendered body snapshot');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->'templateSnapshot'->>'language'='ru','45 template language snapshot');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->'templateSnapshot'->>'channel'='sms','46 template channel snapshot');
+SELECT pg_temp.assert_true(:'operation_v1_result'::jsonb->'operation'->'templateSnapshot'->>'purposeCode'='appointment_confirmation_request','47 template purpose snapshot');
+SELECT pg_temp.assert_true(position('+77001112233' in :'operation_v1_result')=0,'48 raw destination absent');
+SELECT pg_temp.assert_true(position('diagnosis' in lower(:'operation_v1_result'))=0 AND position('balance' in lower(:'operation_v1_result'))=0,'49 clinical financial variables absent');
+SELECT pg_temp.assert_true((SELECT state='scheduled' FROM public.appointment_reminder_jobs WHERE id='d3270000-0000-4000-8000-000000000001'),'50 reminder unchanged');
+SELECT pg_temp.assert_true((SELECT status='new' FROM public.appointments WHERE id=:'appointment_a'),'51 appointment unchanged');
+SELECT pg_temp.assert_true((SELECT count(*)::text=:'confirmations_before' FROM public.appointment_confirmation_attempts),'52 confirmations unchanged');
+
+-- New draft v2, publish, supersede v1, preserve old operation, use v2 for a new operation.
+SELECT public.create_communication_template_draft(
+  :'tenant_a',:'template_id','template-create-draft-v2'
+) AS create_v2_result \gset
+SELECT (:'create_v2_result'::jsonb->'version'->>'id') AS draft_v2_id \gset
+SELECT (:'create_v2_result'::jsonb->'version'->>'updatedAt') AS draft_v2_updated \gset
+SELECT pg_temp.assert_true(:'create_v2_result'::jsonb->'version'->>'versionNumber'='2','53 monotonically increasing version');
+SELECT pg_temp.assert_true(:'create_v2_result'::jsonb->'version'->>'status'='draft','54 v2 draft');
+SELECT public.update_communication_template_draft(
+  :'tenant_a',:'draft_v2_id',NULL,
+  'Новая версия для {{patient_first_name}}: {{appointment_date}} {{appointment_time}}, {{clinic_name}}.',
+  :'draft_v2_updated'::timestamptz,'template-update-v2'
+) AS update_v2_result \gset
+SELECT (:'update_v2_result'::jsonb->'version'->>'updatedAt') AS draft_v2_updated_2 \gset
+SELECT public.publish_communication_template_version(
+  :'tenant_a',:'template_id',:'draft_v2_id',:'draft_v2_updated_2'::timestamptz,'template-publish-v2'
+) AS publish_v2_result \gset
+SELECT pg_temp.assert_true((SELECT status='superseded' FROM public.communication_template_versions WHERE id=:'draft_v1_id'),'55 prior version superseded');
+SELECT pg_temp.assert_true((SELECT status='published' FROM public.communication_template_versions WHERE id=:'draft_v2_id'),'56 v2 published');
+SELECT pg_temp.assert_true((SELECT count(*)=1 FROM public.communication_template_versions WHERE template_id=:'template_id' AND status='published'),'57 one active version enforced');
+SELECT pg_temp.assert_true((SELECT template_version_id=:'draft_v1_id'::uuid AND rendered_body LIKE 'Здравствуйте,%' FROM public.communication_operations WHERE id=:'operation_v1_id'),'58 old operation unchanged');
+SELECT public.prepare_communication_operation(
+  :'tenant_a','d3270000-0000-4000-8000-000000000002','sms','template-operation-v2',
+  :'job_version'::timestamptz,:'appointment_a_updated'::timestamptz
+) AS operation_v2_result \gset
+SELECT pg_temp.assert_true(:'operation_v2_result'::jsonb->'operation'->>'templateVersionId'=:'draft_v2_id','59 new operation uses v2');
+SELECT pg_temp.assert_true(:'operation_v2_result'::jsonb->'operation'->>'templateVersionNumber'='2','60 new operation version number');
+SELECT pg_temp.assert_true(position('Новая версия' in (:'operation_v2_result'::jsonb->'operation'->>'renderedBody'))=1,'61 new rendered content');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_operations WHERE template_id IS NULL OR template_version_id IS NULL OR rendered_content_fingerprint IS NULL),'62 operation snapshots complete');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_operations WHERE rendered_body ~* '(diagnosis|complaint|finding|treatment|balance|debt|invoice|payment)'),'63 no forbidden rendered variables');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_operations WHERE rendered_body LIKE '%+77001112233%'),'64 raw destination absent from rendered content');
+
+-- Direct writes remain blocked, RLS active, audit/activity paired once.
+SELECT pg_temp.expect_error(format(
+  'insert into public.communication_templates(tenant_id,purpose_code,channel,language,display_name,status) values(%L::uuid,%L,%L,%L,%L,%L)',
+  :'tenant_a','appointment_day_before_reminder','email','ru','Direct','inactive'
+),'permission denied');
+SELECT pg_temp.expect_error(format(
+  'update public.communication_template_versions set body=%L where id=%L::uuid','Mutated',:'draft_v1_id'
+),'permission denied');
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.communication_templates'::regclass),'65 template RLS enabled');
+SELECT pg_temp.assert_true((SELECT relrowsecurity FROM pg_class WHERE oid='public.communication_template_versions'::regclass),'66 version RLS enabled');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM information_schema.role_table_grants WHERE grantee='authenticated' AND table_schema='public' AND table_name IN ('communication_templates','communication_template_versions') AND privilege_type IN ('INSERT','UPDATE','DELETE')),'67 no authenticated direct writes');
+SELECT pg_temp.assert_true((SELECT count(*) FROM public.audit_events WHERE tenant_id=:'tenant_a' AND action LIKE 'communication_template_%')=(SELECT count(*) FROM public.activity_events WHERE tenant_id=:'tenant_a' AND type LIKE 'communication_template_%'),'68 audit activity parity');
+SELECT pg_temp.assert_true((SELECT count(*)>0 FROM public.audit_events WHERE tenant_id=:'tenant_a' AND action='communication_template_published'),'69 publish audited');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.audit_events WHERE tenant_id=:'tenant_a' AND metadata::text LIKE '%Пациент Оркестрации%'),'70 no patient rendered body in audit metadata');
+
+-- Archive blocks active resolution but retains versions for audit.
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub',:'owner_a',true);
+SELECT updated_at::text AS template_updated_before_archive FROM public.communication_templates WHERE id=:'template_id' \gset
+SELECT public.archive_communication_template(
+  :'tenant_a',:'template_id',:'template_updated_before_archive'::timestamptz,'template-archive-main'
+) AS archive_result \gset
+SELECT pg_temp.assert_true(:'archive_result'::jsonb->'template'->>'status'='archived','71 template archived');
+SELECT pg_temp.assert_true(public.get_active_communication_template(
+  :'tenant_a','appointment_confirmation_request','sms','ru'
+) IS NULL,'72 archive blocks active resolution');
+SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.communication_template_versions WHERE template_id=:'template_id'),'73 archived versions retained');
+SELECT pg_temp.assert_true((SELECT count(*)=2 FROM public.communication_operations WHERE template_id=:'template_id'),'74 historical operations retained');
+
+-- Side-effect counters.
+RESET ROLE;
+SELECT pg_temp.assert_true((SELECT count(*)::text=:'visits_before' FROM public.patient_visits),'75 visits unchanged');
+SELECT pg_temp.assert_true((SELECT count(*)::text=:'encounters_before' FROM public.clinical_encounters),'76 encounters unchanged');
+SELECT pg_temp.assert_true((SELECT count(*)::text=:'services_before' FROM public.completed_services),'77 completed services unchanged');
+SELECT pg_temp.assert_true((SELECT count(*)::text=:'invoices_before' FROM public.invoices),'78 invoices unchanged');
+SELECT pg_temp.assert_true((SELECT count(*)::text=:'payments_before' FROM public.payments),'79 payments unchanged');
+SELECT pg_temp.assert_true((SELECT balance::text=:'balance_before' FROM public.patients WHERE id=:'patient_a'),'80 patient balance unchanged');
+SELECT pg_temp.assert_true((SELECT count(*)=0 FROM public.communication_operations o JOIN public.communication_templates t ON t.id=o.template_id WHERE o.tenant_id<>t.tenant_id),'81 no cross-tenant operation template link');
+SELECT pg_temp.assert_true(NOT EXISTS (SELECT 1 FROM public.communication_template_versions GROUP BY template_id,version_number HAVING count(*)>1),'82 no duplicate version numbers');
+SELECT pg_temp.assert_true(NOT EXISTS (SELECT 1 FROM public.communication_template_versions WHERE status='published' GROUP BY template_id HAVING count(*)>1),'83 no multiple active versions');
+
+ROLLBACK;
+\echo 'COMMUNICATION-TEMPLATE-FOUNDATION-001 SQL validation passed'


### PR DESCRIPTION
## Summary

Implements the communication template foundation: versioned templates, rendering and command domain logic, repository/hooks, management UI, communication operations integration, Supabase migration 0033, and SQL/concurrency coverage.

Current source of truth:
- PR: #359
- Branch: feature/communication-template-foundation-001
- HEAD: 33e622c7295c835c60068332330d567f5e1f8861
- Changed files: 23
- Local working tree: clean

CI run #760 (run ID 29277781206) tested this exact HEAD. Validation steps passed; the overall run failed only because Merge guard evaluated the earlier protected draft metadata. The PR is now Ready for review and contains no explicit merge prohibition.

## Checks

- Local lint: PASS
- Local tests: PASS — 107 files, 1143 tests
- Local build: PASS
- CI validate on HEAD 33e622c7295c835c60068332330d567f5e1f8861: PASS
- A fresh pull-request CI event must confirm Merge guard: PASS

## Limitations

- Existing React act(...) warnings remain non-failing.
- Vite reports a non-failing bundle-size warning.
- No commit with SHA 2fc098e7059b83a8f4fcb1b35e489bd6c14e4228 exists in the repository; 33e622c7295c835c60068332330d567f5e1f8861 is the verified implementation HEAD.
